### PR TITLE
Use `inline-block` for icon buttons

### DIFF
--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -15,16 +15,17 @@ defmodule PetalComponents.Button do
   # prop disabled, :boolean, default: false
   # slot default
   def button(assigns) do
-    assigns = assigns
-    |> assign_new(:link_type, fn -> "button" end)
-    |> assign_new(:inner_block, fn -> nil end)
-    |> assign_new(:loading, fn -> false end)
-    |> assign_new(:size, fn -> "md" end)
-    |> assign_new(:disabled, fn -> false end)
-    |> assign_new(:extra_assigns, fn -> get_extra_assigns(assigns) end)
-    |> assign_new(:classes, fn -> button_classes(assigns) end)
-    |> assign_new(:class, fn -> "" end)
-    |> assign_new(:to, fn -> nil end)
+    assigns =
+      assigns
+      |> assign_new(:link_type, fn -> "button" end)
+      |> assign_new(:inner_block, fn -> nil end)
+      |> assign_new(:loading, fn -> false end)
+      |> assign_new(:size, fn -> "md" end)
+      |> assign_new(:disabled, fn -> false end)
+      |> assign_new(:extra_assigns, fn -> get_extra_assigns(assigns) end)
+      |> assign_new(:classes, fn -> button_classes(assigns) end)
+      |> assign_new(:class, fn -> "" end)
+      |> assign_new(:to, fn -> nil end)
 
     ~H"""
     <.link to={@to} link_type={@link_type} class={@classes} disabled={@disabled} {@extra_assigns}>
@@ -52,16 +53,17 @@ defmodule PetalComponents.Button do
   # prop disabled, :boolean, default: false
   # slot default
   def icon_button(assigns) do
-    assigns = assigns
-    |> assign_new(:link_type, fn -> "button" end)
-    |> assign_new(:inner_block, fn -> nil end)
-    |> assign_new(:loading, fn -> false end)
-    |> assign_new(:size, fn -> "sm" end)
-    |> assign_new(:disabled, fn -> false end)
-    |> assign_new(:extra_assigns, fn -> get_extra_assigns(assigns) end)
-    |> assign_new(:class, fn -> "" end)
-    |> assign_new(:to, fn -> nil end)
-    |> assign_new(:color, fn -> "gray" end)
+    assigns =
+      assigns
+      |> assign_new(:link_type, fn -> "button" end)
+      |> assign_new(:inner_block, fn -> nil end)
+      |> assign_new(:loading, fn -> false end)
+      |> assign_new(:size, fn -> "sm" end)
+      |> assign_new(:disabled, fn -> false end)
+      |> assign_new(:extra_assigns, fn -> get_extra_assigns(assigns) end)
+      |> assign_new(:class, fn -> "" end)
+      |> assign_new(:to, fn -> nil end)
+      |> assign_new(:color, fn -> "gray" end)
 
     ~H"""
     <.link
@@ -69,7 +71,7 @@ defmodule PetalComponents.Button do
       link_type={@link_type}
       class={Enum.join(
         [
-          "rounded-full p-2",
+          "rounded-full p-2 inline-block",
           get_disabled_classes(@disabled),
           get_icon_button_background_color_classes(@color),
           get_icon_button_color_classes(@color),
@@ -281,20 +283,36 @@ defmodule PetalComponents.Button do
   defp get_icon_button_size_classes("xl"), do: "w-8 h-8"
 
   defp get_icon_button_color_classes("primary"), do: "text-primary-600 dark:text-primary-500"
-  defp get_icon_button_color_classes("secondary"), do: "text-secondary-600 dark:text-secondary-500"
+
+  defp get_icon_button_color_classes("secondary"),
+    do: "text-secondary-600 dark:text-secondary-500"
+
   defp get_icon_button_color_classes("gray"), do: "text-gray-600 dark:text-gray-500"
   defp get_icon_button_color_classes("info"), do: "text-blue-600 dark:text-blue-500"
   defp get_icon_button_color_classes("success"), do: "text-green-600 dark:text-green-500"
   defp get_icon_button_color_classes("warning"), do: "text-yellow-600 dark:text-yellow-500"
   defp get_icon_button_color_classes("danger"), do: "text-red-600 dark:text-red-500"
 
-  defp get_icon_button_background_color_classes("primary"), do: "hover:bg-primary-50 dark:hover:bg-gray-800"
-  defp get_icon_button_background_color_classes("secondary"), do: "hover:bg-secondary-50 dark:hover:bg-gray-800"
-  defp get_icon_button_background_color_classes("gray"), do: "hover:bg-gray-100 dark:hover:bg-gray-800"
-  defp get_icon_button_background_color_classes("info"), do: "hover:bg-blue-50 dark:hover:bg-gray-800"
-  defp get_icon_button_background_color_classes("success"), do: "hover:bg-green-50 dark:hover:bg-gray-800"
-  defp get_icon_button_background_color_classes("warning"), do: "hover:bg-yellow-50 dark:hover:bg-gray-800"
-  defp get_icon_button_background_color_classes("danger"), do: "hover:bg-red-50 dark:hover:bg-gray-800"
+  defp get_icon_button_background_color_classes("primary"),
+    do: "hover:bg-primary-50 dark:hover:bg-gray-800"
+
+  defp get_icon_button_background_color_classes("secondary"),
+    do: "hover:bg-secondary-50 dark:hover:bg-gray-800"
+
+  defp get_icon_button_background_color_classes("gray"),
+    do: "hover:bg-gray-100 dark:hover:bg-gray-800"
+
+  defp get_icon_button_background_color_classes("info"),
+    do: "hover:bg-blue-50 dark:hover:bg-gray-800"
+
+  defp get_icon_button_background_color_classes("success"),
+    do: "hover:bg-green-50 dark:hover:bg-gray-800"
+
+  defp get_icon_button_background_color_classes("warning"),
+    do: "hover:bg-yellow-50 dark:hover:bg-gray-800"
+
+  defp get_icon_button_background_color_classes("danger"),
+    do: "hover:bg-red-50 dark:hover:bg-gray-800"
 
   defp get_disabled_classes(true), do: "disabled cursor-not-allowed opacity-50"
   defp get_disabled_classes(false), do: ""


### PR DESCRIPTION
Using `inline-block` avoids linebreaks inside the icon buttons when
not using a button (e.g. `<a>`).