### PR TITLE
Do not accidentally override form classes

### DIFF
--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -440,6 +440,7 @@ defmodule PetalComponents.Form do
     |> assign_new(:type, fn -> "text" end)
     |> assign_new(:extra_assigns, fn ->
       assigns_to_attributes(assigns, [
+        :class,
         :label,
         :form,
         :field,

--- a/test/petal/progress_test.exs
+++ b/test/petal/progress_test.exs
@@ -18,14 +18,14 @@ defmodule PetalComponents.ProgressTest do
       <.progress color="primary" value={15} max={100} />
       """)
 
-    assert html =~ "bg-blue"
+    assert html =~ "bg-primary"
 
     html =
       rendered_to_string(~H"""
       <.progress color="secondary" value={15} max={100} />
       """)
 
-    assert html =~ "bg-pink"
+    assert html =~ "bg-secondary"
 
     html =
       rendered_to_string(~H"""


### PR DESCRIPTION
- Do not leak the `class` assign as it's already set from `classes`
- Fix tests
