### PR TITLE
Add a CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+# create this in .github/workflows/ci.yml
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    strategy:
+      matrix:
+        otp: ['23.3.4.11', '24.3']
+        elixir: ['1.12.3', '1.13.3']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+      - run: mix deps.get
+      - run: mix test


### PR DESCRIPTION
This is a proposal for a GitHub Workflow to run test on every push. It does:
* Checkout the source
* Set up OTP and Elixir for a matrix of versions, currently the two most recent release branches (the `mix.exs` for
  Petal Components states compatibility with Elixir 1.12 and higher)
* Get dependencies
* Run tests
