### PR TITLE
Forward class attribute to table components

### DIFF
--- a/lib/petal_components/table.ex
+++ b/lib/petal_components/table.ex
@@ -13,7 +13,10 @@ defmodule PetalComponents.Table do
       end)
 
     ~H"""
-    <table class="min-w-full overflow-hidden divide-y divide-gray-200 rounded-sm shadow table-auto dark:divide-y-0 dark:divide-gray-800 sm:rounded" {@extra_assigns}>
+    <table class={Enum.join([
+      "min-w-full overflow-hidden divide-y divide-gray-200 rounded-sm shadow table-auto dark:divide-y-0 dark:divide-gray-800 sm:rounded",
+      @class,
+    ], " ")} {@extra_assigns}>
       <%= render_slot(@inner_block) %>
     </table>
     """
@@ -30,7 +33,10 @@ defmodule PetalComponents.Table do
       end)
 
     ~H"""
-    <th class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-300" {@extra_assigns}>
+    <th class={Enum.join([
+      "px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-300",
+      @class,
+    ], " ")} {@extra_assigns}>
       <%= if @inner_block do %>
         <%= render_slot(@inner_block) %>
       <% end %>
@@ -79,16 +85,18 @@ defmodule PetalComponents.Table do
   end
 
   def user_inner_td(assigns) do
-    assigns = assign_new(assigns, :class, fn -> "" end)
-    assigns = assign_new(assigns, :avatar_assigns, fn -> nil end)
-    |> assign_new(:extra_assigns, fn ->
-      assigns_to_attributes(assigns, ~w(
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "" end)
+      |> assign_new(:avatar_assigns, fn -> nil end)
+      |> assign_new(:extra_assigns, fn ->
+        assigns_to_attributes(assigns, ~w(
         class
         avatar_assigns
         label
         sub_label
       )a)
-    end)
+      end)
 
     ~H"""
     <div class={@class} {@extra_assigns}>

--- a/lib/petal_components/table.ex
+++ b/lib/petal_components/table.ex
@@ -91,11 +91,11 @@ defmodule PetalComponents.Table do
       |> assign_new(:avatar_assigns, fn -> nil end)
       |> assign_new(:extra_assigns, fn ->
         assigns_to_attributes(assigns, ~w(
-        class
-        avatar_assigns
-        label
-        sub_label
-      )a)
+          class
+          avatar_assigns
+          label
+          sub_label
+        )a)
       end)
 
     ~H"""

--- a/test/petal/table_test.exs
+++ b/test/petal/table_test.exs
@@ -95,4 +95,28 @@ defmodule PetalComponents.TableTest do
       <.user_inner_td label="John" sub_label="Smith" custom-attr="123" />
     """) =~ ~s{custom-attr="123"}
   end
+
+  test "components include additional classes" do
+    assigns = %{}
+
+    assert rendered_to_string(~H"""
+      <.table class="extra-class"></.table>
+    """) =~ "extra-class"
+
+    assert rendered_to_string(~H"""
+      <.tr class="extra-class"></.tr>
+    """) =~ "extra-class"
+
+    assert rendered_to_string(~H"""
+      <.th class="extra-class"></.th>
+    """) =~ "extra-class"
+
+    assert rendered_to_string(~H"""
+      <.td class="extra-class"></.td>
+    """) =~ "extra-class"
+
+    assert rendered_to_string(~H"""
+      <.user_inner_td label="John" sub_label="Smith" class="extra-class" />
+    """) =~ "extra-class"
+  end
 end


### PR DESCRIPTION
Ran into this while trying to hide table columns on a small screen. It's possible to hide `<td>` elements but it didn't
work for `<th>`. This patch makes sure to forward the `class` assign to every component in `PetalComponenets.Table`.
