### PR TITLE
Solid Heroicons are meant to be w-5 h-5

### DIFF
--- a/lib/mix/tasks/heroicons/generate.ex
+++ b/lib/mix/tasks/heroicons/generate.ex
@@ -35,6 +35,7 @@ defmodule Mix.Tasks.Heroicons.Generate do
       src_path
       |> File.ls!()
       |> Enum.filter(&(Path.extname(&1) == ".svg"))
+      |> Enum.sort()
       |> Enum.map(&create_component(src_path, &1, folder))
       |> Enum.join("\n\n")
 

--- a/lib/mix/tasks/heroicons/generate.ex
+++ b/lib/mix/tasks/heroicons/generate.ex
@@ -17,8 +17,8 @@ defmodule Mix.Tasks.Heroicons.Generate do
       use Phoenix.Component
       @moduledoc \"\"\"
       Icon name can be the function or passed in as a type eg.
-      <PetalComponents.Heroicons.Solid.home class="w-6 h-6" />
-      <PetalComponents.Heroicons.Solid.render type="home" class="w-6 h-6" />
+      <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
+      <PetalComponents.Heroicons.Solid.render type="home" class="w-5 h-5" />
 
       <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
       <PetalComponents.Heroicons.Outline.render type="home" class="w-6 h-6" />
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Heroicons.Generate do
       src_path
       |> File.ls!()
       |> Enum.filter(&(Path.extname(&1) == ".svg"))
-      |> Enum.map(&create_component(src_path, &1))
+      |> Enum.map(&create_component(src_path, &1, folder))
       |> Enum.join("\n\n")
 
     file_content =
@@ -55,14 +55,14 @@ defmodule Mix.Tasks.Heroicons.Generate do
     File.write!(dest_path, file_content)
   end
 
-  defp create_component(src_path, filename) do
+  defp create_component(src_path, filename, type) do
     svg_content =
       File.read!(Path.join(src_path, filename))
       |> String.trim()
       |> String.replace(~r/<svg /, "<svg class={@class} {@extra_attributes} ")
       |> String.replace(~r/<path/, "  <path")
 
-    build_component(filename, svg_content)
+    build_component(filename, svg_content, type)
   end
 
   defp function_name(current_filename) do
@@ -71,11 +71,13 @@ defmodule Mix.Tasks.Heroicons.Generate do
     |> String.replace("-", "_")
   end
 
-  defp build_component(filename, svg) do
+  defp build_component(filename, svg, type) do
+    class = class_for(type)
+
     """
     def #{function_name(filename)}(assigns) do
       assigns = assigns
-        |> assign_new(:class, fn -> "h-6 w-6" end)
+        |> assign_new(:class, fn -> "#{class}" end)
         |> assign_new(:extra_attributes, fn ->
           assigns_to_attributes(assigns, [:class])
         end)
@@ -86,4 +88,7 @@ defmodule Mix.Tasks.Heroicons.Generate do
     end
     """
   end
+
+  defp class_for("outline"), do: "h-6 w-6"
+  defp class_for("solid"), do: "h-5 w-5"
 end

--- a/lib/petal_components/icons/heroicons/outline.ex
+++ b/lib/petal_components/icons/heroicons/outline.ex
@@ -15,7 +15,7 @@ defmodule PetalComponents.Heroicons.Outline do
     apply(__MODULE__, icon_name, [assigns])
   end
 
-  def share(assigns) do
+  def academic_cap(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -25,12 +25,14 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/>
+      <path d="M12 14l9-5-9-5-9 5 9 5z"/>
+      <path d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222"/>
     </svg>
     """
   end
 
-  def currency_euro(assigns) do
+  def adjustments(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -40,12 +42,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.121 15.536c-1.171 1.952-3.07 1.952-4.242 0-1.172-1.953-1.172-5.119 0-7.072 1.171-1.952 3.07-1.952 4.242 0M8 10.5h4m-4 3h4m9-1.5a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
     </svg>
     """
   end
 
-  def library(assigns) do
+  def annotation(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -55,12 +57,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"/>
     </svg>
     """
   end
 
-  def color_swatch(assigns) do
+  def archive(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -70,12 +72,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
     </svg>
     """
   end
 
-  def finger_print(assigns) do
+  def arrow_circle_down(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -85,12 +87,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13l-3 3m0 0l-3-3m3 3V8m0 13a9 9 0 110-18 9 9 0 010 18z"/>
     </svg>
     """
   end
 
-  def chart_bar(assigns) do
+  def arrow_circle_left(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -100,12 +102,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 15l-3-3m0 0l3-3m-3 3h8M3 12a9 9 0 1118 0 9 9 0 01-18 0z"/>
     </svg>
     """
   end
 
-  def fast_forward(assigns) do
+  def arrow_circle_right(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -115,12 +117,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.933 12.8a1 1 0 000-1.6L6.6 7.2A1 1 0 005 8v8a1 1 0 001.6.8l5.333-4zM19.933 12.8a1 1 0 000-1.6l-5.333-4A1 1 0 0013 8v8a1 1 0 001.6.8l5.333-4z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def chart_pie(assigns) do
+  def arrow_circle_up(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -130,13 +132,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 11l3-3m0 0l3 3m-3-3v8m0-13a9 9 0 110 18 9 9 0 010-18z"/>
     </svg>
     """
   end
 
-  def trending_up(assigns) do
+  def arrow_down(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -146,12 +147,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3"/>
     </svg>
     """
   end
 
-  def reply(assigns) do
+  def arrow_left(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -161,12 +162,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
     </svg>
     """
   end
 
-  def heart(assigns) do
+  def arrow_narrow_down(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -176,12 +177,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 17l-4 4m0 0l-4-4m4 4V3"/>
     </svg>
     """
   end
 
-  def cube(assigns) do
+  def arrow_narrow_left(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -191,12 +192,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16l-4-4m0 0l4-4m-4 4h18"/>
     </svg>
     """
   end
 
-  def lock_closed(assigns) do
+  def arrow_narrow_right(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -206,12 +207,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/>
     </svg>
     """
   end
 
-  def view_grid_add(assigns) do
+  def arrow_narrow_up(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -221,12 +222,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14v6m-3-3h6M6 10h2a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2zm10 0h2a2 2 0 002-2V6a2 2 0 00-2-2h-2a2 2 0 00-2 2v2a2 2 0 002 2zM6 20h2a2 2 0 002-2v-2a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7l4-4m0 0l4 4m-4-4v18"/>
     </svg>
     """
   end
 
-  def document_text(assigns) do
+  def arrow_right(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -236,12 +237,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
     </svg>
     """
   end
 
-  def switch_horizontal(assigns) do
+  def arrow_sm_down(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -251,12 +252,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 13l-5 5m0 0l-5-5m5 5V6"/>
     </svg>
     """
   end
 
-  def wifi(assigns) do
+  def arrow_sm_left(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -266,7 +267,262 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.141 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 17l-5-5m0 0l5-5m-5 5h12"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11l5-5m0 0l5 5m-5-5v12"/>
+    </svg>
+    """
+  end
+
+  def arrow_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18"/>
+    </svg>
+    """
+  end
+
+  def arrows_expand(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"/>
+    </svg>
+    """
+  end
+
+  def at_symbol(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207"/>
+    </svg>
+    """
+  end
+
+  def backspace(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2M3 12l6.414 6.414a2 2 0 001.414.586H19a2 2 0 002-2V7a2 2 0 00-2-2h-8.172a2 2 0 00-1.414.586L3 12z"/>
+    </svg>
+    """
+  end
+
+  def badge_check(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"/>
+    </svg>
+    """
+  end
+
+  def ban(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/>
+    </svg>
+    """
+  end
+
+  def beaker(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"/>
+    </svg>
+    """
+  end
+
+  def bell(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/>
+    </svg>
+    """
+  end
+
+  def book_open(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+    </svg>
+    """
+  end
+
+  def bookmark_alt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 4v12l-4-2-4 2V4M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def bookmark(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"/>
+    </svg>
+    """
+  end
+
+  def briefcase(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def cake(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 15.546c-.523 0-1.046.151-1.5.454a2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.701 2.701 0 00-1.5-.454M9 6v2m3-2v2m3-2v2M9 3h.01M12 3h.01M15 3h.01M21 21v-7a2 2 0 00-2-2H5a2 2 0 00-2 2v7h18zm-3-9v-2a2 2 0 00-2-2H8a2 2 0 00-2 2v2h12z"/>
+    </svg>
+    """
+  end
+
+  def calculator(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def calendar(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
     </svg>
     """
   end
@@ -287,7 +543,7 @@ defmodule PetalComponents.Heroicons.Outline do
     """
   end
 
-  def document_report(assigns) do
+  def cash(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -297,12 +553,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"/>
     </svg>
     """
   end
 
-  def chevron_double_down(assigns) do
+  def chart_bar(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -312,12 +568,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 13l-7 7-7-7m14-8l-7 7-7-7"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
     </svg>
     """
   end
 
-  def arrow_sm_right(assigns) do
+  def chart_pie(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -327,12 +583,13 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z"/>
     </svg>
     """
   end
 
-  def arrow_narrow_down(assigns) do
+  def chart_square_bar(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -342,1391 +599,7 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 17l-4 4m0 0l-4-4m4 4V3"/>
-    </svg>
-    """
-  end
-
-  def collection(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
-    </svg>
-    """
-  end
-
-  def newspaper(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"/>
-    </svg>
-    """
-  end
-
-  def selector(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l4-4 4 4m0 6l-4 4-4-4"/>
-    </svg>
-    """
-  end
-
-  def search_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16l2.879-2.879m0 0a3 3 0 104.243-4.242 3 3 0 00-4.243 4.242zM21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def academic_cap(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path d="M12 14l9-5-9-5-9 5 9 5z"/>
-      <path d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222"/>
-    </svg>
-    """
-  end
-
-  def clipboard_check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
-    </svg>
-    """
-  end
-
-  def flag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"/>
-    </svg>
-    """
-  end
-
-  def chevron_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-    </svg>
-    """
-  end
-
-  def database(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
-    </svg>
-    """
-  end
-
-  def music_note(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/>
-    </svg>
-    """
-  end
-
-  def paper_clip(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"/>
-    </svg>
-    """
-  end
-
-  def logout(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
-    </svg>
-    """
-  end
-
-  def rss(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 5c7.18 0 13 5.82 13 13M6 11a7 7 0 017 7m-6 0a1 1 0 11-2 0 1 1 0 012 0z"/>
-    </svg>
-    """
-  end
-
-  def folder(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/>
-    </svg>
-    """
-  end
-
-  def document_download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-    </svg>
-    """
-  end
-
-  def currency_rupee(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 8h6m-5 0a3 3 0 110 6H9l3 3m-3-6h6m6 1a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def device_tablet(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def key(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
-    </svg>
-    """
-  end
-
-  def arrow_circle_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 15l-3-3m0 0l3-3m-3 3h8M3 12a9 9 0 1118 0 9 9 0 01-18 0z"/>
-    </svg>
-    """
-  end
-
-  def bookmark_alt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 4v12l-4-2-4 2V4M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def cube_transparent(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10l-2 1m0 0l-2-1m2 1v2.5M20 7l-2 1m2-1l-2-1m2 1v2.5M14 4l-2-1-2 1M4 7l2-1M4 7l2 1M4 7v2.5M12 21l-2-1m2 1l2-1m-2 1v-2.5M6 18l-2-1v-2.5M18 18l2-1v-2.5"/>
-    </svg>
-    """
-  end
-
-  def emoji_happy(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def currency_pound(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 9a2 2 0 10-4 0v5a2 2 0 01-2 2h6m-6-4h4m8 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def view_list(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"/>
-    </svg>
-    """
-  end
-
-  def view_grid(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
-    </svg>
-    """
-  end
-
-  def cloud_download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"/>
-    </svg>
-    """
-  end
-
-  def check_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def speakerphone(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"/>
-    </svg>
-    """
-  end
-
-  def server(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/>
-    </svg>
-    """
-  end
-
-  def backspace(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2M3 12l6.414 6.414a2 2 0 001.414.586H19a2 2 0 002-2V7a2 2 0 00-2-2h-8.172a2 2 0 00-1.414.586L3 12z"/>
-    </svg>
-    """
-  end
-
-  def switch_vertical(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"/>
-    </svg>
-    """
-  end
-
-  def user_group(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
-    </svg>
-    """
-  end
-
-  def sun(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
-    </svg>
-    """
-  end
-
-  def clock(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def chevron_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/>
-    </svg>
-    """
-  end
-
-  def shield_exclamation(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016zM12 9v2m0 4h.01"/>
-    </svg>
-    """
-  end
-
-  def download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
-    </svg>
-    """
-  end
-
-  def plus_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def chevron_double_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 11l7-7 7 7M5 19l7-7 7 7"/>
-    </svg>
-    """
-  end
-
-  def clipboard(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
-    </svg>
-    """
-  end
-
-  def variable(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.871 4A17.926 17.926 0 003 12c0 2.874.673 5.59 1.871 8m14.13 0a17.926 17.926 0 001.87-8c0-2.874-.673-5.59-1.87-8M9 9h1.246a1 1 0 01.961.725l1.586 5.55a1 1 0 00.961.725H15m1-7h-.08a2 2 0 00-1.519.698L9.6 15.302A2 2 0 018.08 16H8"/>
-    </svg>
-    """
-  end
-
-  def chat_alt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/>
-    </svg>
-    """
-  end
-
-  def arrow_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
-    </svg>
-    """
-  end
-
-  def folder_add(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
-    </svg>
-    """
-  end
-
-  def document_duplicate(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7v8a2 2 0 002 2h6M8 7V5a2 2 0 012-2h4.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V15a2 2 0 01-2 2h-2M8 7H6a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2v-2"/>
-    </svg>
-    """
-  end
-
-  def calculator(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def mail(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def location_marker(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
-    </svg>
-    """
-  end
-
-  def annotation(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"/>
-    </svg>
-    """
-  end
-
-  def arrow_sm_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11l5-5m0 0l5 5m-5-5v12"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_4(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16"/>
-    </svg>
-    """
-  end
-
-  def cursor_click(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122"/>
-    </svg>
-    """
-  end
-
-  def eye_off(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"/>
-    </svg>
-    """
-  end
-
-  def document_remove(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-    </svg>
-    """
-  end
-
-  def printer(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
-    </svg>
-    """
-  end
-
-  def search(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
-    </svg>
-    """
-  end
-
-  def paper_airplane(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
-    </svg>
-    """
-  end
-
-  def template(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"/>
-    </svg>
-    """
-  end
-
-  def chevron_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
-    </svg>
-    """
-  end
-
-  def x_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def ticket(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z"/>
-    </svg>
-    """
-  end
-
-  def arrow_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3"/>
-    </svg>
-    """
-  end
-
-  def globe_alt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/>
-    </svg>
-    """
-  end
-
-  def cloud(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z"/>
-    </svg>
-    """
-  end
-
-  def cloud_upload(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>
-    </svg>
-    """
-  end
-
-  def currency_bangladeshi(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 11V9a2 2 0 00-2-2m2 4v4a2 2 0 104 0v-1m-4-3H9m2 0h4m6 1a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def eye(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
-    </svg>
-    """
-  end
-
-  def arrow_sm_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 17l-5-5m0 0l5-5m-5 5h12"/>
-    </svg>
-    """
-  end
-
-  def lightning_bolt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
-    </svg>
-    """
-  end
-
-  def hand(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11.5V14m0-2.5v-6a1.5 1.5 0 113 0m-3 6a1.5 1.5 0 00-3 0v2a7.5 7.5 0 0015 0v-5a1.5 1.5 0 00-3 0m-6-3V11m0-5.5v-1a1.5 1.5 0 013 0v1m0 0V11m0-5.5a1.5 1.5 0 013 0v3m0 0V11"/>
-    </svg>
-    """
-  end
-
-  def clipboard_list(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"/>
-    </svg>
-    """
-  end
-
-  def dots_circle_horizontal(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def video_camera(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def phone(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
-    </svg>
-    """
-  end
-
-  def save_as(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16v2a2 2 0 01-2 2H5a2 2 0 01-2-2v-7a2 2 0 012-2h2m3-4H9a2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-1m-1 4l-3 3m0 0l-3-3m3 3V3"/>
-    </svg>
-    """
-  end
-
-  def user_remove(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7a4 4 0 11-8 0 4 4 0 018 0zM9 14a6 6 0 00-6 6v1h12v-1a6 6 0 00-6-6zM21 12h-6"/>
-    </svg>
-    """
-  end
-
-  def filter(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"/>
-    </svg>
-    """
-  end
-
-  def thumb_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14H5.236a2 2 0 01-1.789-2.894l3.5-7A2 2 0 018.736 3h4.018a2 2 0 01.485.06l3.76.94m-7 10v5a2 2 0 002 2h.096c.5 0 .905-.405.905-.904 0-.715.211-1.413.608-2.008L17 13V4m-7 10h2m5-10h2a2 2 0 012 2v6a2 2 0 01-2 2h-2.5"/>
-    </svg>
-    """
-  end
-
-  def sparkles(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"/>
-    </svg>
-    """
-  end
-
-  def volume_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z"/>
-    </svg>
-    """
-  end
-
-  def rewind(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0019 16V8a1 1 0 00-1.6-.8l-5.333 4zM4.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0011 16V8a1 1 0 00-1.6-.8l-5.334 4z"/>
-    </svg>
-    """
-  end
-
-  def trending_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"/>
-    </svg>
-    """
-  end
-
-  def mail_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 19v-8.93a2 2 0 01.89-1.664l7-4.666a2 2 0 012.22 0l7 4.666A2 2 0 0121 10.07V19M3 19a2 2 0 002 2h14a2 2 0 002-2M3 19l6.75-4.5M21 19l-6.75-4.5M3 10l6.75 4.5M21 10l-6.75 4.5m0 0l-1.14.76a2 2 0 01-2.22 0l-1.14-.76"/>
-    </svg>
-    """
-  end
-
-  def question_mark_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def upload(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/>
-    </svg>
-    """
-  end
-
-  def document_search(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 21h7a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v11m0 5l4.879-4.879m0 0a3 3 0 104.243-4.242 3 3 0 00-4.243 4.242z"/>
-    </svg>
-    """
-  end
-
-  def users(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_1(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16"/>
-    </svg>
-    """
-  end
-
-  def scale(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"/>
-    </svg>
-    """
-  end
-
-  def lock_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def chat(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
-    </svg>
-    """
-  end
-
-  def external_link(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
     </svg>
     """
   end
@@ -1746,7 +619,7 @@ defmodule PetalComponents.Heroicons.Outline do
     """
   end
 
-  def arrow_circle_up(assigns) do
+  def chat_alt(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -1756,12 +629,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 11l3-3m0 0l3 3m-3-3v8m0-13a9 9 0 110 18 9 9 0 010-18z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/>
     </svg>
     """
   end
 
-  def translate(assigns) do
+  def chat(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -1771,12 +644,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
     </svg>
     """
   end
 
-  def user(assigns) do
+  def check_circle(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -1786,639 +659,7 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
-    </svg>
-    """
-  end
-
-  def presentation_chart_bar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 13v-1m4 1v-3m4 3V8M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>
-    </svg>
-    """
-  end
-
-  def cash(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"/>
-    </svg>
-    """
-  end
-
-  def cake(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 15.546c-.523 0-1.046.151-1.5.454a2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.701 2.701 0 00-1.5-.454M9 6v2m3-2v2m3-2v2M9 3h.01M12 3h.01M15 3h.01M21 21v-7a2 2 0 00-2-2H5a2 2 0 00-2 2v7h18zm-3-9v-2a2 2 0 00-2-2H8a2 2 0 00-2 2v2h12z"/>
-    </svg>
-    """
-  end
-
-  def home(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
-    </svg>
-    """
-  end
-
-  def volume_off(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" clip-rule="evenodd"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/>
-    </svg>
-    """
-  end
-
-  def stop(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"/>
-    </svg>
-    """
-  end
-
-  def badge_check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"/>
-    </svg>
-    """
-  end
-
-  def moon(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
-    </svg>
-    """
-  end
-
-  def tag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
-    </svg>
-    """
-  end
-
-  def sort_ascending(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12"/>
-    </svg>
-    """
-  end
-
-  def folder_download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3M3 17V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
-    </svg>
-    """
-  end
-
-  def terminal(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def receipt_refund(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z"/>
-    </svg>
-    """
-  end
-
-  def office_building(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7l4-4m0 0l4 4m-4-4v18"/>
-    </svg>
-    """
-  end
-
-  def arrows_expand(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"/>
-    </svg>
-    """
-  end
-
-  def adjustments(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
-    </svg>
-    """
-  end
-
-  def arrow_sm_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 13l-5 5m0 0l-5-5m5 5V6"/>
-    </svg>
-    """
-  end
-
-  def shield_check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
-    </svg>
-    """
-  end
-
-  def qrcode(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"/>
-    </svg>
-    """
-  end
-
-  def status_offline(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636a9 9 0 010 12.728m0 0l-2.829-2.829m2.829 2.829L21 21M15.536 8.464a5 5 0 010 7.072m0 0l-2.829-2.829m-4.243 2.829a4.978 4.978 0 01-1.414-2.83m-1.414 5.658a9 9 0 01-2.167-9.238m7.824 2.167a1 1 0 111.414 1.414m-1.414-1.414L3 3m8.293 8.293l1.414 1.414"/>
-    </svg>
-    """
-  end
-
-  def map(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/>
-    </svg>
-    """
-  end
-
-  def document_add(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m5 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-    </svg>
-    """
-  end
-
-  def at_symbol(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207"/>
-    </svg>
-    """
-  end
-
-  def credit_card(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/>
-    </svg>
-    """
-  end
-
-  def globe(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def sort_descending(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h13M3 8h9m-9 4h9m5-4v12m0 0l-4-4m4 4l4-4"/>
-    </svg>
-    """
-  end
-
-  def trash(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
-    </svg>
-    """
-  end
-
-  def shopping_cart(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"/>
-    </svg>
-    """
-  end
-
-  def dots_horizontal(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z"/>
-    </svg>
-    """
-  end
-
-  def chip(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"/>
-    </svg>
-    """
-  end
-
-  def zoom_out(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM13 10H7"/>
-    </svg>
-    """
-  end
-
-  def photograph(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def chevron_double_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7"/>
-    </svg>
-    """
-  end
-
-  def shopping_bag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"/>
-    </svg>
-    """
-  end
-
-  def puzzle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/>
-    </svg>
-    """
-  end
-
-  def beaker(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"/>
-    </svg>
-    """
-  end
-
-  def desktop_computer(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def gift(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7"/>
-    </svg>
-    """
-  end
-
-  def plus(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
-    </svg>
-    """
-  end
-
-  def thumb_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
@@ -2438,7 +679,7 @@ defmodule PetalComponents.Heroicons.Outline do
     """
   end
 
-  def minus_circle(assigns) do
+  def chevron_double_down(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2448,12 +689,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 13l-7 7-7-7m14-8l-7 7-7-7"/>
     </svg>
     """
   end
 
-  def minus(assigns) do
+  def chevron_double_left(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2463,7 +704,52 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7"/>
+    </svg>
+    """
+  end
+
+  def chevron_double_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7"/>
+    </svg>
+    """
+  end
+
+  def chevron_double_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 11l7-7 7 7M5 19l7-7 7 7"/>
+    </svg>
+    """
+  end
+
+  def chevron_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
     </svg>
     """
   end
@@ -2483,7 +769,7 @@ defmodule PetalComponents.Heroicons.Outline do
     """
   end
 
-  def microphone(assigns) do
+  def chevron_right(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2493,12 +779,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
     </svg>
     """
   end
 
-  def link(assigns) do
+  def chevron_up(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2508,12 +794,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/>
     </svg>
     """
   end
 
-  def currency_yen(assigns) do
+  def chip(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2523,12 +809,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 8l3 5m0 0l3-5m-3 5v4m-3-5h6m-6 3h6m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"/>
     </svg>
     """
   end
 
-  def table(assigns) do
+  def clipboard_check(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2538,12 +824,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
     </svg>
     """
   end
 
-  def minus_sm(assigns) do
+  def clipboard_copy(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2553,12 +839,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 12H6"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/>
     </svg>
     """
   end
 
-  def dots_vertical(assigns) do
+  def clipboard_list(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2568,12 +854,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"/>
     </svg>
     """
   end
 
-  def arrow_up(assigns) do
+  def clipboard(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2583,12 +869,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
     </svg>
     """
   end
 
-  def emoji_sad(assigns) do
+  def clock(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2598,12 +884,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def scissors(assigns) do
+  def cloud_download(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2613,7 +899,52 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.121 14.121L19 19m-7-7l7-7m-7 7l-2.879 2.879M12 12L9.121 9.121m0 5.758a3 3 0 10-4.243 4.243 3 3 0 004.243-4.243zm0-5.758a3 3 0 10-4.243-4.243 3 3 0 004.243 4.243z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"/>
+    </svg>
+    """
+  end
+
+  def cloud_upload(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>
+    </svg>
+    """
+  end
+
+  def cloud(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z"/>
+    </svg>
+    """
+  end
+
+  def code(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
     </svg>
     """
   end
@@ -2634,7 +965,7 @@ defmodule PetalComponents.Heroicons.Outline do
     """
   end
 
-  def arrow_circle_right(assigns) do
+  def collection(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2644,12 +975,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
     </svg>
     """
   end
 
-  def pencil(assigns) do
+  def color_swatch(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2659,12 +990,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"/>
     </svg>
     """
   end
 
-  def phone_outgoing(assigns) do
+  def credit_card(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2674,12 +1005,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 3h5m0 0v5m0-5l-6 6M5 3a2 2 0 00-2 2v1c0 8.284 6.716 15 15 15h1a2 2 0 002-2v-3.28a1 1 0 00-.684-.948l-4.493-1.498a1 1 0 00-1.21.502l-1.13 2.257a11.042 11.042 0 01-5.516-5.517l2.257-1.128a1 1 0 00.502-1.21L9.228 3.683A1 1 0 008.279 3H5z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/>
     </svg>
     """
   end
 
-  def code(assigns) do
+  def cube_transparent(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2689,12 +1020,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10l-2 1m0 0l-2-1m2 1v2.5M20 7l-2 1m2-1l-2-1m2 1v2.5M14 4l-2-1-2 1M4 7l2-1M4 7l2 1M4 7v2.5M12 21l-2-1m2 1l2-1m-2 1v-2.5M6 18l-2-1v-2.5M18 18l2-1v-2.5"/>
     </svg>
     """
   end
 
-  def pause(assigns) do
+  def cube(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2704,12 +1035,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
     </svg>
     """
   end
 
-  def chart_square_bar(assigns) do
+  def currency_bangladeshi(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2719,12 +1050,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 11V9a2 2 0 00-2-2m2 4v4a2 2 0 104 0v-1m-4-3H9m2 0h4m6 1a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def exclamation_circle(assigns) do
+  def currency_dollar(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2734,12 +1065,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def play(assigns) do
+  def currency_euro(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2749,13 +1080,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.121 15.536c-1.171 1.952-3.07 1.952-4.242 0-1.172-1.953-1.172-5.119 0-7.072 1.171-1.952 3.07-1.952 4.242 0M8 10.5h4m-4 3h4m9-1.5a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def menu_alt_2(assigns) do
+  def currency_pound(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2765,12 +1095,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 9a2 2 0 10-4 0v5a2 2 0 01-2 2h6m-6-4h4m8 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def chevron_double_left(assigns) do
+  def currency_rupee(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2780,12 +1110,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 8h6m-5 0a3 3 0 110 6H9l3 3m-3-6h6m6 1a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def status_online(assigns) do
+  def currency_yen(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2795,12 +1125,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728m-9.9-2.829a5 5 0 010-7.07m7.072 0a5 5 0 010 7.07M13 12a1 1 0 11-2 0 1 1 0 012 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 8l3 5m0 0l3-5m-3 5v4m-3-5h6m-6 3h6m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def bookmark(assigns) do
+  def cursor_click(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2810,12 +1140,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122"/>
     </svg>
     """
   end
 
-  def refresh(assigns) do
+  def database(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2825,12 +1155,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
     </svg>
     """
   end
 
-  def x(assigns) do
+  def desktop_computer(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2840,12 +1170,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
     </svg>
     """
   end
 
-  def receipt_tax(assigns) do
+  def device_mobile(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2855,12 +1185,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2zM10 8.5a.5.5 0 11-1 0 .5.5 0 011 0zm5 5a.5.5 0 11-1 0 .5.5 0 011 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/>
     </svg>
     """
   end
 
-  def support(assigns) do
+  def device_tablet(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2870,12 +1200,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
     </svg>
     """
   end
 
-  def exclamation(assigns) do
+  def document_add(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2885,12 +1215,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m5 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
     </svg>
     """
   end
 
-  def phone_incoming(assigns) do
+  def document_download(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2900,12 +1230,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 3l-6 6m0 0V4m0 5h5M5 3a2 2 0 00-2 2v1c0 8.284 6.716 15 15 15h1a2 2 0 002-2v-3.28a1 1 0 00-.684-.948l-4.493-1.498a1 1 0 00-1.21.502l-1.13 2.257a11.042 11.042 0 01-5.516-5.517l2.257-1.128a1 1 0 00.502-1.21L9.228 3.683A1 1 0 008.279 3H5z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
     </svg>
     """
   end
 
-  def arrow_right(assigns) do
+  def document_duplicate(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2915,12 +1245,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7v8a2 2 0 002 2h6M8 7V5a2 2 0 012-2h4.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V15a2 2 0 01-2 2h-2M8 7H6a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2v-2"/>
     </svg>
     """
   end
 
-  def truck(assigns) do
+  def document_remove(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2930,13 +1260,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path d="M9 17a2 2 0 11-4 0 2 2 0 014 0zM19 17a2 2 0 11-4 0 2 2 0 014 0z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16V6a1 1 0 00-1-1H4a1 1 0 00-1 1v10a1 1 0 001 1h1m8-1a1 1 0 01-1 1H9m4-1V8a1 1 0 011-1h2.586a1 1 0 01.707.293l3.414 3.414a1 1 0 01.293.707V16a1 1 0 01-1 1h-1m-6-1a1 1 0 001 1h1M5 17a2 2 0 104 0m-4 0a2 2 0 114 0m6 0a2 2 0 104 0m-4 0a2 2 0 114 0"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
     </svg>
     """
   end
 
-  def zoom_in(assigns) do
+  def document_report(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2946,12 +1275,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
     </svg>
     """
   end
 
-  def inbox(assigns) do
+  def document_search(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2961,12 +1290,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 21h7a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v11m0 5l4.879-4.879m0 0a3 3 0 104.243-4.242 3 3 0 00-4.243 4.242z"/>
     </svg>
     """
   end
 
-  def hashtag(assigns) do
+  def document_text(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2976,12 +1305,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
     </svg>
     """
   end
 
-  def plus_sm(assigns) do
+  def document(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2991,12 +1320,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
     </svg>
     """
   end
 
-  def inbox_in(assigns) do
+  def dots_circle_horizontal(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3006,12 +1335,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 4H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-2m-4-1v8m0 0l3-3m-3 3L9 8m-5 5h2.586a1 1 0 01.707.293l2.414 2.414a1 1 0 00.707.293h3.172a1 1 0 00.707-.293l2.414-2.414a1 1 0 01.707-.293H20"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def user_circle(assigns) do
+  def dots_horizontal(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3021,12 +1350,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z"/>
     </svg>
     """
   end
 
-  def light_bulb(assigns) do
+  def dots_vertical(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3036,12 +1365,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"/>
     </svg>
     """
   end
 
-  def calendar(assigns) do
+  def download(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3051,82 +1380,7 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def folder_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 19a2 2 0 01-2-2V7a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1M5 19h14a2 2 0 002-2v-5a2 2 0 00-2-2H9a2 2 0 00-2 2v5a2 2 0 01-2 2z"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16l-4-4m0 0l4-4m-4 4h18"/>
-    </svg>
-    """
-  end
-
-  def book_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
-    </svg>
-    """
-  end
-
-  def folder_remove(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6M3 17V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
-    </svg>
-    """
-  end
-
-  def briefcase(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
     </svg>
     """
   end
@@ -3146,7 +1400,7 @@ defmodule PetalComponents.Heroicons.Outline do
     """
   end
 
-  def star(assigns) do
+  def emoji_happy(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3156,7 +1410,113 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def emoji_sad(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def exclamation_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def exclamation(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+    </svg>
+    """
+  end
+
+  def external_link(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+    </svg>
+    """
+  end
+
+  def eye_off(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"/>
+    </svg>
+    """
+  end
+
+  def eye(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+    </svg>
+    """
+  end
+
+  def fast_forward(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.933 12.8a1 1 0 000-1.6L6.6 7.2A1 1 0 005 8v8a1 1 0 001.6.8l5.333-4zM19.933 12.8a1 1 0 000-1.6l-5.333-4A1 1 0 0013 8v8a1 1 0 001.6.8l5.333-4z"/>
     </svg>
     """
   end
@@ -3172,6 +1532,36 @@ defmodule PetalComponents.Heroicons.Outline do
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z"/>
+    </svg>
+    """
+  end
+
+  def filter(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"/>
+    </svg>
+    """
+  end
+
+  def finger_print(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4"/>
     </svg>
     """
   end
@@ -3192,7 +1582,7 @@ defmodule PetalComponents.Heroicons.Outline do
     """
   end
 
-  def clipboard_copy(assigns) do
+  def flag(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3202,12 +1592,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"/>
     </svg>
     """
   end
 
-  def document(assigns) do
+  def folder_add(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3217,12 +1607,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
     </svg>
     """
   end
 
-  def bell(assigns) do
+  def folder_download(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3232,12 +1622,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3M3 17V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
     </svg>
     """
   end
 
-  def pencil_alt(assigns) do
+  def folder_open(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3247,12 +1637,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 19a2 2 0 01-2-2V7a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1M5 19h14a2 2 0 002-2v-5a2 2 0 00-2-2H9a2 2 0 00-2 2v5a2 2 0 01-2 2z"/>
     </svg>
     """
   end
 
-  def login(assigns) do
+  def folder_remove(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3262,12 +1652,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6M3 17V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
     </svg>
     """
   end
 
-  def presentation_chart_line(assigns) do
+  def folder(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3277,12 +1667,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/>
     </svg>
     """
   end
 
-  def information_circle(assigns) do
+  def gift(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3292,12 +1682,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7"/>
     </svg>
     """
   end
 
-  def view_boards(assigns) do
+  def globe_alt(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3307,12 +1697,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/>
     </svg>
     """
   end
 
-  def device_mobile(assigns) do
+  def globe(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3322,12 +1712,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def currency_dollar(assigns) do
+  def hand(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3337,7 +1727,52 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11.5V14m0-2.5v-6a1.5 1.5 0 113 0m-3 6a1.5 1.5 0 00-3 0v2a7.5 7.5 0 0015 0v-5a1.5 1.5 0 00-3 0m-6-3V11m0-5.5v-1a1.5 1.5 0 013 0v1m0 0V11m0-5.5a1.5 1.5 0 013 0v3m0 0V11"/>
+    </svg>
+    """
+  end
+
+  def hashtag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14"/>
+    </svg>
+    """
+  end
+
+  def heart(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
+    </svg>
+    """
+  end
+
+  def home(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
     </svg>
     """
   end
@@ -3357,7 +1792,7 @@ defmodule PetalComponents.Heroicons.Outline do
     """
   end
 
-  def ban(assigns) do
+  def inbox_in(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3367,12 +1802,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 4H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-2m-4-1v8m0 0l3-3m-3 3L9 8m-5 5h2.586a1 1 0 01.707.293l2.414 2.414a1 1 0 00.707.293h3.172a1 1 0 00.707-.293l2.414-2.414a1 1 0 01.707-.293H20"/>
     </svg>
     """
   end
 
-  def menu(assigns) do
+  def inbox(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3382,12 +1817,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
     </svg>
     """
   end
 
-  def save(assigns) do
+  def information_circle(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3397,12 +1832,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def arrow_circle_down(assigns) do
+  def key(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3412,12 +1847,12 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13l-3 3m0 0l-3-3m3 3V8m0 13a9 9 0 110-18 9 9 0 010 18z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
     </svg>
     """
   end
 
-  def archive(assigns) do
+  def library(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3427,7 +1862,203 @@ defmodule PetalComponents.Heroicons.Outline do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z"/>
+    </svg>
+    """
+  end
+
+  def light_bulb(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
+    </svg>
+    """
+  end
+
+  def lightning_bolt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+    </svg>
+    """
+  end
+
+  def link(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
+    </svg>
+    """
+  end
+
+  def location_marker(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
+    </svg>
+    """
+  end
+
+  def lock_closed(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
+    </svg>
+    """
+  end
+
+  def lock_open(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def login(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"/>
+    </svg>
+    """
+  end
+
+  def logout(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
+    </svg>
+    """
+  end
+
+  def mail_open(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 19v-8.93a2 2 0 01.89-1.664l7-4.666a2 2 0 012.22 0l7 4.666A2 2 0 0121 10.07V19M3 19a2 2 0 002 2h14a2 2 0 002-2M3 19l6.75-4.5M21 19l-6.75-4.5M3 10l6.75 4.5M21 10l-6.75 4.5m0 0l-1.14.76a2 2 0 01-2.22 0l-1.14-.76"/>
+    </svg>
+    """
+  end
+
+  def mail(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def map(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/>
+    </svg>
+    """
+  end
+
+  def menu_alt_1(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16"/>
+    </svg>
+    """
+  end
+
+  def menu_alt_2(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7"/>
     </svg>
     """
   end
@@ -3447,6 +2078,246 @@ defmodule PetalComponents.Heroicons.Outline do
     """
   end
 
+  def menu_alt_4(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16"/>
+    </svg>
+    """
+  end
+
+  def menu(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
+    </svg>
+    """
+  end
+
+  def microphone(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"/>
+    </svg>
+    """
+  end
+
+  def minus_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def minus_sm(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 12H6"/>
+    </svg>
+    """
+  end
+
+  def minus(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"/>
+    </svg>
+    """
+  end
+
+  def moon(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
+    </svg>
+    """
+  end
+
+  def music_note(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/>
+    </svg>
+    """
+  end
+
+  def newspaper(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"/>
+    </svg>
+    """
+  end
+
+  def office_building(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+    </svg>
+    """
+  end
+
+  def paper_airplane(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
+    </svg>
+    """
+  end
+
+  def paper_clip(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"/>
+    </svg>
+    """
+  end
+
+  def pause(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def pencil_alt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+    </svg>
+    """
+  end
+
+  def pencil(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/>
+    </svg>
+    """
+  end
+
+  def phone_incoming(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 3l-6 6m0 0V4m0 5h5M5 3a2 2 0 00-2 2v1c0 8.284 6.716 15 15 15h1a2 2 0 002-2v-3.28a1 1 0 00-.684-.948l-4.493-1.498a1 1 0 00-1.21.502l-1.13 2.257a11.042 11.042 0 01-5.516-5.517l2.257-1.128a1 1 0 00.502-1.21L9.228 3.683A1 1 0 008.279 3H5z"/>
+    </svg>
+    """
+  end
+
   def phone_missed_call(assigns) do
     assigns =
       assigns
@@ -3462,6 +2333,864 @@ defmodule PetalComponents.Heroicons.Outline do
     """
   end
 
+  def phone_outgoing(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 3h5m0 0v5m0-5l-6 6M5 3a2 2 0 00-2 2v1c0 8.284 6.716 15 15 15h1a2 2 0 002-2v-3.28a1 1 0 00-.684-.948l-4.493-1.498a1 1 0 00-1.21.502l-1.13 2.257a11.042 11.042 0 01-5.516-5.517l2.257-1.128a1 1 0 00.502-1.21L9.228 3.683A1 1 0 008.279 3H5z"/>
+    </svg>
+    """
+  end
+
+  def phone(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+    </svg>
+    """
+  end
+
+  def photograph(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def play(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def plus_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def plus_sm(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
+    </svg>
+    """
+  end
+
+  def plus(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+    </svg>
+    """
+  end
+
+  def presentation_chart_bar(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 13v-1m4 1v-3m4 3V8M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>
+    </svg>
+    """
+  end
+
+  def presentation_chart_line(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>
+    </svg>
+    """
+  end
+
+  def printer(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
+    </svg>
+    """
+  end
+
+  def puzzle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/>
+    </svg>
+    """
+  end
+
+  def qrcode(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"/>
+    </svg>
+    """
+  end
+
+  def question_mark_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def receipt_refund(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z"/>
+    </svg>
+    """
+  end
+
+  def receipt_tax(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2zM10 8.5a.5.5 0 11-1 0 .5.5 0 011 0zm5 5a.5.5 0 11-1 0 .5.5 0 011 0z"/>
+    </svg>
+    """
+  end
+
+  def refresh(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+    </svg>
+    """
+  end
+
+  def reply(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/>
+    </svg>
+    """
+  end
+
+  def rewind(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0019 16V8a1 1 0 00-1.6-.8l-5.333 4zM4.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0011 16V8a1 1 0 00-1.6-.8l-5.334 4z"/>
+    </svg>
+    """
+  end
+
+  def rss(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 5c7.18 0 13 5.82 13 13M6 11a7 7 0 017 7m-6 0a1 1 0 11-2 0 1 1 0 012 0z"/>
+    </svg>
+    """
+  end
+
+  def save_as(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16v2a2 2 0 01-2 2H5a2 2 0 01-2-2v-7a2 2 0 012-2h2m3-4H9a2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-1m-1 4l-3 3m0 0l-3-3m3 3V3"/>
+    </svg>
+    """
+  end
+
+  def save(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4"/>
+    </svg>
+    """
+  end
+
+  def scale(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"/>
+    </svg>
+    """
+  end
+
+  def scissors(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.121 14.121L19 19m-7-7l7-7m-7 7l-2.879 2.879M12 12L9.121 9.121m0 5.758a3 3 0 10-4.243 4.243 3 3 0 004.243-4.243zm0-5.758a3 3 0 10-4.243-4.243 3 3 0 004.243 4.243z"/>
+    </svg>
+    """
+  end
+
+  def search_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16l2.879-2.879m0 0a3 3 0 104.243-4.242 3 3 0 00-4.243 4.242zM21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def search(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+    </svg>
+    """
+  end
+
+  def selector(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l4-4 4 4m0 6l-4 4-4-4"/>
+    </svg>
+    """
+  end
+
+  def server(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/>
+    </svg>
+    """
+  end
+
+  def share(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/>
+    </svg>
+    """
+  end
+
+  def shield_check(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
+    </svg>
+    """
+  end
+
+  def shield_exclamation(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016zM12 9v2m0 4h.01"/>
+    </svg>
+    """
+  end
+
+  def shopping_bag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"/>
+    </svg>
+    """
+  end
+
+  def shopping_cart(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"/>
+    </svg>
+    """
+  end
+
+  def sort_ascending(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12"/>
+    </svg>
+    """
+  end
+
+  def sort_descending(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h13M3 8h9m-9 4h9m5-4v12m0 0l-4-4m4 4l4-4"/>
+    </svg>
+    """
+  end
+
+  def sparkles(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"/>
+    </svg>
+    """
+  end
+
+  def speakerphone(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"/>
+    </svg>
+    """
+  end
+
+  def star(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
+    </svg>
+    """
+  end
+
+  def status_offline(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636a9 9 0 010 12.728m0 0l-2.829-2.829m2.829 2.829L21 21M15.536 8.464a5 5 0 010 7.072m0 0l-2.829-2.829m-4.243 2.829a4.978 4.978 0 01-1.414-2.83m-1.414 5.658a9 9 0 01-2.167-9.238m7.824 2.167a1 1 0 111.414 1.414m-1.414-1.414L3 3m8.293 8.293l1.414 1.414"/>
+    </svg>
+    """
+  end
+
+  def status_online(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728m-9.9-2.829a5 5 0 010-7.07m7.072 0a5 5 0 010 7.07M13 12a1 1 0 11-2 0 1 1 0 012 0z"/>
+    </svg>
+    """
+  end
+
+  def stop(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"/>
+    </svg>
+    """
+  end
+
+  def sun(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+    </svg>
+    """
+  end
+
+  def support(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z"/>
+    </svg>
+    """
+  end
+
+  def switch_horizontal(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/>
+    </svg>
+    """
+  end
+
+  def switch_vertical(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"/>
+    </svg>
+    """
+  end
+
+  def table(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def tag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
+    </svg>
+    """
+  end
+
+  def template(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"/>
+    </svg>
+    """
+  end
+
+  def terminal(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def thumb_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14H5.236a2 2 0 01-1.789-2.894l3.5-7A2 2 0 018.736 3h4.018a2 2 0 01.485.06l3.76.94m-7 10v5a2 2 0 002 2h.096c.5 0 .905-.405.905-.904 0-.715.211-1.413.608-2.008L17 13V4m-7 10h2m5-10h2a2 2 0 012 2v6a2 2 0 01-2 2h-2.5"/>
+    </svg>
+    """
+  end
+
+  def thumb_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5"/>
+    </svg>
+    """
+  end
+
+  def ticket(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z"/>
+    </svg>
+    """
+  end
+
+  def translate(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/>
+    </svg>
+    """
+  end
+
+  def trash(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+    </svg>
+    """
+  end
+
+  def trending_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"/>
+    </svg>
+    """
+  end
+
+  def trending_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/>
+    </svg>
+    """
+  end
+
+  def truck(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path d="M9 17a2 2 0 11-4 0 2 2 0 014 0zM19 17a2 2 0 11-4 0 2 2 0 014 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16V6a1 1 0 00-1-1H4a1 1 0 00-1 1v10a1 1 0 001 1h1m8-1a1 1 0 01-1 1H9m4-1V8a1 1 0 011-1h2.586a1 1 0 01.707.293l3.414 3.414a1 1 0 01.293.707V16a1 1 0 01-1 1h-1m-6-1a1 1 0 001 1h1M5 17a2 2 0 104 0m-4 0a2 2 0 114 0m6 0a2 2 0 104 0m-4 0a2 2 0 114 0"/>
+    </svg>
+    """
+  end
+
+  def upload(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/>
+    </svg>
+    """
+  end
+
   def user_add(assigns) do
     assigns =
       assigns
@@ -3473,6 +3202,277 @@ defmodule PetalComponents.Heroicons.Outline do
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/>
+    </svg>
+    """
+  end
+
+  def user_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def user_group(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
+    </svg>
+    """
+  end
+
+  def user_remove(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7a4 4 0 11-8 0 4 4 0 018 0zM9 14a6 6 0 00-6 6v1h12v-1a6 6 0 00-6-6zM21 12h-6"/>
+    </svg>
+    """
+  end
+
+  def user(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+    </svg>
+    """
+  end
+
+  def users(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
+    </svg>
+    """
+  end
+
+  def variable(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.871 4A17.926 17.926 0 003 12c0 2.874.673 5.59 1.871 8m14.13 0a17.926 17.926 0 001.87-8c0-2.874-.673-5.59-1.87-8M9 9h1.246a1 1 0 01.961.725l1.586 5.55a1 1 0 00.961.725H15m1-7h-.08a2 2 0 00-1.519.698L9.6 15.302A2 2 0 018.08 16H8"/>
+    </svg>
+    """
+  end
+
+  def video_camera(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def view_boards(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2"/>
+    </svg>
+    """
+  end
+
+  def view_grid_add(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14v6m-3-3h6M6 10h2a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2zm10 0h2a2 2 0 002-2V6a2 2 0 00-2-2h-2a2 2 0 00-2 2v2a2 2 0 002 2zM6 20h2a2 2 0 002-2v-2a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def view_grid(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
+    </svg>
+    """
+  end
+
+  def view_list(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"/>
+    </svg>
+    """
+  end
+
+  def volume_off(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" clip-rule="evenodd"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2"/>
+    </svg>
+    """
+  end
+
+  def volume_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z"/>
+    </svg>
+    """
+  end
+
+  def wifi(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.141 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0"/>
+    </svg>
+    """
+  end
+
+  def x_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def x(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+    </svg>
+    """
+  end
+
+  def zoom_in(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7"/>
+    </svg>
+    """
+  end
+
+  def zoom_out(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM13 10H7"/>
     </svg>
     """
   end

--- a/lib/petal_components/icons/heroicons/outline.ex
+++ b/lib/petal_components/icons/heroicons/outline.ex
@@ -3,8 +3,8 @@ defmodule PetalComponents.Heroicons.Outline do
 
   @moduledoc """
   Icon name can be the function or passed in as a type eg.
-  <PetalComponents.Heroicons.Solid.home class="w-6 h-6" />
-  <PetalComponents.Heroicons.Solid.render type="home" class="w-6 h-6" />
+  <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
+  <PetalComponents.Heroicons.Solid.render type="home" class="w-5 h-5" />
 
   <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
   <PetalComponents.Heroicons.Outline.render type="home" class="w-6 h-6" />
@@ -15,7 +15,7 @@ defmodule PetalComponents.Heroicons.Outline do
     apply(__MODULE__, icon_name, [assigns])
   end
 
-  def hand(assigns) do
+  def share(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -24,8 +24,1153 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11.5V14m0-2.5v-6a1.5 1.5 0 113 0m-3 6a1.5 1.5 0 00-3 0v2a7.5 7.5 0 0015 0v-5a1.5 1.5 0 00-3 0m-6-3V11m0-5.5v-1a1.5 1.5 0 013 0v1m0 0V11m0-5.5a1.5 1.5 0 013 0v3m0 0V11"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/>
+    </svg>
+    """
+  end
+
+  def currency_euro(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.121 15.536c-1.171 1.952-3.07 1.952-4.242 0-1.172-1.953-1.172-5.119 0-7.072 1.171-1.952 3.07-1.952 4.242 0M8 10.5h4m-4 3h4m9-1.5a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def library(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z"/>
+    </svg>
+    """
+  end
+
+  def color_swatch(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"/>
+    </svg>
+    """
+  end
+
+  def finger_print(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4"/>
+    </svg>
+    """
+  end
+
+  def chart_bar(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+    </svg>
+    """
+  end
+
+  def fast_forward(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.933 12.8a1 1 0 000-1.6L6.6 7.2A1 1 0 005 8v8a1 1 0 001.6.8l5.333-4zM19.933 12.8a1 1 0 000-1.6l-5.333-4A1 1 0 0013 8v8a1 1 0 001.6.8l5.333-4z"/>
+    </svg>
+    """
+  end
+
+  def chart_pie(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z"/>
+    </svg>
+    """
+  end
+
+  def trending_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/>
+    </svg>
+    """
+  end
+
+  def reply(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/>
+    </svg>
+    """
+  end
+
+  def heart(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
+    </svg>
+    """
+  end
+
+  def cube(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
+    </svg>
+    """
+  end
+
+  def lock_closed(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
+    </svg>
+    """
+  end
+
+  def view_grid_add(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14v6m-3-3h6M6 10h2a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2zm10 0h2a2 2 0 002-2V6a2 2 0 00-2-2h-2a2 2 0 00-2 2v2a2 2 0 002 2zM6 20h2a2 2 0 002-2v-2a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def document_text(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+    </svg>
+    """
+  end
+
+  def switch_horizontal(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/>
+    </svg>
+    """
+  end
+
+  def wifi(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.141 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0"/>
+    </svg>
+    """
+  end
+
+  def camera(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>
+    </svg>
+    """
+  end
+
+  def document_report(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+    </svg>
+    """
+  end
+
+  def chevron_double_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 13l-7 7-7-7m14-8l-7 7-7-7"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/>
+    </svg>
+    """
+  end
+
+  def arrow_narrow_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 17l-4 4m0 0l-4-4m4 4V3"/>
+    </svg>
+    """
+  end
+
+  def collection(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
+    </svg>
+    """
+  end
+
+  def newspaper(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"/>
+    </svg>
+    """
+  end
+
+  def selector(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l4-4 4 4m0 6l-4 4-4-4"/>
+    </svg>
+    """
+  end
+
+  def search_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16l2.879-2.879m0 0a3 3 0 104.243-4.242 3 3 0 00-4.243 4.242zM21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def academic_cap(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path d="M12 14l9-5-9-5-9 5 9 5z"/>
+      <path d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222"/>
+    </svg>
+    """
+  end
+
+  def clipboard_check(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
+    </svg>
+    """
+  end
+
+  def flag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"/>
+    </svg>
+    """
+  end
+
+  def chevron_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+    </svg>
+    """
+  end
+
+  def database(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
+    </svg>
+    """
+  end
+
+  def music_note(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/>
+    </svg>
+    """
+  end
+
+  def paper_clip(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"/>
+    </svg>
+    """
+  end
+
+  def logout(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
+    </svg>
+    """
+  end
+
+  def rss(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 5c7.18 0 13 5.82 13 13M6 11a7 7 0 017 7m-6 0a1 1 0 11-2 0 1 1 0 012 0z"/>
+    </svg>
+    """
+  end
+
+  def folder(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/>
+    </svg>
+    """
+  end
+
+  def document_download(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+    </svg>
+    """
+  end
+
+  def currency_rupee(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 8h6m-5 0a3 3 0 110 6H9l3 3m-3-6h6m6 1a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def device_tablet(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def key(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
+    </svg>
+    """
+  end
+
+  def arrow_circle_left(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 15l-3-3m0 0l3-3m-3 3h8M3 12a9 9 0 1118 0 9 9 0 01-18 0z"/>
+    </svg>
+    """
+  end
+
+  def bookmark_alt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 4v12l-4-2-4 2V4M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def cube_transparent(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10l-2 1m0 0l-2-1m2 1v2.5M20 7l-2 1m2-1l-2-1m2 1v2.5M14 4l-2-1-2 1M4 7l2-1M4 7l2 1M4 7v2.5M12 21l-2-1m2 1l2-1m-2 1v-2.5M6 18l-2-1v-2.5M18 18l2-1v-2.5"/>
+    </svg>
+    """
+  end
+
+  def emoji_happy(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def currency_pound(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 9a2 2 0 10-4 0v5a2 2 0 01-2 2h6m-6-4h4m8 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def view_list(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"/>
+    </svg>
+    """
+  end
+
+  def view_grid(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
+    </svg>
+    """
+  end
+
+  def cloud_download(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"/>
+    </svg>
+    """
+  end
+
+  def check_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def speakerphone(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"/>
+    </svg>
+    """
+  end
+
+  def server(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/>
+    </svg>
+    """
+  end
+
+  def backspace(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2M3 12l6.414 6.414a2 2 0 001.414.586H19a2 2 0 002-2V7a2 2 0 00-2-2h-8.172a2 2 0 00-1.414.586L3 12z"/>
+    </svg>
+    """
+  end
+
+  def switch_vertical(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"/>
+    </svg>
+    """
+  end
+
+  def user_group(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
+    </svg>
+    """
+  end
+
+  def sun(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+    </svg>
+    """
+  end
+
+  def clock(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def chevron_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/>
+    </svg>
+    """
+  end
+
+  def shield_exclamation(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016zM12 9v2m0 4h.01"/>
+    </svg>
+    """
+  end
+
+  def download(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
+    </svg>
+    """
+  end
+
+  def plus_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def chevron_double_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 11l7-7 7 7M5 19l7-7 7 7"/>
+    </svg>
+    """
+  end
+
+  def clipboard(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+    </svg>
+    """
+  end
+
+  def variable(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.871 4A17.926 17.926 0 003 12c0 2.874.673 5.59 1.871 8m14.13 0a17.926 17.926 0 001.87-8c0-2.874-.673-5.59-1.87-8M9 9h1.246a1 1 0 01.961.725l1.586 5.55a1 1 0 00.961.725H15m1-7h-.08a2 2 0 00-1.519.698L9.6 15.302A2 2 0 018.08 16H8"/>
+    </svg>
+    """
+  end
+
+  def chat_alt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/>
+    </svg>
+    """
+  end
+
+  def arrow_left(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
+    </svg>
+    """
+  end
+
+  def folder_add(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
+    </svg>
+    """
+  end
+
+  def document_duplicate(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7v8a2 2 0 002 2h6M8 7V5a2 2 0 012-2h4.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V15a2 2 0 01-2 2h-2M8 7H6a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2v-2"/>
+    </svg>
+    """
+  end
+
+  def calculator(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def mail(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def location_marker(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
+    </svg>
+    """
+  end
+
+  def annotation(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11l5-5m0 0l5 5m-5-5v12"/>
+    </svg>
+    """
+  end
+
+  def menu_alt_4(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16"/>
+    </svg>
+    """
+  end
+
+  def cursor_click(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122"/>
+    </svg>
+    """
+  end
+
+  def eye_off(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"/>
+    </svg>
+    """
+  end
+
+  def document_remove(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+    </svg>
+    """
+  end
+
+  def printer(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
     </svg>
     """
   end
@@ -39,8 +1184,83 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+    </svg>
+    """
+  end
+
+  def paper_airplane(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
+    </svg>
+    """
+  end
+
+  def template(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"/>
+    </svg>
+    """
+  end
+
+  def chevron_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+    </svg>
+    """
+  end
+
+  def x_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def ticket(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z"/>
     </svg>
     """
   end
@@ -54,8 +1274,579 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3"/>
+    </svg>
+    """
+  end
+
+  def globe_alt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/>
+    </svg>
+    """
+  end
+
+  def cloud(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z"/>
+    </svg>
+    """
+  end
+
+  def cloud_upload(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>
+    </svg>
+    """
+  end
+
+  def currency_bangladeshi(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 11V9a2 2 0 00-2-2m2 4v4a2 2 0 104 0v-1m-4-3H9m2 0h4m6 1a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def eye(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_left(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 17l-5-5m0 0l5-5m-5 5h12"/>
+    </svg>
+    """
+  end
+
+  def lightning_bolt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+    </svg>
+    """
+  end
+
+  def hand(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11.5V14m0-2.5v-6a1.5 1.5 0 113 0m-3 6a1.5 1.5 0 00-3 0v2a7.5 7.5 0 0015 0v-5a1.5 1.5 0 00-3 0m-6-3V11m0-5.5v-1a1.5 1.5 0 013 0v1m0 0V11m0-5.5a1.5 1.5 0 013 0v3m0 0V11"/>
+    </svg>
+    """
+  end
+
+  def clipboard_list(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"/>
+    </svg>
+    """
+  end
+
+  def dots_circle_horizontal(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def video_camera(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def phone(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+    </svg>
+    """
+  end
+
+  def save_as(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16v2a2 2 0 01-2 2H5a2 2 0 01-2-2v-7a2 2 0 012-2h2m3-4H9a2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-1m-1 4l-3 3m0 0l-3-3m3 3V3"/>
+    </svg>
+    """
+  end
+
+  def user_remove(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7a4 4 0 11-8 0 4 4 0 018 0zM9 14a6 6 0 00-6 6v1h12v-1a6 6 0 00-6-6zM21 12h-6"/>
+    </svg>
+    """
+  end
+
+  def filter(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"/>
+    </svg>
+    """
+  end
+
+  def thumb_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14H5.236a2 2 0 01-1.789-2.894l3.5-7A2 2 0 018.736 3h4.018a2 2 0 01.485.06l3.76.94m-7 10v5a2 2 0 002 2h.096c.5 0 .905-.405.905-.904 0-.715.211-1.413.608-2.008L17 13V4m-7 10h2m5-10h2a2 2 0 012 2v6a2 2 0 01-2 2h-2.5"/>
+    </svg>
+    """
+  end
+
+  def sparkles(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"/>
+    </svg>
+    """
+  end
+
+  def volume_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z"/>
+    </svg>
+    """
+  end
+
+  def rewind(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0019 16V8a1 1 0 00-1.6-.8l-5.333 4zM4.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0011 16V8a1 1 0 00-1.6-.8l-5.334 4z"/>
+    </svg>
+    """
+  end
+
+  def trending_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"/>
+    </svg>
+    """
+  end
+
+  def mail_open(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 19v-8.93a2 2 0 01.89-1.664l7-4.666a2 2 0 012.22 0l7 4.666A2 2 0 0121 10.07V19M3 19a2 2 0 002 2h14a2 2 0 002-2M3 19l6.75-4.5M21 19l-6.75-4.5M3 10l6.75 4.5M21 10l-6.75 4.5m0 0l-1.14.76a2 2 0 01-2.22 0l-1.14-.76"/>
+    </svg>
+    """
+  end
+
+  def question_mark_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def upload(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/>
+    </svg>
+    """
+  end
+
+  def document_search(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 21h7a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v11m0 5l4.879-4.879m0 0a3 3 0 104.243-4.242 3 3 0 00-4.243 4.242z"/>
+    </svg>
+    """
+  end
+
+  def users(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
+    </svg>
+    """
+  end
+
+  def menu_alt_1(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16"/>
+    </svg>
+    """
+  end
+
+  def scale(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"/>
+    </svg>
+    """
+  end
+
+  def lock_open(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def chat(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
+    </svg>
+    """
+  end
+
+  def external_link(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+    </svg>
+    """
+  end
+
+  def chat_alt_2(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 14h4a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l.586-.586z"/>
+    </svg>
+    """
+  end
+
+  def arrow_circle_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 11l3-3m0 0l3 3m-3-3v8m0-13a9 9 0 110 18 9 9 0 010-18z"/>
+    </svg>
+    """
+  end
+
+  def translate(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/>
+    </svg>
+    """
+  end
+
+  def user(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+    </svg>
+    """
+  end
+
+  def presentation_chart_bar(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 13v-1m4 1v-3m4 3V8M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>
+    </svg>
+    """
+  end
+
+  def cash(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"/>
+    </svg>
+    """
+  end
+
+  def cake(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 15.546c-.523 0-1.046.151-1.5.454a2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.701 2.701 0 00-1.5-.454M9 6v2m3-2v2m3-2v2M9 3h.01M12 3h.01M15 3h.01M21 21v-7a2 2 0 00-2-2H5a2 2 0 00-2 2v7h18zm-3-9v-2a2 2 0 00-2-2H8a2 2 0 00-2 2v2h12z"/>
+    </svg>
+    """
+  end
+
+  def home(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
     </svg>
     """
   end
@@ -69,9 +1860,385 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" clip-rule="evenodd"/>
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2"/>
+    </svg>
+    """
+  end
+
+  def arrow_narrow_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/>
+    </svg>
+    """
+  end
+
+  def stop(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"/>
+    </svg>
+    """
+  end
+
+  def badge_check(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"/>
+    </svg>
+    """
+  end
+
+  def moon(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
+    </svg>
+    """
+  end
+
+  def tag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
+    </svg>
+    """
+  end
+
+  def sort_ascending(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12"/>
+    </svg>
+    """
+  end
+
+  def folder_download(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3M3 17V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
+    </svg>
+    """
+  end
+
+  def terminal(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def receipt_refund(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z"/>
+    </svg>
+    """
+  end
+
+  def office_building(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+    </svg>
+    """
+  end
+
+  def arrow_narrow_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7l4-4m0 0l4 4m-4-4v18"/>
+    </svg>
+    """
+  end
+
+  def arrows_expand(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"/>
+    </svg>
+    """
+  end
+
+  def adjustments(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 13l-5 5m0 0l-5-5m5 5V6"/>
+    </svg>
+    """
+  end
+
+  def shield_check(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
+    </svg>
+    """
+  end
+
+  def qrcode(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"/>
+    </svg>
+    """
+  end
+
+  def status_offline(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636a9 9 0 010 12.728m0 0l-2.829-2.829m2.829 2.829L21 21M15.536 8.464a5 5 0 010 7.072m0 0l-2.829-2.829m-4.243 2.829a4.978 4.978 0 01-1.414-2.83m-1.414 5.658a9 9 0 01-2.167-9.238m7.824 2.167a1 1 0 111.414 1.414m-1.414-1.414L3 3m8.293 8.293l1.414 1.414"/>
+    </svg>
+    """
+  end
+
+  def map(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/>
+    </svg>
+    """
+  end
+
+  def document_add(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m5 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+    </svg>
+    """
+  end
+
+  def at_symbol(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207"/>
+    </svg>
+    """
+  end
+
+  def credit_card(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/>
+    </svg>
+    """
+  end
+
+  def globe(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def sort_descending(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h13M3 8h9m-9 4h9m5-4v12m0 0l-4-4m4 4l4-4"/>
+    </svg>
+    """
+  end
+
+  def trash(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+    </svg>
+    """
+  end
+
+  def shopping_cart(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"/>
     </svg>
     """
   end
@@ -85,8 +2252,353 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z"/>
+    </svg>
+    """
+  end
+
+  def chip(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"/>
+    </svg>
+    """
+  end
+
+  def zoom_out(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM13 10H7"/>
+    </svg>
+    """
+  end
+
+  def photograph(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def chevron_double_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7"/>
+    </svg>
+    """
+  end
+
+  def shopping_bag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"/>
+    </svg>
+    """
+  end
+
+  def puzzle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/>
+    </svg>
+    """
+  end
+
+  def beaker(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"/>
+    </svg>
+    """
+  end
+
+  def desktop_computer(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def gift(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7"/>
+    </svg>
+    """
+  end
+
+  def plus(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+    </svg>
+    """
+  end
+
+  def thumb_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5"/>
+    </svg>
+    """
+  end
+
+  def check(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+    </svg>
+    """
+  end
+
+  def minus_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def minus(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"/>
+    </svg>
+    """
+  end
+
+  def chevron_left(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+    </svg>
+    """
+  end
+
+  def microphone(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"/>
+    </svg>
+    """
+  end
+
+  def link(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
+    </svg>
+    """
+  end
+
+  def currency_yen(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 8l3 5m0 0l3-5m-3 5v4m-3-5h6m-6 3h6m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def table(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def minus_sm(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 12H6"/>
+    </svg>
+    """
+  end
+
+  def dots_vertical(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"/>
+    </svg>
+    """
+  end
+
+  def arrow_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18"/>
+    </svg>
+    """
+  end
+
+  def emoji_sad(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
@@ -100,7 +2612,7 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.121 14.121L19 19m-7-7l7-7m-7 7l-2.879 2.879M12 12L9.121 9.121m0 5.758a3 3 0 10-4.243 4.243 3 3 0 004.243-4.243zm0-5.758a3 3 0 10-4.243-4.243 3 3 0 004.243 4.243z"/>
     </svg>
     """
@@ -115,14 +2627,14 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
     </svg>
     """
   end
 
-  def currency_pound(assigns) do
+  def arrow_circle_right(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -131,13 +2643,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 9a2 2 0 10-4 0v5a2 2 0 01-2 2h6m-6-4h4m8 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def sort_descending(assigns) do
+  def pencil(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -146,849 +2658,8 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h13M3 8h9m-9 4h9m5-4v12m0 0l-4-4m4 4l4-4"/>
-    </svg>
-    """
-  end
-
-  def reply(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/>
-    </svg>
-    """
-  end
-
-  def thumb_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5"/>
-    </svg>
-    """
-  end
-
-  def translate(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/>
-    </svg>
-    """
-  end
-
-  def adjustments(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
-    </svg>
-    """
-  end
-
-  def user(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
-    </svg>
-    """
-  end
-
-  def view_grid(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
-    </svg>
-    """
-  end
-
-  def receipt_tax(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2zM10 8.5a.5.5 0 11-1 0 .5.5 0 011 0zm5 5a.5.5 0 11-1 0 .5.5 0 011 0z"/>
-    </svg>
-    """
-  end
-
-  def x_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def view_list(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"/>
-    </svg>
-    """
-  end
-
-  def home(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
-    </svg>
-    """
-  end
-
-  def globe_alt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/>
-    </svg>
-    """
-  end
-
-  def chevron_double_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7"/>
-    </svg>
-    """
-  end
-
-  def library(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z"/>
-    </svg>
-    """
-  end
-
-  def chevron_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-    </svg>
-    """
-  end
-
-  def chevron_double_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7"/>
-    </svg>
-    """
-  end
-
-  def logout(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
-    </svg>
-    """
-  end
-
-  def chip(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"/>
-    </svg>
-    """
-  end
-
-  def ticket(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z"/>
-    </svg>
-    """
-  end
-
-  def tag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
-    </svg>
-    """
-  end
-
-  def briefcase(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def arrow_circle_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 11l3-3m0 0l3 3m-3-3v8m0-13a9 9 0 110 18 9 9 0 010-18z"/>
-    </svg>
-    """
-  end
-
-  def save_as(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16v2a2 2 0 01-2 2H5a2 2 0 01-2-2v-7a2 2 0 012-2h2m3-4H9a2 2 0 00-2 2v7a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-1m-1 4l-3 3m0 0l-3-3m3 3V3"/>
-    </svg>
-    """
-  end
-
-  def document_search(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 21h7a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v11m0 5l4.879-4.879m0 0a3 3 0 104.243-4.242 3 3 0 00-4.243 4.242z"/>
-    </svg>
-    """
-  end
-
-  def map(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/>
-    </svg>
-    """
-  end
-
-  def inbox(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
-    </svg>
-    """
-  end
-
-  def microphone(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"/>
-    </svg>
-    """
-  end
-
-  def database(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
-    </svg>
-    """
-  end
-
-  def puzzle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/>
-    </svg>
-    """
-  end
-
-  def duplicate(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def folder_remove(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6M3 17V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
-    </svg>
-    """
-  end
-
-  def terminal(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def sparkles(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"/>
-    </svg>
-    """
-  end
-
-  def chevron_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/>
-    </svg>
-    """
-  end
-
-  def folder_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 19a2 2 0 01-2-2V7a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1M5 19h14a2 2 0 002-2v-5a2 2 0 00-2-2H9a2 2 0 00-2 2v5a2 2 0 01-2 2z"/>
-    </svg>
-    """
-  end
-
-  def document_add(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m5 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-    </svg>
-    """
-  end
-
-  def x(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-    </svg>
-    """
-  end
-
-  def at_symbol(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207"/>
-    </svg>
-    """
-  end
-
-  def bookmark_alt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 4v12l-4-2-4 2V4M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def cloud_upload(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>
-    </svg>
-    """
-  end
-
-  def fire(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10c0-2 .5-5 2.986-7C14 5 16.09 5.777 17.656 7.343A7.975 7.975 0 0120 13a7.975 7.975 0 01-2.343 5.657z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.879 16.121A3 3 0 1012.015 11L11 14H9c0 .768.293 1.536.879 2.121z"/>
-    </svg>
-    """
-  end
-
-  def ban(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/>
-    </svg>
-    """
-  end
-
-  def shopping_bag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"/>
-    </svg>
-    """
-  end
-
-  def chat_alt_2(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 14h4a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l.586-.586z"/>
-    </svg>
-    """
-  end
-
-  def arrow_sm_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11l5-5m0 0l5 5m-5-5v12"/>
-    </svg>
-    """
-  end
-
-  def chevron_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
-    </svg>
-    """
-  end
-
-  def clipboard(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
-    </svg>
-    """
-  end
-
-  def link(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
-    </svg>
-    """
-  end
-
-  def key(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
-    </svg>
-    """
-  end
-
-  def beaker(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"/>
-    </svg>
-    """
-  end
-
-  def arrow_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
-    </svg>
-    """
-  end
-
-  def selector(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l4-4 4 4m0 6l-4 4-4-4"/>
-    </svg>
-    """
-  end
-
-  def qrcode(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"/>
-    </svg>
-    """
-  end
-
-  def currency_rupee(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 8h6m-5 0a3 3 0 110 6H9l3 3m-3-6h6m6 1a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_4(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16"/>
-    </svg>
-    """
-  end
-
-  def paper_clip(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"/>
-    </svg>
-    """
-  end
-
-  def archive(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/>
     </svg>
     """
   end
@@ -1002,13 +2673,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 3h5m0 0v5m0-5l-6 6M5 3a2 2 0 00-2 2v1c0 8.284 6.716 15 15 15h1a2 2 0 002-2v-3.28a1 1 0 00-.684-.948l-4.493-1.498a1 1 0 00-1.21.502l-1.13 2.257a11.042 11.042 0 01-5.516-5.517l2.257-1.128a1 1 0 00.502-1.21L9.228 3.683A1 1 0 008.279 3H5z"/>
     </svg>
     """
   end
 
-  def mail(assigns) do
+  def code(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -1017,13 +2688,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
     </svg>
     """
   end
 
-  def currency_bangladeshi(assigns) do
+  def pause(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -1032,13 +2703,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 11V9a2 2 0 00-2-2m2 4v4a2 2 0 104 0v-1m-4-3H9m2 0h4m6 1a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def download(assigns) do
+  def chart_square_bar(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -1047,13 +2718,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
     </svg>
     """
   end
 
-  def chat_alt(assigns) do
+  def exclamation_circle(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -1062,13 +2733,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def book_open(assigns) do
+  def play(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -1077,13 +2748,14 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     """
   end
 
-  def location_marker(assigns) do
+  def menu_alt_2(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -1092,14 +2764,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7"/>
     </svg>
     """
   end
 
-  def arrow_sm_down(assigns) do
+  def chevron_double_left(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -1108,13 +2779,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 13l-5 5m0 0l-5-5m5 5V6"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7"/>
     </svg>
     """
   end
 
-  def server(assigns) do
+  def status_online(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -1123,8 +2794,189 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728m-9.9-2.829a5 5 0 010-7.07m7.072 0a5 5 0 010 7.07M13 12a1 1 0 11-2 0 1 1 0 012 0z"/>
+    </svg>
+    """
+  end
+
+  def bookmark(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"/>
+    </svg>
+    """
+  end
+
+  def refresh(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+    </svg>
+    """
+  end
+
+  def x(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+    </svg>
+    """
+  end
+
+  def receipt_tax(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2zM10 8.5a.5.5 0 11-1 0 .5.5 0 011 0zm5 5a.5.5 0 11-1 0 .5.5 0 011 0z"/>
+    </svg>
+    """
+  end
+
+  def support(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z"/>
+    </svg>
+    """
+  end
+
+  def exclamation(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+    </svg>
+    """
+  end
+
+  def phone_incoming(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 3l-6 6m0 0V4m0 5h5M5 3a2 2 0 00-2 2v1c0 8.284 6.716 15 15 15h1a2 2 0 002-2v-3.28a1 1 0 00-.684-.948l-4.493-1.498a1 1 0 00-1.21.502l-1.13 2.257a11.042 11.042 0 01-5.516-5.517l2.257-1.128a1 1 0 00.502-1.21L9.228 3.683A1 1 0 008.279 3H5z"/>
+    </svg>
+    """
+  end
+
+  def arrow_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/>
+    </svg>
+    """
+  end
+
+  def truck(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path d="M9 17a2 2 0 11-4 0 2 2 0 014 0zM19 17a2 2 0 11-4 0 2 2 0 014 0z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16V6a1 1 0 00-1-1H4a1 1 0 00-1 1v10a1 1 0 001 1h1m8-1a1 1 0 01-1 1H9m4-1V8a1 1 0 011-1h2.586a1 1 0 01.707.293l3.414 3.414a1 1 0 01.293.707V16a1 1 0 01-1 1h-1m-6-1a1 1 0 001 1h1M5 17a2 2 0 104 0m-4 0a2 2 0 114 0m6 0a2 2 0 104 0m-4 0a2 2 0 114 0"/>
+    </svg>
+    """
+  end
+
+  def zoom_in(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7"/>
+    </svg>
+    """
+  end
+
+  def inbox(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
+    </svg>
+    """
+  end
+
+  def hashtag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14"/>
     </svg>
     """
   end
@@ -1138,7 +2990,7 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
     </svg>
     """
@@ -1153,1318 +3005,8 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 4H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-2m-4-1v8m0 0l3-3m-3 3L9 8m-5 5h2.586a1 1 0 01.707.293l2.414 2.414a1 1 0 00.707.293h3.172a1 1 0 00.707-.293l2.414-2.414a1 1 0 01.707-.293H20"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16l-4-4m0 0l4-4m-4 4h18"/>
-    </svg>
-    """
-  end
-
-  def login(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"/>
-    </svg>
-    """
-  end
-
-  def variable(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.871 4A17.926 17.926 0 003 12c0 2.874.673 5.59 1.871 8m14.13 0a17.926 17.926 0 001.87-8c0-2.874-.673-5.59-1.87-8M9 9h1.246a1 1 0 01.961.725l1.586 5.55a1 1 0 00.961.725H15m1-7h-.08a2 2 0 00-1.519.698L9.6 15.302A2 2 0 018.08 16H8"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_1(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16"/>
-    </svg>
-    """
-  end
-
-  def bell(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/>
-    </svg>
-    """
-  end
-
-  def code(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
-    </svg>
-    """
-  end
-
-  def cake(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 15.546c-.523 0-1.046.151-1.5.454a2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.701 2.701 0 00-1.5-.454M9 6v2m3-2v2m3-2v2M9 3h.01M12 3h.01M15 3h.01M21 21v-7a2 2 0 00-2-2H5a2 2 0 00-2 2v7h18zm-3-9v-2a2 2 0 00-2-2H8a2 2 0 00-2 2v2h12z"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7l4-4m0 0l4 4m-4-4v18"/>
-    </svg>
-    """
-  end
-
-  def flag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"/>
-    </svg>
-    """
-  end
-
-  def eye_off(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"/>
-    </svg>
-    """
-  end
-
-  def stop(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"/>
-    </svg>
-    """
-  end
-
-  def arrow_circle_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 15l-3-3m0 0l3-3m-3 3h8M3 12a9 9 0 1118 0 9 9 0 01-18 0z"/>
-    </svg>
-    """
-  end
-
-  def newspaper(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"/>
-    </svg>
-    """
-  end
-
-  def cube(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
-    </svg>
-    """
-  end
-
-  def emoji_happy(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def minus_sm(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 12H6"/>
-    </svg>
-    """
-  end
-
-  def dots_circle_horizontal(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def support(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z"/>
-    </svg>
-    """
-  end
-
-  def clipboard_list(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"/>
-    </svg>
-    """
-  end
-
-  def user_remove(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7a4 4 0 11-8 0 4 4 0 018 0zM9 14a6 6 0 00-6 6v1h12v-1a6 6 0 00-6-6zM21 12h-6"/>
-    </svg>
-    """
-  end
-
-  def plus(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
-    </svg>
-    """
-  end
-
-  def document(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def music_note(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/>
-    </svg>
-    """
-  end
-
-  def check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_2(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7"/>
-    </svg>
-    """
-  end
-
-  def view_boards(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2"/>
-    </svg>
-    """
-  end
-
-  def rss(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 5c7.18 0 13 5.82 13 13M6 11a7 7 0 017 7m-6 0a1 1 0 11-2 0 1 1 0 012 0z"/>
-    </svg>
-    """
-  end
-
-  def wifi(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.141 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_3(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"/>
-    </svg>
-    """
-  end
-
-  def scale(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"/>
-    </svg>
-    """
-  end
-
-  def arrow_circle_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def user_add(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/>
-    </svg>
-    """
-  end
-
-  def arrow_sm_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 17l-5-5m0 0l5-5m-5 5h12"/>
-    </svg>
-    """
-  end
-
-  def zoom_in(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7"/>
-    </svg>
-    """
-  end
-
-  def arrow_sm_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/>
-    </svg>
-    """
-  end
-
-  def cube_transparent(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10l-2 1m0 0l-2-1m2 1v2.5M20 7l-2 1m2-1l-2-1m2 1v2.5M14 4l-2-1-2 1M4 7l2-1M4 7l2 1M4 7v2.5M12 21l-2-1m2 1l2-1m-2 1v-2.5M6 18l-2-1v-2.5M18 18l2-1v-2.5"/>
-    </svg>
-    """
-  end
-
-  def refresh(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
-    </svg>
-    """
-  end
-
-  def check_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def thumb_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14H5.236a2 2 0 01-1.789-2.894l3.5-7A2 2 0 018.736 3h4.018a2 2 0 01.485.06l3.76.94m-7 10v5a2 2 0 002 2h.096c.5 0 .905-.405.905-.904 0-.715.211-1.413.608-2.008L17 13V4m-7 10h2m5-10h2a2 2 0 012 2v6a2 2 0 01-2 2h-2.5"/>
-    </svg>
-    """
-  end
-
-  def device_tablet(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def save(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4"/>
-    </svg>
-    """
-  end
-
-  def status_online(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728m-9.9-2.829a5 5 0 010-7.07m7.072 0a5 5 0 010 7.07M13 12a1 1 0 11-2 0 1 1 0 012 0z"/>
-    </svg>
-    """
-  end
-
-  def paper_airplane(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
-    </svg>
-    """
-  end
-
-  def shield_exclamation(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016zM12 9v2m0 4h.01"/>
-    </svg>
-    """
-  end
-
-  def fast_forward(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.933 12.8a1 1 0 000-1.6L6.6 7.2A1 1 0 005 8v8a1 1 0 001.6.8l5.333-4zM19.933 12.8a1 1 0 000-1.6l-5.333-4A1 1 0 0013 8v8a1 1 0 001.6.8l5.333-4z"/>
-    </svg>
-    """
-  end
-
-  def currency_yen(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 8l3 5m0 0l3-5m-3 5v4m-3-5h6m-6 3h6m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def zoom_out(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM13 10H7"/>
-    </svg>
-    """
-  end
-
-  def play(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def chat(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
-    </svg>
-    """
-  end
-
-  def pencil_alt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
-    </svg>
-    """
-  end
-
-  def cursor_click(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122"/>
-    </svg>
-    """
-  end
-
-  def table(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def badge_check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"/>
-    </svg>
-    """
-  end
-
-  def document_text(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-    </svg>
-    """
-  end
-
-  def camera(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>
-    </svg>
-    """
-  end
-
-  def printer(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
-    </svg>
-    """
-  end
-
-  def truck(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path d="M9 17a2 2 0 11-4 0 2 2 0 014 0zM19 17a2 2 0 11-4 0 2 2 0 014 0z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16V6a1 1 0 00-1-1H4a1 1 0 00-1 1v10a1 1 0 001 1h1m8-1a1 1 0 01-1 1H9m4-1V8a1 1 0 011-1h2.586a1 1 0 01.707.293l3.414 3.414a1 1 0 01.293.707V16a1 1 0 01-1 1h-1m-6-1a1 1 0 001 1h1M5 17a2 2 0 104 0m-4 0a2 2 0 114 0m6 0a2 2 0 104 0m-4 0a2 2 0 114 0"/>
-    </svg>
-    """
-  end
-
-  def identification(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2"/>
-    </svg>
-    """
-  end
-
-  def device_mobile(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def document_report(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-    </svg>
-    """
-  end
-
-  def document_download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-    </svg>
-    """
-  end
-
-  def emoji_sad(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def exclamation_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def currency_euro(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.121 15.536c-1.171 1.952-3.07 1.952-4.242 0-1.172-1.953-1.172-5.119 0-7.072 1.171-1.952 3.07-1.952 4.242 0M8 10.5h4m-4 3h4m9-1.5a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def arrows_expand(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"/>
-    </svg>
-    """
-  end
-
-  def trash(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
-    </svg>
-    """
-  end
-
-  def chart_bar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
-    </svg>
-    """
-  end
-
-  def view_grid_add(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14v6m-3-3h6M6 10h2a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2zm10 0h2a2 2 0 002-2V6a2 2 0 00-2-2h-2a2 2 0 00-2 2v2a2 2 0 002 2zM6 20h2a2 2 0 002-2v-2a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def switch_horizontal(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/>
-    </svg>
-    """
-  end
-
-  def volume_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z"/>
-    </svg>
-    """
-  end
-
-  def hashtag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14"/>
-    </svg>
-    """
-  end
-
-  def presentation_chart_line(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>
-    </svg>
-    """
-  end
-
-  def template(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"/>
-    </svg>
-    """
-  end
-
-  def star(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
-    </svg>
-    """
-  end
-
-  def sun(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
-    </svg>
-    """
-  end
-
-  def receipt_refund(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z"/>
-    </svg>
-    """
-  end
-
-  def arrow_circle_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13l-3 3m0 0l-3-3m3 3V8m0 13a9 9 0 110-18 9 9 0 010 18z"/>
-    </svg>
-    """
-  end
-
-  def folder_download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3M3 17V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
-    </svg>
-    """
-  end
-
-  def chart_pie(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z"/>
-    </svg>
-    """
-  end
-
-  def cash(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"/>
-    </svg>
-    """
-  end
-
-  def mail_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 19v-8.93a2 2 0 01.89-1.664l7-4.666a2 2 0 012.22 0l7 4.666A2 2 0 0121 10.07V19M3 19a2 2 0 002 2h14a2 2 0 002-2M3 19l6.75-4.5M21 19l-6.75-4.5M3 10l6.75 4.5M21 10l-6.75 4.5m0 0l-1.14.76a2 2 0 01-2.22 0l-1.14-.76"/>
-    </svg>
-    """
-  end
-
-  def collection(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
-    </svg>
-    """
-  end
-
-  def search_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16l2.879-2.879m0 0a3 3 0 104.243-4.242 3 3 0 00-4.243 4.242zM21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def plus_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 17l-4 4m0 0l-4-4m4 4V3"/>
-    </svg>
-    """
-  end
-
-  def information_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def credit_card(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/>
     </svg>
     """
   end
@@ -2478,144 +3020,8 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def lightning_bolt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
-    </svg>
-    """
-  end
-
-  def office_building(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
-    </svg>
-    """
-  end
-
-  def pencil(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/>
-    </svg>
-    """
-  end
-
-  def status_offline(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636a9 9 0 010 12.728m0 0l-2.829-2.829m2.829 2.829L21 21M15.536 8.464a5 5 0 010 7.072m0 0l-2.829-2.829m-4.243 2.829a4.978 4.978 0 01-1.414-2.83m-1.414 5.658a9 9 0 01-2.167-9.238m7.824 2.167a1 1 0 111.414 1.414m-1.414-1.414L3 3m8.293 8.293l1.414 1.414"/>
-    </svg>
-    """
-  end
-
-  def user_group(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
-    </svg>
-    """
-  end
-
-  def document_duplicate(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7v8a2 2 0 002 2h6M8 7V5a2 2 0 012-2h4.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V15a2 2 0 01-2 2h-2M8 7H6a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2v-2"/>
-    </svg>
-    """
-  end
-
-  def clock(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def phone(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
-    </svg>
-    """
-  end
-
-  def eye(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
     </svg>
     """
   end
@@ -2629,173 +3035,8 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
-    </svg>
-    """
-  end
-
-  def phone_missed_call(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 8l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2M5 3a2 2 0 00-2 2v1c0 8.284 6.716 15 15 15h1a2 2 0 002-2v-3.28a1 1 0 00-.684-.948l-4.493-1.498a1 1 0 00-1.21.502l-1.13 2.257a11.042 11.042 0 01-5.516-5.517l2.257-1.128a1 1 0 00.502-1.21L9.228 3.683A1 1 0 008.279 3H5z"/>
-    </svg>
-    """
-  end
-
-  def gift(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7"/>
-    </svg>
-    """
-  end
-
-  def external_link(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
-    </svg>
-    """
-  end
-
-  def question_mark_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def share(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/>
-    </svg>
-    """
-  end
-
-  def arrow_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18"/>
-    </svg>
-    """
-  end
-
-  def folder_add(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
-    </svg>
-    """
-  end
-
-  def filter(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/>
-    </svg>
-    """
-  end
-
-  def phone_incoming(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 3l-6 6m0 0V4m0 5h5M5 3a2 2 0 00-2 2v1c0 8.284 6.716 15 15 15h1a2 2 0 002-2v-3.28a1 1 0 00-.684-.948l-4.493-1.498a1 1 0 00-1.21.502l-1.13 2.257a11.042 11.042 0 01-5.516-5.517l2.257-1.128a1 1 0 00.502-1.21L9.228 3.683A1 1 0 008.279 3H5z"/>
-    </svg>
-    """
-  end
-
-  def photograph(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
     </svg>
     """
   end
@@ -2809,13 +3050,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
     </svg>
     """
   end
 
-  def video_camera(assigns) do
+  def folder_open(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2824,13 +3065,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 19a2 2 0 01-2-2V7a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1M5 19h14a2 2 0 002-2v-5a2 2 0 00-2-2H9a2 2 0 00-2 2v5a2 2 0 01-2 2z"/>
     </svg>
     """
   end
 
-  def globe(assigns) do
+  def arrow_narrow_left(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2839,13 +3080,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16l-4-4m0 0l4-4m-4 4h18"/>
     </svg>
     """
   end
 
-  def arrow_left(assigns) do
+  def book_open(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2854,13 +3095,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
     </svg>
     """
   end
 
-  def minus_circle(assigns) do
+  def folder_remove(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2869,13 +3110,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6M3 17V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
     </svg>
     """
   end
 
-  def desktop_computer(assigns) do
+  def briefcase(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2884,13 +3125,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
     </svg>
     """
   end
 
-  def lock_closed(assigns) do
+  def duplicate(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2899,13 +3140,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
     </svg>
     """
   end
 
-  def finger_print(assigns) do
+  def star(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -2914,443 +3155,8 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4"/>
-    </svg>
-    """
-  end
-
-  def cloud(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z"/>
-    </svg>
-    """
-  end
-
-  def document_remove(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-    </svg>
-    """
-  end
-
-  def rewind(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0019 16V8a1 1 0 00-1.6-.8l-5.333 4zM4.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0011 16V8a1 1 0 00-1.6-.8l-5.334 4z"/>
-    </svg>
-    """
-  end
-
-  def speakerphone(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"/>
-    </svg>
-    """
-  end
-
-  def upload(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/>
-    </svg>
-    """
-  end
-
-  def trending_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"/>
-    </svg>
-    """
-  end
-
-  def pause(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def bookmark(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"/>
-    </svg>
-    """
-  end
-
-  def switch_vertical(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"/>
-    </svg>
-    """
-  end
-
-  def currency_dollar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-    """
-  end
-
-  def cloud_download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"/>
-    </svg>
-    """
-  end
-
-  def lock_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def menu(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
-    </svg>
-    """
-  end
-
-  def backspace(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2M3 12l6.414 6.414a2 2 0 001.414.586H19a2 2 0 002-2V7a2 2 0 00-2-2h-8.172a2 2 0 00-1.414.586L3 12z"/>
-    </svg>
-    """
-  end
-
-  def shopping_cart(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"/>
-    </svg>
-    """
-  end
-
-  def sort_ascending(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12"/>
-    </svg>
-    """
-  end
-
-  def calculator(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def chart_square_bar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 8v8m-4-5v5m-4-2v2m-2 4h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-    </svg>
-    """
-  end
-
-  def shield_check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
-    </svg>
-    """
-  end
-
-  def clipboard_copy(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/>
-    </svg>
-    """
-  end
-
-  def presentation_chart_bar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 13v-1m4 1v-3m4 3V8M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>
-    </svg>
-    """
-  end
-
-  def folder(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/>
-    </svg>
-    """
-  end
-
-  def users(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
-    </svg>
-    """
-  end
-
-  def color_swatch(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"/>
-    </svg>
-    """
-  end
-
-  def clipboard_check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
-    </svg>
-    """
-  end
-
-  def minus(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"/>
-    </svg>
-    """
-  end
-
-  def chevron_double_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 13l-7 7-7-7m14-8l-7 7-7-7"/>
-    </svg>
-    """
-  end
-
-  def chevron_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
-    </svg>
-    """
-  end
-
-  def annotation(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
     </svg>
     """
   end
@@ -3364,13 +3170,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z"/>
     </svg>
     """
   end
 
-  def moon(assigns) do
+  def fire(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3379,13 +3185,14 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10c0-2 .5-5 2.986-7C14 5 16.09 5.777 17.656 7.343A7.975 7.975 0 0120 13a7.975 7.975 0 01-2.343 5.657z"/>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.879 16.121A3 3 0 1012.015 11L11 14H9c0 .768.293 1.536.879 2.121z"/>
     </svg>
     """
   end
 
-  def exclamation(assigns) do
+  def clipboard_copy(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3394,13 +3201,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/>
     </svg>
     """
   end
 
-  def dots_vertical(assigns) do
+  def document(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3409,13 +3216,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
     </svg>
     """
   end
 
-  def chevron_double_up(assigns) do
+  def bell(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3424,13 +3231,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 11l7-7 7 7M5 19l7-7 7 7"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/>
     </svg>
     """
   end
 
-  def heart(assigns) do
+  def pencil_alt(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3439,13 +3246,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
     </svg>
     """
   end
 
-  def trending_up(assigns) do
+  def login(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3454,13 +3261,13 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"/>
     </svg>
     """
   end
 
-  def academic_cap(assigns) do
+  def presentation_chart_line(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-6 w-6" end)
@@ -3469,10 +3276,203 @@ defmodule PetalComponents.Heroicons.Outline do
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path d="M12 14l9-5-9-5-9 5 9 5z"/>
-      <path d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z"/>
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>
+    </svg>
+    """
+  end
+
+  def information_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def view_boards(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2"/>
+    </svg>
+    """
+  end
+
+  def device_mobile(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+    </svg>
+    """
+  end
+
+  def currency_dollar(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    """
+  end
+
+  def identification(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2"/>
+    </svg>
+    """
+  end
+
+  def ban(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/>
+    </svg>
+    """
+  end
+
+  def menu(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
+    </svg>
+    """
+  end
+
+  def save(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4"/>
+    </svg>
+    """
+  end
+
+  def arrow_circle_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13l-3 3m0 0l-3-3m3 3V8m0 13a9 9 0 110-18 9 9 0 010 18z"/>
+    </svg>
+    """
+  end
+
+  def archive(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
+    </svg>
+    """
+  end
+
+  def menu_alt_3(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"/>
+    </svg>
+    """
+  end
+
+  def phone_missed_call(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 8l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2M5 3a2 2 0 00-2 2v1c0 8.284 6.716 15 15 15h1a2 2 0 002-2v-3.28a1 1 0 00-.684-.948l-4.493-1.498a1 1 0 00-1.21.502l-1.13 2.257a11.042 11.042 0 01-5.516-5.517l2.257-1.128a1 1 0 00.502-1.21L9.228 3.683A1 1 0 008.279 3H5z"/>
+    </svg>
+    """
+  end
+
+  def user_add(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/>
     </svg>
     """
   end

--- a/lib/petal_components/icons/heroicons/solid.ex
+++ b/lib/petal_components/icons/heroicons/solid.ex
@@ -3,8 +3,8 @@ defmodule PetalComponents.Heroicons.Solid do
 
   @moduledoc """
   Icon name can be the function or passed in as a type eg.
-  <PetalComponents.Heroicons.Solid.home class="w-6 h-6" />
-  <PetalComponents.Heroicons.Solid.render type="home" class="w-6 h-6" />
+  <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
+  <PetalComponents.Heroicons.Solid.render type="home" class="w-5 h-5" />
 
   <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
   <PetalComponents.Heroicons.Outline.render type="home" class="w-6 h-6" />
@@ -15,17 +15,1171 @@ defmodule PetalComponents.Heroicons.Solid do
     apply(__MODULE__, icon_name, [assigns])
   end
 
-  def hand(assigns) do
+  def share(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M9 3a1 1 0 012 0v5.5a.5.5 0 001 0V4a1 1 0 112 0v4.5a.5.5 0 001 0V6a1 1 0 112 0v5a7 7 0 11-14 0V9a1 1 0 012 0v2.5a.5.5 0 001 0V4a1 1 0 012 0v4.5a.5.5 0 001 0V3z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M15 8a3 3 0 10-2.977-2.63l-4.94 2.47a3 3 0 100 4.319l4.94 2.47a3 3 0 10.895-1.789l-4.94-2.47a3.027 3.027 0 000-.74l4.94-2.47C13.456 7.68 14.19 8 15 8z"/>
+    </svg>
+    """
+  end
+
+  def currency_euro(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.736 6.979C9.208 6.193 9.696 6 10 6c.304 0 .792.193 1.264.979a1 1 0 001.715-1.029C12.279 4.784 11.232 4 10 4s-2.279.784-2.979 1.95c-.285.475-.507 1-.67 1.55H6a1 1 0 000 2h.013a9.358 9.358 0 000 1H6a1 1 0 100 2h.351c.163.55.385 1.075.67 1.55C7.721 15.216 8.768 16 10 16s2.279-.784 2.979-1.95a1 1 0 10-1.715-1.029c-.472.786-.96.979-1.264.979-.304 0-.792-.193-1.264-.979a4.265 4.265 0 01-.264-.521H10a1 1 0 100-2H8.017a7.36 7.36 0 010-1H10a1 1 0 100-2H8.472c.08-.185.167-.36.264-.521z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def library(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10.496 2.132a1 1 0 00-.992 0l-7 4A1 1 0 003 8v7a1 1 0 100 2h14a1 1 0 100-2V8a1 1 0 00.496-1.868l-7-4zM6 9a1 1 0 00-1 1v3a1 1 0 102 0v-3a1 1 0 00-1-1zm3 1a1 1 0 012 0v3a1 1 0 11-2 0v-3zm5-1a1 1 0 00-1 1v3a1 1 0 102 0v-3a1 1 0 00-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def color_swatch(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 2a2 2 0 00-2 2v11a3 3 0 106 0V4a2 2 0 00-2-2H4zm1 14a1 1 0 100-2 1 1 0 000 2zm5-1.757l4.9-4.9a2 2 0 000-2.828L13.485 5.1a2 2 0 00-2.828 0L10 5.757v8.486zM16 18H9.071l6-6H16a2 2 0 012 2v2a2 2 0 01-2 2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def finger_print(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6.625 2.655A9 9 0 0119 11a1 1 0 11-2 0 7 7 0 00-9.625-6.492 1 1 0 11-.75-1.853zM4.662 4.959A1 1 0 014.75 6.37 6.97 6.97 0 003 11a1 1 0 11-2 0 8.97 8.97 0 012.25-5.953 1 1 0 011.412-.088z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M5 11a5 5 0 1110 0 1 1 0 11-2 0 3 3 0 10-6 0c0 1.677-.345 3.276-.968 4.729a1 1 0 11-1.838-.789A9.964 9.964 0 005 11zm8.921 2.012a1 1 0 01.831 1.145 19.86 19.86 0 01-.545 2.436 1 1 0 11-1.92-.558c.207-.713.371-1.445.49-2.192a1 1 0 011.144-.83z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M10 10a1 1 0 011 1c0 2.236-.46 4.368-1.29 6.304a1 1 0 01-1.838-.789A13.952 13.952 0 009 11a1 1 0 011-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def chart_bar(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z"/>
+    </svg>
+    """
+  end
+
+  def fast_forward(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M4.555 5.168A1 1 0 003 6v8a1 1 0 001.555.832L10 11.202V14a1 1 0 001.555.832l6-4a1 1 0 000-1.664l-6-4A1 1 0 0010 6v2.798l-5.445-3.63z"/>
+    </svg>
+    """
+  end
+
+  def chart_pie(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 10a8 8 0 018-8v8h8a8 8 0 11-16 0z"/>
+      <path d="M12 2.252A8.014 8.014 0 0117.748 8H12V2.252z"/>
+    </svg>
+    """
+  end
+
+  def trending_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12 7a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0V8.414l-4.293 4.293a1 1 0 01-1.414 0L8 10.414l-4.293 4.293a1 1 0 01-1.414-1.414l5-5a1 1 0 011.414 0L11 10.586 14.586 7H12z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def reply(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M7.707 3.293a1 1 0 010 1.414L5.414 7H11a7 7 0 017 7v2a1 1 0 11-2 0v-2a5 5 0 00-5-5H5.414l2.293 2.293a1 1 0 11-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def heart(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cube(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M11 17a1 1 0 001.447.894l4-2A1 1 0 0017 15V9.236a1 1 0 00-1.447-.894l-4 2a1 1 0 00-.553.894V17zM15.211 6.276a1 1 0 000-1.788l-4.764-2.382a1 1 0 00-.894 0L4.789 4.488a1 1 0 000 1.788l4.764 2.382a1 1 0 00.894 0l4.764-2.382zM4.447 8.342A1 1 0 003 9.236V15a1 1 0 00.553.894l4 2A1 1 0 009 17v-5.764a1 1 0 00-.553-.894l-4-2z"/>
+    </svg>
+    """
+  end
+
+  def lock_closed(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def view_grid_add(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM14 11a1 1 0 011 1v1h1a1 1 0 110 2h-1v1a1 1 0 11-2 0v-1h-1a1 1 0 110-2h1v-1a1 1 0 011-1z"/>
+    </svg>
+    """
+  end
+
+  def document_text(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def switch_horizontal(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8 5a1 1 0 100 2h5.586l-1.293 1.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L13.586 5H8zM12 15a1 1 0 100-2H6.414l1.293-1.293a1 1 0 10-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L6.414 15H12z"/>
+    </svg>
+    """
+  end
+
+  def wifi(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M17.778 8.222c-4.296-4.296-11.26-4.296-15.556 0A1 1 0 01.808 6.808c5.076-5.077 13.308-5.077 18.384 0a1 1 0 01-1.414 1.414zM14.95 11.05a7 7 0 00-9.9 0 1 1 0 01-1.414-1.414 9 9 0 0112.728 0 1 1 0 01-1.414 1.414zM12.12 13.88a3 3 0 00-4.242 0 1 1 0 01-1.415-1.415 5 5 0 017.072 0 1 1 0 01-1.415 1.415zM9 16a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def camera(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 5a2 2 0 00-2 2v8a2 2 0 002 2h12a2 2 0 002-2V7a2 2 0 00-2-2h-1.586a1 1 0 01-.707-.293l-1.121-1.121A2 2 0 0011.172 3H8.828a2 2 0 00-1.414.586L6.293 4.707A1 1 0 015.586 5H4zm6 9a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def document_report(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm2 10a1 1 0 10-2 0v3a1 1 0 102 0v-3zm2-3a1 1 0 011 1v5a1 1 0 11-2 0v-5a1 1 0 011-1zm4-1a1 1 0 10-2 0v7a1 1 0 102 0V8z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def chevron_double_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M15.707 4.293a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-5-5a1 1 0 011.414-1.414L10 8.586l4.293-4.293a1 1 0 011.414 0zm0 6a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-5-5a1 1 0 111.414-1.414L10 14.586l4.293-4.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L12.586 11H5a1 1 0 110-2h7.586l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_narrow_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M14.707 12.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L9 14.586V3a1 1 0 012 0v11.586l2.293-2.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def collection(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M7 3a1 1 0 000 2h6a1 1 0 100-2H7zM4 7a1 1 0 011-1h10a1 1 0 110 2H5a1 1 0 01-1-1zM2 11a2 2 0 012-2h12a2 2 0 012 2v4a2 2 0 01-2 2H4a2 2 0 01-2-2v-4z"/>
+    </svg>
+    """
+  end
+
+  def newspaper(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h8a2 2 0 012 2v10a2 2 0 002 2H4a2 2 0 01-2-2V5zm3 1h6v4H5V6zm6 6H5v2h6v-2z" clip-rule="evenodd"/>
+      <path d="M15 7h1a2 2 0 012 2v5.5a1.5 1.5 0 01-3 0V7z"/>
+    </svg>
+    """
+  end
+
+  def selector(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def search_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9 9a2 2 0 114 0 2 2 0 01-4 0z"/>
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a4 4 0 00-3.446 6.032l-2.261 2.26a1 1 0 101.414 1.415l2.261-2.261A4 4 0 1011 5z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def academic_cap(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z"/>
+    </svg>
+    """
+  end
+
+  def clipboard_check(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/>
+      <path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm9.707 5.707a1 1 0 00-1.414-1.414L9 12.586l-1.293-1.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def flag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def chevron_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def database(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M3 12v3c0 1.657 3.134 3 7 3s7-1.343 7-3v-3c0 1.657-3.134 3-7 3s-7-1.343-7-3z"/>
+      <path d="M3 7v3c0 1.657 3.134 3 7 3s7-1.343 7-3V7c0 1.657-3.134 3-7 3S3 8.657 3 7z"/>
+      <path d="M17 5c0 1.657-3.134 3-7 3S3 6.657 3 5s3.134-3 7-3 7 1.343 7 3z"/>
+    </svg>
+    """
+  end
+
+  def music_note(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M18 3a1 1 0 00-1.196-.98l-10 2A1 1 0 006 5v9.114A4.369 4.369 0 005 14c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V7.82l8-1.6v5.894A4.37 4.37 0 0015 12c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V3z"/>
+    </svg>
+    """
+  end
+
+  def paper_clip(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def logout(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 3a1 1 0 00-1 1v12a1 1 0 102 0V4a1 1 0 00-1-1zm10.293 9.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L14.586 9H7a1 1 0 100 2h7.586l-1.293 1.293z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def rss(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 3a1 1 0 000 2c5.523 0 10 4.477 10 10a1 1 0 102 0C17 8.373 11.627 3 5 3z"/>
+      <path d="M4 9a1 1 0 011-1 7 7 0 017 7 1 1 0 11-2 0 5 5 0 00-5-5 1 1 0 01-1-1zM3 15a2 2 0 114 0 2 2 0 01-4 0z"/>
+    </svg>
+    """
+  end
+
+  def folder(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
+    </svg>
+    """
+  end
+
+  def document_download(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v3.586l-1.293-1.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 11.586V8z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def currency_rupee(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 5a1 1 0 100 2h1a2 2 0 011.732 1H7a1 1 0 100 2h2.732A2 2 0 018 11H7a1 1 0 00-.707 1.707l3 3a1 1 0 001.414-1.414l-1.483-1.484A4.008 4.008 0 0011.874 10H13a1 1 0 100-2h-1.126a3.976 3.976 0 00-.41-1H13a1 1 0 100-2H7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def device_tablet(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V4a2 2 0 00-2-2H6zm4 14a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def key(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_circle_left(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.707-10.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L9.414 11H13a1 1 0 100-2H9.414l1.293-1.293z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def bookmark_alt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V5zm11 1H6v8l4-2 4 2V6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cube_transparent(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9.504 1.132a1 1 0 01.992 0l1.75 1a1 1 0 11-.992 1.736L10 3.152l-1.254.716a1 1 0 11-.992-1.736l1.75-1zM5.618 4.504a1 1 0 01-.372 1.364L5.016 6l.23.132a1 1 0 11-.992 1.736L4 7.723V8a1 1 0 01-2 0V6a.996.996 0 01.52-.878l1.734-.99a1 1 0 011.364.372zm8.764 0a1 1 0 011.364-.372l1.733.99A1.002 1.002 0 0118 6v2a1 1 0 11-2 0v-.277l-.254.145a1 1 0 11-.992-1.736l.23-.132-.23-.132a1 1 0 01-.372-1.364zm-7 4a1 1 0 011.364-.372L10 8.848l1.254-.716a1 1 0 11.992 1.736L11 10.58V12a1 1 0 11-2 0v-1.42l-1.246-.712a1 1 0 01-.372-1.364zM3 11a1 1 0 011 1v1.42l1.246.712a1 1 0 11-.992 1.736l-1.75-1A1 1 0 012 14v-2a1 1 0 011-1zm14 0a1 1 0 011 1v2a1 1 0 01-.504.868l-1.75 1a1 1 0 11-.992-1.736L16 13.42V12a1 1 0 011-1zm-9.618 5.504a1 1 0 011.364-.372l.254.145V16a1 1 0 112 0v.277l.254-.145a1 1 0 11.992 1.736l-1.735.992a.995.995 0 01-1.022 0l-1.735-.992a1 1 0 01-.372-1.364z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def emoji_happy(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 100-2 1 1 0 000 2zm7-1a1 1 0 11-2 0 1 1 0 012 0zm-.464 5.535a1 1 0 10-1.415-1.414 3 3 0 01-4.242 0 1 1 0 00-1.415 1.414 5 5 0 007.072 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def currency_pound(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-14a3 3 0 00-3 3v2H7a1 1 0 000 2h1v1a1 1 0 01-1 1 1 1 0 100 2h6a1 1 0 100-2H9.83c.11-.313.17-.65.17-1v-1h1a1 1 0 100-2h-1V7a1 1 0 112 0 1 1 0 102 0 3 3 0 00-3-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def view_list(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def view_grid(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
+    </svg>
+    """
+  end
+
+  def cloud_download(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2 9.5A3.5 3.5 0 005.5 13H9v2.586l-1.293-1.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 15.586V13h2.5a4.5 4.5 0 10-.616-8.958 4.002 4.002 0 10-7.753 1.977A3.5 3.5 0 002 9.5zm9 3.5H9V8a1 1 0 012 0v5z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def check_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def speakerphone(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 3a1 1 0 00-1.447-.894L8.763 6H5a3 3 0 000 6h.28l1.771 5.316A1 1 0 008 18h1a1 1 0 001-1v-4.382l6.553 3.276A1 1 0 0018 15V3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def server(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v2a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm14 1a1 1 0 11-2 0 1 1 0 012 0zM2 13a2 2 0 012-2h12a2 2 0 012 2v2a2 2 0 01-2 2H4a2 2 0 01-2-2v-2zm14 1a1 1 0 11-2 0 1 1 0 012 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def backspace(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6.707 4.879A3 3 0 018.828 4H15a3 3 0 013 3v6a3 3 0 01-3 3H8.828a3 3 0 01-2.12-.879l-4.415-4.414a1 1 0 010-1.414l4.414-4.414zm4 2.414a1 1 0 00-1.414 1.414L10.586 10l-1.293 1.293a1 1 0 101.414 1.414L12 11.414l1.293 1.293a1 1 0 001.414-1.414L13.414 10l1.293-1.293a1 1 0 00-1.414-1.414L12 8.586l-1.293-1.293z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def switch_vertical(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 12a1 1 0 102 0V6.414l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L5 6.414V12zM15 8a1 1 0 10-2 0v5.586l-1.293-1.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L15 13.586V8z"/>
+    </svg>
+    """
+  end
+
+  def user_group(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z"/>
+    </svg>
+    """
+  end
+
+  def sun(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def clock(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def chevron_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def shield_exclamation(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 1.944A11.954 11.954 0 012.166 5C2.056 5.649 2 6.319 2 7c0 5.225 3.34 9.67 8 11.317C14.66 16.67 18 12.225 18 7c0-.682-.057-1.35-.166-2.001A11.954 11.954 0 0110 1.944zM11 14a1 1 0 11-2 0 1 1 0 012 0zm0-7a1 1 0 10-2 0v3a1 1 0 102 0V7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def download(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def plus_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def chevron_double_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4.293 15.707a1 1 0 010-1.414l5-5a1 1 0 011.414 0l5 5a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414 0zm0-6a1 1 0 010-1.414l5-5a1 1 0 011.414 0l5 5a1 1 0 01-1.414 1.414L10 5.414 5.707 9.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def clipboard(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z"/>
+      <path d="M6 3a2 2 0 00-2 2v11a2 2 0 002 2h8a2 2 0 002-2V5a2 2 0 00-2-2 3 3 0 01-3 3H9a3 3 0 01-3-3z"/>
+    </svg>
+    """
+  end
+
+  def variable(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4.649 3.084A1 1 0 015.163 4.4 13.95 13.95 0 004 10c0 1.993.416 3.886 1.164 5.6a1 1 0 01-1.832.8A15.95 15.95 0 012 10c0-2.274.475-4.44 1.332-6.4a1 1 0 011.317-.516zM12.96 7a3 3 0 00-2.342 1.126l-.328.41-.111-.279A2 2 0 008.323 7H8a1 1 0 000 2h.323l.532 1.33-1.035 1.295a1 1 0 01-.781.375H7a1 1 0 100 2h.039a3 3 0 002.342-1.126l.328-.41.111.279A2 2 0 0011.677 14H12a1 1 0 100-2h-.323l-.532-1.33 1.035-1.295A1 1 0 0112.961 9H13a1 1 0 100-2h-.039zm1.874-2.6a1 1 0 011.833-.8A15.95 15.95 0 0118 10c0 2.274-.475 4.44-1.332 6.4a1 1 0 11-1.832-.8A13.949 13.949 0 0016 10c0-1.993-.416-3.886-1.165-5.6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def chat_alt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zM7 8H5v2h2V8zm2 0h2v2H9V8zm6 0h-2v2h2V8z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_left(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def folder_add(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
+      <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11h4m-2-2v4"/>
+    </svg>
+    """
+  end
+
+  def document_duplicate(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9 2a2 2 0 00-2 2v8a2 2 0 002 2h6a2 2 0 002-2V6.414A2 2 0 0016.414 5L14 2.586A2 2 0 0012.586 2H9z"/>
+      <path d="M3 8a2 2 0 012-2v10h8a2 2 0 01-2 2H5a2 2 0 01-2-2V8z"/>
+    </svg>
+    """
+  end
+
+  def calculator(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V4a2 2 0 00-2-2H6zm1 2a1 1 0 000 2h6a1 1 0 100-2H7zm6 7a1 1 0 011 1v3a1 1 0 11-2 0v-3a1 1 0 011-1zm-3 3a1 1 0 100 2h.01a1 1 0 100-2H10zm-4 1a1 1 0 011-1h.01a1 1 0 110 2H7a1 1 0 01-1-1zm1-4a1 1 0 100 2h.01a1 1 0 100-2H7zm2 1a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm4-4a1 1 0 100 2h.01a1 1 0 100-2H13zM9 9a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zM7 8a1 1 0 000 2h.01a1 1 0 000-2H7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def mail(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"/>
+      <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z"/>
+    </svg>
+    """
+  end
+
+  def location_marker(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def annotation(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 13V5a2 2 0 00-2-2H4a2 2 0 00-2 2v8a2 2 0 002 2h3l3 3 3-3h3a2 2 0 002-2zM5 7a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1zm1 3a1 1 0 100 2h3a1 1 0 100-2H6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5.293 9.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L11 7.414V15a1 1 0 11-2 0V7.414L6.707 9.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def menu_alt_4(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 7a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 13a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cursor_click(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6.672 1.911a1 1 0 10-1.932.518l.259.966a1 1 0 001.932-.518l-.26-.966zM2.429 4.74a1 1 0 10-.517 1.932l.966.259a1 1 0 00.517-1.932l-.966-.26zm8.814-.569a1 1 0 00-1.415-1.414l-.707.707a1 1 0 101.415 1.415l.707-.708zm-7.071 7.072l.707-.707A1 1 0 003.465 9.12l-.708.707a1 1 0 001.415 1.415zm3.2-5.171a1 1 0 00-1.3 1.3l4 10a1 1 0 001.823.075l1.38-2.759 3.018 3.02a1 1 0 001.414-1.415l-3.019-3.02 2.76-1.379a1 1 0 00-.076-1.822l-10-4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def eye_off(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clip-rule="evenodd"/>
+      <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z"/>
+    </svg>
+    """
+  end
+
+  def document_remove(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm1 8a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def printer(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 4v3H4a2 2 0 00-2 2v3a2 2 0 002 2h1v2a2 2 0 002 2h6a2 2 0 002-2v-2h1a2 2 0 002-2V9a2 2 0 00-2-2h-1V4a2 2 0 00-2-2H7a2 2 0 00-2 2zm8 0H7v3h6V4zm0 8H7v4h6v-4z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -33,14 +1187,89 @@ defmodule PetalComponents.Heroicons.Solid do
   def search(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def paper_airplane(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112 0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z"/>
+    </svg>
+    """
+  end
+
+  def template(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zM3 10a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zM14 9a1 1 0 00-1 1v6a1 1 0 001 1h2a1 1 0 001-1v-6a1 1 0 00-1-1h-2z"/>
+    </svg>
+    """
+  end
+
+  def chevron_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def x_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def ticket(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 6a2 2 0 012-2h12a2 2 0 012 2v2a2 2 0 100 4v2a2 2 0 01-2 2H4a2 2 0 01-2-2v-2a2 2 0 100-4V6z"/>
     </svg>
     """
   end
@@ -48,14 +1277,591 @@ defmodule PetalComponents.Heroicons.Solid do
   def arrow_down(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M16.707 10.293a1 1 0 010 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 111.414-1.414L9 14.586V3a1 1 0 012 0v11.586l4.293-4.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def globe_alt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4.083 9h1.946c.089-1.546.383-2.97.837-4.118A6.004 6.004 0 004.083 9zM10 2a8 8 0 100 16 8 8 0 000-16zm0 2c-.076 0-.232.032-.465.262-.238.234-.497.623-.737 1.182-.389.907-.673 2.142-.766 3.556h3.936c-.093-1.414-.377-2.649-.766-3.556-.24-.56-.5-.948-.737-1.182C10.232 4.032 10.076 4 10 4zm3.971 5c-.089-1.546-.383-2.97-.837-4.118A6.004 6.004 0 0115.917 9h-1.946zm-2.003 2H8.032c.093 1.414.377 2.649.766 3.556.24.56.5.948.737 1.182.233.23.389.262.465.262.076 0 .232-.032.465-.262.238-.234.498-.623.737-1.182.389-.907.673-2.142.766-3.556zm1.166 4.118c.454-1.147.748-2.572.837-4.118h1.946a6.004 6.004 0 01-2.783 4.118zm-6.268 0C6.412 13.97 6.118 12.546 6.03 11H4.083a6.004 6.004 0 002.783 4.118z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cloud(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5.5 16a3.5 3.5 0 01-.369-6.98 4 4 0 117.753-1.977A4.5 4.5 0 1113.5 16h-8z"/>
+    </svg>
+    """
+  end
+
+  def cloud_upload(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5.5 13a3.5 3.5 0 01-.369-6.98 4 4 0 117.753-1.977A4.5 4.5 0 1113.5 13H11V9.413l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13H5.5z"/>
+      <path d="M9 13h2v5a1 1 0 11-2 0v-5z"/>
+    </svg>
+    """
+  end
+
+  def currency_bangladeshi(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 4a1 1 0 000 2 1 1 0 011 1v1H7a1 1 0 000 2h1v3a3 3 0 106 0v-1a1 1 0 10-2 0v1a1 1 0 11-2 0v-3h3a1 1 0 100-2h-3V7a3 3 0 00-3-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def eye(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
+      <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_left(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L7.414 9H15a1 1 0 110 2H7.414l2.293 2.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def lightning_bolt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def hand(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9 3a1 1 0 012 0v5.5a.5.5 0 001 0V4a1 1 0 112 0v4.5a.5.5 0 001 0V6a1 1 0 112 0v5a7 7 0 11-14 0V9a1 1 0 012 0v2.5a.5.5 0 001 0V4a1 1 0 012 0v4.5a.5.5 0 001 0V3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def clipboard_list(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/>
+      <path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def dots_circle_horizontal(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def video_camera(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 6a2 2 0 012-2h6a2 2 0 012 2v8a2 2 0 01-2 2H4a2 2 0 01-2-2V6zM14.553 7.106A1 1 0 0014 8v4a1 1 0 00.553.894l2 1A1 1 0 0018 13V7a1 1 0 00-1.447-.894l-2 1z"/>
+    </svg>
+    """
+  end
+
+  def phone(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
+    </svg>
+    """
+  end
+
+  def save_as(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9.707 7.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L13 8.586V5h3a2 2 0 012 2v5a2 2 0 01-2 2H8a2 2 0 01-2-2V7a2 2 0 012-2h3v3.586L9.707 7.293zM11 3a1 1 0 112 0v2h-2V3z"/>
+      <path d="M4 9a2 2 0 00-2 2v5a2 2 0 002 2h8a2 2 0 002-2H4V9z"/>
+    </svg>
+    """
+  end
+
+  def user_remove(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M11 6a3 3 0 11-6 0 3 3 0 016 0zM14 17a6 6 0 00-12 0h12zM13 8a1 1 0 100 2h4a1 1 0 100-2h-4z"/>
+    </svg>
+    """
+  end
+
+  def filter(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 11.414V15a1 1 0 01-.293.707l-2 2A1 1 0 018 17v-5.586L3.293 6.707A1 1 0 013 6V3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def thumb_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M18 9.5a1.5 1.5 0 11-3 0v-6a1.5 1.5 0 013 0v6zM14 9.667v-5.43a2 2 0 00-1.105-1.79l-.05-.025A4 4 0 0011.055 2H5.64a2 2 0 00-1.962 1.608l-1.2 6A2 2 0 004.44 12H8v4a2 2 0 002 2 1 1 0 001-1v-.667a4 4 0 01.8-2.4l1.4-1.866a4 4 0 00.8-2.4z"/>
+    </svg>
+    """
+  end
+
+  def sparkles(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 2a1 1 0 011 1v1h1a1 1 0 010 2H6v1a1 1 0 01-2 0V6H3a1 1 0 010-2h1V3a1 1 0 011-1zm0 10a1 1 0 011 1v1h1a1 1 0 110 2H6v1a1 1 0 11-2 0v-1H3a1 1 0 110-2h1v-1a1 1 0 011-1zM12 2a1 1 0 01.967.744L14.146 7.2 17.5 9.134a1 1 0 010 1.732l-3.354 1.935-1.18 4.455a1 1 0 01-1.933 0L9.854 12.8 6.5 10.866a1 1 0 010-1.732l3.354-1.935 1.18-4.455A1 1 0 0112 2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def volume_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM14.657 2.929a1 1 0 011.414 0A9.972 9.972 0 0119 10a9.972 9.972 0 01-2.929 7.071 1 1 0 01-1.414-1.414A7.971 7.971 0 0017 10c0-2.21-.894-4.208-2.343-5.657a1 1 0 010-1.414zm-2.829 2.828a1 1 0 011.415 0A5.983 5.983 0 0115 10a5.984 5.984 0 01-1.757 4.243 1 1 0 01-1.415-1.415A3.984 3.984 0 0013 10a3.983 3.983 0 00-1.172-2.828 1 1 0 010-1.415z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def rewind(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8.445 14.832A1 1 0 0010 14v-2.798l5.445 3.63A1 1 0 0017 14V6a1 1 0 00-1.555-.832L10 8.798V6a1 1 0 00-1.555-.832l-6 4a1 1 0 000 1.664l6 4z"/>
+    </svg>
+    """
+  end
+
+  def trending_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12 13a1 1 0 100 2h5a1 1 0 001-1V9a1 1 0 10-2 0v2.586l-4.293-4.293a1 1 0 00-1.414 0L8 9.586 3.707 5.293a1 1 0 00-1.414 1.414l5 5a1 1 0 001.414 0L11 9.414 14.586 13H12z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def mail_open(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2.94 6.412A2 2 0 002 8.108V16a2 2 0 002 2h12a2 2 0 002-2V8.108a2 2 0 00-.94-1.696l-6-3.75a2 2 0 00-2.12 0l-6 3.75zm2.615 2.423a1 1 0 10-1.11 1.664l5 3.333a1 1 0 001.11 0l5-3.333a1 1 0 00-1.11-1.664L10 11.798 5.555 8.835z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def question_mark_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def upload(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def document_search(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2h-1.528A6 6 0 004 9.528V4z"/>
+      <path fill-rule="evenodd" d="M8 10a4 4 0 00-3.446 6.032l-1.261 1.26a1 1 0 101.414 1.415l1.261-1.261A4 4 0 108 10zm-2 4a2 2 0 114 0 2 2 0 01-4 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def users(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z"/>
+    </svg>
+    """
+  end
+
+  def menu_alt_1(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def scale(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1.323l3.954 1.582 1.599-.8a1 1 0 01.894 1.79l-1.233.616 1.738 5.42a1 1 0 01-.285 1.05A3.989 3.989 0 0115 15a3.989 3.989 0 01-2.667-1.019 1 1 0 01-.285-1.05l1.715-5.349L11 6.477V16h2a1 1 0 110 2H7a1 1 0 110-2h2V6.477L6.237 7.582l1.715 5.349a1 1 0 01-.285 1.05A3.989 3.989 0 015 15a3.989 3.989 0 01-2.667-1.019 1 1 0 01-.285-1.05l1.738-5.42-1.233-.617a1 1 0 01.894-1.788l1.599.799L9 4.323V3a1 1 0 011-1zm-5 8.274l-.818 2.552c.25.112.526.174.818.174.292 0 .569-.062.818-.174L5 10.274zm10 0l-.818 2.552c.25.112.526.174.818.174.292 0 .569-.062.818-.174L15 10.274z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def lock_open(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10 2a5 5 0 00-5 5v2a2 2 0 00-2 2v5a2 2 0 002 2h10a2 2 0 002-2v-5a2 2 0 00-2-2H7V7a3 3 0 015.905-.75 1 1 0 001.937-.5A5.002 5.002 0 0010 2z"/>
+    </svg>
+    """
+  end
+
+  def chat(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def external_link(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"/>
+      <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"/>
+    </svg>
+    """
+  end
+
+  def chat_alt_2(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 5a2 2 0 012-2h7a2 2 0 012 2v4a2 2 0 01-2 2H9l-3 3v-3H4a2 2 0 01-2-2V5z"/>
+      <path d="M15 7v2a4 4 0 01-4 4H9.828l-1.766 1.767c.28.149.599.233.938.233h2l3 3v-3h2a2 2 0 002-2V9a2 2 0 00-2-2h-1z"/>
+    </svg>
+    """
+  end
+
+  def arrow_circle_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def translate(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M7 2a1 1 0 011 1v1h3a1 1 0 110 2H9.578a18.87 18.87 0 01-1.724 4.78c.29.354.596.696.914 1.026a1 1 0 11-1.44 1.389c-.188-.196-.373-.396-.554-.6a19.098 19.098 0 01-3.107 3.567 1 1 0 01-1.334-1.49 17.087 17.087 0 003.13-3.733 18.992 18.992 0 01-1.487-2.494 1 1 0 111.79-.89c.234.47.489.928.764 1.372.417-.934.752-1.913.997-2.927H3a1 1 0 110-2h3V3a1 1 0 011-1zm6 6a1 1 0 01.894.553l2.991 5.982a.869.869 0 01.02.037l.99 1.98a1 1 0 11-1.79.895L15.383 16h-4.764l-.724 1.447a1 1 0 11-1.788-.894l.99-1.98.019-.038 2.99-5.982A1 1 0 0113 8zm-1.382 6h2.764L13 11.236 11.618 14z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def user(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def presentation_chart_bar(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11 4a1 1 0 10-2 0v4a1 1 0 102 0V7zm-3 1a1 1 0 10-2 0v3a1 1 0 102 0V8zM8 9a1 1 0 00-2 0v2a1 1 0 102 0V9z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cash(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cake(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6 3a1 1 0 011-1h.01a1 1 0 010 2H7a1 1 0 01-1-1zm2 3a1 1 0 00-2 0v1a2 2 0 00-2 2v1a2 2 0 00-2 2v.683a3.7 3.7 0 011.055.485 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0A3.7 3.7 0 0118 12.683V12a2 2 0 00-2-2V9a2 2 0 00-2-2V6a1 1 0 10-2 0v1h-1V6a1 1 0 10-2 0v1H8V6zm10 8.868a3.704 3.704 0 01-4.055-.036 1.704 1.704 0 00-1.89 0 3.704 3.704 0 01-4.11 0 1.704 1.704 0 00-1.89 0A3.704 3.704 0 012 14.868V17a1 1 0 001 1h14a1 1 0 001-1v-2.132zM9 3a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm3 0a1 1 0 011-1h.01a1 1 0 110 2H13a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def home(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/>
     </svg>
     """
   end
@@ -63,14 +1869,392 @@ defmodule PetalComponents.Heroicons.Solid do
   def volume_off(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM12.293 7.293a1 1 0 011.414 0L15 8.586l1.293-1.293a1 1 0 111.414 1.414L16.414 10l1.293 1.293a1 1 0 01-1.414 1.414L15 11.414l-1.293 1.293a1 1 0 01-1.414-1.414L13.586 10l-1.293-1.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_narrow_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def stop(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8 7a1 1 0 00-1 1v4a1 1 0 001 1h4a1 1 0 001-1V8a1 1 0 00-1-1H8z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def badge_check(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def moon(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
+    </svg>
+    """
+  end
+
+  def tag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M17.707 9.293a1 1 0 010 1.414l-7 7a1 1 0 01-1.414 0l-7-7A.997.997 0 012 10V5a3 3 0 013-3h5c.256 0 .512.098.707.293l7 7zM5 6a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def sort_ascending(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M3 3a1 1 0 000 2h11a1 1 0 100-2H3zM3 7a1 1 0 000 2h5a1 1 0 000-2H3zM3 11a1 1 0 100 2h4a1 1 0 100-2H3zM13 16a1 1 0 102 0v-5.586l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 101.414 1.414L13 10.414V16z"/>
+    </svg>
+    """
+  end
+
+  def folder_download(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
+      <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v4m0 0l-2-2m2 2l2-2"/>
+    </svg>
+    """
+  end
+
+  def terminal(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm3.293 1.293a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 01-1.414-1.414L7.586 10 5.293 7.707a1 1 0 010-1.414zM11 12a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def receipt_refund(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 2a2 2 0 00-2 2v14l3.5-2 3.5 2 3.5-2 3.5 2V4a2 2 0 00-2-2H5zm4.707 3.707a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L8.414 9H10a3 3 0 013 3v1a1 1 0 102 0v-1a5 5 0 00-5-5H8.414l1.293-1.293z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def office_building(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h8a2 2 0 012 2v12a1 1 0 110 2h-3a1 1 0 01-1-1v-2a1 1 0 00-1-1H9a1 1 0 00-1 1v2a1 1 0 01-1 1H4a1 1 0 110-2V4zm3 1h2v2H7V5zm2 4H7v2h2V9zm2-4h2v2h-2V5zm2 4h-2v2h2V9z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_narrow_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5.293 7.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L11 5.414V17a1 1 0 11-2 0V5.414L6.707 7.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrows_expand(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19 20" fill="currentColor">
+      <path stroke="#374151" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8V4m0 0h4M3 4l4 4m8 0V4m0 0h-4m4 0l-4 4m-8 4v4m0 0h4m-4 0l4-4m8 4l-4-4m4 4v-4m0 4h-4"/>
+    </svg>
+    """
+  end
+
+  def adjustments(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 4a1 1 0 00-2 0v7.268a2 2 0 000 3.464V16a1 1 0 102 0v-1.268a2 2 0 000-3.464V4zM11 4a1 1 0 10-2 0v1.268a2 2 0 000 3.464V16a1 1 0 102 0V8.732a2 2 0 000-3.464V4zM16 3a1 1 0 011 1v7.268a2 2 0 010 3.464V16a1 1 0 11-2 0v-1.268a2 2 0 010-3.464V4a1 1 0 011-1z"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M14.707 10.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L9 12.586V5a1 1 0 012 0v7.586l2.293-2.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def shield_check(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def qrcode(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm2 2V5h1v1H5zM3 13a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1v-3zm2 2v-1h1v1H5zM13 3a1 1 0 00-1 1v3a1 1 0 001 1h3a1 1 0 001-1V4a1 1 0 00-1-1h-3zm1 2v1h1V5h-1z" clip-rule="evenodd"/>
+      <path d="M11 4a1 1 0 10-2 0v1a1 1 0 002 0V4zM10 7a1 1 0 011 1v1h2a1 1 0 110 2h-3a1 1 0 01-1-1V8a1 1 0 011-1zM16 9a1 1 0 100 2 1 1 0 000-2zM9 13a1 1 0 011-1h1a1 1 0 110 2v2a1 1 0 11-2 0v-3zM7 11a1 1 0 100-2H4a1 1 0 100 2h3zM17 13a1 1 0 01-1 1h-2a1 1 0 110-2h2a1 1 0 011 1zM16 17a1 1 0 100-2h-3a1 1 0 100 2h3z"/>
+    </svg>
+    """
+  end
+
+  def status_offline(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M3.707 2.293a1 1 0 00-1.414 1.414l6.921 6.922c.05.062.105.118.168.167l6.91 6.911a1 1 0 001.415-1.414l-.675-.675a9.001 9.001 0 00-.668-11.982A1 1 0 1014.95 5.05a7.002 7.002 0 01.657 9.143l-1.435-1.435a5.002 5.002 0 00-.636-6.294A1 1 0 0012.12 7.88c.924.923 1.12 2.3.587 3.415l-1.992-1.992a.922.922 0 00-.018-.018l-6.99-6.991zM3.238 8.187a1 1 0 00-1.933-.516c-.8 3-.025 6.336 2.331 8.693a1 1 0 001.414-1.415 6.997 6.997 0 01-1.812-6.762zM7.4 11.5a1 1 0 10-1.73 1c.214.371.48.72.795 1.035a1 1 0 001.414-1.414c-.191-.191-.35-.4-.478-.622z"/>
+    </svg>
+    """
+  end
+
+  def map(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12 1.586l-4 4v12.828l4-4V1.586zM3.707 3.293A1 1 0 002 4v10a1 1 0 00.293.707L6 18.414V5.586L3.707 3.293zM17.707 5.293L14 1.586v12.828l2.293 2.293A1 1 0 0018 16V6a1 1 0 00-.293-.707z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def document_add(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V8z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def at_symbol(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M14.243 5.757a6 6 0 10-.986 9.284 1 1 0 111.087 1.678A8 8 0 1118 10a3 3 0 01-4.8 2.401A4 4 0 1114 10a1 1 0 102 0c0-1.537-.586-3.07-1.757-4.243zM12 10a2 2 0 10-4 0 2 2 0 004 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def credit_card(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M4 4a2 2 0 00-2 2v1h16V6a2 2 0 00-2-2H4z"/>
+      <path fill-rule="evenodd" d="M18 9H2v5a2 2 0 002 2h12a2 2 0 002-2V9zM4 13a1 1 0 011-1h1a1 1 0 110 2H5a1 1 0 01-1-1zm5-1a1 1 0 100 2h1a1 1 0 100-2H9z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def globe(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM4.332 8.027a6.012 6.012 0 011.912-2.706C6.512 5.73 6.974 6 7.5 6A1.5 1.5 0 019 7.5V8a2 2 0 004 0 2 2 0 011.523-1.943A5.977 5.977 0 0116 10c0 .34-.028.675-.083 1H15a2 2 0 00-2 2v2.197A5.973 5.973 0 0110 16v-2a2 2 0 00-2-2 2 2 0 01-2-2 2 2 0 00-1.668-1.973z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def sort_descending(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M3 3a1 1 0 000 2h11a1 1 0 100-2H3zM3 7a1 1 0 000 2h7a1 1 0 100-2H3zM3 11a1 1 0 100 2h4a1 1 0 100-2H3zM15 8a1 1 0 10-2 0v5.586l-1.293-1.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L15 13.586V8z"/>
+    </svg>
+    """
+  end
+
+  def trash(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def shopping_cart(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M3 1a1 1 0 000 2h1.22l.305 1.222a.997.997 0 00.01.042l1.358 5.43-.893.892C3.74 11.846 4.632 14 6.414 14H15a1 1 0 000-2H6.414l1-1H14a1 1 0 00.894-.553l3-6A1 1 0 0017 3H6.28l-.31-1.243A1 1 0 005 1H3zM16 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM6.5 18a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/>
     </svg>
     """
   end
@@ -78,14 +2262,363 @@ defmodule PetalComponents.Heroicons.Solid do
   def dots_horizontal(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z"/>
+    </svg>
+    """
+  end
+
+  def chip(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M13 7H7v6h6V7z"/>
+      <path fill-rule="evenodd" d="M7 2a1 1 0 012 0v1h2V2a1 1 0 112 0v1h2a2 2 0 012 2v2h1a1 1 0 110 2h-1v2h1a1 1 0 110 2h-1v2a2 2 0 01-2 2h-2v1a1 1 0 11-2 0v-1H9v1a1 1 0 11-2 0v-1H5a2 2 0 01-2-2v-2H2a1 1 0 110-2h1V9H2a1 1 0 010-2h1V5a2 2 0 012-2h2V2zM5 5h10v10H5V5z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def zoom_out(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M5 8a1 1 0 011-1h4a1 1 0 110 2H6a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def photograph(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def chevron_double_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10.293 15.707a1 1 0 010-1.414L14.586 10l-4.293-4.293a1 1 0 111.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M4.293 15.707a1 1 0 010-1.414L8.586 10 4.293 5.707a1 1 0 011.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def shopping_bag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 2a4 4 0 00-4 4v1H5a1 1 0 00-.994.89l-1 9A1 1 0 004 18h12a1 1 0 00.994-1.11l-1-9A1 1 0 0015 7h-1V6a4 4 0 00-4-4zm2 5V6a2 2 0 10-4 0v1h4zm-6 3a1 1 0 112 0 1 1 0 01-2 0zm7-1a1 1 0 100 2 1 1 0 000-2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def puzzle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10 3.5a1.5 1.5 0 013 0V4a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-.5a1.5 1.5 0 000 3h.5a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-.5a1.5 1.5 0 00-3 0v.5a1 1 0 01-1 1H6a1 1 0 01-1-1v-3a1 1 0 00-1-1h-.5a1.5 1.5 0 010-3H4a1 1 0 001-1V6a1 1 0 011-1h3a1 1 0 001-1v-.5z"/>
+    </svg>
+    """
+  end
+
+  def beaker(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M7 2a1 1 0 00-.707 1.707L7 4.414v3.758a1 1 0 01-.293.707l-4 4C.817 14.769 2.156 18 4.828 18h10.343c2.673 0 4.012-3.231 2.122-5.121l-4-4A1 1 0 0113 8.172V4.414l.707-.707A1 1 0 0013 2H7zm2 6.172V4h2v4.172a3 3 0 00.879 2.12l1.027 1.028a4 4 0 00-2.171.102l-.47.156a4 4 0 01-2.53 0l-.563-.187a1.993 1.993 0 00-.114-.035l1.063-1.063A3 3 0 009 8.172z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def desktop_computer(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def gift(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 5a3 3 0 015-2.236A3 3 0 0114.83 6H16a2 2 0 110 4h-5V9a1 1 0 10-2 0v1H4a2 2 0 110-4h1.17C5.06 5.687 5 5.35 5 5zm4 1V5a1 1 0 10-1 1h1zm3 0a1 1 0 10-1-1v1h1z" clip-rule="evenodd"/>
+      <path d="M9 11H3v5a2 2 0 002 2h4v-7zM11 18h4a2 2 0 002-2v-5h-6v7z"/>
+    </svg>
+    """
+  end
+
+  def plus(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def thumb_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 10.5a1.5 1.5 0 113 0v6a1.5 1.5 0 01-3 0v-6zM6 10.333v5.43a2 2 0 001.106 1.79l.05.025A4 4 0 008.943 18h5.416a2 2 0 001.962-1.608l1.2-6A2 2 0 0015.56 8H12V4a2 2 0 00-2-2 1 1 0 00-1 1v.667a4 4 0 01-.8 2.4L6.8 7.933a4 4 0 00-.8 2.4z"/>
+    </svg>
+    """
+  end
+
+  def check(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def minus_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 000 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def minus(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def chevron_left(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def microphone(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M7 4a3 3 0 016 0v4a3 3 0 11-6 0V4zm4 10.93A7.001 7.001 0 0017 8a1 1 0 10-2 0A5 5 0 015 8a1 1 0 00-2 0 7.001 7.001 0 006 6.93V17H6a1 1 0 100 2h8a1 1 0 100-2h-3v-2.07z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def link(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def currency_yen(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7.858 5.485a1 1 0 00-1.715 1.03L7.633 9H7a1 1 0 100 2h1.834l.166.277V12H7a1 1 0 100 2h2v1a1 1 0 102 0v-1h2a1 1 0 100-2h-2v-.723l.166-.277H13a1 1 0 100-2h-.634l1.492-2.486a1 1 0 10-1.716-1.029L10.034 9h-.068L7.858 5.485z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def table(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 4a3 3 0 00-3 3v6a3 3 0 003 3h10a3 3 0 003-3V7a3 3 0 00-3-3H5zm-1 9v-1h5v2H5a1 1 0 01-1-1zm7 1h4a1 1 0 001-1v-1h-5v2zm0-4h5V8h-5v2zM9 8H4v2h5V8z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def minus_sm(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 10a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def dots_vertical(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z"/>
+    </svg>
+    """
+  end
+
+  def arrow_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3.293 9.707a1 1 0 010-1.414l6-6a1 1 0 011.414 0l6 6a1 1 0 01-1.414 1.414L11 5.414V17a1 1 0 11-2 0V5.414L4.707 9.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def emoji_sad(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 100-2 1 1 0 000 2zm7-1a1 1 0 11-2 0 1 1 0 012 0zm-7.536 5.879a1 1 0 001.415 0 3 3 0 014.242 0 1 1 0 001.415-1.415 5 5 0 00-7.072 0 1 1 0 000 1.415z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -93,13 +2626,13 @@ defmodule PetalComponents.Heroicons.Solid do
   def scissors(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M5.5 2a3.5 3.5 0 101.665 6.58L8.585 10l-1.42 1.42a3.5 3.5 0 101.414 1.414l8.128-8.127a1 1 0 00-1.414-1.414L10 8.586l-1.42-1.42A3.5 3.5 0 005.5 2zM4 5.5a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zm0 9a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z" clip-rule="evenodd"/>
       <path d="M12.828 11.414a1 1 0 00-1.414 1.414l3.879 3.88a1 1 0 001.414-1.415l-3.879-3.879z"/>
     </svg>
@@ -109,899 +2642,44 @@ defmodule PetalComponents.Heroicons.Solid do
   def cog(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def currency_pound(assigns) do
+  def arrow_circle_right(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-14a3 3 0 00-3 3v2H7a1 1 0 000 2h1v1a1 1 0 01-1 1 1 1 0 100 2h6a1 1 0 100-2H9.83c.11-.313.17-.65.17-1v-1h1a1 1 0 100-2h-1V7a1 1 0 112 0 1 1 0 102 0 3 3 0 00-3-3z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 1.414L10.586 9H7a1 1 0 100 2h3.586l-1.293 1.293a1 1 0 101.414 1.414l3-3a1 1 0 000-1.414z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def sort_descending(assigns) do
+  def pencil(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M3 3a1 1 0 000 2h11a1 1 0 100-2H3zM3 7a1 1 0 000 2h7a1 1 0 100-2H3zM3 11a1 1 0 100 2h4a1 1 0 100-2H3zM15 8a1 1 0 10-2 0v5.586l-1.293-1.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L15 13.586V8z"/>
-    </svg>
-    """
-  end
-
-  def reply(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M7.707 3.293a1 1 0 010 1.414L5.414 7H11a7 7 0 017 7v2a1 1 0 11-2 0v-2a5 5 0 00-5-5H5.414l2.293 2.293a1 1 0 11-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def thumb_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2 10.5a1.5 1.5 0 113 0v6a1.5 1.5 0 01-3 0v-6zM6 10.333v5.43a2 2 0 001.106 1.79l.05.025A4 4 0 008.943 18h5.416a2 2 0 001.962-1.608l1.2-6A2 2 0 0015.56 8H12V4a2 2 0 00-2-2 1 1 0 00-1 1v.667a4 4 0 01-.8 2.4L6.8 7.933a4 4 0 00-.8 2.4z"/>
-    </svg>
-    """
-  end
-
-  def translate(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M7 2a1 1 0 011 1v1h3a1 1 0 110 2H9.578a18.87 18.87 0 01-1.724 4.78c.29.354.596.696.914 1.026a1 1 0 11-1.44 1.389c-.188-.196-.373-.396-.554-.6a19.098 19.098 0 01-3.107 3.567 1 1 0 01-1.334-1.49 17.087 17.087 0 003.13-3.733 18.992 18.992 0 01-1.487-2.494 1 1 0 111.79-.89c.234.47.489.928.764 1.372.417-.934.752-1.913.997-2.927H3a1 1 0 110-2h3V3a1 1 0 011-1zm6 6a1 1 0 01.894.553l2.991 5.982a.869.869 0 01.02.037l.99 1.98a1 1 0 11-1.79.895L15.383 16h-4.764l-.724 1.447a1 1 0 11-1.788-.894l.99-1.98.019-.038 2.99-5.982A1 1 0 0113 8zm-1.382 6h2.764L13 11.236 11.618 14z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def adjustments(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M5 4a1 1 0 00-2 0v7.268a2 2 0 000 3.464V16a1 1 0 102 0v-1.268a2 2 0 000-3.464V4zM11 4a1 1 0 10-2 0v1.268a2 2 0 000 3.464V16a1 1 0 102 0V8.732a2 2 0 000-3.464V4zM16 3a1 1 0 011 1v7.268a2 2 0 010 3.464V16a1 1 0 11-2 0v-1.268a2 2 0 010-3.464V4a1 1 0 011-1z"/>
-    </svg>
-    """
-  end
-
-  def user(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def view_grid(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
-    </svg>
-    """
-  end
-
-  def receipt_tax(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5 2a2 2 0 00-2 2v14l3.5-2 3.5 2 3.5-2 3.5 2V4a2 2 0 00-2-2H5zm2.5 3a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm6.207.293a1 1 0 00-1.414 0l-6 6a1 1 0 101.414 1.414l6-6a1 1 0 000-1.414zM12.5 10a1.5 1.5 0 100 3 1.5 1.5 0 000-3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def x_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def view_list(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def home(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/>
-    </svg>
-    """
-  end
-
-  def globe_alt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M4.083 9h1.946c.089-1.546.383-2.97.837-4.118A6.004 6.004 0 004.083 9zM10 2a8 8 0 100 16 8 8 0 000-16zm0 2c-.076 0-.232.032-.465.262-.238.234-.497.623-.737 1.182-.389.907-.673 2.142-.766 3.556h3.936c-.093-1.414-.377-2.649-.766-3.556-.24-.56-.5-.948-.737-1.182C10.232 4.032 10.076 4 10 4zm3.971 5c-.089-1.546-.383-2.97-.837-4.118A6.004 6.004 0 0115.917 9h-1.946zm-2.003 2H8.032c.093 1.414.377 2.649.766 3.556.24.56.5.948.737 1.182.233.23.389.262.465.262.076 0 .232-.032.465-.262.238-.234.498-.623.737-1.182.389-.907.673-2.142.766-3.556zm1.166 4.118c.454-1.147.748-2.572.837-4.118h1.946a6.004 6.004 0 01-2.783 4.118zm-6.268 0C6.412 13.97 6.118 12.546 6.03 11H4.083a6.004 6.004 0 002.783 4.118z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chevron_double_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10.293 15.707a1 1 0 010-1.414L14.586 10l-4.293-4.293a1 1 0 111.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-      <path fill-rule="evenodd" d="M4.293 15.707a1 1 0 010-1.414L8.586 10 4.293 5.707a1 1 0 011.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def library(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10.496 2.132a1 1 0 00-.992 0l-7 4A1 1 0 003 8v7a1 1 0 100 2h14a1 1 0 100-2V8a1 1 0 00.496-1.868l-7-4zM6 9a1 1 0 00-1 1v3a1 1 0 102 0v-3a1 1 0 00-1-1zm3 1a1 1 0 012 0v3a1 1 0 11-2 0v-3zm5-1a1 1 0 00-1 1v3a1 1 0 102 0v-3a1 1 0 00-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chevron_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chevron_double_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M15.707 15.707a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 010 1.414zm-6 0a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 011.414 1.414L5.414 10l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def logout(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 3a1 1 0 00-1 1v12a1 1 0 102 0V4a1 1 0 00-1-1zm10.293 9.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L14.586 9H7a1 1 0 100 2h7.586l-1.293 1.293z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chip(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M13 7H7v6h6V7z"/>
-      <path fill-rule="evenodd" d="M7 2a1 1 0 012 0v1h2V2a1 1 0 112 0v1h2a2 2 0 012 2v2h1a1 1 0 110 2h-1v2h1a1 1 0 110 2h-1v2a2 2 0 01-2 2h-2v1a1 1 0 11-2 0v-1H9v1a1 1 0 11-2 0v-1H5a2 2 0 01-2-2v-2H2a1 1 0 110-2h1V9H2a1 1 0 010-2h1V5a2 2 0 012-2h2V2zM5 5h10v10H5V5z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def ticket(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2 6a2 2 0 012-2h12a2 2 0 012 2v2a2 2 0 100 4v2a2 2 0 01-2 2H4a2 2 0 01-2-2v-2a2 2 0 100-4V6z"/>
-    </svg>
-    """
-  end
-
-  def tag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M17.707 9.293a1 1 0 010 1.414l-7 7a1 1 0 01-1.414 0l-7-7A.997.997 0 012 10V5a3 3 0 013-3h5c.256 0 .512.098.707.293l7 7zM5 6a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def briefcase(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M6 6V5a3 3 0 013-3h2a3 3 0 013 3v1h2a2 2 0 012 2v3.57A22.952 22.952 0 0110 13a22.95 22.95 0 01-8-1.43V8a2 2 0 012-2h2zm2-1a1 1 0 011-1h2a1 1 0 011 1v1H8V5zm1 5a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clip-rule="evenodd"/>
-      <path d="M2 13.692V16a2 2 0 002 2h12a2 2 0 002-2v-2.308A24.974 24.974 0 0110 15c-2.796 0-5.487-.46-8-1.308z"/>
-    </svg>
-    """
-  end
-
-  def arrow_circle_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def save_as(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M9.707 7.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L13 8.586V5h3a2 2 0 012 2v5a2 2 0 01-2 2H8a2 2 0 01-2-2V7a2 2 0 012-2h3v3.586L9.707 7.293zM11 3a1 1 0 112 0v2h-2V3z"/>
-      <path d="M4 9a2 2 0 00-2 2v5a2 2 0 002 2h8a2 2 0 002-2H4V9z"/>
-    </svg>
-    """
-  end
-
-  def document_search(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2h-1.528A6 6 0 004 9.528V4z"/>
-      <path fill-rule="evenodd" d="M8 10a4 4 0 00-3.446 6.032l-1.261 1.26a1 1 0 101.414 1.415l1.261-1.261A4 4 0 108 10zm-2 4a2 2 0 114 0 2 2 0 01-4 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def map(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M12 1.586l-4 4v12.828l4-4V1.586zM3.707 3.293A1 1 0 002 4v10a1 1 0 00.293.707L6 18.414V5.586L3.707 3.293zM17.707 5.293L14 1.586v12.828l2.293 2.293A1 1 0 0018 16V6a1 1 0 00-.293-.707z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def inbox(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5 3a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2H5zm0 2h10v7h-2l-1 2H8l-1-2H5V5z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def microphone(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M7 4a3 3 0 016 0v4a3 3 0 11-6 0V4zm4 10.93A7.001 7.001 0 0017 8a1 1 0 10-2 0A5 5 0 015 8a1 1 0 00-2 0 7.001 7.001 0 006 6.93V17H6a1 1 0 100 2h8a1 1 0 100-2h-3v-2.07z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def database(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M3 12v3c0 1.657 3.134 3 7 3s7-1.343 7-3v-3c0 1.657-3.134 3-7 3s-7-1.343-7-3z"/>
-      <path d="M3 7v3c0 1.657 3.134 3 7 3s7-1.343 7-3V7c0 1.657-3.134 3-7 3S3 8.657 3 7z"/>
-      <path d="M17 5c0 1.657-3.134 3-7 3S3 6.657 3 5s3.134-3 7-3 7 1.343 7 3z"/>
-    </svg>
-    """
-  end
-
-  def puzzle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M10 3.5a1.5 1.5 0 013 0V4a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-.5a1.5 1.5 0 000 3h.5a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-.5a1.5 1.5 0 00-3 0v.5a1 1 0 01-1 1H6a1 1 0 01-1-1v-3a1 1 0 00-1-1h-.5a1.5 1.5 0 010-3H4a1 1 0 001-1V6a1 1 0 011-1h3a1 1 0 001-1v-.5z"/>
-    </svg>
-    """
-  end
-
-  def duplicate(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M7 9a2 2 0 012-2h6a2 2 0 012 2v6a2 2 0 01-2 2H9a2 2 0 01-2-2V9z"/>
-      <path d="M5 3a2 2 0 00-2 2v6a2 2 0 002 2V5h8a2 2 0 00-2-2H5z"/>
-    </svg>
-    """
-  end
-
-  def folder_remove(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
-      <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11h4"/>
-    </svg>
-    """
-  end
-
-  def terminal(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm3.293 1.293a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 01-1.414-1.414L7.586 10 5.293 7.707a1 1 0 010-1.414zM11 12a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def sparkles(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5 2a1 1 0 011 1v1h1a1 1 0 010 2H6v1a1 1 0 01-2 0V6H3a1 1 0 010-2h1V3a1 1 0 011-1zm0 10a1 1 0 011 1v1h1a1 1 0 110 2H6v1a1 1 0 11-2 0v-1H3a1 1 0 110-2h1v-1a1 1 0 011-1zM12 2a1 1 0 01.967.744L14.146 7.2 17.5 9.134a1 1 0 010 1.732l-3.354 1.935-1.18 4.455a1 1 0 01-1.933 0L9.854 12.8 6.5 10.866a1 1 0 010-1.732l3.354-1.935 1.18-4.455A1 1 0 0112 2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chevron_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def folder_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M2 6a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1H8a3 3 0 00-3 3v1.5a1.5 1.5 0 01-3 0V6z" clip-rule="evenodd"/>
-      <path d="M6 12a2 2 0 012-2h8a2 2 0 012 2v2a2 2 0 01-2 2H2h2a2 2 0 002-2v-2z"/>
-    </svg>
-    """
-  end
-
-  def document_add(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def x(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def at_symbol(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M14.243 5.757a6 6 0 10-.986 9.284 1 1 0 111.087 1.678A8 8 0 1118 10a3 3 0 01-4.8 2.401A4 4 0 1114 10a1 1 0 102 0c0-1.537-.586-3.07-1.757-4.243zM12 10a2 2 0 10-4 0 2 2 0 004 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def bookmark_alt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V5zm11 1H6v8l4-2 4 2V6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def cloud_upload(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M5.5 13a3.5 3.5 0 01-.369-6.98 4 4 0 117.753-1.977A4.5 4.5 0 1113.5 13H11V9.413l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13H5.5z"/>
-      <path d="M9 13h2v5a1 1 0 11-2 0v-5z"/>
-    </svg>
-    """
-  end
-
-  def fire(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M12.395 2.553a1 1 0 00-1.45-.385c-.345.23-.614.558-.822.88-.214.33-.403.713-.57 1.116-.334.804-.614 1.768-.84 2.734a31.365 31.365 0 00-.613 3.58 2.64 2.64 0 01-.945-1.067c-.328-.68-.398-1.534-.398-2.654A1 1 0 005.05 6.05 6.981 6.981 0 003 11a7 7 0 1011.95-4.95c-.592-.591-.98-.985-1.348-1.467-.363-.476-.724-1.063-1.207-2.03zM12.12 15.12A3 3 0 017 13s.879.5 2.5.5c0-1 .5-4 1.25-4.5.5 1 .786 1.293 1.371 1.879A2.99 2.99 0 0113 13a2.99 2.99 0 01-.879 2.121z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def ban(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M13.477 14.89A6 6 0 015.11 6.524l8.367 8.368zm1.414-1.414L6.524 5.11a6 6 0 018.367 8.367zM18 10a8 8 0 11-16 0 8 8 0 0116 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def shopping_bag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 2a4 4 0 00-4 4v1H5a1 1 0 00-.994.89l-1 9A1 1 0 004 18h12a1 1 0 00.994-1.11l-1-9A1 1 0 0015 7h-1V6a4 4 0 00-4-4zm2 5V6a2 2 0 10-4 0v1h4zm-6 3a1 1 0 112 0 1 1 0 01-2 0zm7-1a1 1 0 100 2 1 1 0 000-2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chat_alt_2(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2 5a2 2 0 012-2h7a2 2 0 012 2v4a2 2 0 01-2 2H9l-3 3v-3H4a2 2 0 01-2-2V5z"/>
-      <path d="M15 7v2a4 4 0 01-4 4H9.828l-1.766 1.767c.28.149.599.233.938.233h2l3 3v-3h2a2 2 0 002-2V9a2 2 0 00-2-2h-1z"/>
-    </svg>
-    """
-  end
-
-  def arrow_sm_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5.293 9.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L11 7.414V15a1 1 0 11-2 0V7.414L6.707 9.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chevron_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def clipboard(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M8 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z"/>
-      <path d="M6 3a2 2 0 00-2 2v11a2 2 0 002 2h8a2 2 0 002-2V5a2 2 0 00-2-2 3 3 0 01-3 3H9a3 3 0 01-3-3z"/>
-    </svg>
-    """
-  end
-
-  def link(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def key(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def beaker(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M7 2a1 1 0 00-.707 1.707L7 4.414v3.758a1 1 0 01-.293.707l-4 4C.817 14.769 2.156 18 4.828 18h10.343c2.673 0 4.012-3.231 2.122-5.121l-4-4A1 1 0 0113 8.172V4.414l.707-.707A1 1 0 0013 2H7zm2 6.172V4h2v4.172a3 3 0 00.879 2.12l1.027 1.028a4 4 0 00-2.171.102l-.47.156a4 4 0 01-2.53 0l-.563-.187a1.993 1.993 0 00-.114-.035l1.063-1.063A3 3 0 009 8.172z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def selector(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def qrcode(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm2 2V5h1v1H5zM3 13a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1v-3zm2 2v-1h1v1H5zM13 3a1 1 0 00-1 1v3a1 1 0 001 1h3a1 1 0 001-1V4a1 1 0 00-1-1h-3zm1 2v1h1V5h-1z" clip-rule="evenodd"/>
-      <path d="M11 4a1 1 0 10-2 0v1a1 1 0 002 0V4zM10 7a1 1 0 011 1v1h2a1 1 0 110 2h-3a1 1 0 01-1-1V8a1 1 0 011-1zM16 9a1 1 0 100 2 1 1 0 000-2zM9 13a1 1 0 011-1h1a1 1 0 110 2v2a1 1 0 11-2 0v-3zM7 11a1 1 0 100-2H4a1 1 0 100 2h3zM17 13a1 1 0 01-1 1h-2a1 1 0 110-2h2a1 1 0 011 1zM16 17a1 1 0 100-2h-3a1 1 0 100 2h3z"/>
-    </svg>
-    """
-  end
-
-  def currency_rupee(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 5a1 1 0 100 2h1a2 2 0 011.732 1H7a1 1 0 100 2h2.732A2 2 0 018 11H7a1 1 0 00-.707 1.707l3 3a1 1 0 001.414-1.414l-1.483-1.484A4.008 4.008 0 0011.874 10H13a1 1 0 100-2h-1.126a3.976 3.976 0 00-.41-1H13a1 1 0 100-2H7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_4(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 7a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 13a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def paper_clip(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def archive(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M4 3a2 2 0 100 4h12a2 2 0 100-4H4z"/>
-      <path fill-rule="evenodd" d="M3 8h14v7a2 2 0 01-2 2H5a2 2 0 01-2-2V8zm5 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/>
     </svg>
     """
   end
@@ -1009,136 +2687,318 @@ defmodule PetalComponents.Heroicons.Solid do
   def phone_outgoing(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path d="M17.924 2.617a.997.997 0 00-.215-.322l-.004-.004A.997.997 0 0017 2h-4a1 1 0 100 2h1.586l-3.293 3.293a1 1 0 001.414 1.414L16 5.414V7a1 1 0 102 0V3a.997.997 0 00-.076-.383z"/>
       <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
     </svg>
     """
   end
 
-  def mail(assigns) do
+  def code(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"/>
-      <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def currency_bangladeshi(assigns) do
+  def pause(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 4a1 1 0 000 2 1 1 0 011 1v1H7a1 1 0 000 2h1v3a3 3 0 106 0v-1a1 1 0 10-2 0v1a1 1 0 11-2 0v-3h3a1 1 0 100-2h-3V7a3 3 0 00-3-3z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def download(assigns) do
+  def chart_square_bar(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 3a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2H5zm9 4a1 1 0 10-2 0v6a1 1 0 102 0V7zm-3 2a1 1 0 10-2 0v4a1 1 0 102 0V9zm-3 3a1 1 0 10-2 0v1a1 1 0 102 0v-1z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def chat_alt(assigns) do
+  def exclamation_circle(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zM7 8H5v2h2V8zm2 0h2v2H9V8zm6 0h-2v2h2V8z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def book_open(assigns) do
+  def play(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M9 4.804A7.968 7.968 0 005.5 4c-1.255 0-2.443.29-3.5.804v10A7.969 7.969 0 015.5 14c1.669 0 3.218.51 4.5 1.385A7.962 7.962 0 0114.5 14c1.255 0 2.443.29 3.5.804v-10A7.968 7.968 0 0014.5 4c-1.255 0-2.443.29-3.5.804V12a1 1 0 11-2 0V4.804z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def location_marker(assigns) do
+  def menu_alt_2(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def arrow_sm_down(assigns) do
+  def chevron_double_left(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M14.707 10.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L9 12.586V5a1 1 0 012 0v7.586l2.293-2.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M15.707 15.707a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 010 1.414zm-6 0a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 011.414 1.414L5.414 10l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def server(assigns) do
+  def status_online(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v2a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm14 1a1 1 0 11-2 0 1 1 0 012 0zM2 13a2 2 0 012-2h12a2 2 0 012 2v2a2 2 0 01-2 2H4a2 2 0 01-2-2v-2zm14 1a1 1 0 11-2 0 1 1 0 012 0z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5.05 3.636a1 1 0 010 1.414 7 7 0 000 9.9 1 1 0 11-1.414 1.414 9 9 0 010-12.728 1 1 0 011.414 0zm9.9 0a1 1 0 011.414 0 9 9 0 010 12.728 1 1 0 11-1.414-1.414 7 7 0 000-9.9 1 1 0 010-1.414zM7.879 6.464a1 1 0 010 1.414 3 3 0 000 4.243 1 1 0 11-1.415 1.414 5 5 0 010-7.07 1 1 0 011.415 0zm4.242 0a1 1 0 011.415 0 5 5 0 010 7.072 1 1 0 01-1.415-1.415 3 3 0 000-4.242 1 1 0 010-1.415zM10 9a1 1 0 011 1v.01a1 1 0 11-2 0V10a1 1 0 011-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def bookmark(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z"/>
+    </svg>
+    """
+  end
+
+  def refresh(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def x(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def receipt_tax(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 2a2 2 0 00-2 2v14l3.5-2 3.5 2 3.5-2 3.5 2V4a2 2 0 00-2-2H5zm2.5 3a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm6.207.293a1 1 0 00-1.414 0l-6 6a1 1 0 101.414 1.414l6-6a1 1 0 000-1.414zM12.5 10a1.5 1.5 0 100 3 1.5 1.5 0 000-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def support(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-2 0c0 .993-.241 1.929-.668 2.754l-1.524-1.525a3.997 3.997 0 00.078-2.183l1.562-1.562C15.802 8.249 16 9.1 16 10zm-5.165 3.913l1.58 1.58A5.98 5.98 0 0110 16a5.976 5.976 0 01-2.516-.552l1.562-1.562a4.006 4.006 0 001.789.027zm-4.677-2.796a4.002 4.002 0 01-.041-2.08l-.08.08-1.53-1.533A5.98 5.98 0 004 10c0 .954.223 1.856.619 2.657l1.54-1.54zm1.088-6.45A5.974 5.974 0 0110 4c.954 0 1.856.223 2.657.619l-1.54 1.54a4.002 4.002 0 00-2.346.033L7.246 4.668zM12 10a2 2 0 11-4 0 2 2 0 014 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def exclamation(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def phone_incoming(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M14.414 7l3.293-3.293a1 1 0 00-1.414-1.414L13 5.586V4a1 1 0 10-2 0v4.003a.996.996 0 00.617.921A.997.997 0 0012 9h4a1 1 0 100-2h-1.586z"/>
+      <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
+    </svg>
+    """
+  end
+
+  def arrow_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def truck(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM15 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z"/>
+      <path d="M3 4a1 1 0 00-1 1v10a1 1 0 001 1h1.05a2.5 2.5 0 014.9 0H10a1 1 0 001-1V5a1 1 0 00-1-1H3zM14 7a1 1 0 00-1 1v6.05A2.5 2.5 0 0115.95 16H17a1 1 0 001-1v-5a1 1 0 00-.293-.707l-2-2A1 1 0 0015 7h-1z"/>
+    </svg>
+    """
+  end
+
+  def zoom_in(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 8a1 1 0 011-1h1V6a1 1 0 012 0v1h1a1 1 0 110 2H9v1a1 1 0 11-2 0V9H6a1 1 0 01-1-1z"/>
+      <path fill-rule="evenodd" d="M2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8zm6-4a4 4 0 100 8 4 4 0 000-8z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def inbox(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 3a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2H5zm0 2h10v7h-2l-1 2H8l-1-2H5V5z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def hashtag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9.243 3.03a1 1 0 01.727 1.213L9.53 6h2.94l.56-2.243a1 1 0 111.94.486L14.53 6H17a1 1 0 110 2h-2.97l-1 4H15a1 1 0 110 2h-2.47l-.56 2.242a1 1 0 11-1.94-.485L10.47 14H7.53l-.56 2.242a1 1 0 11-1.94-.485L5.47 14H3a1 1 0 110-2h2.97l1-4H5a1 1 0 110-2h2.47l.56-2.243a1 1 0 011.213-.727zM9.03 8l-1 4h2.938l1-4H9.031z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -1146,13 +3006,13 @@ defmodule PetalComponents.Heroicons.Solid do
   def plus_sm(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clip-rule="evenodd"/>
     </svg>
     """
@@ -1161,1332 +3021,15 @@ defmodule PetalComponents.Heroicons.Solid do
   def inbox_in(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path d="M8.707 7.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l2-2a1 1 0 00-1.414-1.414L11 7.586V3a1 1 0 10-2 0v4.586l-.293-.293z"/>
       <path d="M3 5a2 2 0 012-2h1a1 1 0 010 2H5v7h2l1 2h4l1-2h2V5h-1a1 1 0 110-2h1a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V5z"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M7.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l2.293 2.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def login(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 3a1 1 0 011 1v12a1 1 0 11-2 0V4a1 1 0 011-1zm7.707 3.293a1 1 0 010 1.414L9.414 9H17a1 1 0 110 2H9.414l1.293 1.293a1 1 0 01-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def variable(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M4.649 3.084A1 1 0 015.163 4.4 13.95 13.95 0 004 10c0 1.993.416 3.886 1.164 5.6a1 1 0 01-1.832.8A15.95 15.95 0 012 10c0-2.274.475-4.44 1.332-6.4a1 1 0 011.317-.516zM12.96 7a3 3 0 00-2.342 1.126l-.328.41-.111-.279A2 2 0 008.323 7H8a1 1 0 000 2h.323l.532 1.33-1.035 1.295a1 1 0 01-.781.375H7a1 1 0 100 2h.039a3 3 0 002.342-1.126l.328-.41.111.279A2 2 0 0011.677 14H12a1 1 0 100-2h-.323l-.532-1.33 1.035-1.295A1 1 0 0112.961 9H13a1 1 0 100-2h-.039zm1.874-2.6a1 1 0 011.833-.8A15.95 15.95 0 0118 10c0 2.274-.475 4.44-1.332 6.4a1 1 0 11-1.832-.8A13.949 13.949 0 0016 10c0-1.993-.416-3.886-1.165-5.6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_1(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def bell(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z"/>
-    </svg>
-    """
-  end
-
-  def code(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def cake(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M6 3a1 1 0 011-1h.01a1 1 0 010 2H7a1 1 0 01-1-1zm2 3a1 1 0 00-2 0v1a2 2 0 00-2 2v1a2 2 0 00-2 2v.683a3.7 3.7 0 011.055.485 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0A3.7 3.7 0 0118 12.683V12a2 2 0 00-2-2V9a2 2 0 00-2-2V6a1 1 0 10-2 0v1h-1V6a1 1 0 10-2 0v1H8V6zm10 8.868a3.704 3.704 0 01-4.055-.036 1.704 1.704 0 00-1.89 0 3.704 3.704 0 01-4.11 0 1.704 1.704 0 00-1.89 0A3.704 3.704 0 012 14.868V17a1 1 0 001 1h14a1 1 0 001-1v-2.132zM9 3a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm3 0a1 1 0 011-1h.01a1 1 0 110 2H13a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5.293 7.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L11 5.414V17a1 1 0 11-2 0V5.414L6.707 7.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def flag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def eye_off(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clip-rule="evenodd"/>
-      <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z"/>
-    </svg>
-    """
-  end
-
-  def stop(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8 7a1 1 0 00-1 1v4a1 1 0 001 1h4a1 1 0 001-1V8a1 1 0 00-1-1H8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_circle_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.707-10.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L9.414 11H13a1 1 0 100-2H9.414l1.293-1.293z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def newspaper(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h8a2 2 0 012 2v10a2 2 0 002 2H4a2 2 0 01-2-2V5zm3 1h6v4H5V6zm6 6H5v2h6v-2z" clip-rule="evenodd"/>
-      <path d="M15 7h1a2 2 0 012 2v5.5a1.5 1.5 0 01-3 0V7z"/>
-    </svg>
-    """
-  end
-
-  def cube(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M11 17a1 1 0 001.447.894l4-2A1 1 0 0017 15V9.236a1 1 0 00-1.447-.894l-4 2a1 1 0 00-.553.894V17zM15.211 6.276a1 1 0 000-1.788l-4.764-2.382a1 1 0 00-.894 0L4.789 4.488a1 1 0 000 1.788l4.764 2.382a1 1 0 00.894 0l4.764-2.382zM4.447 8.342A1 1 0 003 9.236V15a1 1 0 00.553.894l4 2A1 1 0 009 17v-5.764a1 1 0 00-.553-.894l-4-2z"/>
-    </svg>
-    """
-  end
-
-  def emoji_happy(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 100-2 1 1 0 000 2zm7-1a1 1 0 11-2 0 1 1 0 012 0zm-.464 5.535a1 1 0 10-1.415-1.414 3 3 0 01-4.242 0 1 1 0 00-1.415 1.414 5 5 0 007.072 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def minus_sm(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5 10a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def dots_circle_horizontal(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def support(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-2 0c0 .993-.241 1.929-.668 2.754l-1.524-1.525a3.997 3.997 0 00.078-2.183l1.562-1.562C15.802 8.249 16 9.1 16 10zm-5.165 3.913l1.58 1.58A5.98 5.98 0 0110 16a5.976 5.976 0 01-2.516-.552l1.562-1.562a4.006 4.006 0 001.789.027zm-4.677-2.796a4.002 4.002 0 01-.041-2.08l-.08.08-1.53-1.533A5.98 5.98 0 004 10c0 .954.223 1.856.619 2.657l1.54-1.54zm1.088-6.45A5.974 5.974 0 0110 4c.954 0 1.856.223 2.657.619l-1.54 1.54a4.002 4.002 0 00-2.346.033L7.246 4.668zM12 10a2 2 0 11-4 0 2 2 0 014 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def clipboard_list(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/>
-      <path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def user_remove(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M11 6a3 3 0 11-6 0 3 3 0 016 0zM14 17a6 6 0 00-12 0h12zM13 8a1 1 0 100 2h4a1 1 0 100-2h-4z"/>
-    </svg>
-    """
-  end
-
-  def plus(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def document(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def music_note(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M18 3a1 1 0 00-1.196-.98l-10 2A1 1 0 006 5v9.114A4.369 4.369 0 005 14c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V7.82l8-1.6v5.894A4.37 4.37 0 0015 12c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V3z"/>
-    </svg>
-    """
-  end
-
-  def check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_2(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def view_boards(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1H3a1 1 0 01-1-1V4zM8 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1H9a1 1 0 01-1-1V4zM15 3a1 1 0 00-1 1v12a1 1 0 001 1h2a1 1 0 001-1V4a1 1 0 00-1-1h-2z"/>
-    </svg>
-    """
-  end
-
-  def rss(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M5 3a1 1 0 000 2c5.523 0 10 4.477 10 10a1 1 0 102 0C17 8.373 11.627 3 5 3z"/>
-      <path d="M4 9a1 1 0 011-1 7 7 0 017 7 1 1 0 11-2 0 5 5 0 00-5-5 1 1 0 01-1-1zM3 15a2 2 0 114 0 2 2 0 01-4 0z"/>
-    </svg>
-    """
-  end
-
-  def wifi(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M17.778 8.222c-4.296-4.296-11.26-4.296-15.556 0A1 1 0 01.808 6.808c5.076-5.077 13.308-5.077 18.384 0a1 1 0 01-1.414 1.414zM14.95 11.05a7 7 0 00-9.9 0 1 1 0 01-1.414-1.414 9 9 0 0112.728 0 1 1 0 01-1.414 1.414zM12.12 13.88a3 3 0 00-4.242 0 1 1 0 01-1.415-1.415 5 5 0 017.072 0 1 1 0 01-1.415 1.415zM9 16a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_3(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM9 15a1 1 0 011-1h6a1 1 0 110 2h-6a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def scale(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1.323l3.954 1.582 1.599-.8a1 1 0 01.894 1.79l-1.233.616 1.738 5.42a1 1 0 01-.285 1.05A3.989 3.989 0 0115 15a3.989 3.989 0 01-2.667-1.019 1 1 0 01-.285-1.05l1.715-5.349L11 6.477V16h2a1 1 0 110 2H7a1 1 0 110-2h2V6.477L6.237 7.582l1.715 5.349a1 1 0 01-.285 1.05A3.989 3.989 0 015 15a3.989 3.989 0 01-2.667-1.019 1 1 0 01-.285-1.05l1.738-5.42-1.233-.617a1 1 0 01.894-1.788l1.599.799L9 4.323V3a1 1 0 011-1zm-5 8.274l-.818 2.552c.25.112.526.174.818.174.292 0 .569-.062.818-.174L5 10.274zm10 0l-.818 2.552c.25.112.526.174.818.174.292 0 .569-.062.818-.174L15 10.274z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_circle_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 1.414L10.586 9H7a1 1 0 100 2h3.586l-1.293 1.293a1 1 0 101.414 1.414l3-3a1 1 0 000-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def user_add(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z"/>
-    </svg>
-    """
-  end
-
-  def arrow_sm_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M9.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L7.414 9H15a1 1 0 110 2H7.414l2.293 2.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def zoom_in(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M5 8a1 1 0 011-1h1V6a1 1 0 012 0v1h1a1 1 0 110 2H9v1a1 1 0 11-2 0V9H6a1 1 0 01-1-1z"/>
-      <path fill-rule="evenodd" d="M2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8zm6-4a4 4 0 100 8 4 4 0 000-8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_sm_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L12.586 11H5a1 1 0 110-2h7.586l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def cube_transparent(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M9.504 1.132a1 1 0 01.992 0l1.75 1a1 1 0 11-.992 1.736L10 3.152l-1.254.716a1 1 0 11-.992-1.736l1.75-1zM5.618 4.504a1 1 0 01-.372 1.364L5.016 6l.23.132a1 1 0 11-.992 1.736L4 7.723V8a1 1 0 01-2 0V6a.996.996 0 01.52-.878l1.734-.99a1 1 0 011.364.372zm8.764 0a1 1 0 011.364-.372l1.733.99A1.002 1.002 0 0118 6v2a1 1 0 11-2 0v-.277l-.254.145a1 1 0 11-.992-1.736l.23-.132-.23-.132a1 1 0 01-.372-1.364zm-7 4a1 1 0 011.364-.372L10 8.848l1.254-.716a1 1 0 11.992 1.736L11 10.58V12a1 1 0 11-2 0v-1.42l-1.246-.712a1 1 0 01-.372-1.364zM3 11a1 1 0 011 1v1.42l1.246.712a1 1 0 11-.992 1.736l-1.75-1A1 1 0 012 14v-2a1 1 0 011-1zm14 0a1 1 0 011 1v2a1 1 0 01-.504.868l-1.75 1a1 1 0 11-.992-1.736L16 13.42V12a1 1 0 011-1zm-9.618 5.504a1 1 0 011.364-.372l.254.145V16a1 1 0 112 0v.277l.254-.145a1 1 0 11.992 1.736l-1.735.992a.995.995 0 01-1.022 0l-1.735-.992a1 1 0 01-.372-1.364z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def refresh(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def check_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def thumb_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M18 9.5a1.5 1.5 0 11-3 0v-6a1.5 1.5 0 013 0v6zM14 9.667v-5.43a2 2 0 00-1.105-1.79l-.05-.025A4 4 0 0011.055 2H5.64a2 2 0 00-1.962 1.608l-1.2 6A2 2 0 004.44 12H8v4a2 2 0 002 2 1 1 0 001-1v-.667a4 4 0 01.8-2.4l1.4-1.866a4 4 0 00.8-2.4z"/>
-    </svg>
-    """
-  end
-
-  def device_tablet(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V4a2 2 0 00-2-2H6zm4 14a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def save(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M7.707 10.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 11.586V6h5a2 2 0 012 2v7a2 2 0 01-2 2H4a2 2 0 01-2-2V8a2 2 0 012-2h5v5.586l-1.293-1.293zM9 4a1 1 0 012 0v2H9V4z"/>
-    </svg>
-    """
-  end
-
-  def status_online(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5.05 3.636a1 1 0 010 1.414 7 7 0 000 9.9 1 1 0 11-1.414 1.414 9 9 0 010-12.728 1 1 0 011.414 0zm9.9 0a1 1 0 011.414 0 9 9 0 010 12.728 1 1 0 11-1.414-1.414 7 7 0 000-9.9 1 1 0 010-1.414zM7.879 6.464a1 1 0 010 1.414 3 3 0 000 4.243 1 1 0 11-1.415 1.414 5 5 0 010-7.07 1 1 0 011.415 0zm4.242 0a1 1 0 011.415 0 5 5 0 010 7.072 1 1 0 01-1.415-1.415 3 3 0 000-4.242 1 1 0 010-1.415zM10 9a1 1 0 011 1v.01a1 1 0 11-2 0V10a1 1 0 011-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def paper_airplane(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112 0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z"/>
-    </svg>
-    """
-  end
-
-  def shield_exclamation(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 1.944A11.954 11.954 0 012.166 5C2.056 5.649 2 6.319 2 7c0 5.225 3.34 9.67 8 11.317C14.66 16.67 18 12.225 18 7c0-.682-.057-1.35-.166-2.001A11.954 11.954 0 0110 1.944zM11 14a1 1 0 11-2 0 1 1 0 012 0zm0-7a1 1 0 10-2 0v3a1 1 0 102 0V7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def fast_forward(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M4.555 5.168A1 1 0 003 6v8a1 1 0 001.555.832L10 11.202V14a1 1 0 001.555.832l6-4a1 1 0 000-1.664l-6-4A1 1 0 0010 6v2.798l-5.445-3.63z"/>
-    </svg>
-    """
-  end
-
-  def currency_yen(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7.858 5.485a1 1 0 00-1.715 1.03L7.633 9H7a1 1 0 100 2h1.834l.166.277V12H7a1 1 0 100 2h2v1a1 1 0 102 0v-1h2a1 1 0 100-2h-2v-.723l.166-.277H13a1 1 0 100-2h-.634l1.492-2.486a1 1 0 10-1.716-1.029L10.034 9h-.068L7.858 5.485z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def zoom_out(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"/>
-      <path fill-rule="evenodd" d="M5 8a1 1 0 011-1h4a1 1 0 110 2H6a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def play(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chat(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def pencil_alt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M17.414 2.586a2 2 0 00-2.828 0L7 10.172V13h2.828l7.586-7.586a2 2 0 000-2.828z"/>
-      <path fill-rule="evenodd" d="M2 6a2 2 0 012-2h4a1 1 0 010 2H4v10h10v-4a1 1 0 112 0v4a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def cursor_click(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M6.672 1.911a1 1 0 10-1.932.518l.259.966a1 1 0 001.932-.518l-.26-.966zM2.429 4.74a1 1 0 10-.517 1.932l.966.259a1 1 0 00.517-1.932l-.966-.26zm8.814-.569a1 1 0 00-1.415-1.414l-.707.707a1 1 0 101.415 1.415l.707-.708zm-7.071 7.072l.707-.707A1 1 0 003.465 9.12l-.708.707a1 1 0 001.415 1.415zm3.2-5.171a1 1 0 00-1.3 1.3l4 10a1 1 0 001.823.075l1.38-2.759 3.018 3.02a1 1 0 001.414-1.415l-3.019-3.02 2.76-1.379a1 1 0 00-.076-1.822l-10-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def table(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5 4a3 3 0 00-3 3v6a3 3 0 003 3h10a3 3 0 003-3V7a3 3 0 00-3-3H5zm-1 9v-1h5v2H5a1 1 0 01-1-1zm7 1h4a1 1 0 001-1v-1h-5v2zm0-4h5V8h-5v2zM9 8H4v2h5V8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def badge_check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def document_text(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def camera(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M4 5a2 2 0 00-2 2v8a2 2 0 002 2h12a2 2 0 002-2V7a2 2 0 00-2-2h-1.586a1 1 0 01-.707-.293l-1.121-1.121A2 2 0 0011.172 3H8.828a2 2 0 00-1.414.586L6.293 4.707A1 1 0 015.586 5H4zm6 9a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def printer(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5 4v3H4a2 2 0 00-2 2v3a2 2 0 002 2h1v2a2 2 0 002 2h6a2 2 0 002-2v-2h1a2 2 0 002-2V9a2 2 0 00-2-2h-1V4a2 2 0 00-2-2H7a2 2 0 00-2 2zm8 0H7v3h6V4zm0 8H7v4h6v-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def truck(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M8 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM15 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z"/>
-      <path d="M3 4a1 1 0 00-1 1v10a1 1 0 001 1h1.05a2.5 2.5 0 014.9 0H10a1 1 0 001-1V5a1 1 0 00-1-1H3zM14 7a1 1 0 00-1 1v6.05A2.5 2.5 0 0115.95 16H17a1 1 0 001-1v-5a1 1 0 00-.293-.707l-2-2A1 1 0 0015 7h-1z"/>
-    </svg>
-    """
-  end
-
-  def identification(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 2a1 1 0 00-1 1v1a1 1 0 002 0V3a1 1 0 00-1-1zM4 4h3a3 3 0 006 0h3a2 2 0 012 2v9a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2zm2.5 7a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm2.45 4a2.5 2.5 0 10-4.9 0h4.9zM12 9a1 1 0 100 2h3a1 1 0 100-2h-3zm-1 4a1 1 0 011-1h2a1 1 0 110 2h-2a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def device_mobile(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M7 2a2 2 0 00-2 2v12a2 2 0 002 2h6a2 2 0 002-2V4a2 2 0 00-2-2H7zm3 14a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def document_report(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm2 10a1 1 0 10-2 0v3a1 1 0 102 0v-3zm2-3a1 1 0 011 1v5a1 1 0 11-2 0v-5a1 1 0 011-1zm4-1a1 1 0 10-2 0v7a1 1 0 102 0V8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def document_download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v3.586l-1.293-1.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 11.586V8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def emoji_sad(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 100-2 1 1 0 000 2zm7-1a1 1 0 11-2 0 1 1 0 012 0zm-7.536 5.879a1 1 0 001.415 0 3 3 0 014.242 0 1 1 0 001.415-1.415 5 5 0 00-7.072 0 1 1 0 000 1.415z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def exclamation_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def currency_euro(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.736 6.979C9.208 6.193 9.696 6 10 6c.304 0 .792.193 1.264.979a1 1 0 001.715-1.029C12.279 4.784 11.232 4 10 4s-2.279.784-2.979 1.95c-.285.475-.507 1-.67 1.55H6a1 1 0 000 2h.013a9.358 9.358 0 000 1H6a1 1 0 100 2h.351c.163.55.385 1.075.67 1.55C7.721 15.216 8.768 16 10 16s2.279-.784 2.979-1.95a1 1 0 10-1.715-1.029c-.472.786-.96.979-1.264.979-.304 0-.792-.193-1.264-.979a4.265 4.265 0 01-.264-.521H10a1 1 0 100-2H8.017a7.36 7.36 0 010-1H10a1 1 0 100-2H8.472c.08-.185.167-.36.264-.521z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrows_expand(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h4a1 1 0 010 2H6.414l2.293 2.293a1 1 0 01-1.414 1.414L5 6.414V8a1 1 0 01-2 0V4zm9 1a1 1 0 110-2h4a1 1 0 011 1v4a1 1 0 11-2 0V6.414l-2.293 2.293a1 1 0 11-1.414-1.414L13.586 5H12zm-9 7a1 1 0 112 0v1.586l2.293-2.293a1 1 0 011.414 1.414L6.414 15H8a1 1 0 110 2H4a1 1 0 01-1-1v-4zm13-1a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 110-2h1.586l-2.293-2.293a1 1 0 011.414-1.414L15 13.586V12a1 1 0 011-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def trash(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chart_bar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z"/>
-    </svg>
-    """
-  end
-
-  def view_grid_add(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM14 11a1 1 0 011 1v1h1a1 1 0 110 2h-1v1a1 1 0 11-2 0v-1h-1a1 1 0 110-2h1v-1a1 1 0 011-1z"/>
-    </svg>
-    """
-  end
-
-  def switch_horizontal(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M8 5a1 1 0 100 2h5.586l-1.293 1.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L13.586 5H8zM12 15a1 1 0 100-2H6.414l1.293-1.293a1 1 0 10-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L6.414 15H12z"/>
-    </svg>
-    """
-  end
-
-  def volume_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM14.657 2.929a1 1 0 011.414 0A9.972 9.972 0 0119 10a9.972 9.972 0 01-2.929 7.071 1 1 0 01-1.414-1.414A7.971 7.971 0 0017 10c0-2.21-.894-4.208-2.343-5.657a1 1 0 010-1.414zm-2.829 2.828a1 1 0 011.415 0A5.983 5.983 0 0115 10a5.984 5.984 0 01-1.757 4.243 1 1 0 01-1.415-1.415A3.984 3.984 0 0013 10a3.983 3.983 0 00-1.172-2.828 1 1 0 010-1.415z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def hashtag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M9.243 3.03a1 1 0 01.727 1.213L9.53 6h2.94l.56-2.243a1 1 0 111.94.486L14.53 6H17a1 1 0 110 2h-2.97l-1 4H15a1 1 0 110 2h-2.47l-.56 2.242a1 1 0 11-1.94-.485L10.47 14H7.53l-.56 2.242a1 1 0 11-1.94-.485L5.47 14H3a1 1 0 110-2h2.97l1-4H5a1 1 0 110-2h2.47l.56-2.243a1 1 0 011.213-.727zM9.03 8l-1 4h2.938l1-4H9.031z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def presentation_chart_line(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 0l-2 2a1 1 0 101.414 1.414L8 10.414l1.293 1.293a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def template(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zM3 10a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zM14 9a1 1 0 00-1 1v6a1 1 0 001 1h2a1 1 0 001-1v-6a1 1 0 00-1-1h-2z"/>
-    </svg>
-    """
-  end
-
-  def star(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
-    </svg>
-    """
-  end
-
-  def sun(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def receipt_refund(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5 2a2 2 0 00-2 2v14l3.5-2 3.5 2 3.5-2 3.5 2V4a2 2 0 00-2-2H5zm4.707 3.707a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L8.414 9H10a3 3 0 013 3v1a1 1 0 102 0v-1a5 5 0 00-5-5H8.414l1.293-1.293z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_circle_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v3.586L7.707 9.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 10.586V7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def folder_download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
-      <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v4m0 0l-2-2m2 2l2-2"/>
-    </svg>
-    """
-  end
-
-  def chart_pie(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2 10a8 8 0 018-8v8h8a8 8 0 11-16 0z"/>
-      <path d="M12 2.252A8.014 8.014 0 0117.748 8H12V2.252z"/>
-    </svg>
-    """
-  end
-
-  def cash(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def mail_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M2.94 6.412A2 2 0 002 8.108V16a2 2 0 002 2h12a2 2 0 002-2V8.108a2 2 0 00-.94-1.696l-6-3.75a2 2 0 00-2.12 0l-6 3.75zm2.615 2.423a1 1 0 10-1.11 1.664l5 3.333a1 1 0 001.11 0l5-3.333a1 1 0 00-1.11-1.664L10 11.798 5.555 8.835z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def collection(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M7 3a1 1 0 000 2h6a1 1 0 100-2H7zM4 7a1 1 0 011-1h10a1 1 0 110 2H5a1 1 0 01-1-1zM2 11a2 2 0 012-2h12a2 2 0 012 2v4a2 2 0 01-2 2H4a2 2 0 01-2-2v-4z"/>
-    </svg>
-    """
-  end
-
-  def search_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M9 9a2 2 0 114 0 2 2 0 01-4 0z"/>
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a4 4 0 00-3.446 6.032l-2.261 2.26a1 1 0 101.414 1.415l2.261-2.261A4 4 0 1011 5z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def plus_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M14.707 12.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L9 14.586V3a1 1 0 012 0v11.586l2.293-2.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def information_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def credit_card(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M4 4a2 2 0 00-2 2v1h16V6a2 2 0 00-2-2H4z"/>
-      <path fill-rule="evenodd" d="M18 9H2v5a2 2 0 002 2h12a2 2 0 002-2V9zM4 13a1 1 0 011-1h1a1 1 0 110 2H5a1 1 0 01-1-1zm5-1a1 1 0 100 2h1a1 1 0 100-2H9z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -2494,151 +3037,14 @@ defmodule PetalComponents.Heroicons.Solid do
   def user_circle(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-6-3a2 2 0 11-4 0 2 2 0 014 0zm-2 4a5 5 0 00-4.546 2.916A5.986 5.986 0 0010 16a5.986 5.986 0 004.546-2.084A5 5 0 0010 11z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def lightning_bolt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def office_building(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h8a2 2 0 012 2v12a1 1 0 110 2h-3a1 1 0 01-1-1v-2a1 1 0 00-1-1H9a1 1 0 00-1 1v2a1 1 0 01-1 1H4a1 1 0 110-2V4zm3 1h2v2H7V5zm2 4H7v2h2V9zm2-4h2v2h-2V5zm2 4h-2v2h2V9z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def pencil(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/>
-    </svg>
-    """
-  end
-
-  def status_offline(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M3.707 2.293a1 1 0 00-1.414 1.414l6.921 6.922c.05.062.105.118.168.167l6.91 6.911a1 1 0 001.415-1.414l-.675-.675a9.001 9.001 0 00-.668-11.982A1 1 0 1014.95 5.05a7.002 7.002 0 01.657 9.143l-1.435-1.435a5.002 5.002 0 00-.636-6.294A1 1 0 0012.12 7.88c.924.923 1.12 2.3.587 3.415l-1.992-1.992a.922.922 0 00-.018-.018l-6.99-6.991zM3.238 8.187a1 1 0 00-1.933-.516c-.8 3-.025 6.336 2.331 8.693a1 1 0 001.414-1.415 6.997 6.997 0 01-1.812-6.762zM7.4 11.5a1 1 0 10-1.73 1c.214.371.48.72.795 1.035a1 1 0 001.414-1.414c-.191-.191-.35-.4-.478-.622z"/>
-    </svg>
-    """
-  end
-
-  def user_group(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z"/>
-    </svg>
-    """
-  end
-
-  def document_duplicate(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M9 2a2 2 0 00-2 2v8a2 2 0 002 2h6a2 2 0 002-2V6.414A2 2 0 0016.414 5L14 2.586A2 2 0 0012.586 2H9z"/>
-      <path d="M3 8a2 2 0 012-2v10h8a2 2 0 01-2 2H5a2 2 0 01-2-2V8z"/>
-    </svg>
-    """
-  end
-
-  def clock(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def phone(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
-    </svg>
-    """
-  end
-
-  def eye(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
-      <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -2646,184 +3052,14 @@ defmodule PetalComponents.Heroicons.Solid do
   def light_bulb(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path d="M11 3a1 1 0 10-2 0v1a1 1 0 102 0V3zM15.657 5.757a1 1 0 00-1.414-1.414l-.707.707a1 1 0 001.414 1.414l.707-.707zM18 10a1 1 0 01-1 1h-1a1 1 0 110-2h1a1 1 0 011 1zM5.05 6.464A1 1 0 106.464 5.05l-.707-.707a1 1 0 00-1.414 1.414l.707.707zM5 10a1 1 0 01-1 1H3a1 1 0 110-2h1a1 1 0 011 1zM8 16v-1h4v1a2 2 0 11-4 0zM12 14c.015-.34.208-.646.477-.859a4 4 0 10-4.954 0c.27.213.462.519.476.859h4.002z"/>
-    </svg>
-    """
-  end
-
-  def phone_missed_call(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
-      <path d="M16.707 3.293a1 1 0 010 1.414L15.414 6l1.293 1.293a1 1 0 01-1.414 1.414L14 7.414l-1.293 1.293a1 1 0 11-1.414-1.414L12.586 6l-1.293-1.293a1 1 0 011.414-1.414L14 4.586l1.293-1.293a1 1 0 011.414 0z"/>
-    </svg>
-    """
-  end
-
-  def gift(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5 5a3 3 0 015-2.236A3 3 0 0114.83 6H16a2 2 0 110 4h-5V9a1 1 0 10-2 0v1H4a2 2 0 110-4h1.17C5.06 5.687 5 5.35 5 5zm4 1V5a1 1 0 10-1 1h1zm3 0a1 1 0 10-1-1v1h1z" clip-rule="evenodd"/>
-      <path d="M9 11H3v5a2 2 0 002 2h4v-7zM11 18h4a2 2 0 002-2v-5h-6v7z"/>
-    </svg>
-    """
-  end
-
-  def external_link(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"/>
-      <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"/>
-    </svg>
-    """
-  end
-
-  def question_mark_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def share(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M15 8a3 3 0 10-2.977-2.63l-4.94 2.47a3 3 0 100 4.319l4.94 2.47a3 3 0 10.895-1.789l-4.94-2.47a3.027 3.027 0 000-.74l4.94-2.47C13.456 7.68 14.19 8 15 8z"/>
-    </svg>
-    """
-  end
-
-  def arrow_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3.293 9.707a1 1 0 010-1.414l6-6a1 1 0 011.414 0l6 6a1 1 0 01-1.414 1.414L11 5.414V17a1 1 0 11-2 0V5.414L4.707 9.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def folder_add(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
-      <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11h4m-2-2v4"/>
-    </svg>
-    """
-  end
-
-  def filter(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 11.414V15a1 1 0 01-.293.707l-2 2A1 1 0 018 17v-5.586L3.293 6.707A1 1 0 013 6V3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M12.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def phone_incoming(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M14.414 7l3.293-3.293a1 1 0 00-1.414-1.414L13 5.586V4a1 1 0 10-2 0v4.003a.996.996 0 00.617.921A.997.997 0 0012 9h4a1 1 0 100-2h-1.586z"/>
-      <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
-    </svg>
-    """
-  end
-
-  def photograph(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -2831,559 +3067,123 @@ defmodule PetalComponents.Heroicons.Solid do
   def calendar(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def video_camera(assigns) do
+  def folder_open(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M2 6a2 2 0 012-2h6a2 2 0 012 2v8a2 2 0 01-2 2H4a2 2 0 01-2-2V6zM14.553 7.106A1 1 0 0014 8v4a1 1 0 00.553.894l2 1A1 1 0 0018 13V7a1 1 0 00-1.447-.894l-2 1z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2 6a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1H8a3 3 0 00-3 3v1.5a1.5 1.5 0 01-3 0V6z" clip-rule="evenodd"/>
+      <path d="M6 12a2 2 0 012-2h8a2 2 0 012 2v2a2 2 0 01-2 2H2h2a2 2 0 002-2v-2z"/>
     </svg>
     """
   end
 
-  def globe(assigns) do
+  def arrow_narrow_left(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM4.332 8.027a6.012 6.012 0 011.912-2.706C6.512 5.73 6.974 6 7.5 6A1.5 1.5 0 019 7.5V8a2 2 0 004 0 2 2 0 011.523-1.943A5.977 5.977 0 0116 10c0 .34-.028.675-.083 1H15a2 2 0 00-2 2v2.197A5.973 5.973 0 0110 16v-2a2 2 0 00-2-2 2 2 0 01-2-2 2 2 0 00-1.668-1.973z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M7.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l2.293 2.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def arrow_left(assigns) do
+  def book_open(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9 4.804A7.968 7.968 0 005.5 4c-1.255 0-2.443.29-3.5.804v10A7.969 7.969 0 015.5 14c1.669 0 3.218.51 4.5 1.385A7.962 7.962 0 0114.5 14c1.255 0 2.443.29 3.5.804v-10A7.968 7.968 0 0014.5 4c-1.255 0-2.443.29-3.5.804V12a1 1 0 11-2 0V4.804z"/>
     </svg>
     """
   end
 
-  def minus_circle(assigns) do
+  def folder_remove(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 000 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def desktop_computer(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def lock_closed(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def finger_print(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M6.625 2.655A9 9 0 0119 11a1 1 0 11-2 0 7 7 0 00-9.625-6.492 1 1 0 11-.75-1.853zM4.662 4.959A1 1 0 014.75 6.37 6.97 6.97 0 003 11a1 1 0 11-2 0 8.97 8.97 0 012.25-5.953 1 1 0 011.412-.088z" clip-rule="evenodd"/>
-      <path fill-rule="evenodd" d="M5 11a5 5 0 1110 0 1 1 0 11-2 0 3 3 0 10-6 0c0 1.677-.345 3.276-.968 4.729a1 1 0 11-1.838-.789A9.964 9.964 0 005 11zm8.921 2.012a1 1 0 01.831 1.145 19.86 19.86 0 01-.545 2.436 1 1 0 11-1.92-.558c.207-.713.371-1.445.49-2.192a1 1 0 011.144-.83z" clip-rule="evenodd"/>
-      <path fill-rule="evenodd" d="M10 10a1 1 0 011 1c0 2.236-.46 4.368-1.29 6.304a1 1 0 01-1.838-.789A13.952 13.952 0 009 11a1 1 0 011-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def cloud(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M5.5 16a3.5 3.5 0 01-.369-6.98 4 4 0 117.753-1.977A4.5 4.5 0 1113.5 16h-8z"/>
-    </svg>
-    """
-  end
-
-  def document_remove(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm1 8a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def rewind(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M8.445 14.832A1 1 0 0010 14v-2.798l5.445 3.63A1 1 0 0017 14V6a1 1 0 00-1.555-.832L10 8.798V6a1 1 0 00-1.555-.832l-6 4a1 1 0 000 1.664l6 4z"/>
-    </svg>
-    """
-  end
-
-  def speakerphone(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M18 3a1 1 0 00-1.447-.894L8.763 6H5a3 3 0 000 6h.28l1.771 5.316A1 1 0 008 18h1a1 1 0 001-1v-4.382l6.553 3.276A1 1 0 0018 15V3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def upload(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def trending_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M12 13a1 1 0 100 2h5a1 1 0 001-1V9a1 1 0 10-2 0v2.586l-4.293-4.293a1 1 0 00-1.414 0L8 9.586 3.707 5.293a1 1 0 00-1.414 1.414l5 5a1 1 0 001.414 0L11 9.414 14.586 13H12z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def pause(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def bookmark(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z"/>
-    </svg>
-    """
-  end
-
-  def switch_vertical(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M5 12a1 1 0 102 0V6.414l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L5 6.414V12zM15 8a1 1 0 10-2 0v5.586l-1.293-1.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L15 13.586V8z"/>
-    </svg>
-    """
-  end
-
-  def currency_dollar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M8.433 7.418c.155-.103.346-.196.567-.267v1.698a2.305 2.305 0 01-.567-.267C8.07 8.34 8 8.114 8 8c0-.114.07-.34.433-.582zM11 12.849v-1.698c.22.071.412.164.567.267.364.243.433.468.433.582 0 .114-.07.34-.433.582a2.305 2.305 0 01-.567.267z"/>
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676.662C6.602 6.234 6 7.009 6 8c0 .99.602 1.765 1.324 2.246.48.32 1.054.545 1.676.662v1.941c-.391-.127-.68-.317-.843-.504a1 1 0 10-1.51 1.31c.562.649 1.413 1.076 2.353 1.253V15a1 1 0 102 0v-.092a4.535 4.535 0 001.676-.662C13.398 13.766 14 12.991 14 12c0-.99-.602-1.765-1.324-2.246A4.535 4.535 0 0011 9.092V7.151c.391.127.68.317.843.504a1 1 0 101.511-1.31c-.563-.649-1.413-1.076-2.354-1.253V5z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def cloud_download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M2 9.5A3.5 3.5 0 005.5 13H9v2.586l-1.293-1.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 15.586V13h2.5a4.5 4.5 0 10-.616-8.958 4.002 4.002 0 10-7.753 1.977A3.5 3.5 0 002 9.5zm9 3.5H9V8a1 1 0 012 0v5z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def lock_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M10 2a5 5 0 00-5 5v2a2 2 0 00-2 2v5a2 2 0 002 2h10a2 2 0 002-2v-5a2 2 0 00-2-2H7V7a3 3 0 015.905-.75 1 1 0 001.937-.5A5.002 5.002 0 0010 2z"/>
-    </svg>
-    """
-  end
-
-  def menu(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def backspace(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M6.707 4.879A3 3 0 018.828 4H15a3 3 0 013 3v6a3 3 0 01-3 3H8.828a3 3 0 01-2.12-.879l-4.415-4.414a1 1 0 010-1.414l4.414-4.414zm4 2.414a1 1 0 00-1.414 1.414L10.586 10l-1.293 1.293a1 1 0 101.414 1.414L12 11.414l1.293 1.293a1 1 0 001.414-1.414L13.414 10l1.293-1.293a1 1 0 00-1.414-1.414L12 8.586l-1.293-1.293z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def shopping_cart(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M3 1a1 1 0 000 2h1.22l.305 1.222a.997.997 0 00.01.042l1.358 5.43-.893.892C3.74 11.846 4.632 14 6.414 14H15a1 1 0 000-2H6.414l1-1H14a1 1 0 00.894-.553l3-6A1 1 0 0017 3H6.28l-.31-1.243A1 1 0 005 1H3zM16 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM6.5 18a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/>
-    </svg>
-    """
-  end
-
-  def sort_ascending(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M3 3a1 1 0 000 2h11a1 1 0 100-2H3zM3 7a1 1 0 000 2h5a1 1 0 000-2H3zM3 11a1 1 0 100 2h4a1 1 0 100-2H3zM13 16a1 1 0 102 0v-5.586l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 101.414 1.414L13 10.414V16z"/>
-    </svg>
-    """
-  end
-
-  def calculator(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V4a2 2 0 00-2-2H6zm1 2a1 1 0 000 2h6a1 1 0 100-2H7zm6 7a1 1 0 011 1v3a1 1 0 11-2 0v-3a1 1 0 011-1zm-3 3a1 1 0 100 2h.01a1 1 0 100-2H10zm-4 1a1 1 0 011-1h.01a1 1 0 110 2H7a1 1 0 01-1-1zm1-4a1 1 0 100 2h.01a1 1 0 100-2H7zm2 1a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm4-4a1 1 0 100 2h.01a1 1 0 100-2H13zM9 9a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zM7 8a1 1 0 000 2h.01a1 1 0 000-2H7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chart_square_bar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M5 3a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2H5zm9 4a1 1 0 10-2 0v6a1 1 0 102 0V7zm-3 2a1 1 0 10-2 0v4a1 1 0 102 0V9zm-3 3a1 1 0 10-2 0v1a1 1 0 102 0v-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def shield_check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def clipboard_copy(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M8 2a1 1 0 000 2h2a1 1 0 100-2H8z"/>
-      <path d="M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z"/>
-    </svg>
-    """
-  end
-
-  def presentation_chart_bar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11 4a1 1 0 10-2 0v4a1 1 0 102 0V7zm-3 1a1 1 0 10-2 0v3a1 1 0 102 0V8zM8 9a1 1 0 00-2 0v2a1 1 0 102 0V9z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def folder(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
+      <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11h4"/>
     </svg>
     """
   end
 
-  def users(assigns) do
+  def briefcase(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6 6V5a3 3 0 013-3h2a3 3 0 013 3v1h2a2 2 0 012 2v3.57A22.952 22.952 0 0110 13a22.95 22.95 0 01-8-1.43V8a2 2 0 012-2h2zm2-1a1 1 0 011-1h2a1 1 0 011 1v1H8V5zm1 5a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clip-rule="evenodd"/>
+      <path d="M2 13.692V16a2 2 0 002 2h12a2 2 0 002-2v-2.308A24.974 24.974 0 0110 15c-2.796 0-5.487-.46-8-1.308z"/>
     </svg>
     """
   end
 
-  def color_swatch(assigns) do
+  def duplicate(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M4 2a2 2 0 00-2 2v11a3 3 0 106 0V4a2 2 0 00-2-2H4zm1 14a1 1 0 100-2 1 1 0 000 2zm5-1.757l4.9-4.9a2 2 0 000-2.828L13.485 5.1a2 2 0 00-2.828 0L10 5.757v8.486zM16 18H9.071l6-6H16a2 2 0 012 2v2a2 2 0 01-2 2z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M7 9a2 2 0 012-2h6a2 2 0 012 2v6a2 2 0 01-2 2H9a2 2 0 01-2-2V9z"/>
+      <path d="M5 3a2 2 0 00-2 2v6a2 2 0 002 2V5h8a2 2 0 00-2-2H5z"/>
     </svg>
     """
   end
 
-  def clipboard_check(assigns) do
+  def star(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/>
-      <path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm9.707 5.707a1 1 0 00-1.414-1.414L9 12.586l-1.293-1.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def minus(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chevron_double_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M15.707 4.293a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-5-5a1 1 0 011.414-1.414L10 8.586l4.293-4.293a1 1 0 011.414 0zm0 6a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-5-5a1 1 0 111.414-1.414L10 14.586l4.293-4.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chevron_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def annotation(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M18 13V5a2 2 0 00-2-2H4a2 2 0 00-2 2v8a2 2 0 002 2h3l3 3 3-3h3a2 2 0 002-2zM5 7a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1zm1 3a1 1 0 100 2h3a1 1 0 100-2H6z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
     </svg>
     """
   end
@@ -3391,119 +3191,319 @@ defmodule PetalComponents.Heroicons.Solid do
   def film(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm3 2h6v4H7V5zm8 8v2h1v-2h-1zm-2-2H7v4h6v-4zm2 0h1V9h-1v2zm1-4V5h-1v2h1zM5 5v2H4V5h1zm0 4H4v2h1V9zm-1 4h1v2H4v-2z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def moon(assigns) do
+  def fire(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12.395 2.553a1 1 0 00-1.45-.385c-.345.23-.614.558-.822.88-.214.33-.403.713-.57 1.116-.334.804-.614 1.768-.84 2.734a31.365 31.365 0 00-.613 3.58 2.64 2.64 0 01-.945-1.067c-.328-.68-.398-1.534-.398-2.654A1 1 0 005.05 6.05 6.981 6.981 0 003 11a7 7 0 1011.95-4.95c-.592-.591-.98-.985-1.348-1.467-.363-.476-.724-1.063-1.207-2.03zM12.12 15.12A3 3 0 017 13s.879.5 2.5.5c0-1 .5-4 1.25-4.5.5 1 .786 1.293 1.371 1.879A2.99 2.99 0 0113 13a2.99 2.99 0 01-.879 2.121z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def exclamation(assigns) do
+  def clipboard_copy(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8 2a1 1 0 000 2h2a1 1 0 100-2H8z"/>
+      <path d="M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z"/>
     </svg>
     """
   end
 
-  def dots_vertical(assigns) do
+  def document(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def chevron_double_up(assigns) do
+  def bell(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M4.293 15.707a1 1 0 010-1.414l5-5a1 1 0 011.414 0l5 5a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414 0zm0-6a1 1 0 010-1.414l5-5a1 1 0 011.414 0l5 5a1 1 0 01-1.414 1.414L10 5.414 5.707 9.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z"/>
     </svg>
     """
   end
 
-  def heart(assigns) do
+  def pencil_alt(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M17.414 2.586a2 2 0 00-2.828 0L7 10.172V13h2.828l7.586-7.586a2 2 0 000-2.828z"/>
+      <path fill-rule="evenodd" d="M2 6a2 2 0 012-2h4a1 1 0 010 2H4v10h10v-4a1 1 0 112 0v4a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def trending_up(assigns) do
+  def login(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path fill-rule="evenodd" d="M12 7a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0V8.414l-4.293 4.293a1 1 0 01-1.414 0L8 10.414l-4.293 4.293a1 1 0 01-1.414-1.414l5-5a1 1 0 011.414 0L11 10.586 14.586 7H12z" clip-rule="evenodd"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 3a1 1 0 011 1v12a1 1 0 11-2 0V4a1 1 0 011-1zm7.707 3.293a1 1 0 010 1.414L9.414 9H17a1 1 0 110 2H9.414l1.293 1.293a1 1 0 01-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def academic_cap(assigns) do
+  def presentation_chart_line(assigns) do
     assigns =
       assigns
-      |> assign_new(:class, fn -> "h-6 w-6" end)
+      |> assign_new(:class, fn -> "h-5 w-5" end)
       |> assign_new(:extra_attributes, fn ->
         assigns_to_attributes(assigns, [:class])
       end)
 
     ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z"/>
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 0l-2 2a1 1 0 101.414 1.414L8 10.414l1.293 1.293a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def information_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def view_boards(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1H3a1 1 0 01-1-1V4zM8 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1H9a1 1 0 01-1-1V4zM15 3a1 1 0 00-1 1v12a1 1 0 001 1h2a1 1 0 001-1V4a1 1 0 00-1-1h-2z"/>
+    </svg>
+    """
+  end
+
+  def device_mobile(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M7 2a2 2 0 00-2 2v12a2 2 0 002 2h6a2 2 0 002-2V4a2 2 0 00-2-2H7zm3 14a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def currency_dollar(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8.433 7.418c.155-.103.346-.196.567-.267v1.698a2.305 2.305 0 01-.567-.267C8.07 8.34 8 8.114 8 8c0-.114.07-.34.433-.582zM11 12.849v-1.698c.22.071.412.164.567.267.364.243.433.468.433.582 0 .114-.07.34-.433.582a2.305 2.305 0 01-.567.267z"/>
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676.662C6.602 6.234 6 7.009 6 8c0 .99.602 1.765 1.324 2.246.48.32 1.054.545 1.676.662v1.941c-.391-.127-.68-.317-.843-.504a1 1 0 10-1.51 1.31c.562.649 1.413 1.076 2.353 1.253V15a1 1 0 102 0v-.092a4.535 4.535 0 001.676-.662C13.398 13.766 14 12.991 14 12c0-.99-.602-1.765-1.324-2.246A4.535 4.535 0 0011 9.092V7.151c.391.127.68.317.843.504a1 1 0 101.511-1.31c-.563-.649-1.413-1.076-2.354-1.253V5z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def identification(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 2a1 1 0 00-1 1v1a1 1 0 002 0V3a1 1 0 00-1-1zM4 4h3a3 3 0 006 0h3a2 2 0 012 2v9a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2zm2.5 7a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm2.45 4a2.5 2.5 0 10-4.9 0h4.9zM12 9a1 1 0 100 2h3a1 1 0 100-2h-3zm-1 4a1 1 0 011-1h2a1 1 0 110 2h-2a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def ban(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M13.477 14.89A6 6 0 015.11 6.524l8.367 8.368zm1.414-1.414L6.524 5.11a6 6 0 018.367 8.367zM18 10a8 8 0 11-16 0 8 8 0 0116 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def menu(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def save(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M7.707 10.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 11.586V6h5a2 2 0 012 2v7a2 2 0 01-2 2H4a2 2 0 01-2-2V8a2 2 0 012-2h5v5.586l-1.293-1.293zM9 4a1 1 0 012 0v2H9V4z"/>
+    </svg>
+    """
+  end
+
+  def arrow_circle_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v3.586L7.707 9.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 10.586V7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def archive(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M4 3a2 2 0 100 4h12a2 2 0 100-4H4z"/>
+      <path fill-rule="evenodd" d="M3 8h14v7a2 2 0 01-2 2H5a2 2 0 01-2-2V8zm5 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def menu_alt_3(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM9 15a1 1 0 011-1h6a1 1 0 110 2h-6a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def phone_missed_call(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
+      <path d="M16.707 3.293a1 1 0 010 1.414L15.414 6l1.293 1.293a1 1 0 01-1.414 1.414L14 7.414l-1.293 1.293a1 1 0 11-1.414-1.414L12.586 6l-1.293-1.293a1 1 0 011.414-1.414L14 4.586l1.293-1.293a1 1 0 011.414 0z"/>
+    </svg>
+    """
+  end
+
+  def user_add(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z"/>
     </svg>
     """
   end

--- a/lib/petal_components/icons/heroicons/solid.ex
+++ b/lib/petal_components/icons/heroicons/solid.ex
@@ -15,7 +15,7 @@ defmodule PetalComponents.Heroicons.Solid do
     apply(__MODULE__, icon_name, [assigns])
   end
 
-  def share(assigns) do
+  def academic_cap(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -25,12 +25,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M15 8a3 3 0 10-2.977-2.63l-4.94 2.47a3 3 0 100 4.319l4.94 2.47a3 3 0 10.895-1.789l-4.94-2.47a3.027 3.027 0 000-.74l4.94-2.47C13.456 7.68 14.19 8 15 8z"/>
+      <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z"/>
     </svg>
     """
   end
 
-  def currency_euro(assigns) do
+  def adjustments(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -40,12 +40,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.736 6.979C9.208 6.193 9.696 6 10 6c.304 0 .792.193 1.264.979a1 1 0 001.715-1.029C12.279 4.784 11.232 4 10 4s-2.279.784-2.979 1.95c-.285.475-.507 1-.67 1.55H6a1 1 0 000 2h.013a9.358 9.358 0 000 1H6a1 1 0 100 2h.351c.163.55.385 1.075.67 1.55C7.721 15.216 8.768 16 10 16s2.279-.784 2.979-1.95a1 1 0 10-1.715-1.029c-.472.786-.96.979-1.264.979-.304 0-.792-.193-1.264-.979a4.265 4.265 0 01-.264-.521H10a1 1 0 100-2H8.017a7.36 7.36 0 010-1H10a1 1 0 100-2H8.472c.08-.185.167-.36.264-.521z" clip-rule="evenodd"/>
+      <path d="M5 4a1 1 0 00-2 0v7.268a2 2 0 000 3.464V16a1 1 0 102 0v-1.268a2 2 0 000-3.464V4zM11 4a1 1 0 10-2 0v1.268a2 2 0 000 3.464V16a1 1 0 102 0V8.732a2 2 0 000-3.464V4zM16 3a1 1 0 011 1v7.268a2 2 0 010 3.464V16a1 1 0 11-2 0v-1.268a2 2 0 010-3.464V4a1 1 0 011-1z"/>
     </svg>
     """
   end
 
-  def library(assigns) do
+  def annotation(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -55,12 +55,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10.496 2.132a1 1 0 00-.992 0l-7 4A1 1 0 003 8v7a1 1 0 100 2h14a1 1 0 100-2V8a1 1 0 00.496-1.868l-7-4zM6 9a1 1 0 00-1 1v3a1 1 0 102 0v-3a1 1 0 00-1-1zm3 1a1 1 0 012 0v3a1 1 0 11-2 0v-3zm5-1a1 1 0 00-1 1v3a1 1 0 102 0v-3a1 1 0 00-1-1z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M18 13V5a2 2 0 00-2-2H4a2 2 0 00-2 2v8a2 2 0 002 2h3l3 3 3-3h3a2 2 0 002-2zM5 7a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1zm1 3a1 1 0 100 2h3a1 1 0 100-2H6z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def color_swatch(assigns) do
+  def archive(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -70,12 +70,13 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M4 2a2 2 0 00-2 2v11a3 3 0 106 0V4a2 2 0 00-2-2H4zm1 14a1 1 0 100-2 1 1 0 000 2zm5-1.757l4.9-4.9a2 2 0 000-2.828L13.485 5.1a2 2 0 00-2.828 0L10 5.757v8.486zM16 18H9.071l6-6H16a2 2 0 012 2v2a2 2 0 01-2 2z" clip-rule="evenodd"/>
+      <path d="M4 3a2 2 0 100 4h12a2 2 0 100-4H4z"/>
+      <path fill-rule="evenodd" d="M3 8h14v7a2 2 0 01-2 2H5a2 2 0 01-2-2V8zm5 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def finger_print(assigns) do
+  def arrow_circle_down(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -85,9 +86,473 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M6.625 2.655A9 9 0 0119 11a1 1 0 11-2 0 7 7 0 00-9.625-6.492 1 1 0 11-.75-1.853zM4.662 4.959A1 1 0 014.75 6.37 6.97 6.97 0 003 11a1 1 0 11-2 0 8.97 8.97 0 012.25-5.953 1 1 0 011.412-.088z" clip-rule="evenodd"/>
-      <path fill-rule="evenodd" d="M5 11a5 5 0 1110 0 1 1 0 11-2 0 3 3 0 10-6 0c0 1.677-.345 3.276-.968 4.729a1 1 0 11-1.838-.789A9.964 9.964 0 005 11zm8.921 2.012a1 1 0 01.831 1.145 19.86 19.86 0 01-.545 2.436 1 1 0 11-1.92-.558c.207-.713.371-1.445.49-2.192a1 1 0 011.144-.83z" clip-rule="evenodd"/>
-      <path fill-rule="evenodd" d="M10 10a1 1 0 011 1c0 2.236-.46 4.368-1.29 6.304a1 1 0 01-1.838-.789A13.952 13.952 0 009 11a1 1 0 011-1z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v3.586L7.707 9.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 10.586V7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_circle_left(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.707-10.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L9.414 11H13a1 1 0 100-2H9.414l1.293-1.293z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_circle_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 1.414L10.586 9H7a1 1 0 100 2h3.586l-1.293 1.293a1 1 0 101.414 1.414l3-3a1 1 0 000-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_circle_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M16.707 10.293a1 1 0 010 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 111.414-1.414L9 14.586V3a1 1 0 012 0v11.586l4.293-4.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_left(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_narrow_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M14.707 12.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L9 14.586V3a1 1 0 012 0v11.586l2.293-2.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_narrow_left(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M7.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l2.293 2.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_narrow_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_narrow_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5.293 7.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L11 5.414V17a1 1 0 11-2 0V5.414L6.707 7.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M14.707 10.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L9 12.586V5a1 1 0 012 0v7.586l2.293-2.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_left(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L7.414 9H15a1 1 0 110 2H7.414l2.293 2.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_right(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L12.586 11H5a1 1 0 110-2h7.586l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_sm_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5.293 9.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L11 7.414V15a1 1 0 11-2 0V7.414L6.707 9.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrow_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3.293 9.707a1 1 0 010-1.414l6-6a1 1 0 011.414 0l6 6a1 1 0 01-1.414 1.414L11 5.414V17a1 1 0 11-2 0V5.414L4.707 9.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def arrows_expand(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19 20" fill="currentColor">
+      <path stroke="#374151" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8V4m0 0h4M3 4l4 4m8 0V4m0 0h-4m4 0l-4 4m-8 4v4m0 0h4m-4 0l4-4m8 4l-4-4m4 4v-4m0 4h-4"/>
+    </svg>
+    """
+  end
+
+  def at_symbol(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M14.243 5.757a6 6 0 10-.986 9.284 1 1 0 111.087 1.678A8 8 0 1118 10a3 3 0 01-4.8 2.401A4 4 0 1114 10a1 1 0 102 0c0-1.537-.586-3.07-1.757-4.243zM12 10a2 2 0 10-4 0 2 2 0 004 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def backspace(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6.707 4.879A3 3 0 018.828 4H15a3 3 0 013 3v6a3 3 0 01-3 3H8.828a3 3 0 01-2.12-.879l-4.415-4.414a1 1 0 010-1.414l4.414-4.414zm4 2.414a1 1 0 00-1.414 1.414L10.586 10l-1.293 1.293a1 1 0 101.414 1.414L12 11.414l1.293 1.293a1 1 0 001.414-1.414L13.414 10l1.293-1.293a1 1 0 00-1.414-1.414L12 8.586l-1.293-1.293z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def badge_check(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def ban(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M13.477 14.89A6 6 0 015.11 6.524l8.367 8.368zm1.414-1.414L6.524 5.11a6 6 0 018.367 8.367zM18 10a8 8 0 11-16 0 8 8 0 0116 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def beaker(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M7 2a1 1 0 00-.707 1.707L7 4.414v3.758a1 1 0 01-.293.707l-4 4C.817 14.769 2.156 18 4.828 18h10.343c2.673 0 4.012-3.231 2.122-5.121l-4-4A1 1 0 0113 8.172V4.414l.707-.707A1 1 0 0013 2H7zm2 6.172V4h2v4.172a3 3 0 00.879 2.12l1.027 1.028a4 4 0 00-2.171.102l-.47.156a4 4 0 01-2.53 0l-.563-.187a1.993 1.993 0 00-.114-.035l1.063-1.063A3 3 0 009 8.172z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def bell(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z"/>
+    </svg>
+    """
+  end
+
+  def book_open(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9 4.804A7.968 7.968 0 005.5 4c-1.255 0-2.443.29-3.5.804v10A7.969 7.969 0 015.5 14c1.669 0 3.218.51 4.5 1.385A7.962 7.962 0 0114.5 14c1.255 0 2.443.29 3.5.804v-10A7.968 7.968 0 0014.5 4c-1.255 0-2.443.29-3.5.804V12a1 1 0 11-2 0V4.804z"/>
+    </svg>
+    """
+  end
+
+  def bookmark_alt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V5zm11 1H6v8l4-2 4 2V6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def bookmark(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z"/>
+    </svg>
+    """
+  end
+
+  def briefcase(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6 6V5a3 3 0 013-3h2a3 3 0 013 3v1h2a2 2 0 012 2v3.57A22.952 22.952 0 0110 13a22.95 22.95 0 01-8-1.43V8a2 2 0 012-2h2zm2-1a1 1 0 011-1h2a1 1 0 011 1v1H8V5zm1 5a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clip-rule="evenodd"/>
+      <path d="M2 13.692V16a2 2 0 002 2h12a2 2 0 002-2v-2.308A24.974 24.974 0 0110 15c-2.796 0-5.487-.46-8-1.308z"/>
+    </svg>
+    """
+  end
+
+  def cake(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6 3a1 1 0 011-1h.01a1 1 0 010 2H7a1 1 0 01-1-1zm2 3a1 1 0 00-2 0v1a2 2 0 00-2 2v1a2 2 0 00-2 2v.683a3.7 3.7 0 011.055.485 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0A3.7 3.7 0 0118 12.683V12a2 2 0 00-2-2V9a2 2 0 00-2-2V6a1 1 0 10-2 0v1h-1V6a1 1 0 10-2 0v1H8V6zm10 8.868a3.704 3.704 0 01-4.055-.036 1.704 1.704 0 00-1.89 0 3.704 3.704 0 01-4.11 0 1.704 1.704 0 00-1.89 0A3.704 3.704 0 012 14.868V17a1 1 0 001 1h14a1 1 0 001-1v-2.132zM9 3a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm3 0a1 1 0 011-1h.01a1 1 0 110 2H13a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def calculator(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V4a2 2 0 00-2-2H6zm1 2a1 1 0 000 2h6a1 1 0 100-2H7zm6 7a1 1 0 011 1v3a1 1 0 11-2 0v-3a1 1 0 011-1zm-3 3a1 1 0 100 2h.01a1 1 0 100-2H10zm-4 1a1 1 0 011-1h.01a1 1 0 110 2H7a1 1 0 01-1-1zm1-4a1 1 0 100 2h.01a1 1 0 100-2H7zm2 1a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm4-4a1 1 0 100 2h.01a1 1 0 100-2H13zM9 9a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zM7 8a1 1 0 000 2h.01a1 1 0 000-2H7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def calendar(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def camera(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 5a2 2 0 00-2 2v8a2 2 0 002 2h12a2 2 0 002-2V7a2 2 0 00-2-2h-1.586a1 1 0 01-.707-.293l-1.121-1.121A2 2 0 0011.172 3H8.828a2 2 0 00-1.414.586L6.293 4.707A1 1 0 015.586 5H4zm6 9a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cash(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -103,21 +568,6 @@ defmodule PetalComponents.Heroicons.Solid do
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z"/>
-    </svg>
-    """
-  end
-
-  def fast_forward(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M4.555 5.168A1 1 0 003 6v8a1 1 0 001.555.832L10 11.202V14a1 1 0 001.555.832l6-4a1 1 0 000-1.664l-6-4A1 1 0 0010 6v2.798l-5.445-3.63z"/>
     </svg>
     """
   end
@@ -138,7 +588,7 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def trending_up(assigns) do
+  def chart_square_bar(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -148,12 +598,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M12 7a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0V8.414l-4.293 4.293a1 1 0 01-1.414 0L8 10.414l-4.293 4.293a1 1 0 01-1.414-1.414l5-5a1 1 0 011.414 0L11 10.586 14.586 7H12z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M5 3a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2H5zm9 4a1 1 0 10-2 0v6a1 1 0 102 0V7zm-3 2a1 1 0 10-2 0v4a1 1 0 102 0V9zm-3 3a1 1 0 10-2 0v1a1 1 0 102 0v-1z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def reply(assigns) do
+  def chat_alt_2(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -163,12 +613,13 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M7.707 3.293a1 1 0 010 1.414L5.414 7H11a7 7 0 017 7v2a1 1 0 11-2 0v-2a5 5 0 00-5-5H5.414l2.293 2.293a1 1 0 11-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/>
+      <path d="M2 5a2 2 0 012-2h7a2 2 0 012 2v4a2 2 0 01-2 2H9l-3 3v-3H4a2 2 0 01-2-2V5z"/>
+      <path d="M15 7v2a4 4 0 01-4 4H9.828l-1.766 1.767c.28.149.599.233.938.233h2l3 3v-3h2a2 2 0 002-2V9a2 2 0 00-2-2h-1z"/>
     </svg>
     """
   end
 
-  def heart(assigns) do
+  def chat_alt(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -178,12 +629,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zM7 8H5v2h2V8zm2 0h2v2H9V8zm6 0h-2v2h2V8z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def cube(assigns) do
+  def chat(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -193,12 +644,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M11 17a1 1 0 001.447.894l4-2A1 1 0 0017 15V9.236a1 1 0 00-1.447-.894l-4 2a1 1 0 00-.553.894V17zM15.211 6.276a1 1 0 000-1.788l-4.764-2.382a1 1 0 00-.894 0L4.789 4.488a1 1 0 000 1.788l4.764 2.382a1 1 0 00.894 0l4.764-2.382zM4.447 8.342A1 1 0 003 9.236V15a1 1 0 00.553.894l4 2A1 1 0 009 17v-5.764a1 1 0 00-.553-.894l-4-2z"/>
+      <path fill-rule="evenodd" d="M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def lock_closed(assigns) do
+  def check_circle(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -208,12 +659,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def view_grid_add(assigns) do
+  def check(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -223,82 +674,7 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM14 11a1 1 0 011 1v1h1a1 1 0 110 2h-1v1a1 1 0 11-2 0v-1h-1a1 1 0 110-2h1v-1a1 1 0 011-1z"/>
-    </svg>
-    """
-  end
-
-  def document_text(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def switch_horizontal(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M8 5a1 1 0 100 2h5.586l-1.293 1.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L13.586 5H8zM12 15a1 1 0 100-2H6.414l1.293-1.293a1 1 0 10-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L6.414 15H12z"/>
-    </svg>
-    """
-  end
-
-  def wifi(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M17.778 8.222c-4.296-4.296-11.26-4.296-15.556 0A1 1 0 01.808 6.808c5.076-5.077 13.308-5.077 18.384 0a1 1 0 01-1.414 1.414zM14.95 11.05a7 7 0 00-9.9 0 1 1 0 01-1.414-1.414 9 9 0 0112.728 0 1 1 0 01-1.414 1.414zM12.12 13.88a3 3 0 00-4.242 0 1 1 0 01-1.415-1.415 5 5 0 017.072 0 1 1 0 01-1.415 1.415zM9 16a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def camera(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M4 5a2 2 0 00-2 2v8a2 2 0 002 2h12a2 2 0 002-2V7a2 2 0 00-2-2h-1.586a1 1 0 01-.707-.293l-1.121-1.121A2 2 0 0011.172 3H8.828a2 2 0 00-1.414.586L6.293 4.707A1 1 0 015.586 5H4zm6 9a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def document_report(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm2 10a1 1 0 10-2 0v3a1 1 0 102 0v-3zm2-3a1 1 0 011 1v5a1 1 0 11-2 0v-5a1 1 0 011-1zm4-1a1 1 0 10-2 0v7a1 1 0 102 0V8z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -318,7 +694,7 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def arrow_sm_right(assigns) do
+  def chevron_double_left(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -328,12 +704,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L12.586 11H5a1 1 0 110-2h7.586l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M15.707 15.707a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 010 1.414zm-6 0a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 011.414 1.414L5.414 10l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def arrow_narrow_down(assigns) do
+  def chevron_double_right(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -343,12 +719,13 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M14.707 12.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L9 14.586V3a1 1 0 012 0v11.586l2.293-2.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M10.293 15.707a1 1 0 010-1.414L14.586 10l-4.293-4.293a1 1 0 111.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M4.293 15.707a1 1 0 010-1.414L8.586 10 4.293 5.707a1 1 0 011.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def collection(assigns) do
+  def chevron_double_up(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -358,12 +735,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M7 3a1 1 0 000 2h6a1 1 0 100-2H7zM4 7a1 1 0 011-1h10a1 1 0 110 2H5a1 1 0 01-1-1zM2 11a2 2 0 012-2h12a2 2 0 012 2v4a2 2 0 01-2 2H4a2 2 0 01-2-2v-4z"/>
+      <path fill-rule="evenodd" d="M4.293 15.707a1 1 0 010-1.414l5-5a1 1 0 011.414 0l5 5a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414 0zm0-6a1 1 0 010-1.414l5-5a1 1 0 011.414 0l5 5a1 1 0 01-1.414 1.414L10 5.414 5.707 9.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def newspaper(assigns) do
+  def chevron_down(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -373,13 +750,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h8a2 2 0 012 2v10a2 2 0 002 2H4a2 2 0 01-2-2V5zm3 1h6v4H5V6zm6 6H5v2h6v-2z" clip-rule="evenodd"/>
-      <path d="M15 7h1a2 2 0 012 2v5.5a1.5 1.5 0 01-3 0V7z"/>
+      <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def selector(assigns) do
+  def chevron_left(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -389,12 +765,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def search_circle(assigns) do
+  def chevron_right(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -404,13 +780,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M9 9a2 2 0 114 0 2 2 0 01-4 0z"/>
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a4 4 0 00-3.446 6.032l-2.261 2.26a1 1 0 101.414 1.415l2.261-2.261A4 4 0 1011 5z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def academic_cap(assigns) do
+  def chevron_up(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -420,7 +795,23 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z"/>
+      <path fill-rule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def chip(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M13 7H7v6h6V7z"/>
+      <path fill-rule="evenodd" d="M7 2a1 1 0 012 0v1h2V2a1 1 0 112 0v1h2a2 2 0 012 2v2h1a1 1 0 110 2h-1v2h1a1 1 0 110 2h-1v2a2 2 0 01-2 2h-2v1a1 1 0 11-2 0v-1H9v1a1 1 0 11-2 0v-1H5a2 2 0 01-2-2v-2H2a1 1 0 110-2h1V9H2a1 1 0 010-2h1V5a2 2 0 012-2h2V2zM5 5h10v10H5V5z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -441,7 +832,7 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def flag(assigns) do
+  def clipboard_copy(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -451,12 +842,13 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"/>
+      <path d="M8 2a1 1 0 000 2h2a1 1 0 100-2H8z"/>
+      <path d="M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z"/>
     </svg>
     """
   end
 
-  def chevron_down(assigns) do
+  def clipboard_list(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -466,7 +858,297 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
+      <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/>
+      <path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def clipboard(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z"/>
+      <path d="M6 3a2 2 0 00-2 2v11a2 2 0 002 2h8a2 2 0 002-2V5a2 2 0 00-2-2 3 3 0 01-3 3H9a3 3 0 01-3-3z"/>
+    </svg>
+    """
+  end
+
+  def clock(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cloud_download(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2 9.5A3.5 3.5 0 005.5 13H9v2.586l-1.293-1.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 15.586V13h2.5a4.5 4.5 0 10-.616-8.958 4.002 4.002 0 10-7.753 1.977A3.5 3.5 0 002 9.5zm9 3.5H9V8a1 1 0 012 0v5z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cloud_upload(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5.5 13a3.5 3.5 0 01-.369-6.98 4 4 0 117.753-1.977A4.5 4.5 0 1113.5 13H11V9.413l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13H5.5z"/>
+      <path d="M9 13h2v5a1 1 0 11-2 0v-5z"/>
+    </svg>
+    """
+  end
+
+  def cloud(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5.5 16a3.5 3.5 0 01-.369-6.98 4 4 0 117.753-1.977A4.5 4.5 0 1113.5 16h-8z"/>
+    </svg>
+    """
+  end
+
+  def code(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cog(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def collection(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M7 3a1 1 0 000 2h6a1 1 0 100-2H7zM4 7a1 1 0 011-1h10a1 1 0 110 2H5a1 1 0 01-1-1zM2 11a2 2 0 012-2h12a2 2 0 012 2v4a2 2 0 01-2 2H4a2 2 0 01-2-2v-4z"/>
+    </svg>
+    """
+  end
+
+  def color_swatch(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 2a2 2 0 00-2 2v11a3 3 0 106 0V4a2 2 0 00-2-2H4zm1 14a1 1 0 100-2 1 1 0 000 2zm5-1.757l4.9-4.9a2 2 0 000-2.828L13.485 5.1a2 2 0 00-2.828 0L10 5.757v8.486zM16 18H9.071l6-6H16a2 2 0 012 2v2a2 2 0 01-2 2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def credit_card(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M4 4a2 2 0 00-2 2v1h16V6a2 2 0 00-2-2H4z"/>
+      <path fill-rule="evenodd" d="M18 9H2v5a2 2 0 002 2h12a2 2 0 002-2V9zM4 13a1 1 0 011-1h1a1 1 0 110 2H5a1 1 0 01-1-1zm5-1a1 1 0 100 2h1a1 1 0 100-2H9z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cube_transparent(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9.504 1.132a1 1 0 01.992 0l1.75 1a1 1 0 11-.992 1.736L10 3.152l-1.254.716a1 1 0 11-.992-1.736l1.75-1zM5.618 4.504a1 1 0 01-.372 1.364L5.016 6l.23.132a1 1 0 11-.992 1.736L4 7.723V8a1 1 0 01-2 0V6a.996.996 0 01.52-.878l1.734-.99a1 1 0 011.364.372zm8.764 0a1 1 0 011.364-.372l1.733.99A1.002 1.002 0 0118 6v2a1 1 0 11-2 0v-.277l-.254.145a1 1 0 11-.992-1.736l.23-.132-.23-.132a1 1 0 01-.372-1.364zm-7 4a1 1 0 011.364-.372L10 8.848l1.254-.716a1 1 0 11.992 1.736L11 10.58V12a1 1 0 11-2 0v-1.42l-1.246-.712a1 1 0 01-.372-1.364zM3 11a1 1 0 011 1v1.42l1.246.712a1 1 0 11-.992 1.736l-1.75-1A1 1 0 012 14v-2a1 1 0 011-1zm14 0a1 1 0 011 1v2a1 1 0 01-.504.868l-1.75 1a1 1 0 11-.992-1.736L16 13.42V12a1 1 0 011-1zm-9.618 5.504a1 1 0 011.364-.372l.254.145V16a1 1 0 112 0v.277l.254-.145a1 1 0 11.992 1.736l-1.735.992a.995.995 0 01-1.022 0l-1.735-.992a1 1 0 01-.372-1.364z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cube(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M11 17a1 1 0 001.447.894l4-2A1 1 0 0017 15V9.236a1 1 0 00-1.447-.894l-4 2a1 1 0 00-.553.894V17zM15.211 6.276a1 1 0 000-1.788l-4.764-2.382a1 1 0 00-.894 0L4.789 4.488a1 1 0 000 1.788l4.764 2.382a1 1 0 00.894 0l4.764-2.382zM4.447 8.342A1 1 0 003 9.236V15a1 1 0 00.553.894l4 2A1 1 0 009 17v-5.764a1 1 0 00-.553-.894l-4-2z"/>
+    </svg>
+    """
+  end
+
+  def currency_bangladeshi(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 4a1 1 0 000 2 1 1 0 011 1v1H7a1 1 0 000 2h1v3a3 3 0 106 0v-1a1 1 0 10-2 0v1a1 1 0 11-2 0v-3h3a1 1 0 100-2h-3V7a3 3 0 00-3-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def currency_dollar(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8.433 7.418c.155-.103.346-.196.567-.267v1.698a2.305 2.305 0 01-.567-.267C8.07 8.34 8 8.114 8 8c0-.114.07-.34.433-.582zM11 12.849v-1.698c.22.071.412.164.567.267.364.243.433.468.433.582 0 .114-.07.34-.433.582a2.305 2.305 0 01-.567.267z"/>
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676.662C6.602 6.234 6 7.009 6 8c0 .99.602 1.765 1.324 2.246.48.32 1.054.545 1.676.662v1.941c-.391-.127-.68-.317-.843-.504a1 1 0 10-1.51 1.31c.562.649 1.413 1.076 2.353 1.253V15a1 1 0 102 0v-.092a4.535 4.535 0 001.676-.662C13.398 13.766 14 12.991 14 12c0-.99-.602-1.765-1.324-2.246A4.535 4.535 0 0011 9.092V7.151c.391.127.68.317.843.504a1 1 0 101.511-1.31c-.563-.649-1.413-1.076-2.354-1.253V5z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def currency_euro(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.736 6.979C9.208 6.193 9.696 6 10 6c.304 0 .792.193 1.264.979a1 1 0 001.715-1.029C12.279 4.784 11.232 4 10 4s-2.279.784-2.979 1.95c-.285.475-.507 1-.67 1.55H6a1 1 0 000 2h.013a9.358 9.358 0 000 1H6a1 1 0 100 2h.351c.163.55.385 1.075.67 1.55C7.721 15.216 8.768 16 10 16s2.279-.784 2.979-1.95a1 1 0 10-1.715-1.029c-.472.786-.96.979-1.264.979-.304 0-.792-.193-1.264-.979a4.265 4.265 0 01-.264-.521H10a1 1 0 100-2H8.017a7.36 7.36 0 010-1H10a1 1 0 100-2H8.472c.08-.185.167-.36.264-.521z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def currency_pound(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-14a3 3 0 00-3 3v2H7a1 1 0 000 2h1v1a1 1 0 01-1 1 1 1 0 100 2h6a1 1 0 100-2H9.83c.11-.313.17-.65.17-1v-1h1a1 1 0 100-2h-1V7a1 1 0 112 0 1 1 0 102 0 3 3 0 00-3-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def currency_rupee(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 5a1 1 0 100 2h1a2 2 0 011.732 1H7a1 1 0 100 2h2.732A2 2 0 018 11H7a1 1 0 00-.707 1.707l3 3a1 1 0 001.414-1.414l-1.483-1.484A4.008 4.008 0 0011.874 10H13a1 1 0 100-2h-1.126a3.976 3.976 0 00-.41-1H13a1 1 0 100-2H7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def currency_yen(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7.858 5.485a1 1 0 00-1.715 1.03L7.633 9H7a1 1 0 100 2h1.834l.166.277V12H7a1 1 0 100 2h2v1a1 1 0 102 0v-1h2a1 1 0 100-2h-2v-.723l.166-.277H13a1 1 0 100-2h-.634l1.492-2.486a1 1 0 10-1.716-1.029L10.034 9h-.068L7.858 5.485z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def cursor_click(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6.672 1.911a1 1 0 10-1.932.518l.259.966a1 1 0 001.932-.518l-.26-.966zM2.429 4.74a1 1 0 10-.517 1.932l.966.259a1 1 0 00.517-1.932l-.966-.26zm8.814-.569a1 1 0 00-1.415-1.414l-.707.707a1 1 0 101.415 1.415l.707-.708zm-7.071 7.072l.707-.707A1 1 0 003.465 9.12l-.708.707a1 1 0 001.415 1.415zm3.2-5.171a1 1 0 00-1.3 1.3l4 10a1 1 0 001.823.075l1.38-2.759 3.018 3.02a1 1 0 001.414-1.415l-3.019-3.02 2.76-1.379a1 1 0 00-.076-1.822l-10-4z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -488,7 +1170,7 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def music_note(assigns) do
+  def desktop_computer(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -498,12 +1180,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M18 3a1 1 0 00-1.196-.98l-10 2A1 1 0 006 5v9.114A4.369 4.369 0 005 14c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V7.82l8-1.6v5.894A4.37 4.37 0 0015 12c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V3z"/>
+      <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def paper_clip(assigns) do
+  def device_mobile(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -513,83 +1195,7 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def logout(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 3a1 1 0 00-1 1v12a1 1 0 102 0V4a1 1 0 00-1-1zm10.293 9.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L14.586 9H7a1 1 0 100 2h7.586l-1.293 1.293z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def rss(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M5 3a1 1 0 000 2c5.523 0 10 4.477 10 10a1 1 0 102 0C17 8.373 11.627 3 5 3z"/>
-      <path d="M4 9a1 1 0 011-1 7 7 0 017 7 1 1 0 11-2 0 5 5 0 00-5-5 1 1 0 01-1-1zM3 15a2 2 0 114 0 2 2 0 01-4 0z"/>
-    </svg>
-    """
-  end
-
-  def folder(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
-    </svg>
-    """
-  end
-
-  def document_download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v3.586l-1.293-1.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 11.586V8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def currency_rupee(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 5a1 1 0 100 2h1a2 2 0 011.732 1H7a1 1 0 100 2h2.732A2 2 0 018 11H7a1 1 0 00-.707 1.707l3 3a1 1 0 001.414-1.414l-1.483-1.484A4.008 4.008 0 0011.874 10H13a1 1 0 100-2h-1.126a3.976 3.976 0 00-.41-1H13a1 1 0 100-2H7z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M7 2a2 2 0 00-2 2v12a2 2 0 002 2h6a2 2 0 002-2V4a2 2 0 00-2-2H7zm3 14a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -609,7 +1215,7 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def key(assigns) do
+  def document_add(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -619,12 +1225,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V8z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def arrow_circle_left(assigns) do
+  def document_download(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -634,384 +1240,7 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.707-10.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L9.414 11H13a1 1 0 100-2H9.414l1.293-1.293z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def bookmark_alt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V5zm11 1H6v8l4-2 4 2V6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def cube_transparent(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M9.504 1.132a1 1 0 01.992 0l1.75 1a1 1 0 11-.992 1.736L10 3.152l-1.254.716a1 1 0 11-.992-1.736l1.75-1zM5.618 4.504a1 1 0 01-.372 1.364L5.016 6l.23.132a1 1 0 11-.992 1.736L4 7.723V8a1 1 0 01-2 0V6a.996.996 0 01.52-.878l1.734-.99a1 1 0 011.364.372zm8.764 0a1 1 0 011.364-.372l1.733.99A1.002 1.002 0 0118 6v2a1 1 0 11-2 0v-.277l-.254.145a1 1 0 11-.992-1.736l.23-.132-.23-.132a1 1 0 01-.372-1.364zm-7 4a1 1 0 011.364-.372L10 8.848l1.254-.716a1 1 0 11.992 1.736L11 10.58V12a1 1 0 11-2 0v-1.42l-1.246-.712a1 1 0 01-.372-1.364zM3 11a1 1 0 011 1v1.42l1.246.712a1 1 0 11-.992 1.736l-1.75-1A1 1 0 012 14v-2a1 1 0 011-1zm14 0a1 1 0 011 1v2a1 1 0 01-.504.868l-1.75 1a1 1 0 11-.992-1.736L16 13.42V12a1 1 0 011-1zm-9.618 5.504a1 1 0 011.364-.372l.254.145V16a1 1 0 112 0v.277l.254-.145a1 1 0 11.992 1.736l-1.735.992a.995.995 0 01-1.022 0l-1.735-.992a1 1 0 01-.372-1.364z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def emoji_happy(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 100-2 1 1 0 000 2zm7-1a1 1 0 11-2 0 1 1 0 012 0zm-.464 5.535a1 1 0 10-1.415-1.414 3 3 0 01-4.242 0 1 1 0 00-1.415 1.414 5 5 0 007.072 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def currency_pound(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-14a3 3 0 00-3 3v2H7a1 1 0 000 2h1v1a1 1 0 01-1 1 1 1 0 100 2h6a1 1 0 100-2H9.83c.11-.313.17-.65.17-1v-1h1a1 1 0 100-2h-1V7a1 1 0 112 0 1 1 0 102 0 3 3 0 00-3-3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def view_list(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def view_grid(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
-    </svg>
-    """
-  end
-
-  def cloud_download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M2 9.5A3.5 3.5 0 005.5 13H9v2.586l-1.293-1.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 15.586V13h2.5a4.5 4.5 0 10-.616-8.958 4.002 4.002 0 10-7.753 1.977A3.5 3.5 0 002 9.5zm9 3.5H9V8a1 1 0 012 0v5z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def check_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def speakerphone(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M18 3a1 1 0 00-1.447-.894L8.763 6H5a3 3 0 000 6h.28l1.771 5.316A1 1 0 008 18h1a1 1 0 001-1v-4.382l6.553 3.276A1 1 0 0018 15V3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def server(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v2a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm14 1a1 1 0 11-2 0 1 1 0 012 0zM2 13a2 2 0 012-2h12a2 2 0 012 2v2a2 2 0 01-2 2H4a2 2 0 01-2-2v-2zm14 1a1 1 0 11-2 0 1 1 0 012 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def backspace(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M6.707 4.879A3 3 0 018.828 4H15a3 3 0 013 3v6a3 3 0 01-3 3H8.828a3 3 0 01-2.12-.879l-4.415-4.414a1 1 0 010-1.414l4.414-4.414zm4 2.414a1 1 0 00-1.414 1.414L10.586 10l-1.293 1.293a1 1 0 101.414 1.414L12 11.414l1.293 1.293a1 1 0 001.414-1.414L13.414 10l1.293-1.293a1 1 0 00-1.414-1.414L12 8.586l-1.293-1.293z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def switch_vertical(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M5 12a1 1 0 102 0V6.414l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L5 6.414V12zM15 8a1 1 0 10-2 0v5.586l-1.293-1.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L15 13.586V8z"/>
-    </svg>
-    """
-  end
-
-  def user_group(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z"/>
-    </svg>
-    """
-  end
-
-  def sun(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def clock(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chevron_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def shield_exclamation(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 1.944A11.954 11.954 0 012.166 5C2.056 5.649 2 6.319 2 7c0 5.225 3.34 9.67 8 11.317C14.66 16.67 18 12.225 18 7c0-.682-.057-1.35-.166-2.001A11.954 11.954 0 0110 1.944zM11 14a1 1 0 11-2 0 1 1 0 012 0zm0-7a1 1 0 10-2 0v3a1 1 0 102 0V7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def plus_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chevron_double_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M4.293 15.707a1 1 0 010-1.414l5-5a1 1 0 011.414 0l5 5a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414 0zm0-6a1 1 0 010-1.414l5-5a1 1 0 011.414 0l5 5a1 1 0 01-1.414 1.414L10 5.414 5.707 9.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def clipboard(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M8 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z"/>
-      <path d="M6 3a2 2 0 00-2 2v11a2 2 0 002 2h8a2 2 0 002-2V5a2 2 0 00-2-2 3 3 0 01-3 3H9a3 3 0 01-3-3z"/>
-    </svg>
-    """
-  end
-
-  def variable(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M4.649 3.084A1 1 0 015.163 4.4 13.95 13.95 0 004 10c0 1.993.416 3.886 1.164 5.6a1 1 0 01-1.832.8A15.95 15.95 0 012 10c0-2.274.475-4.44 1.332-6.4a1 1 0 011.317-.516zM12.96 7a3 3 0 00-2.342 1.126l-.328.41-.111-.279A2 2 0 008.323 7H8a1 1 0 000 2h.323l.532 1.33-1.035 1.295a1 1 0 01-.781.375H7a1 1 0 100 2h.039a3 3 0 002.342-1.126l.328-.41.111.279A2 2 0 0011.677 14H12a1 1 0 100-2h-.323l-.532-1.33 1.035-1.295A1 1 0 0112.961 9H13a1 1 0 100-2h-.039zm1.874-2.6a1 1 0 011.833-.8A15.95 15.95 0 0118 10c0 2.274-.475 4.44-1.332 6.4a1 1 0 11-1.832-.8A13.949 13.949 0 0016 10c0-1.993-.416-3.886-1.165-5.6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chat_alt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zM7 8H5v2h2V8zm2 0h2v2H9V8zm6 0h-2v2h2V8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def folder_add(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
-      <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11h4m-2-2v4"/>
+      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v3.586l-1.293-1.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 11.586V8z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -1032,128 +1261,6 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def calculator(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V4a2 2 0 00-2-2H6zm1 2a1 1 0 000 2h6a1 1 0 100-2H7zm6 7a1 1 0 011 1v3a1 1 0 11-2 0v-3a1 1 0 011-1zm-3 3a1 1 0 100 2h.01a1 1 0 100-2H10zm-4 1a1 1 0 011-1h.01a1 1 0 110 2H7a1 1 0 01-1-1zm1-4a1 1 0 100 2h.01a1 1 0 100-2H7zm2 1a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm4-4a1 1 0 100 2h.01a1 1 0 100-2H13zM9 9a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zM7 8a1 1 0 000 2h.01a1 1 0 000-2H7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def mail(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"/>
-      <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z"/>
-    </svg>
-    """
-  end
-
-  def location_marker(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def annotation(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M18 13V5a2 2 0 00-2-2H4a2 2 0 00-2 2v8a2 2 0 002 2h3l3 3 3-3h3a2 2 0 002-2zM5 7a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1zm1 3a1 1 0 100 2h3a1 1 0 100-2H6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_sm_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5.293 9.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L11 7.414V15a1 1 0 11-2 0V7.414L6.707 9.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_4(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 7a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 13a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def cursor_click(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M6.672 1.911a1 1 0 10-1.932.518l.259.966a1 1 0 001.932-.518l-.26-.966zM2.429 4.74a1 1 0 10-.517 1.932l.966.259a1 1 0 00.517-1.932l-.966-.26zm8.814-.569a1 1 0 00-1.415-1.414l-.707.707a1 1 0 101.415 1.415l.707-.708zm-7.071 7.072l.707-.707A1 1 0 003.465 9.12l-.708.707a1 1 0 001.415 1.415zm3.2-5.171a1 1 0 00-1.3 1.3l4 10a1 1 0 001.823.075l1.38-2.759 3.018 3.02a1 1 0 001.414-1.415l-3.019-3.02 2.76-1.379a1 1 0 00-.076-1.822l-10-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def eye_off(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clip-rule="evenodd"/>
-      <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z"/>
-    </svg>
-    """
-  end
-
   def document_remove(assigns) do
     assigns =
       assigns
@@ -1169,7 +1276,7 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def printer(assigns) do
+  def document_report(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -1179,461 +1286,7 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5 4v3H4a2 2 0 00-2 2v3a2 2 0 002 2h1v2a2 2 0 002 2h6a2 2 0 002-2v-2h1a2 2 0 002-2V9a2 2 0 00-2-2h-1V4a2 2 0 00-2-2H7a2 2 0 00-2 2zm8 0H7v3h6V4zm0 8H7v4h6v-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def search(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def paper_airplane(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112 0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z"/>
-    </svg>
-    """
-  end
-
-  def template(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zM3 10a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zM14 9a1 1 0 00-1 1v6a1 1 0 001 1h2a1 1 0 001-1v-6a1 1 0 00-1-1h-2z"/>
-    </svg>
-    """
-  end
-
-  def chevron_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def x_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def ticket(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M2 6a2 2 0 012-2h12a2 2 0 012 2v2a2 2 0 100 4v2a2 2 0 01-2 2H4a2 2 0 01-2-2v-2a2 2 0 100-4V6z"/>
-    </svg>
-    """
-  end
-
-  def arrow_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M16.707 10.293a1 1 0 010 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 111.414-1.414L9 14.586V3a1 1 0 012 0v11.586l4.293-4.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def globe_alt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M4.083 9h1.946c.089-1.546.383-2.97.837-4.118A6.004 6.004 0 004.083 9zM10 2a8 8 0 100 16 8 8 0 000-16zm0 2c-.076 0-.232.032-.465.262-.238.234-.497.623-.737 1.182-.389.907-.673 2.142-.766 3.556h3.936c-.093-1.414-.377-2.649-.766-3.556-.24-.56-.5-.948-.737-1.182C10.232 4.032 10.076 4 10 4zm3.971 5c-.089-1.546-.383-2.97-.837-4.118A6.004 6.004 0 0115.917 9h-1.946zm-2.003 2H8.032c.093 1.414.377 2.649.766 3.556.24.56.5.948.737 1.182.233.23.389.262.465.262.076 0 .232-.032.465-.262.238-.234.498-.623.737-1.182.389-.907.673-2.142.766-3.556zm1.166 4.118c.454-1.147.748-2.572.837-4.118h1.946a6.004 6.004 0 01-2.783 4.118zm-6.268 0C6.412 13.97 6.118 12.546 6.03 11H4.083a6.004 6.004 0 002.783 4.118z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def cloud(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M5.5 16a3.5 3.5 0 01-.369-6.98 4 4 0 117.753-1.977A4.5 4.5 0 1113.5 16h-8z"/>
-    </svg>
-    """
-  end
-
-  def cloud_upload(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M5.5 13a3.5 3.5 0 01-.369-6.98 4 4 0 117.753-1.977A4.5 4.5 0 1113.5 13H11V9.413l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13H5.5z"/>
-      <path d="M9 13h2v5a1 1 0 11-2 0v-5z"/>
-    </svg>
-    """
-  end
-
-  def currency_bangladeshi(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 4a1 1 0 000 2 1 1 0 011 1v1H7a1 1 0 000 2h1v3a3 3 0 106 0v-1a1 1 0 10-2 0v1a1 1 0 11-2 0v-3h3a1 1 0 100-2h-3V7a3 3 0 00-3-3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def eye(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
-      <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_sm_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M9.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L7.414 9H15a1 1 0 110 2H7.414l2.293 2.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def lightning_bolt(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def hand(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M9 3a1 1 0 012 0v5.5a.5.5 0 001 0V4a1 1 0 112 0v4.5a.5.5 0 001 0V6a1 1 0 112 0v5a7 7 0 11-14 0V9a1 1 0 012 0v2.5a.5.5 0 001 0V4a1 1 0 012 0v4.5a.5.5 0 001 0V3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def clipboard_list(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/>
-      <path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def dots_circle_horizontal(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def video_camera(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M2 6a2 2 0 012-2h6a2 2 0 012 2v8a2 2 0 01-2 2H4a2 2 0 01-2-2V6zM14.553 7.106A1 1 0 0014 8v4a1 1 0 00.553.894l2 1A1 1 0 0018 13V7a1 1 0 00-1.447-.894l-2 1z"/>
-    </svg>
-    """
-  end
-
-  def phone(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
-    </svg>
-    """
-  end
-
-  def save_as(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M9.707 7.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L13 8.586V5h3a2 2 0 012 2v5a2 2 0 01-2 2H8a2 2 0 01-2-2V7a2 2 0 012-2h3v3.586L9.707 7.293zM11 3a1 1 0 112 0v2h-2V3z"/>
-      <path d="M4 9a2 2 0 00-2 2v5a2 2 0 002 2h8a2 2 0 002-2H4V9z"/>
-    </svg>
-    """
-  end
-
-  def user_remove(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M11 6a3 3 0 11-6 0 3 3 0 016 0zM14 17a6 6 0 00-12 0h12zM13 8a1 1 0 100 2h4a1 1 0 100-2h-4z"/>
-    </svg>
-    """
-  end
-
-  def filter(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 11.414V15a1 1 0 01-.293.707l-2 2A1 1 0 018 17v-5.586L3.293 6.707A1 1 0 013 6V3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def thumb_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M18 9.5a1.5 1.5 0 11-3 0v-6a1.5 1.5 0 013 0v6zM14 9.667v-5.43a2 2 0 00-1.105-1.79l-.05-.025A4 4 0 0011.055 2H5.64a2 2 0 00-1.962 1.608l-1.2 6A2 2 0 004.44 12H8v4a2 2 0 002 2 1 1 0 001-1v-.667a4 4 0 01.8-2.4l1.4-1.866a4 4 0 00.8-2.4z"/>
-    </svg>
-    """
-  end
-
-  def sparkles(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5 2a1 1 0 011 1v1h1a1 1 0 010 2H6v1a1 1 0 01-2 0V6H3a1 1 0 010-2h1V3a1 1 0 011-1zm0 10a1 1 0 011 1v1h1a1 1 0 110 2H6v1a1 1 0 11-2 0v-1H3a1 1 0 110-2h1v-1a1 1 0 011-1zM12 2a1 1 0 01.967.744L14.146 7.2 17.5 9.134a1 1 0 010 1.732l-3.354 1.935-1.18 4.455a1 1 0 01-1.933 0L9.854 12.8 6.5 10.866a1 1 0 010-1.732l3.354-1.935 1.18-4.455A1 1 0 0112 2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def volume_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM14.657 2.929a1 1 0 011.414 0A9.972 9.972 0 0119 10a9.972 9.972 0 01-2.929 7.071 1 1 0 01-1.414-1.414A7.971 7.971 0 0017 10c0-2.21-.894-4.208-2.343-5.657a1 1 0 010-1.414zm-2.829 2.828a1 1 0 011.415 0A5.983 5.983 0 0115 10a5.984 5.984 0 01-1.757 4.243 1 1 0 01-1.415-1.415A3.984 3.984 0 0013 10a3.983 3.983 0 00-1.172-2.828 1 1 0 010-1.415z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def rewind(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M8.445 14.832A1 1 0 0010 14v-2.798l5.445 3.63A1 1 0 0017 14V6a1 1 0 00-1.555-.832L10 8.798V6a1 1 0 00-1.555-.832l-6 4a1 1 0 000 1.664l6 4z"/>
-    </svg>
-    """
-  end
-
-  def trending_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M12 13a1 1 0 100 2h5a1 1 0 001-1V9a1 1 0 10-2 0v2.586l-4.293-4.293a1 1 0 00-1.414 0L8 9.586 3.707 5.293a1 1 0 00-1.414 1.414l5 5a1 1 0 001.414 0L11 9.414 14.586 13H12z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def mail_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M2.94 6.412A2 2 0 002 8.108V16a2 2 0 002 2h12a2 2 0 002-2V8.108a2 2 0 00-.94-1.696l-6-3.75a2 2 0 00-2.12 0l-6 3.75zm2.615 2.423a1 1 0 10-1.11 1.664l5 3.333a1 1 0 001.11 0l5-3.333a1 1 0 00-1.11-1.664L10 11.798 5.555 8.835z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def question_mark_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def upload(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm2 10a1 1 0 10-2 0v3a1 1 0 102 0v-3zm2-3a1 1 0 011 1v5a1 1 0 11-2 0v-5a1 1 0 011-1zm4-1a1 1 0 10-2 0v7a1 1 0 102 0V8z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -1654,7 +1307,7 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def users(assigns) do
+  def document_text(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -1664,12 +1317,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z"/>
+      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def menu_alt_1(assigns) do
+  def document(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -1679,12 +1332,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def scale(assigns) do
+  def dots_circle_horizontal(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -1694,567 +1347,7 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1.323l3.954 1.582 1.599-.8a1 1 0 01.894 1.79l-1.233.616 1.738 5.42a1 1 0 01-.285 1.05A3.989 3.989 0 0115 15a3.989 3.989 0 01-2.667-1.019 1 1 0 01-.285-1.05l1.715-5.349L11 6.477V16h2a1 1 0 110 2H7a1 1 0 110-2h2V6.477L6.237 7.582l1.715 5.349a1 1 0 01-.285 1.05A3.989 3.989 0 015 15a3.989 3.989 0 01-2.667-1.019 1 1 0 01-.285-1.05l1.738-5.42-1.233-.617a1 1 0 01.894-1.788l1.599.799L9 4.323V3a1 1 0 011-1zm-5 8.274l-.818 2.552c.25.112.526.174.818.174.292 0 .569-.062.818-.174L5 10.274zm10 0l-.818 2.552c.25.112.526.174.818.174.292 0 .569-.062.818-.174L15 10.274z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def lock_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M10 2a5 5 0 00-5 5v2a2 2 0 00-2 2v5a2 2 0 002 2h10a2 2 0 002-2v-5a2 2 0 00-2-2H7V7a3 3 0 015.905-.75 1 1 0 001.937-.5A5.002 5.002 0 0010 2z"/>
-    </svg>
-    """
-  end
-
-  def chat(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def external_link(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"/>
-      <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"/>
-    </svg>
-    """
-  end
-
-  def chat_alt_2(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M2 5a2 2 0 012-2h7a2 2 0 012 2v4a2 2 0 01-2 2H9l-3 3v-3H4a2 2 0 01-2-2V5z"/>
-      <path d="M15 7v2a4 4 0 01-4 4H9.828l-1.766 1.767c.28.149.599.233.938.233h2l3 3v-3h2a2 2 0 002-2V9a2 2 0 00-2-2h-1z"/>
-    </svg>
-    """
-  end
-
-  def arrow_circle_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def translate(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M7 2a1 1 0 011 1v1h3a1 1 0 110 2H9.578a18.87 18.87 0 01-1.724 4.78c.29.354.596.696.914 1.026a1 1 0 11-1.44 1.389c-.188-.196-.373-.396-.554-.6a19.098 19.098 0 01-3.107 3.567 1 1 0 01-1.334-1.49 17.087 17.087 0 003.13-3.733 18.992 18.992 0 01-1.487-2.494 1 1 0 111.79-.89c.234.47.489.928.764 1.372.417-.934.752-1.913.997-2.927H3a1 1 0 110-2h3V3a1 1 0 011-1zm6 6a1 1 0 01.894.553l2.991 5.982a.869.869 0 01.02.037l.99 1.98a1 1 0 11-1.79.895L15.383 16h-4.764l-.724 1.447a1 1 0 11-1.788-.894l.99-1.98.019-.038 2.99-5.982A1 1 0 0113 8zm-1.382 6h2.764L13 11.236 11.618 14z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def user(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def presentation_chart_bar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11 4a1 1 0 10-2 0v4a1 1 0 102 0V7zm-3 1a1 1 0 10-2 0v3a1 1 0 102 0V8zM8 9a1 1 0 00-2 0v2a1 1 0 102 0V9z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def cash(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def cake(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M6 3a1 1 0 011-1h.01a1 1 0 010 2H7a1 1 0 01-1-1zm2 3a1 1 0 00-2 0v1a2 2 0 00-2 2v1a2 2 0 00-2 2v.683a3.7 3.7 0 011.055.485 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0 3.704 3.704 0 014.11 0 1.704 1.704 0 001.89 0A3.7 3.7 0 0118 12.683V12a2 2 0 00-2-2V9a2 2 0 00-2-2V6a1 1 0 10-2 0v1h-1V6a1 1 0 10-2 0v1H8V6zm10 8.868a3.704 3.704 0 01-4.055-.036 1.704 1.704 0 00-1.89 0 3.704 3.704 0 01-4.11 0 1.704 1.704 0 00-1.89 0A3.704 3.704 0 012 14.868V17a1 1 0 001 1h14a1 1 0 001-1v-2.132zM9 3a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm3 0a1 1 0 011-1h.01a1 1 0 110 2H13a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def home(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/>
-    </svg>
-    """
-  end
-
-  def volume_off(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM12.293 7.293a1 1 0 011.414 0L15 8.586l1.293-1.293a1 1 0 111.414 1.414L16.414 10l1.293 1.293a1 1 0 01-1.414 1.414L15 11.414l-1.293 1.293a1 1 0 01-1.414-1.414L13.586 10l-1.293-1.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M12.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def stop(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8 7a1 1 0 00-1 1v4a1 1 0 001 1h4a1 1 0 001-1V8a1 1 0 00-1-1H8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def badge_check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def moon(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
-    </svg>
-    """
-  end
-
-  def tag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M17.707 9.293a1 1 0 010 1.414l-7 7a1 1 0 01-1.414 0l-7-7A.997.997 0 012 10V5a3 3 0 013-3h5c.256 0 .512.098.707.293l7 7zM5 6a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def sort_ascending(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M3 3a1 1 0 000 2h11a1 1 0 100-2H3zM3 7a1 1 0 000 2h5a1 1 0 000-2H3zM3 11a1 1 0 100 2h4a1 1 0 100-2H3zM13 16a1 1 0 102 0v-5.586l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 101.414 1.414L13 10.414V16z"/>
-    </svg>
-    """
-  end
-
-  def folder_download(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
-      <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v4m0 0l-2-2m2 2l2-2"/>
-    </svg>
-    """
-  end
-
-  def terminal(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm3.293 1.293a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 01-1.414-1.414L7.586 10 5.293 7.707a1 1 0 010-1.414zM11 12a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def receipt_refund(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5 2a2 2 0 00-2 2v14l3.5-2 3.5 2 3.5-2 3.5 2V4a2 2 0 00-2-2H5zm4.707 3.707a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L8.414 9H10a3 3 0 013 3v1a1 1 0 102 0v-1a5 5 0 00-5-5H8.414l1.293-1.293z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def office_building(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h8a2 2 0 012 2v12a1 1 0 110 2h-3a1 1 0 01-1-1v-2a1 1 0 00-1-1H9a1 1 0 00-1 1v2a1 1 0 01-1 1H4a1 1 0 110-2V4zm3 1h2v2H7V5zm2 4H7v2h2V9zm2-4h2v2h-2V5zm2 4h-2v2h2V9z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5.293 7.707a1 1 0 010-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 01-1.414 1.414L11 5.414V17a1 1 0 11-2 0V5.414L6.707 7.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrows_expand(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19 20" fill="currentColor">
-      <path stroke="#374151" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8V4m0 0h4M3 4l4 4m8 0V4m0 0h-4m4 0l-4 4m-8 4v4m0 0h4m-4 0l4-4m8 4l-4-4m4 4v-4m0 4h-4"/>
-    </svg>
-    """
-  end
-
-  def adjustments(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M5 4a1 1 0 00-2 0v7.268a2 2 0 000 3.464V16a1 1 0 102 0v-1.268a2 2 0 000-3.464V4zM11 4a1 1 0 10-2 0v1.268a2 2 0 000 3.464V16a1 1 0 102 0V8.732a2 2 0 000-3.464V4zM16 3a1 1 0 011 1v7.268a2 2 0 010 3.464V16a1 1 0 11-2 0v-1.268a2 2 0 010-3.464V4a1 1 0 011-1z"/>
-    </svg>
-    """
-  end
-
-  def arrow_sm_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M14.707 10.293a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 111.414-1.414L9 12.586V5a1 1 0 012 0v7.586l2.293-2.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def shield_check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def qrcode(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm2 2V5h1v1H5zM3 13a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1v-3zm2 2v-1h1v1H5zM13 3a1 1 0 00-1 1v3a1 1 0 001 1h3a1 1 0 001-1V4a1 1 0 00-1-1h-3zm1 2v1h1V5h-1z" clip-rule="evenodd"/>
-      <path d="M11 4a1 1 0 10-2 0v1a1 1 0 002 0V4zM10 7a1 1 0 011 1v1h2a1 1 0 110 2h-3a1 1 0 01-1-1V8a1 1 0 011-1zM16 9a1 1 0 100 2 1 1 0 000-2zM9 13a1 1 0 011-1h1a1 1 0 110 2v2a1 1 0 11-2 0v-3zM7 11a1 1 0 100-2H4a1 1 0 100 2h3zM17 13a1 1 0 01-1 1h-2a1 1 0 110-2h2a1 1 0 011 1zM16 17a1 1 0 100-2h-3a1 1 0 100 2h3z"/>
-    </svg>
-    """
-  end
-
-  def status_offline(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M3.707 2.293a1 1 0 00-1.414 1.414l6.921 6.922c.05.062.105.118.168.167l6.91 6.911a1 1 0 001.415-1.414l-.675-.675a9.001 9.001 0 00-.668-11.982A1 1 0 1014.95 5.05a7.002 7.002 0 01.657 9.143l-1.435-1.435a5.002 5.002 0 00-.636-6.294A1 1 0 0012.12 7.88c.924.923 1.12 2.3.587 3.415l-1.992-1.992a.922.922 0 00-.018-.018l-6.99-6.991zM3.238 8.187a1 1 0 00-1.933-.516c-.8 3-.025 6.336 2.331 8.693a1 1 0 001.414-1.415 6.997 6.997 0 01-1.812-6.762zM7.4 11.5a1 1 0 10-1.73 1c.214.371.48.72.795 1.035a1 1 0 001.414-1.414c-.191-.191-.35-.4-.478-.622z"/>
-    </svg>
-    """
-  end
-
-  def map(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M12 1.586l-4 4v12.828l4-4V1.586zM3.707 3.293A1 1 0 002 4v10a1 1 0 00.293.707L6 18.414V5.586L3.707 3.293zM17.707 5.293L14 1.586v12.828l2.293 2.293A1 1 0 0018 16V6a1 1 0 00-.293-.707z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def document_add(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def at_symbol(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M14.243 5.757a6 6 0 10-.986 9.284 1 1 0 111.087 1.678A8 8 0 1118 10a3 3 0 01-4.8 2.401A4 4 0 1114 10a1 1 0 102 0c0-1.537-.586-3.07-1.757-4.243zM12 10a2 2 0 10-4 0 2 2 0 004 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def credit_card(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M4 4a2 2 0 00-2 2v1h16V6a2 2 0 00-2-2H4z"/>
-      <path fill-rule="evenodd" d="M18 9H2v5a2 2 0 002 2h12a2 2 0 002-2V9zM4 13a1 1 0 011-1h1a1 1 0 110 2H5a1 1 0 01-1-1zm5-1a1 1 0 100 2h1a1 1 0 100-2H9z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def globe(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM4.332 8.027a6.012 6.012 0 011.912-2.706C6.512 5.73 6.974 6 7.5 6A1.5 1.5 0 019 7.5V8a2 2 0 004 0 2 2 0 011.523-1.943A5.977 5.977 0 0116 10c0 .34-.028.675-.083 1H15a2 2 0 00-2 2v2.197A5.973 5.973 0 0110 16v-2a2 2 0 00-2-2 2 2 0 01-2-2 2 2 0 00-1.668-1.973z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def sort_descending(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M3 3a1 1 0 000 2h11a1 1 0 100-2H3zM3 7a1 1 0 000 2h7a1 1 0 100-2H3zM3 11a1 1 0 100 2h4a1 1 0 100-2H3zM15 8a1 1 0 10-2 0v5.586l-1.293-1.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L15 13.586V8z"/>
-    </svg>
-    """
-  end
-
-  def trash(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def shopping_cart(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M3 1a1 1 0 000 2h1.22l.305 1.222a.997.997 0 00.01.042l1.358 5.43-.893.892C3.74 11.846 4.632 14 6.414 14H15a1 1 0 000-2H6.414l1-1H14a1 1 0 00.894-.553l3-6A1 1 0 0017 3H6.28l-.31-1.243A1 1 0 005 1H3zM16 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM6.5 18a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/>
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -2274,310 +1367,6 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def chip(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M13 7H7v6h6V7z"/>
-      <path fill-rule="evenodd" d="M7 2a1 1 0 012 0v1h2V2a1 1 0 112 0v1h2a2 2 0 012 2v2h1a1 1 0 110 2h-1v2h1a1 1 0 110 2h-1v2a2 2 0 01-2 2h-2v1a1 1 0 11-2 0v-1H9v1a1 1 0 11-2 0v-1H5a2 2 0 01-2-2v-2H2a1 1 0 110-2h1V9H2a1 1 0 010-2h1V5a2 2 0 012-2h2V2zM5 5h10v10H5V5z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def zoom_out(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"/>
-      <path fill-rule="evenodd" d="M5 8a1 1 0 011-1h4a1 1 0 110 2H6a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def photograph(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chevron_double_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10.293 15.707a1 1 0 010-1.414L14.586 10l-4.293-4.293a1 1 0 111.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-      <path fill-rule="evenodd" d="M4.293 15.707a1 1 0 010-1.414L8.586 10 4.293 5.707a1 1 0 011.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def shopping_bag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 2a4 4 0 00-4 4v1H5a1 1 0 00-.994.89l-1 9A1 1 0 004 18h12a1 1 0 00.994-1.11l-1-9A1 1 0 0015 7h-1V6a4 4 0 00-4-4zm2 5V6a2 2 0 10-4 0v1h4zm-6 3a1 1 0 112 0 1 1 0 01-2 0zm7-1a1 1 0 100 2 1 1 0 000-2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def puzzle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M10 3.5a1.5 1.5 0 013 0V4a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-.5a1.5 1.5 0 000 3h.5a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-.5a1.5 1.5 0 00-3 0v.5a1 1 0 01-1 1H6a1 1 0 01-1-1v-3a1 1 0 00-1-1h-.5a1.5 1.5 0 010-3H4a1 1 0 001-1V6a1 1 0 011-1h3a1 1 0 001-1v-.5z"/>
-    </svg>
-    """
-  end
-
-  def beaker(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M7 2a1 1 0 00-.707 1.707L7 4.414v3.758a1 1 0 01-.293.707l-4 4C.817 14.769 2.156 18 4.828 18h10.343c2.673 0 4.012-3.231 2.122-5.121l-4-4A1 1 0 0113 8.172V4.414l.707-.707A1 1 0 0013 2H7zm2 6.172V4h2v4.172a3 3 0 00.879 2.12l1.027 1.028a4 4 0 00-2.171.102l-.47.156a4 4 0 01-2.53 0l-.563-.187a1.993 1.993 0 00-.114-.035l1.063-1.063A3 3 0 009 8.172z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def desktop_computer(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def gift(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5 5a3 3 0 015-2.236A3 3 0 0114.83 6H16a2 2 0 110 4h-5V9a1 1 0 10-2 0v1H4a2 2 0 110-4h1.17C5.06 5.687 5 5.35 5 5zm4 1V5a1 1 0 10-1 1h1zm3 0a1 1 0 10-1-1v1h1z" clip-rule="evenodd"/>
-      <path d="M9 11H3v5a2 2 0 002 2h4v-7zM11 18h4a2 2 0 002-2v-5h-6v7z"/>
-    </svg>
-    """
-  end
-
-  def plus(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def thumb_up(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M2 10.5a1.5 1.5 0 113 0v6a1.5 1.5 0 01-3 0v-6zM6 10.333v5.43a2 2 0 001.106 1.79l.05.025A4 4 0 008.943 18h5.416a2 2 0 001.962-1.608l1.2-6A2 2 0 0015.56 8H12V4a2 2 0 00-2-2 1 1 0 00-1 1v.667a4 4 0 01-.8 2.4L6.8 7.933a4 4 0 00-.8 2.4z"/>
-    </svg>
-    """
-  end
-
-  def check(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def minus_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 000 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def minus(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chevron_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def microphone(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M7 4a3 3 0 016 0v4a3 3 0 11-6 0V4zm4 10.93A7.001 7.001 0 0017 8a1 1 0 10-2 0A5 5 0 015 8a1 1 0 00-2 0 7.001 7.001 0 006 6.93V17H6a1 1 0 100 2h8a1 1 0 100-2h-3v-2.07z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def link(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def currency_yen(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7.858 5.485a1 1 0 00-1.715 1.03L7.633 9H7a1 1 0 100 2h1.834l.166.277V12H7a1 1 0 100 2h2v1a1 1 0 102 0v-1h2a1 1 0 100-2h-2v-.723l.166-.277H13a1 1 0 100-2h-.634l1.492-2.486a1 1 0 10-1.716-1.029L10.034 9h-.068L7.858 5.485z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def table(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5 4a3 3 0 00-3 3v6a3 3 0 003 3h10a3 3 0 003-3V7a3 3 0 00-3-3H5zm-1 9v-1h5v2H5a1 1 0 01-1-1zm7 1h4a1 1 0 001-1v-1h-5v2zm0-4h5V8h-5v2zM9 8H4v2h5V8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def minus_sm(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5 10a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
   def dots_vertical(assigns) do
     assigns =
       assigns
@@ -2593,7 +1382,7 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def arrow_up(assigns) do
+  def download(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -2603,556 +1392,7 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3.293 9.707a1 1 0 010-1.414l6-6a1 1 0 011.414 0l6 6a1 1 0 01-1.414 1.414L11 5.414V17a1 1 0 11-2 0V5.414L4.707 9.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def emoji_sad(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 100-2 1 1 0 000 2zm7-1a1 1 0 11-2 0 1 1 0 012 0zm-7.536 5.879a1 1 0 001.415 0 3 3 0 014.242 0 1 1 0 001.415-1.415 5 5 0 00-7.072 0 1 1 0 000 1.415z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def scissors(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5.5 2a3.5 3.5 0 101.665 6.58L8.585 10l-1.42 1.42a3.5 3.5 0 101.414 1.414l8.128-8.127a1 1 0 00-1.414-1.414L10 8.586l-1.42-1.42A3.5 3.5 0 005.5 2zM4 5.5a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zm0 9a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z" clip-rule="evenodd"/>
-      <path d="M12.828 11.414a1 1 0 00-1.414 1.414l3.879 3.88a1 1 0 001.414-1.415l-3.879-3.879z"/>
-    </svg>
-    """
-  end
-
-  def cog(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def arrow_circle_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 1.414L10.586 9H7a1 1 0 100 2h3.586l-1.293 1.293a1 1 0 101.414 1.414l3-3a1 1 0 000-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def pencil(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/>
-    </svg>
-    """
-  end
-
-  def phone_outgoing(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M17.924 2.617a.997.997 0 00-.215-.322l-.004-.004A.997.997 0 0017 2h-4a1 1 0 100 2h1.586l-3.293 3.293a1 1 0 001.414 1.414L16 5.414V7a1 1 0 102 0V3a.997.997 0 00-.076-.383z"/>
-      <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
-    </svg>
-    """
-  end
-
-  def code(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def pause(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chart_square_bar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5 3a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2H5zm9 4a1 1 0 10-2 0v6a1 1 0 102 0V7zm-3 2a1 1 0 10-2 0v4a1 1 0 102 0V9zm-3 3a1 1 0 10-2 0v1a1 1 0 102 0v-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def exclamation_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def play(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_2(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def chevron_double_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M15.707 15.707a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 010 1.414zm-6 0a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 011.414 1.414L5.414 10l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def status_online(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5.05 3.636a1 1 0 010 1.414 7 7 0 000 9.9 1 1 0 11-1.414 1.414 9 9 0 010-12.728 1 1 0 011.414 0zm9.9 0a1 1 0 011.414 0 9 9 0 010 12.728 1 1 0 11-1.414-1.414 7 7 0 000-9.9 1 1 0 010-1.414zM7.879 6.464a1 1 0 010 1.414 3 3 0 000 4.243 1 1 0 11-1.415 1.414 5 5 0 010-7.07 1 1 0 011.415 0zm4.242 0a1 1 0 011.415 0 5 5 0 010 7.072 1 1 0 01-1.415-1.415 3 3 0 000-4.242 1 1 0 010-1.415zM10 9a1 1 0 011 1v.01a1 1 0 11-2 0V10a1 1 0 011-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def bookmark(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z"/>
-    </svg>
-    """
-  end
-
-  def refresh(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def x(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def receipt_tax(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5 2a2 2 0 00-2 2v14l3.5-2 3.5 2 3.5-2 3.5 2V4a2 2 0 00-2-2H5zm2.5 3a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm6.207.293a1 1 0 00-1.414 0l-6 6a1 1 0 101.414 1.414l6-6a1 1 0 000-1.414zM12.5 10a1.5 1.5 0 100 3 1.5 1.5 0 000-3z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def support(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-2 0c0 .993-.241 1.929-.668 2.754l-1.524-1.525a3.997 3.997 0 00.078-2.183l1.562-1.562C15.802 8.249 16 9.1 16 10zm-5.165 3.913l1.58 1.58A5.98 5.98 0 0110 16a5.976 5.976 0 01-2.516-.552l1.562-1.562a4.006 4.006 0 001.789.027zm-4.677-2.796a4.002 4.002 0 01-.041-2.08l-.08.08-1.53-1.533A5.98 5.98 0 004 10c0 .954.223 1.856.619 2.657l1.54-1.54zm1.088-6.45A5.974 5.974 0 0110 4c.954 0 1.856.223 2.657.619l-1.54 1.54a4.002 4.002 0 00-2.346.033L7.246 4.668zM12 10a2 2 0 11-4 0 2 2 0 014 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def exclamation(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def phone_incoming(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M14.414 7l3.293-3.293a1 1 0 00-1.414-1.414L13 5.586V4a1 1 0 10-2 0v4.003a.996.996 0 00.617.921A.997.997 0 0012 9h4a1 1 0 100-2h-1.586z"/>
-      <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
-    </svg>
-    """
-  end
-
-  def arrow_right(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def truck(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M8 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM15 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z"/>
-      <path d="M3 4a1 1 0 00-1 1v10a1 1 0 001 1h1.05a2.5 2.5 0 014.9 0H10a1 1 0 001-1V5a1 1 0 00-1-1H3zM14 7a1 1 0 00-1 1v6.05A2.5 2.5 0 0115.95 16H17a1 1 0 001-1v-5a1 1 0 00-.293-.707l-2-2A1 1 0 0015 7h-1z"/>
-    </svg>
-    """
-  end
-
-  def zoom_in(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M5 8a1 1 0 011-1h1V6a1 1 0 012 0v1h1a1 1 0 110 2H9v1a1 1 0 11-2 0V9H6a1 1 0 01-1-1z"/>
-      <path fill-rule="evenodd" d="M2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8zm6-4a4 4 0 100 8 4 4 0 000-8z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def inbox(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M5 3a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2H5zm0 2h10v7h-2l-1 2H8l-1-2H5V5z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def hashtag(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M9.243 3.03a1 1 0 01.727 1.213L9.53 6h2.94l.56-2.243a1 1 0 111.94.486L14.53 6H17a1 1 0 110 2h-2.97l-1 4H15a1 1 0 110 2h-2.47l-.56 2.242a1 1 0 11-1.94-.485L10.47 14H7.53l-.56 2.242a1 1 0 11-1.94-.485L5.47 14H3a1 1 0 110-2h2.97l1-4H5a1 1 0 110-2h2.47l.56-2.243a1 1 0 011.213-.727zM9.03 8l-1 4h2.938l1-4H9.031z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def plus_sm(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def inbox_in(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M8.707 7.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l2-2a1 1 0 00-1.414-1.414L11 7.586V3a1 1 0 10-2 0v4.586l-.293-.293z"/>
-      <path d="M3 5a2 2 0 012-2h1a1 1 0 010 2H5v7h2l1 2h4l1-2h2V5h-1a1 1 0 110-2h1a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V5z"/>
-    </svg>
-    """
-  end
-
-  def user_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-6-3a2 2 0 11-4 0 2 2 0 014 0zm-2 4a5 5 0 00-4.546 2.916A5.986 5.986 0 0010 16a5.986 5.986 0 004.546-2.084A5 5 0 0010 11z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def light_bulb(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M11 3a1 1 0 10-2 0v1a1 1 0 102 0V3zM15.657 5.757a1 1 0 00-1.414-1.414l-.707.707a1 1 0 001.414 1.414l.707-.707zM18 10a1 1 0 01-1 1h-1a1 1 0 110-2h1a1 1 0 011 1zM5.05 6.464A1 1 0 106.464 5.05l-.707-.707a1 1 0 00-1.414 1.414l.707.707zM5 10a1 1 0 01-1 1H3a1 1 0 110-2h1a1 1 0 011 1zM8 16v-1h4v1a2 2 0 11-4 0zM12 14c.015-.34.208-.646.477-.859a4 4 0 10-4.954 0c.27.213.462.519.476.859h4.002z"/>
-    </svg>
-    """
-  end
-
-  def calendar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def folder_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M2 6a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1H8a3 3 0 00-3 3v1.5a1.5 1.5 0 01-3 0V6z" clip-rule="evenodd"/>
-      <path d="M6 12a2 2 0 012-2h8a2 2 0 012 2v2a2 2 0 01-2 2H2h2a2 2 0 002-2v-2z"/>
-    </svg>
-    """
-  end
-
-  def arrow_narrow_left(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M7.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l2.293 2.293a1 1 0 010 1.414z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def book_open(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M9 4.804A7.968 7.968 0 005.5 4c-1.255 0-2.443.29-3.5.804v10A7.969 7.969 0 015.5 14c1.669 0 3.218.51 4.5 1.385A7.962 7.962 0 0114.5 14c1.255 0 2.443.29 3.5.804v-10A7.968 7.968 0 0014.5 4c-1.255 0-2.443.29-3.5.804V12a1 1 0 11-2 0V4.804z"/>
-    </svg>
-    """
-  end
-
-  def folder_remove(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
-      <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11h4"/>
-    </svg>
-    """
-  end
-
-  def briefcase(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M6 6V5a3 3 0 013-3h2a3 3 0 013 3v1h2a2 2 0 012 2v3.57A22.952 22.952 0 0110 13a22.95 22.95 0 01-8-1.43V8a2 2 0 012-2h2zm2-1a1 1 0 011-1h2a1 1 0 011 1v1H8V5zm1 5a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clip-rule="evenodd"/>
-      <path d="M2 13.692V16a2 2 0 002 2h12a2 2 0 002-2v-2.308A24.974 24.974 0 0110 15c-2.796 0-5.487-.46-8-1.308z"/>
+      <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -3173,7 +1413,7 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def star(assigns) do
+  def emoji_happy(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -3183,7 +1423,115 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 100-2 1 1 0 000 2zm7-1a1 1 0 11-2 0 1 1 0 012 0zm-.464 5.535a1 1 0 10-1.415-1.414 3 3 0 01-4.242 0 1 1 0 00-1.415 1.414 5 5 0 007.072 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def emoji_sad(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 100-2 1 1 0 000 2zm7-1a1 1 0 11-2 0 1 1 0 012 0zm-7.536 5.879a1 1 0 001.415 0 3 3 0 014.242 0 1 1 0 001.415-1.415 5 5 0 00-7.072 0 1 1 0 000 1.415z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def exclamation_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def exclamation(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def external_link(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"/>
+      <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"/>
+    </svg>
+    """
+  end
+
+  def eye_off(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clip-rule="evenodd"/>
+      <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z"/>
+    </svg>
+    """
+  end
+
+  def eye(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
+      <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def fast_forward(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M4.555 5.168A1 1 0 003 6v8a1 1 0 001.555.832L10 11.202V14a1 1 0 001.555.832l6-4a1 1 0 000-1.664l-6-4A1 1 0 0010 6v2.798l-5.445-3.63z"/>
     </svg>
     """
   end
@@ -3203,6 +1551,38 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
+  def filter(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 11.414V15a1 1 0 01-.293.707l-2 2A1 1 0 018 17v-5.586L3.293 6.707A1 1 0 013 6V3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def finger_print(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M6.625 2.655A9 9 0 0119 11a1 1 0 11-2 0 7 7 0 00-9.625-6.492 1 1 0 11-.75-1.853zM4.662 4.959A1 1 0 014.75 6.37 6.97 6.97 0 003 11a1 1 0 11-2 0 8.97 8.97 0 012.25-5.953 1 1 0 011.412-.088z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M5 11a5 5 0 1110 0 1 1 0 11-2 0 3 3 0 10-6 0c0 1.677-.345 3.276-.968 4.729a1 1 0 11-1.838-.789A9.964 9.964 0 005 11zm8.921 2.012a1 1 0 01.831 1.145 19.86 19.86 0 01-.545 2.436 1 1 0 11-1.92-.558c.207-.713.371-1.445.49-2.192a1 1 0 011.144-.83z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M10 10a1 1 0 011 1c0 2.236-.46 4.368-1.29 6.304a1 1 0 01-1.838-.789A13.952 13.952 0 009 11a1 1 0 011-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
   def fire(assigns) do
     assigns =
       assigns
@@ -3218,7 +1598,7 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def clipboard_copy(assigns) do
+  def flag(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -3228,13 +1608,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M8 2a1 1 0 000 2h2a1 1 0 100-2H8z"/>
-      <path d="M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z"/>
+      <path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd"/>
     </svg>
     """
   end
 
-  def document(assigns) do
+  def folder_add(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -3244,12 +1623,13 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/>
+      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
+      <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11h4m-2-2v4"/>
     </svg>
     """
   end
 
-  def bell(assigns) do
+  def folder_download(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -3259,7 +1639,659 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z"/>
+      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
+      <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v4m0 0l-2-2m2 2l2-2"/>
+    </svg>
+    """
+  end
+
+  def folder_open(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2 6a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1H8a3 3 0 00-3 3v1.5a1.5 1.5 0 01-3 0V6z" clip-rule="evenodd"/>
+      <path d="M6 12a2 2 0 012-2h8a2 2 0 012 2v2a2 2 0 01-2 2H2h2a2 2 0 002-2v-2z"/>
+    </svg>
+    """
+  end
+
+  def folder_remove(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
+      <path stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11h4"/>
+    </svg>
+    """
+  end
+
+  def folder(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/>
+    </svg>
+    """
+  end
+
+  def gift(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 5a3 3 0 015-2.236A3 3 0 0114.83 6H16a2 2 0 110 4h-5V9a1 1 0 10-2 0v1H4a2 2 0 110-4h1.17C5.06 5.687 5 5.35 5 5zm4 1V5a1 1 0 10-1 1h1zm3 0a1 1 0 10-1-1v1h1z" clip-rule="evenodd"/>
+      <path d="M9 11H3v5a2 2 0 002 2h4v-7zM11 18h4a2 2 0 002-2v-5h-6v7z"/>
+    </svg>
+    """
+  end
+
+  def globe_alt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4.083 9h1.946c.089-1.546.383-2.97.837-4.118A6.004 6.004 0 004.083 9zM10 2a8 8 0 100 16 8 8 0 000-16zm0 2c-.076 0-.232.032-.465.262-.238.234-.497.623-.737 1.182-.389.907-.673 2.142-.766 3.556h3.936c-.093-1.414-.377-2.649-.766-3.556-.24-.56-.5-.948-.737-1.182C10.232 4.032 10.076 4 10 4zm3.971 5c-.089-1.546-.383-2.97-.837-4.118A6.004 6.004 0 0115.917 9h-1.946zm-2.003 2H8.032c.093 1.414.377 2.649.766 3.556.24.56.5.948.737 1.182.233.23.389.262.465.262.076 0 .232-.032.465-.262.238-.234.498-.623.737-1.182.389-.907.673-2.142.766-3.556zm1.166 4.118c.454-1.147.748-2.572.837-4.118h1.946a6.004 6.004 0 01-2.783 4.118zm-6.268 0C6.412 13.97 6.118 12.546 6.03 11H4.083a6.004 6.004 0 002.783 4.118z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def globe(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM4.332 8.027a6.012 6.012 0 011.912-2.706C6.512 5.73 6.974 6 7.5 6A1.5 1.5 0 019 7.5V8a2 2 0 004 0 2 2 0 011.523-1.943A5.977 5.977 0 0116 10c0 .34-.028.675-.083 1H15a2 2 0 00-2 2v2.197A5.973 5.973 0 0110 16v-2a2 2 0 00-2-2 2 2 0 01-2-2 2 2 0 00-1.668-1.973z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def hand(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9 3a1 1 0 012 0v5.5a.5.5 0 001 0V4a1 1 0 112 0v4.5a.5.5 0 001 0V6a1 1 0 112 0v5a7 7 0 11-14 0V9a1 1 0 012 0v2.5a.5.5 0 001 0V4a1 1 0 012 0v4.5a.5.5 0 001 0V3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def hashtag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9.243 3.03a1 1 0 01.727 1.213L9.53 6h2.94l.56-2.243a1 1 0 111.94.486L14.53 6H17a1 1 0 110 2h-2.97l-1 4H15a1 1 0 110 2h-2.47l-.56 2.242a1 1 0 11-1.94-.485L10.47 14H7.53l-.56 2.242a1 1 0 11-1.94-.485L5.47 14H3a1 1 0 110-2h2.97l1-4H5a1 1 0 110-2h2.47l.56-2.243a1 1 0 011.213-.727zM9.03 8l-1 4h2.938l1-4H9.031z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def heart(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def home(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/>
+    </svg>
+    """
+  end
+
+  def identification(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 2a1 1 0 00-1 1v1a1 1 0 002 0V3a1 1 0 00-1-1zM4 4h3a3 3 0 006 0h3a2 2 0 012 2v9a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2zm2.5 7a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm2.45 4a2.5 2.5 0 10-4.9 0h4.9zM12 9a1 1 0 100 2h3a1 1 0 100-2h-3zm-1 4a1 1 0 011-1h2a1 1 0 110 2h-2a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def inbox_in(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8.707 7.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l2-2a1 1 0 00-1.414-1.414L11 7.586V3a1 1 0 10-2 0v4.586l-.293-.293z"/>
+      <path d="M3 5a2 2 0 012-2h1a1 1 0 010 2H5v7h2l1 2h4l1-2h2V5h-1a1 1 0 110-2h1a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V5z"/>
+    </svg>
+    """
+  end
+
+  def inbox(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 3a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2H5zm0 2h10v7h-2l-1 2H8l-1-2H5V5z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def information_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def key(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def library(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10.496 2.132a1 1 0 00-.992 0l-7 4A1 1 0 003 8v7a1 1 0 100 2h14a1 1 0 100-2V8a1 1 0 00.496-1.868l-7-4zM6 9a1 1 0 00-1 1v3a1 1 0 102 0v-3a1 1 0 00-1-1zm3 1a1 1 0 012 0v3a1 1 0 11-2 0v-3zm5-1a1 1 0 00-1 1v3a1 1 0 102 0v-3a1 1 0 00-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def light_bulb(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M11 3a1 1 0 10-2 0v1a1 1 0 102 0V3zM15.657 5.757a1 1 0 00-1.414-1.414l-.707.707a1 1 0 001.414 1.414l.707-.707zM18 10a1 1 0 01-1 1h-1a1 1 0 110-2h1a1 1 0 011 1zM5.05 6.464A1 1 0 106.464 5.05l-.707-.707a1 1 0 00-1.414 1.414l.707.707zM5 10a1 1 0 01-1 1H3a1 1 0 110-2h1a1 1 0 011 1zM8 16v-1h4v1a2 2 0 11-4 0zM12 14c.015-.34.208-.646.477-.859a4 4 0 10-4.954 0c.27.213.462.519.476.859h4.002z"/>
+    </svg>
+    """
+  end
+
+  def lightning_bolt(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def link(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def location_marker(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def lock_closed(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def lock_open(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10 2a5 5 0 00-5 5v2a2 2 0 00-2 2v5a2 2 0 002 2h10a2 2 0 002-2v-5a2 2 0 00-2-2H7V7a3 3 0 015.905-.75 1 1 0 001.937-.5A5.002 5.002 0 0010 2z"/>
+    </svg>
+    """
+  end
+
+  def login(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 3a1 1 0 011 1v12a1 1 0 11-2 0V4a1 1 0 011-1zm7.707 3.293a1 1 0 010 1.414L9.414 9H17a1 1 0 110 2H9.414l1.293 1.293a1 1 0 01-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def logout(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 3a1 1 0 00-1 1v12a1 1 0 102 0V4a1 1 0 00-1-1zm10.293 9.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L14.586 9H7a1 1 0 100 2h7.586l-1.293 1.293z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def mail_open(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2.94 6.412A2 2 0 002 8.108V16a2 2 0 002 2h12a2 2 0 002-2V8.108a2 2 0 00-.94-1.696l-6-3.75a2 2 0 00-2.12 0l-6 3.75zm2.615 2.423a1 1 0 10-1.11 1.664l5 3.333a1 1 0 001.11 0l5-3.333a1 1 0 00-1.11-1.664L10 11.798 5.555 8.835z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def mail(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"/>
+      <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z"/>
+    </svg>
+    """
+  end
+
+  def map(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12 1.586l-4 4v12.828l4-4V1.586zM3.707 3.293A1 1 0 002 4v10a1 1 0 00.293.707L6 18.414V5.586L3.707 3.293zM17.707 5.293L14 1.586v12.828l2.293 2.293A1 1 0 0018 16V6a1 1 0 00-.293-.707z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def menu_alt_1(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def menu_alt_2(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def menu_alt_3(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM9 15a1 1 0 011-1h6a1 1 0 110 2h-6a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def menu_alt_4(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 7a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 13a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def menu(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def microphone(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M7 4a3 3 0 016 0v4a3 3 0 11-6 0V4zm4 10.93A7.001 7.001 0 0017 8a1 1 0 10-2 0A5 5 0 015 8a1 1 0 00-2 0 7.001 7.001 0 006 6.93V17H6a1 1 0 100 2h8a1 1 0 100-2h-3v-2.07z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def minus_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 000 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def minus_sm(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 10a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def minus(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def moon(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
+    </svg>
+    """
+  end
+
+  def music_note(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M18 3a1 1 0 00-1.196-.98l-10 2A1 1 0 006 5v9.114A4.369 4.369 0 005 14c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V7.82l8-1.6v5.894A4.37 4.37 0 0015 12c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V3z"/>
+    </svg>
+    """
+  end
+
+  def newspaper(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h8a2 2 0 012 2v10a2 2 0 002 2H4a2 2 0 01-2-2V5zm3 1h6v4H5V6zm6 6H5v2h6v-2z" clip-rule="evenodd"/>
+      <path d="M15 7h1a2 2 0 012 2v5.5a1.5 1.5 0 01-3 0V7z"/>
+    </svg>
+    """
+  end
+
+  def office_building(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h8a2 2 0 012 2v12a1 1 0 110 2h-3a1 1 0 01-1-1v-2a1 1 0 00-1-1H9a1 1 0 00-1 1v2a1 1 0 01-1 1H4a1 1 0 110-2V4zm3 1h2v2H7V5zm2 4H7v2h2V9zm2-4h2v2h-2V5zm2 4h-2v2h2V9z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def paper_airplane(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112 0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z"/>
+    </svg>
+    """
+  end
+
+  def paper_clip(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def pause(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/>
     </svg>
     """
   end
@@ -3280,7 +2312,7 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
-  def login(assigns) do
+  def pencil(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -3290,12 +2322,12 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 3a1 1 0 011 1v12a1 1 0 11-2 0V4a1 1 0 011-1zm7.707 3.293a1 1 0 010 1.414L9.414 9H17a1 1 0 110 2H9.414l1.293 1.293a1 1 0 01-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0z" clip-rule="evenodd"/>
+      <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/>
     </svg>
     """
   end
 
-  def presentation_chart_line(assigns) do
+  def phone_incoming(assigns) do
     assigns =
       assigns
       |> assign_new(:class, fn -> "h-5 w-5" end)
@@ -3305,174 +2337,8 @@ defmodule PetalComponents.Heroicons.Solid do
 
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 0l-2 2a1 1 0 101.414 1.414L8 10.414l1.293 1.293a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def information_circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def view_boards(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M2 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1H3a1 1 0 01-1-1V4zM8 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1H9a1 1 0 01-1-1V4zM15 3a1 1 0 00-1 1v12a1 1 0 001 1h2a1 1 0 001-1V4a1 1 0 00-1-1h-2z"/>
-    </svg>
-    """
-  end
-
-  def device_mobile(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M7 2a2 2 0 00-2 2v12a2 2 0 002 2h6a2 2 0 002-2V4a2 2 0 00-2-2H7zm3 14a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def currency_dollar(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M8.433 7.418c.155-.103.346-.196.567-.267v1.698a2.305 2.305 0 01-.567-.267C8.07 8.34 8 8.114 8 8c0-.114.07-.34.433-.582zM11 12.849v-1.698c.22.071.412.164.567.267.364.243.433.468.433.582 0 .114-.07.34-.433.582a2.305 2.305 0 01-.567.267z"/>
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676.662C6.602 6.234 6 7.009 6 8c0 .99.602 1.765 1.324 2.246.48.32 1.054.545 1.676.662v1.941c-.391-.127-.68-.317-.843-.504a1 1 0 10-1.51 1.31c.562.649 1.413 1.076 2.353 1.253V15a1 1 0 102 0v-.092a4.535 4.535 0 001.676-.662C13.398 13.766 14 12.991 14 12c0-.99-.602-1.765-1.324-2.246A4.535 4.535 0 0011 9.092V7.151c.391.127.68.317.843.504a1 1 0 101.511-1.31c-.563-.649-1.413-1.076-2.354-1.253V5z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def identification(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 2a1 1 0 00-1 1v1a1 1 0 002 0V3a1 1 0 00-1-1zM4 4h3a3 3 0 006 0h3a2 2 0 012 2v9a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2zm2.5 7a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm2.45 4a2.5 2.5 0 10-4.9 0h4.9zM12 9a1 1 0 100 2h3a1 1 0 100-2h-3zm-1 4a1 1 0 011-1h2a1 1 0 110 2h-2a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def ban(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M13.477 14.89A6 6 0 015.11 6.524l8.367 8.368zm1.414-1.414L6.524 5.11a6 6 0 018.367 8.367zM18 10a8 8 0 11-16 0 8 8 0 0116 0z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def menu(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def save(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M7.707 10.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 11.586V6h5a2 2 0 012 2v7a2 2 0 01-2 2H4a2 2 0 01-2-2V8a2 2 0 012-2h5v5.586l-1.293-1.293zM9 4a1 1 0 012 0v2H9V4z"/>
-    </svg>
-    """
-  end
-
-  def arrow_circle_down(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v3.586L7.707 9.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 10.586V7z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def archive(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path d="M4 3a2 2 0 100 4h12a2 2 0 100-4H4z"/>
-      <path fill-rule="evenodd" d="M3 8h14v7a2 2 0 01-2 2H5a2 2 0 01-2-2V8zm5 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z" clip-rule="evenodd"/>
-    </svg>
-    """
-  end
-
-  def menu_alt_3(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:class, fn -> "h-5 w-5" end)
-      |> assign_new(:extra_attributes, fn ->
-        assigns_to_attributes(assigns, [:class])
-      end)
-
-    ~H"""
-    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM9 15a1 1 0 011-1h6a1 1 0 110 2h-6a1 1 0 01-1-1z" clip-rule="evenodd"/>
+      <path d="M14.414 7l3.293-3.293a1 1 0 00-1.414-1.414L13 5.586V4a1 1 0 10-2 0v4.003a.996.996 0 00.617.921A.997.997 0 0012 9h4a1 1 0 100-2h-1.586z"/>
+      <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
     </svg>
     """
   end
@@ -3493,6 +2359,868 @@ defmodule PetalComponents.Heroicons.Solid do
     """
   end
 
+  def phone_outgoing(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M17.924 2.617a.997.997 0 00-.215-.322l-.004-.004A.997.997 0 0017 2h-4a1 1 0 100 2h1.586l-3.293 3.293a1 1 0 001.414 1.414L16 5.414V7a1 1 0 102 0V3a.997.997 0 00-.076-.383z"/>
+      <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
+    </svg>
+    """
+  end
+
+  def phone(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/>
+    </svg>
+    """
+  end
+
+  def photograph(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def play(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def plus_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def plus_sm(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def plus(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def presentation_chart_bar(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11 4a1 1 0 10-2 0v4a1 1 0 102 0V7zm-3 1a1 1 0 10-2 0v3a1 1 0 102 0V8zM8 9a1 1 0 00-2 0v2a1 1 0 102 0V9z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def presentation_chart_line(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 0l-2 2a1 1 0 101.414 1.414L8 10.414l1.293 1.293a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def printer(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 4v3H4a2 2 0 00-2 2v3a2 2 0 002 2h1v2a2 2 0 002 2h6a2 2 0 002-2v-2h1a2 2 0 002-2V9a2 2 0 00-2-2h-1V4a2 2 0 00-2-2H7a2 2 0 00-2 2zm8 0H7v3h6V4zm0 8H7v4h6v-4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def puzzle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M10 3.5a1.5 1.5 0 013 0V4a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-.5a1.5 1.5 0 000 3h.5a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-.5a1.5 1.5 0 00-3 0v.5a1 1 0 01-1 1H6a1 1 0 01-1-1v-3a1 1 0 00-1-1h-.5a1.5 1.5 0 010-3H4a1 1 0 001-1V6a1 1 0 011-1h3a1 1 0 001-1v-.5z"/>
+    </svg>
+    """
+  end
+
+  def qrcode(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm2 2V5h1v1H5zM3 13a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1v-3zm2 2v-1h1v1H5zM13 3a1 1 0 00-1 1v3a1 1 0 001 1h3a1 1 0 001-1V4a1 1 0 00-1-1h-3zm1 2v1h1V5h-1z" clip-rule="evenodd"/>
+      <path d="M11 4a1 1 0 10-2 0v1a1 1 0 002 0V4zM10 7a1 1 0 011 1v1h2a1 1 0 110 2h-3a1 1 0 01-1-1V8a1 1 0 011-1zM16 9a1 1 0 100 2 1 1 0 000-2zM9 13a1 1 0 011-1h1a1 1 0 110 2v2a1 1 0 11-2 0v-3zM7 11a1 1 0 100-2H4a1 1 0 100 2h3zM17 13a1 1 0 01-1 1h-2a1 1 0 110-2h2a1 1 0 011 1zM16 17a1 1 0 100-2h-3a1 1 0 100 2h3z"/>
+    </svg>
+    """
+  end
+
+  def question_mark_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def receipt_refund(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 2a2 2 0 00-2 2v14l3.5-2 3.5 2 3.5-2 3.5 2V4a2 2 0 00-2-2H5zm4.707 3.707a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L8.414 9H10a3 3 0 013 3v1a1 1 0 102 0v-1a5 5 0 00-5-5H8.414l1.293-1.293z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def receipt_tax(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 2a2 2 0 00-2 2v14l3.5-2 3.5 2 3.5-2 3.5 2V4a2 2 0 00-2-2H5zm2.5 3a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm6.207.293a1 1 0 00-1.414 0l-6 6a1 1 0 101.414 1.414l6-6a1 1 0 000-1.414zM12.5 10a1.5 1.5 0 100 3 1.5 1.5 0 000-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def refresh(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def reply(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M7.707 3.293a1 1 0 010 1.414L5.414 7H11a7 7 0 017 7v2a1 1 0 11-2 0v-2a5 5 0 00-5-5H5.414l2.293 2.293a1 1 0 11-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def rewind(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8.445 14.832A1 1 0 0010 14v-2.798l5.445 3.63A1 1 0 0017 14V6a1 1 0 00-1.555-.832L10 8.798V6a1 1 0 00-1.555-.832l-6 4a1 1 0 000 1.664l6 4z"/>
+    </svg>
+    """
+  end
+
+  def rss(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 3a1 1 0 000 2c5.523 0 10 4.477 10 10a1 1 0 102 0C17 8.373 11.627 3 5 3z"/>
+      <path d="M4 9a1 1 0 011-1 7 7 0 017 7 1 1 0 11-2 0 5 5 0 00-5-5 1 1 0 01-1-1zM3 15a2 2 0 114 0 2 2 0 01-4 0z"/>
+    </svg>
+    """
+  end
+
+  def save_as(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9.707 7.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L13 8.586V5h3a2 2 0 012 2v5a2 2 0 01-2 2H8a2 2 0 01-2-2V7a2 2 0 012-2h3v3.586L9.707 7.293zM11 3a1 1 0 112 0v2h-2V3z"/>
+      <path d="M4 9a2 2 0 00-2 2v5a2 2 0 002 2h8a2 2 0 002-2H4V9z"/>
+    </svg>
+    """
+  end
+
+  def save(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M7.707 10.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 11.586V6h5a2 2 0 012 2v7a2 2 0 01-2 2H4a2 2 0 01-2-2V8a2 2 0 012-2h5v5.586l-1.293-1.293zM9 4a1 1 0 012 0v2H9V4z"/>
+    </svg>
+    """
+  end
+
+  def scale(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1.323l3.954 1.582 1.599-.8a1 1 0 01.894 1.79l-1.233.616 1.738 5.42a1 1 0 01-.285 1.05A3.989 3.989 0 0115 15a3.989 3.989 0 01-2.667-1.019 1 1 0 01-.285-1.05l1.715-5.349L11 6.477V16h2a1 1 0 110 2H7a1 1 0 110-2h2V6.477L6.237 7.582l1.715 5.349a1 1 0 01-.285 1.05A3.989 3.989 0 015 15a3.989 3.989 0 01-2.667-1.019 1 1 0 01-.285-1.05l1.738-5.42-1.233-.617a1 1 0 01.894-1.788l1.599.799L9 4.323V3a1 1 0 011-1zm-5 8.274l-.818 2.552c.25.112.526.174.818.174.292 0 .569-.062.818-.174L5 10.274zm10 0l-.818 2.552c.25.112.526.174.818.174.292 0 .569-.062.818-.174L15 10.274z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def scissors(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5.5 2a3.5 3.5 0 101.665 6.58L8.585 10l-1.42 1.42a3.5 3.5 0 101.414 1.414l8.128-8.127a1 1 0 00-1.414-1.414L10 8.586l-1.42-1.42A3.5 3.5 0 005.5 2zM4 5.5a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zm0 9a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z" clip-rule="evenodd"/>
+      <path d="M12.828 11.414a1 1 0 00-1.414 1.414l3.879 3.88a1 1 0 001.414-1.415l-3.879-3.879z"/>
+    </svg>
+    """
+  end
+
+  def search_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9 9a2 2 0 114 0 2 2 0 01-4 0z"/>
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a4 4 0 00-3.446 6.032l-2.261 2.26a1 1 0 101.414 1.415l2.261-2.261A4 4 0 1011 5z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def search(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def selector(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def server(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v2a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm14 1a1 1 0 11-2 0 1 1 0 012 0zM2 13a2 2 0 012-2h12a2 2 0 012 2v2a2 2 0 01-2 2H4a2 2 0 01-2-2v-2zm14 1a1 1 0 11-2 0 1 1 0 012 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def share(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M15 8a3 3 0 10-2.977-2.63l-4.94 2.47a3 3 0 100 4.319l4.94 2.47a3 3 0 10.895-1.789l-4.94-2.47a3.027 3.027 0 000-.74l4.94-2.47C13.456 7.68 14.19 8 15 8z"/>
+    </svg>
+    """
+  end
+
+  def shield_check(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def shield_exclamation(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 1.944A11.954 11.954 0 012.166 5C2.056 5.649 2 6.319 2 7c0 5.225 3.34 9.67 8 11.317C14.66 16.67 18 12.225 18 7c0-.682-.057-1.35-.166-2.001A11.954 11.954 0 0110 1.944zM11 14a1 1 0 11-2 0 1 1 0 012 0zm0-7a1 1 0 10-2 0v3a1 1 0 102 0V7z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def shopping_bag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 2a4 4 0 00-4 4v1H5a1 1 0 00-.994.89l-1 9A1 1 0 004 18h12a1 1 0 00.994-1.11l-1-9A1 1 0 0015 7h-1V6a4 4 0 00-4-4zm2 5V6a2 2 0 10-4 0v1h4zm-6 3a1 1 0 112 0 1 1 0 01-2 0zm7-1a1 1 0 100 2 1 1 0 000-2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def shopping_cart(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M3 1a1 1 0 000 2h1.22l.305 1.222a.997.997 0 00.01.042l1.358 5.43-.893.892C3.74 11.846 4.632 14 6.414 14H15a1 1 0 000-2H6.414l1-1H14a1 1 0 00.894-.553l3-6A1 1 0 0017 3H6.28l-.31-1.243A1 1 0 005 1H3zM16 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM6.5 18a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/>
+    </svg>
+    """
+  end
+
+  def sort_ascending(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M3 3a1 1 0 000 2h11a1 1 0 100-2H3zM3 7a1 1 0 000 2h5a1 1 0 000-2H3zM3 11a1 1 0 100 2h4a1 1 0 100-2H3zM13 16a1 1 0 102 0v-5.586l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 101.414 1.414L13 10.414V16z"/>
+    </svg>
+    """
+  end
+
+  def sort_descending(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M3 3a1 1 0 000 2h11a1 1 0 100-2H3zM3 7a1 1 0 000 2h7a1 1 0 100-2H3zM3 11a1 1 0 100 2h4a1 1 0 100-2H3zM15 8a1 1 0 10-2 0v5.586l-1.293-1.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L15 13.586V8z"/>
+    </svg>
+    """
+  end
+
+  def sparkles(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 2a1 1 0 011 1v1h1a1 1 0 010 2H6v1a1 1 0 01-2 0V6H3a1 1 0 010-2h1V3a1 1 0 011-1zm0 10a1 1 0 011 1v1h1a1 1 0 110 2H6v1a1 1 0 11-2 0v-1H3a1 1 0 110-2h1v-1a1 1 0 011-1zM12 2a1 1 0 01.967.744L14.146 7.2 17.5 9.134a1 1 0 010 1.732l-3.354 1.935-1.18 4.455a1 1 0 01-1.933 0L9.854 12.8 6.5 10.866a1 1 0 010-1.732l3.354-1.935 1.18-4.455A1 1 0 0112 2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def speakerphone(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 3a1 1 0 00-1.447-.894L8.763 6H5a3 3 0 000 6h.28l1.771 5.316A1 1 0 008 18h1a1 1 0 001-1v-4.382l6.553 3.276A1 1 0 0018 15V3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def star(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
+    </svg>
+    """
+  end
+
+  def status_offline(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M3.707 2.293a1 1 0 00-1.414 1.414l6.921 6.922c.05.062.105.118.168.167l6.91 6.911a1 1 0 001.415-1.414l-.675-.675a9.001 9.001 0 00-.668-11.982A1 1 0 1014.95 5.05a7.002 7.002 0 01.657 9.143l-1.435-1.435a5.002 5.002 0 00-.636-6.294A1 1 0 0012.12 7.88c.924.923 1.12 2.3.587 3.415l-1.992-1.992a.922.922 0 00-.018-.018l-6.99-6.991zM3.238 8.187a1 1 0 00-1.933-.516c-.8 3-.025 6.336 2.331 8.693a1 1 0 001.414-1.415 6.997 6.997 0 01-1.812-6.762zM7.4 11.5a1 1 0 10-1.73 1c.214.371.48.72.795 1.035a1 1 0 001.414-1.414c-.191-.191-.35-.4-.478-.622z"/>
+    </svg>
+    """
+  end
+
+  def status_online(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5.05 3.636a1 1 0 010 1.414 7 7 0 000 9.9 1 1 0 11-1.414 1.414 9 9 0 010-12.728 1 1 0 011.414 0zm9.9 0a1 1 0 011.414 0 9 9 0 010 12.728 1 1 0 11-1.414-1.414 7 7 0 000-9.9 1 1 0 010-1.414zM7.879 6.464a1 1 0 010 1.414 3 3 0 000 4.243 1 1 0 11-1.415 1.414 5 5 0 010-7.07 1 1 0 011.415 0zm4.242 0a1 1 0 011.415 0 5 5 0 010 7.072 1 1 0 01-1.415-1.415 3 3 0 000-4.242 1 1 0 010-1.415zM10 9a1 1 0 011 1v.01a1 1 0 11-2 0V10a1 1 0 011-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def stop(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8 7a1 1 0 00-1 1v4a1 1 0 001 1h4a1 1 0 001-1V8a1 1 0 00-1-1H8z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def sun(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def support(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-2 0c0 .993-.241 1.929-.668 2.754l-1.524-1.525a3.997 3.997 0 00.078-2.183l1.562-1.562C15.802 8.249 16 9.1 16 10zm-5.165 3.913l1.58 1.58A5.98 5.98 0 0110 16a5.976 5.976 0 01-2.516-.552l1.562-1.562a4.006 4.006 0 001.789.027zm-4.677-2.796a4.002 4.002 0 01-.041-2.08l-.08.08-1.53-1.533A5.98 5.98 0 004 10c0 .954.223 1.856.619 2.657l1.54-1.54zm1.088-6.45A5.974 5.974 0 0110 4c.954 0 1.856.223 2.657.619l-1.54 1.54a4.002 4.002 0 00-2.346.033L7.246 4.668zM12 10a2 2 0 11-4 0 2 2 0 014 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def switch_horizontal(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8 5a1 1 0 100 2h5.586l-1.293 1.293a1 1 0 001.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 10-1.414 1.414L13.586 5H8zM12 15a1 1 0 100-2H6.414l1.293-1.293a1 1 0 10-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L6.414 15H12z"/>
+    </svg>
+    """
+  end
+
+  def switch_vertical(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 12a1 1 0 102 0V6.414l1.293 1.293a1 1 0 001.414-1.414l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L5 6.414V12zM15 8a1 1 0 10-2 0v5.586l-1.293-1.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L15 13.586V8z"/>
+    </svg>
+    """
+  end
+
+  def table(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M5 4a3 3 0 00-3 3v6a3 3 0 003 3h10a3 3 0 003-3V7a3 3 0 00-3-3H5zm-1 9v-1h5v2H5a1 1 0 01-1-1zm7 1h4a1 1 0 001-1v-1h-5v2zm0-4h5V8h-5v2zM9 8H4v2h5V8z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def tag(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M17.707 9.293a1 1 0 010 1.414l-7 7a1 1 0 01-1.414 0l-7-7A.997.997 0 012 10V5a3 3 0 013-3h5c.256 0 .512.098.707.293l7 7zM5 6a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def template(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zM3 10a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zM14 9a1 1 0 00-1 1v6a1 1 0 001 1h2a1 1 0 001-1v-6a1 1 0 00-1-1h-2z"/>
+    </svg>
+    """
+  end
+
+  def terminal(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M2 5a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V5zm3.293 1.293a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 01-1.414-1.414L7.586 10 5.293 7.707a1 1 0 010-1.414zM11 12a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def thumb_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M18 9.5a1.5 1.5 0 11-3 0v-6a1.5 1.5 0 013 0v6zM14 9.667v-5.43a2 2 0 00-1.105-1.79l-.05-.025A4 4 0 0011.055 2H5.64a2 2 0 00-1.962 1.608l-1.2 6A2 2 0 004.44 12H8v4a2 2 0 002 2 1 1 0 001-1v-.667a4 4 0 01.8-2.4l1.4-1.866a4 4 0 00.8-2.4z"/>
+    </svg>
+    """
+  end
+
+  def thumb_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 10.5a1.5 1.5 0 113 0v6a1.5 1.5 0 01-3 0v-6zM6 10.333v5.43a2 2 0 001.106 1.79l.05.025A4 4 0 008.943 18h5.416a2 2 0 001.962-1.608l1.2-6A2 2 0 0015.56 8H12V4a2 2 0 00-2-2 1 1 0 00-1 1v.667a4 4 0 01-.8 2.4L6.8 7.933a4 4 0 00-.8 2.4z"/>
+    </svg>
+    """
+  end
+
+  def ticket(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 6a2 2 0 012-2h12a2 2 0 012 2v2a2 2 0 100 4v2a2 2 0 01-2 2H4a2 2 0 01-2-2v-2a2 2 0 100-4V6z"/>
+    </svg>
+    """
+  end
+
+  def translate(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M7 2a1 1 0 011 1v1h3a1 1 0 110 2H9.578a18.87 18.87 0 01-1.724 4.78c.29.354.596.696.914 1.026a1 1 0 11-1.44 1.389c-.188-.196-.373-.396-.554-.6a19.098 19.098 0 01-3.107 3.567 1 1 0 01-1.334-1.49 17.087 17.087 0 003.13-3.733 18.992 18.992 0 01-1.487-2.494 1 1 0 111.79-.89c.234.47.489.928.764 1.372.417-.934.752-1.913.997-2.927H3a1 1 0 110-2h3V3a1 1 0 011-1zm6 6a1 1 0 01.894.553l2.991 5.982a.869.869 0 01.02.037l.99 1.98a1 1 0 11-1.79.895L15.383 16h-4.764l-.724 1.447a1 1 0 11-1.788-.894l.99-1.98.019-.038 2.99-5.982A1 1 0 0113 8zm-1.382 6h2.764L13 11.236 11.618 14z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def trash(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def trending_down(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12 13a1 1 0 100 2h5a1 1 0 001-1V9a1 1 0 10-2 0v2.586l-4.293-4.293a1 1 0 00-1.414 0L8 9.586 3.707 5.293a1 1 0 00-1.414 1.414l5 5a1 1 0 001.414 0L11 9.414 14.586 13H12z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def trending_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M12 7a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0V8.414l-4.293 4.293a1 1 0 01-1.414 0L8 10.414l-4.293 4.293a1 1 0 01-1.414-1.414l5-5a1 1 0 011.414 0L11 10.586 14.586 7H12z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def truck(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M8 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zM15 16.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z"/>
+      <path d="M3 4a1 1 0 00-1 1v10a1 1 0 001 1h1.05a2.5 2.5 0 014.9 0H10a1 1 0 001-1V5a1 1 0 00-1-1H3zM14 7a1 1 0 00-1 1v6.05A2.5 2.5 0 0115.95 16H17a1 1 0 001-1v-5a1 1 0 00-.293-.707l-2-2A1 1 0 0015 7h-1z"/>
+    </svg>
+    """
+  end
+
+  def upload(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
   def user_add(assigns) do
     assigns =
       assigns
@@ -3504,6 +3232,278 @@ defmodule PetalComponents.Heroicons.Solid do
     ~H"""
     <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
       <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z"/>
+    </svg>
+    """
+  end
+
+  def user_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-6-3a2 2 0 11-4 0 2 2 0 014 0zm-2 4a5 5 0 00-4.546 2.916A5.986 5.986 0 0010 16a5.986 5.986 0 004.546-2.084A5 5 0 0010 11z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def user_group(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z"/>
+    </svg>
+    """
+  end
+
+  def user_remove(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M11 6a3 3 0 11-6 0 3 3 0 016 0zM14 17a6 6 0 00-12 0h12zM13 8a1 1 0 100 2h4a1 1 0 100-2h-4z"/>
+    </svg>
+    """
+  end
+
+  def user(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def users(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z"/>
+    </svg>
+    """
+  end
+
+  def variable(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4.649 3.084A1 1 0 015.163 4.4 13.95 13.95 0 004 10c0 1.993.416 3.886 1.164 5.6a1 1 0 01-1.832.8A15.95 15.95 0 012 10c0-2.274.475-4.44 1.332-6.4a1 1 0 011.317-.516zM12.96 7a3 3 0 00-2.342 1.126l-.328.41-.111-.279A2 2 0 008.323 7H8a1 1 0 000 2h.323l.532 1.33-1.035 1.295a1 1 0 01-.781.375H7a1 1 0 100 2h.039a3 3 0 002.342-1.126l.328-.41.111.279A2 2 0 0011.677 14H12a1 1 0 100-2h-.323l-.532-1.33 1.035-1.295A1 1 0 0112.961 9H13a1 1 0 100-2h-.039zm1.874-2.6a1 1 0 011.833-.8A15.95 15.95 0 0118 10c0 2.274-.475 4.44-1.332 6.4a1 1 0 11-1.832-.8A13.949 13.949 0 0016 10c0-1.993-.416-3.886-1.165-5.6z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def video_camera(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 6a2 2 0 012-2h6a2 2 0 012 2v8a2 2 0 01-2 2H4a2 2 0 01-2-2V6zM14.553 7.106A1 1 0 0014 8v4a1 1 0 00.553.894l2 1A1 1 0 0018 13V7a1 1 0 00-1.447-.894l-2 1z"/>
+    </svg>
+    """
+  end
+
+  def view_boards(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M2 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1H3a1 1 0 01-1-1V4zM8 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1H9a1 1 0 01-1-1V4zM15 3a1 1 0 00-1 1v12a1 1 0 001 1h2a1 1 0 001-1V4a1 1 0 00-1-1h-2z"/>
+    </svg>
+    """
+  end
+
+  def view_grid_add(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM14 11a1 1 0 011 1v1h1a1 1 0 110 2h-1v1a1 1 0 11-2 0v-1h-1a1 1 0 110-2h1v-1a1 1 0 011-1z"/>
+    </svg>
+    """
+  end
+
+  def view_grid(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
+    </svg>
+    """
+  end
+
+  def view_list(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def volume_off(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM12.293 7.293a1 1 0 011.414 0L15 8.586l1.293-1.293a1 1 0 111.414 1.414L16.414 10l1.293 1.293a1 1 0 01-1.414 1.414L15 11.414l-1.293 1.293a1 1 0 01-1.414-1.414L13.586 10l-1.293-1.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def volume_up(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM14.657 2.929a1 1 0 011.414 0A9.972 9.972 0 0119 10a9.972 9.972 0 01-2.929 7.071 1 1 0 01-1.414-1.414A7.971 7.971 0 0017 10c0-2.21-.894-4.208-2.343-5.657a1 1 0 010-1.414zm-2.829 2.828a1 1 0 011.415 0A5.983 5.983 0 0115 10a5.984 5.984 0 01-1.757 4.243 1 1 0 01-1.415-1.415A3.984 3.984 0 0013 10a3.983 3.983 0 00-1.172-2.828 1 1 0 010-1.415z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def wifi(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M17.778 8.222c-4.296-4.296-11.26-4.296-15.556 0A1 1 0 01.808 6.808c5.076-5.077 13.308-5.077 18.384 0a1 1 0 01-1.414 1.414zM14.95 11.05a7 7 0 00-9.9 0 1 1 0 01-1.414-1.414 9 9 0 0112.728 0 1 1 0 01-1.414 1.414zM12.12 13.88a3 3 0 00-4.242 0 1 1 0 01-1.415-1.415 5 5 0 017.072 0 1 1 0 01-1.415 1.415zM9 16a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def x_circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def x(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def zoom_in(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path d="M5 8a1 1 0 011-1h1V6a1 1 0 012 0v1h1a1 1 0 110 2H9v1a1 1 0 11-2 0V9H6a1 1 0 01-1-1z"/>
+      <path fill-rule="evenodd" d="M2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8zm6-4a4 4 0 100 8 4 4 0 000-8z" clip-rule="evenodd"/>
+    </svg>
+    """
+  end
+
+  def zoom_out(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "h-5 w-5" end)
+      |> assign_new(:extra_attributes, fn ->
+        assigns_to_attributes(assigns, [:class])
+      end)
+
+    ~H"""
+    <svg class={@class} {@extra_attributes} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"/>
+      <path fill-rule="evenodd" d="M5 8a1 1 0 011-1h4a1 1 0 110 2H6a1 1 0 01-1-1z" clip-rule="evenodd"/>
     </svg>
     """
   end


### PR DESCRIPTION
According to the Heroicons website, the solid icons are supposed to use `w-5 h-5` and the outline icons use `w-6 h-6`.

This PR fixes this discrepancy, and also introduces a sort in the mix task when generating the modules, so that future re-generations don't cause unnecessary churn in the diffs (sorry this one is so big...).  I also re-generated using Heroicons `v1.0.3`.