### PR TITLE
Begin adding SlideOver component

### DIFF
--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -18,6 +18,7 @@ defmodule PetalComponents do
         Pagination,
         Link,
         Modal,
+        SlideOver,
         Tabs,
         Card,
         Table

--- a/lib/petal_components/slide_over.ex
+++ b/lib/petal_components/slide_over.ex
@@ -1,0 +1,142 @@
+defmodule PetalComponents.SlideOver do
+  use Phoenix.Component
+  alias Phoenix.LiveView.JS
+  # prop title, :string
+  # prop size, :string
+  # slot default
+  def slide_over(assigns) do
+    origin = assigns[:slide_over] || "start"
+    assigns =
+      assigns
+      |> assign_new(:classes, fn -> get_classes(assigns) end)
+      |> assign_new(:extra_assigns, fn ->
+        assigns_to_attributes(assigns, ~w(
+          classes
+          class
+          title
+          size
+          slide_over
+        )a)
+      end)
+
+    ~H"""
+    <div {@extra_assigns} id="slide-over" phx-remove={hide_slide_over(origin)}>
+      <div
+        id="modal-overlay"
+        class="fixed inset-0 z-50 transition-opacity bg-gray-900 dark:bg-gray-900 bg-opacity-30 dark:bg-opacity-70"
+        aria-hidden="true"
+      >
+      </div>
+
+      <div
+        class="fixed inset-0 z-50 flex overflow-hidden transform"
+        role="dialog"
+        aria-modal="true"
+      >
+
+        <div
+          id="modal-content"
+          class={@classes}
+          phx-click-away={hide_slide_over(origin)}
+          phx-window-keydown={hide_slide_over(origin)}
+          phx-key="escape"
+        >
+
+          <!-- Header -->
+          <div class="px-5 py-3 border-b border-gray-100 dark:border-gray-400">
+            <div class="flex items-center justify-between">
+              <div class="font-semibold text-gray-800 dark:text-gray-200">
+                <%= @title %>
+              </div>
+
+              <button phx-click={hide_slide_over(origin)} class="text-gray-400 hover:text-gray-500">
+                <div class="sr-only">Close</div>
+                <svg class="w-4 h-4 fill-current">
+                  <path d="M7.95 6.536l4.242-4.243a1 1 0 111.415 1.414L9.364 7.95l4.243 4.242a1 1 0 11-1.415 1.415L7.95 9.364l-4.243 4.243a1 1 0 01-1.414-1.415L6.536 7.95 2.293 3.707a1 1 0 011.414-1.414L7.95 6.536z" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <!-- Content -->
+          <div class="p-5">
+            <%= render_slot(@inner_block) %>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # The live view that calls <.slide_over> will need to handle the "close_slide_over" event. eg:
+  # def handle_event("close_slide_over", _, socket) do
+  #   {:noreply, push_patch(socket, to: Routes.moderate_users_path(socket, :index))}
+  # end
+  def hide_slide_over(js \\ %JS{}, origin) do
+    origin_class = case origin do
+      x when x in ["start", "end"] -> "translate-x-0"
+      x when x in ["top", "bottom"] -> "translate-y-0"
+    end
+    destination_class = case origin do
+      "start" -> "-translate-x-full"
+      "end" -> "translate-x-full"
+      "top" -> "-translate-y-full"
+      "bottom" -> "translate-y-full"
+    end
+    js
+    |> JS.remove_class("overflow-hidden", to: "body")
+    |> JS.hide(
+      transition: {
+        "ease-in duration-200",
+        "opacity-100",
+        "opacity-0"
+      },
+      to: "#modal-overlay"
+    )
+    |> JS.hide(
+      transition: {
+        "ease-in duration-200",
+        origin_class,
+        destination_class
+      },
+    to: "#modal-content"
+    )
+    |> JS.push("close_slide_over")
+  end
+
+  defp get_classes(assigns) do
+    opts = %{
+      max_width: assigns[:max_width] || "md",
+      class: assigns[:class] || "",
+      origin: assigns[:slide_over] || "start"
+    }
+
+    base_classes = "w-full max-h-full overflow-auto bg-white rounded shadow-lg dark:bg-gray-800"
+
+    slide_over_classes = case opts.origin do
+      "start" -> "transition translate-x-0"
+      "end" -> "transition translate-x-0 absolute right-0 inset-y-0"
+      "top" -> "transition translate-y-0 absolute inset-x-0"
+      "bottom" -> "transition translate-y-0 absolute inset-x-0 bottom-0"
+    end
+
+    max_width_class = case opts.origin do
+      x when x in ["start", "end"] -> (
+        case opts.max_width do
+          "sm" -> "max-w-sm"
+          "md" -> "max-w-xl"
+          "lg" -> "max-w-3xl"
+          "xl" -> "max-w-5xl"
+          "2xl" -> "max-w-7xl"
+          "full" -> "max-w-full"
+        end
+      )
+      x when x in ["top", "bottom"] -> ""
+    end
+
+    custom_classes = opts.class
+
+    [slide_over_classes, max_width_class, base_classes, custom_classes]
+    |> Enum.join(" ")
+  end
+end

--- a/test/petal/slide_over_test.exs
+++ b/test/petal/slide_over_test.exs
@@ -1,0 +1,118 @@
+defmodule PetalComponents.SlideOverTest do
+  use ComponentCase
+  import PetalComponents.SlideOver
+  import PetalComponents.Button
+  import PetalComponents.Form
+
+  test "slide_over" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.button label="start" link_type="live_patch" to="/live" />
+
+      <.slide_over title="SlideOver" slide_over="start">
+        <div class="gap-5 text-sm">
+          <.form_label label="Add some text here." />
+          <div class="flex justify-end">
+            <.button label="close" phx-click={PetalComponents.SlideOver.hide_slide_over("start")} />
+          </div>
+        </div>
+      </.slide_over>
+      """)
+
+    assert html =~ "data-phx-link"
+    assert html =~ "phx-click"
+    assert html =~ "translate-x-0"
+
+    # Test origin options
+    html =
+      rendered_to_string(~H"""
+      <.button label="end" link_type="live_patch" to="/" />
+
+      <.slide_over slide_over="end" title="SlideOver">
+        <div class="gap-5 text-sm">
+          <.form_label label="Add some text here." />
+          <div class="flex justify-end">
+            <.button label="close" phx-click={PetalComponents.SlideOver.hide_slide_over("end")} />
+          </div>
+        </div>
+      </.slide_over>
+      """)
+
+    assert html =~ "data-phx-link"
+    assert html =~ "phx-click"
+    assert html =~ "absolute right-0 inset-y-0"
+
+    html =
+      rendered_to_string(~H"""
+      <.button label="top" link_type="live_patch" to="/live" />
+
+      <.slide_over slide_over="top" title="SlideOver">
+        <div class="gap-5 text-sm">
+          <.form_label label="Add some text here." />
+          <div class="flex justify-end">
+            <.button label="close" phx-click={PetalComponents.SlideOver.hide_slide_over("top")} />
+          </div>
+        </div>
+      </.slide_over>
+      """)
+
+    assert html =~ "data-phx-link"
+    assert html =~ "phx-click"
+    assert html =~ "translate-y-0 absolute inset-x-0"
+
+    html =
+      rendered_to_string(~H"""
+      <.button label="bottom" link_type="live_patch" to="/live" />
+
+      <.slide_over slide_over="bottom" title="SlideOver">
+        <div class="gap-5 text-sm">
+          <.form_label label="Add some text here." />
+          <div class="flex justify-end">
+            <.button label="close" phx-click={PetalComponents.SlideOver.hide_slide_over("bottom")} />
+          </div>
+        </div>
+      </.slide_over>
+      """)
+
+    assert html =~ "data-phx-link"
+    assert html =~ "phx-click"
+    assert html =~ "translate-y-0 absolute inset-x-0 bottom-0"
+  end
+
+  test "dark mode" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.button label="start" link_type="live_patch" to="/live" />
+
+      <.slide_over slide_over="start" title="SlideOver">
+        <div class="gap-5 text-sm">
+          <.form_label label="Add some text here." />
+          <div class="flex justify-end">
+            <.button label="close" phx-click={PetalComponents.SlideOver.hide_slide_over("start")} />
+          </div>
+        </div>
+      </.slide_over>
+      """)
+
+    assert html =~ "data-phx-link"
+    assert html =~ "phx-click"
+    assert html =~ "translate-x-0"
+    assert html =~ "dark:"
+  end
+
+  test "should include additional assigns" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+
+      <.slide_over custom-attrs="123" title="SlideOver"></.slide_over>
+      """)
+
+    assert html =~ ~s{custom-attrs="123"}
+  end
+end


### PR DESCRIPTION
This introduces a basic SlideOver component adapted from the existing Modal.
TODO:
- Work out how to handle max-height/max-width, if at all.
- Add RTL/writing mode support.
- Make any further changes as requested by the Petal components core developers.

Some gifs:
Mobile view:
![slide_over_mobile2](https://user-images.githubusercontent.com/10395940/161369428-1d5153f3-5241-4459-a877-6c6efffab6f3.gif)

Desktop view:
![slide_over](https://user-images.githubusercontent.com/10395940/161369438-5765d1cf-e217-459c-a3da-ee7c81c56aeb.gif)

