### PR TITLE
Generate prettier classes

### DIFF
--- a/lib/petal_components/alert.ex
+++ b/lib/petal_components/alert.ex
@@ -1,5 +1,7 @@
 defmodule PetalComponents.Alert do
   use Phoenix.Component
+  import PetalComponents.Class
+
   alias PetalComponents.Heroicons
 
   # prop color, :string, options: ["info", "success", "warning", "danger"]
@@ -57,7 +59,7 @@ defmodule PetalComponents.Alert do
             </div>
 
             <%= if @close_button_properties do %>
-              <button class={Enum.join(["p-2 mouse-hover flex hover:rounded ", " ", get_dismiss_icon_classes(@color), " "])} {@close_button_properties}>
+              <button class={build_class(["p-2 mouse-hover flex hover:rounded", get_dismiss_icon_classes(@color)])} {@close_button_properties}>
                 <Heroicons.Solid.x class="self-start w-4 h-4" />
               </button>
             <% end %>
@@ -78,12 +80,7 @@ defmodule PetalComponents.Alert do
     color_css = get_color_classes(opts.color)
     custom_classes = opts.class
 
-    [
-      base_classes,
-      color_css,
-      custom_classes
-    ]
-    |> Enum.join(" ")
+    build_class([base_classes, color_css, custom_classes])
   end
 
   defp get_color_classes("info"),

--- a/lib/petal_components/avatar.ex
+++ b/lib/petal_components/avatar.ex
@@ -1,6 +1,7 @@
 defmodule PetalComponents.Avatar do
   use Phoenix.Component
   alias PetalComponents.Heroicons
+  import PetalComponents.Class
 
   # prop src, :string
   # prop size, :string
@@ -25,31 +26,31 @@ defmodule PetalComponents.Avatar do
 
     ~H"""
     <%= if src_blank?(@src) && !@name do %>
-      <div {@extra_assigns} class={Enum.join([
+      <div {@extra_assigns} class={build_class([
         "inline-block relative overflow-hidden bg-gray-100 dark:bg-gray-700 rounded-full",
         get_size_classes(@size),
         @class
-        ], " ")}>
+        ])}>
         <Heroicons.Solid.user class="relative w-full h-full text-gray-300 dark:text-gray-300 dark:bg-gray-700 top-[12%] scale-[1.15] transform" />
       </div>
     <% else %>
       <%= if !@src && @name do %>
         <div {@extra_assigns}
           style={maybe_generate_random_color(@random_color, @name)}
-          class={Enum.join([
+          class={build_class([
             "flex items-center justify-center bg-gray-100 dark:bg-gray-700 rounded-full font-semibold uppercase text-gray-500 dark:text-gray-300",
             get_size_classes(@size),
             @class,
-          ], " ")}
+          ])}
         >
           <%= generate_initials(@name) %>
         </div>
       <% else %>
-        <img  {@extra_assigns} src={@src} class={Enum.join([
+        <img  {@extra_assigns} src={@src} class={build_class([
           "rounded-full object-cover",
           get_size_classes(@size),
           @class
-        ], " ")} />
+        ])} />
       <% end %>
     <% end %>
     """

--- a/lib/petal_components/badge.ex
+++ b/lib/petal_components/badge.ex
@@ -1,5 +1,6 @@
 defmodule PetalComponents.Badge do
   use Phoenix.Component
+  import PetalComponents.Class
 
   # prop label, :string
   # prop size, :string, options: ["xs", "sm", "md", "lg", "xl"]
@@ -28,13 +29,13 @@ defmodule PetalComponents.Badge do
       end)
 
     ~H"""
-    <badge {@extra_assigns} class={Enum.join([
+    <badge {@extra_assigns} class={build_class([
       "rounded inline-flex items-center justify-center focus:outline-none border",
       size_classes(@size),
       icon_classes(@icon),
       get_color_classes(%{color: @color, variant: @variant}),
       @class
-    ], " ")}>
+    ])}>
       <%= if @inner_block do %>
         <%= render_slot(@inner_block) %>
       <% else %>

--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -1,7 +1,10 @@
 defmodule PetalComponents.Button do
   use Phoenix.Component
+
   alias PetalComponents.Loading
   alias PetalComponents.Heroicons
+
+  import PetalComponents.Class
   import PetalComponents.Link
 
   # prop class, :string
@@ -69,24 +72,24 @@ defmodule PetalComponents.Button do
     <.link
       to={@to}
       link_type={@link_type}
-      class={Enum.join(
+      class={build_class(
         [
           "rounded-full p-2 inline-block",
           get_disabled_classes(@disabled),
           get_icon_button_background_color_classes(@color),
           get_icon_button_color_classes(@color),
           @class
-        ], " ")}
+        ])}
       disabled={@disabled}
       {@extra_assigns}
     >
       <%= if @loading do %>
         <Loading.spinner show={true} size_class={get_spinner_size_classes(@size)} />
       <% else %>
-        <Heroicons.Solid.render icon={@icon} class={Enum.join(
+        <Heroicons.Solid.render icon={@icon} class={build_class(
           [
             get_icon_button_size_classes(@size)
-          ], " ")}/>
+          ])}/>
       <% end %>
     </.link>
     """

--- a/lib/petal_components/card.ex
+++ b/lib/petal_components/card.ex
@@ -1,6 +1,8 @@
 defmodule PetalComponents.Card do
   use Phoenix.Component
 
+  import PetalComponents.Class
+
   # prop class, :string
   # prop variant, :string
   # slot default
@@ -17,11 +19,11 @@ defmodule PetalComponents.Card do
       end)
 
     ~H"""
-    <div {@extra_assigns} class={Enum.join([
+    <div {@extra_assigns} class={build_class([
       "flex flex-wrap overflow-hidden",
       get_variant_classes(@variant),
       @class
-    ], " ")}>
+    ])}>
       <div class="flex flex-col w-full max-w-full bg-white dark:bg-gray-800">
         <%= render_slot(@inner_block) %>
       </div>
@@ -48,17 +50,17 @@ defmodule PetalComponents.Card do
 
     ~H"""
     <%= if @src do %>
-      <img {@extra_assigns} src={@src} class={Enum.join([
+      <img {@extra_assigns} src={@src} class={build_class([
         "flex-shrink-0 w-full object-cover",
         @aspect_ratio_class,
         @class
       ], " ")} />
     <% else %>
-      <div {@extra_assigns} class={Enum.join([
+      <div {@extra_assigns} class={build_class([
         "flex-shrink-0 w-full bg-gray-300 dark:bg-gray-700",
         @aspect_ratio_class,
         @class
-      ], " ")}></div>
+      ])}></div>
     <% end %>
     """
   end
@@ -87,10 +89,10 @@ defmodule PetalComponents.Card do
       end)
 
     ~H"""
-    <div {@extra_assigns} class={Enum.join([
+    <div {@extra_assigns} class={build_class([
       "p-6 flex-1 font-light text-gray-500 text-md",
       @class
-    ], " ")}>
+    ])}>
       <%= if @category do %>
         <div class={"mb-3 text-sm font-medium #{@category_color_class}"}>
           <%= @category %>

--- a/lib/petal_components/class.ex
+++ b/lib/petal_components/class.ex
@@ -1,0 +1,38 @@
+defmodule PetalComponents.Class do
+  @moduledoc """
+  Module for constructing dynamic class names
+  """
+
+  @doc """
+  Builds a class string from a given input list by joining them together
+
+  This code was taken from Elixirs `Enum.join/2` function and optimized for
+  building class name (e.g removing empty strings and joining with " " by default)
+  """
+  def build_class(list, joiner \\ " ")
+  def build_class([], _joiner), do: ""
+
+  def build_class(list, joiner) when is_list(list) do
+    join_non_empty_list(list, joiner, [])
+    |> :lists.reverse()
+    |> IO.iodata_to_binary()
+  end
+
+  # Remove joiner (if present), since our last element was empty and isn't added
+  defp join_non_empty_list([""], joiner, [joiner | acc]), do: acc
+  defp join_non_empty_list([""], _joiner, acc), do: acc
+  defp join_non_empty_list([first], _joiner, acc), do: [entry_to_string(first) | acc]
+
+  # Don't append empty string to our class list
+  defp join_non_empty_list(["" | rest], joiner, acc) do
+    join_non_empty_list(rest, joiner, acc)
+  end
+
+  defp join_non_empty_list([first | rest], joiner, acc) do
+    join_non_empty_list(rest, joiner, [joiner, entry_to_string(first) | acc])
+  end
+
+  # Trim the input string
+  defp entry_to_string(entry) when is_binary(entry), do: String.trim(entry)
+  defp entry_to_string(entry), do: String.trim(String.Chars.to_string(entry))
+end

--- a/lib/petal_components/class.ex
+++ b/lib/petal_components/class.ex
@@ -20,11 +20,16 @@ defmodule PetalComponents.Class do
 
   # Remove joiner (if present), since our last element was empty and isn't added
   defp join_non_empty_list([""], joiner, [joiner | acc]), do: acc
+  defp join_non_empty_list([nil], joiner, [joiner | acc]), do: acc
   defp join_non_empty_list([""], _joiner, acc), do: acc
+  defp join_non_empty_list([nil], _joiner, acc), do: acc
   defp join_non_empty_list([first], _joiner, acc), do: [entry_to_string(first) | acc]
 
   # Don't append empty string to our class list
   defp join_non_empty_list(["" | rest], joiner, acc) do
+    join_non_empty_list(rest, joiner, acc)
+  end
+  defp join_non_empty_list([nil | rest], joiner, acc) do
     join_non_empty_list(rest, joiner, acc)
   end
 

--- a/lib/petal_components/container.ex
+++ b/lib/petal_components/container.ex
@@ -1,6 +1,8 @@
 defmodule PetalComponents.Container do
   use Phoenix.Component
 
+  import PetalComponents.Class
+
   # prop max_width, :string, options: ["sm", "md", "lg", "xl", "full"]
   # prop class, :string
   # prop no_padding_on_mobile, :boolean
@@ -19,12 +21,12 @@ defmodule PetalComponents.Container do
       end)
 
     ~H"""
-    <div {@extra_assigns} class={Enum.join([
+    <div {@extra_assigns} class={build_class([
       "mx-auto sm:px-6 lg:px-8 w-full",
       get_width_class(@max_width),
       get_padding_class(@no_padding_on_mobile),
       @class
-    ], " ")}>
+    ])}>
       <%= render_slot(@inner_block) %>
     </div>
     """

--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -1,5 +1,7 @@
 defmodule PetalComponents.Form do
   use Phoenix.Component
+
+  import PetalComponents.Class
   import Phoenix.HTML.Form
 
   @moduledoc """
@@ -470,11 +472,10 @@ defmodule PetalComponents.Form do
       ])
     end)
     |> assign_new(:classes, fn ->
-      [
+      build_class([
         base_classes,
         assigns[:class] || ""
-      ]
-      |> Enum.join(" ")
+      ])
     end)
   end
 

--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -474,7 +474,7 @@ defmodule PetalComponents.Form do
     |> assign_new(:classes, fn ->
       build_class([
         base_classes,
-        assigns[:class] || ""
+        assigns[:class]
       ])
     end)
   end

--- a/lib/petal_components/link.ex
+++ b/lib/petal_components/link.ex
@@ -38,16 +38,19 @@ defmodule PetalComponents.Link do
     <%= Phoenix.HTML.Link.link [to: @to, class: @class] ++ @extra_assigns, do: (if @inner_block, do: render_slot(@inner_block), else: @label) %>
     """
   end
+
   def custom_link(%{link_type: "live_patch"} = assigns) do
     ~H"""
     <%= live_patch [to: @to, class: @class] ++ @extra_assigns, do: (if @inner_block, do: render_slot(@inner_block), else: @label) %>
     """
   end
+
   def custom_link(%{link_type: "live_redirect"} = assigns) do
     ~H"""
     <%= live_redirect [to: @to, class: @class] ++ @extra_assigns, do: (if @inner_block, do: render_slot(@inner_block), else: @label) %>
     """
   end
+
   def custom_link(%{link_type: "button"} = assigns) do
     ~H"""
     <button class={@class} {@extra_assigns}><%= if @inner_block, do: render_slot(@inner_block), else: @label %></button>

--- a/lib/petal_components/loading.ex
+++ b/lib/petal_components/loading.ex
@@ -39,7 +39,7 @@ defmodule PetalComponents.Loading do
 
   defp get_spinner_classes(assigns) do
     base_classes = "animate-spin"
-    custom_classes = assigns[:class] || ""
+    custom_classes = assigns[:class]
     show_class = if assigns[:show] == false, do: "hidden", else: ""
     size_classes = assigns[:size_class] || get_size_classes(assigns[:size])
 

--- a/lib/petal_components/loading.ex
+++ b/lib/petal_components/loading.ex
@@ -1,6 +1,8 @@
 defmodule PetalComponents.Loading do
   use Phoenix.Component
 
+  import PetalComponents.Class
+
   # prop size, :string, values: ["sm", "md", "lg"]
   # prop class, :string, default: ""
   # prop show, :boolean, default: true
@@ -41,15 +43,7 @@ defmodule PetalComponents.Loading do
     show_class = if assigns[:show] == false, do: "hidden", else: ""
     size_classes = assigns[:size_class] || get_size_classes(assigns[:size])
 
-    Enum.join(
-      [
-        base_classes,
-        custom_classes,
-        show_class,
-        size_classes
-      ],
-      " "
-    )
+    build_class([base_classes, custom_classes, show_class, size_classes])
   end
 
   defp get_size_classes("sm"), do: "h-5 w-5"

--- a/lib/petal_components/modal.ex
+++ b/lib/petal_components/modal.ex
@@ -1,6 +1,9 @@
 defmodule PetalComponents.Modal do
   use Phoenix.Component
+
   alias Phoenix.LiveView.JS
+
+  import PetalComponents.Class
 
   # prop title, :string
   # prop size, :string
@@ -136,7 +139,6 @@ defmodule PetalComponents.Modal do
 
     custom_classes = opts.class
 
-    [max_width_class, base_classes, custom_classes]
-    |> Enum.join(" ")
+    build_class([max_width_class, base_classes, custom_classes])
   end
 end

--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -1,6 +1,9 @@
 defmodule PetalComponents.Pagination do
   use Phoenix.Component
+
   alias PetalComponents.Heroicons
+
+  import PetalComponents.Class
   import PetalComponents.Link
 
   # prop path, :string
@@ -150,9 +153,10 @@ defmodule PetalComponents.Pagination do
       end
 
     # Next button
-    items = if current_page < total_pages,
-      do: items ++ [%{type: "next", number: current_page + 1}],
-      else: items
+    items =
+      if current_page < total_pages,
+        do: items ++ [%{type: "next", number: current_page + 1}],
+        else: items
 
     items
   end
@@ -164,7 +168,8 @@ defmodule PetalComponents.Pagination do
     active_classes =
       if is_active,
         do: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300",
-        else: "bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-800 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-400"
+        else:
+          "bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-800 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-400"
 
     rounded_classes =
       cond do
@@ -181,7 +186,7 @@ defmodule PetalComponents.Pagination do
           ""
       end
 
-    Enum.join([base_classes, active_classes, rounded_classes], " ")
+    build_class([base_classes, active_classes, rounded_classes], " ")
   end
 
   defp get_path(path, "previous", current_page) do

--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -186,7 +186,7 @@ defmodule PetalComponents.Pagination do
           ""
       end
 
-    build_class([base_classes, active_classes, rounded_classes], " ")
+    build_class([base_classes, active_classes, rounded_classes])
   end
 
   defp get_path(path, "previous", current_page) do

--- a/lib/petal_components/slide_over.ex
+++ b/lib/petal_components/slide_over.ex
@@ -1,5 +1,8 @@
 defmodule PetalComponents.SlideOver do
   use Phoenix.Component
+
+  import PetalComponents.Class
+
   alias Phoenix.LiveView.JS
 
   # prop origin, :string, options: ["left", "top", "bottom", "right"]
@@ -31,11 +34,11 @@ defmodule PetalComponents.SlideOver do
       </div>
 
       <div
-        class={Enum.join([
+        class={build_class([
           "fixed inset-0 z-50 flex overflow-hidden transform",
           get_margin_classes(@origin),
           @class,
-          ], " ")}
+          ])}
         role="dialog"
         aria-modal="true"
       >
@@ -78,16 +81,20 @@ defmodule PetalComponents.SlideOver do
   #   {:noreply, push_patch(socket, to: Routes.moderate_users_path(socket, :index))}
   # end
   def hide_slide_over(js \\ %JS{}, origin) do
-    origin_class = case origin do
-      x when x in ["left", "right"] -> "translate-x-0"
-      x when x in ["top", "bottom"] -> "translate-y-0"
-    end
-    destination_class = case origin do
-      "left" -> "-translate-x-full"
-      "right" -> "translate-x-full"
-      "top" -> "-translate-y-full"
-      "bottom" -> "translate-y-full"
-    end
+    origin_class =
+      case origin do
+        x when x in ["left", "right"] -> "translate-x-0"
+        x when x in ["top", "bottom"] -> "translate-y-0"
+      end
+
+    destination_class =
+      case origin do
+        "left" -> "-translate-x-full"
+        "right" -> "translate-x-full"
+        "top" -> "-translate-y-full"
+        "bottom" -> "translate-y-full"
+      end
+
     js
     |> JS.remove_class("overflow-hidden", to: "body")
     |> JS.hide(
@@ -104,7 +111,7 @@ defmodule PetalComponents.SlideOver do
         origin_class,
         destination_class
       },
-    to: "#modal-content"
+      to: "#modal-content"
     )
     |> JS.push("close_slide_over")
   end
@@ -112,31 +119,33 @@ defmodule PetalComponents.SlideOver do
   defp get_classes(max_width, origin, class) do
     base_classes = "w-full max-h-full overflow-auto bg-white shadow-lg dark:bg-gray-800"
 
-    slide_over_classes = case origin do
-      "left" -> "transition translate-x-0"
-      "right" -> "transition translate-x-0 absolute right-0 inset-y-0"
-      "top" -> "transition translate-y-0 absolute inset-x-0"
-      "bottom" -> "transition translate-y-0 absolute inset-x-0 bottom-0"
-    end
+    slide_over_classes =
+      case origin do
+        "left" -> "transition translate-x-0"
+        "right" -> "transition translate-x-0 absolute right-0 inset-y-0"
+        "top" -> "transition translate-y-0 absolute inset-x-0"
+        "bottom" -> "transition translate-y-0 absolute inset-x-0 bottom-0"
+      end
 
-    max_width_class = case origin do
-      x when x in ["left", "right"] -> (
-        case max_width do
-          "sm" -> "max-w-sm"
-          "md" -> "max-w-xl"
-          "lg" -> "max-w-3xl"
-          "xl" -> "max-w-5xl"
-          "2xl" -> "max-w-7xl"
-          "full" -> "max-w-full"
-        end
-      )
-      x when x in ["top", "bottom"] -> ""
-    end
+    max_width_class =
+      case origin do
+        x when x in ["left", "right"] ->
+          case max_width do
+            "sm" -> "max-w-sm"
+            "md" -> "max-w-xl"
+            "lg" -> "max-w-3xl"
+            "xl" -> "max-w-5xl"
+            "2xl" -> "max-w-7xl"
+            "full" -> "max-w-full"
+          end
+
+        x when x in ["top", "bottom"] ->
+          ""
+      end
 
     custom_classes = class
 
-    [slide_over_classes, max_width_class, base_classes, custom_classes]
-    |> Enum.join(" ")
+    build_class([slide_over_classes, max_width_class, base_classes, custom_classes])
   end
 
   defp get_margin_classes(margin) do

--- a/lib/petal_components/table.ex
+++ b/lib/petal_components/table.ex
@@ -1,6 +1,8 @@
 defmodule PetalComponents.Table do
   use Phoenix.Component
+
   import PetalComponents.Avatar
+  import PetalComponents.Class
 
   def table(assigns) do
     assigns =
@@ -13,10 +15,10 @@ defmodule PetalComponents.Table do
       end)
 
     ~H"""
-    <table class={Enum.join([
+    <table class={build_class([
       "min-w-full overflow-hidden divide-y divide-gray-200 rounded-sm shadow dark:shadow-2xl table-auto dark:divide-y-0 dark:divide-gray-800 sm:rounded",
       @class,
-    ], " ")} {@extra_assigns}>
+    ])} {@extra_assigns}>
       <%= render_slot(@inner_block) %>
     </table>
     """
@@ -33,7 +35,7 @@ defmodule PetalComponents.Table do
       end)
 
     ~H"""
-    <th class={Enum.join([
+    <th class={build_class([
       "px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-300",
       @class,
     ], " ")} {@extra_assigns}>
@@ -55,10 +57,10 @@ defmodule PetalComponents.Table do
       end)
 
     ~H"""
-    <tr class={Enum.join([
+    <tr class={build_class([
       "border-b dark:border-gray-700 bg-white dark:bg-gray-800 last:border-none",
       @class,
-    ], " ")} {@extra_assigns}>
+    ])} {@extra_assigns}>
       <%= render_slot(@inner_block) %>
     </tr>
     """
@@ -75,7 +77,7 @@ defmodule PetalComponents.Table do
       end)
 
     ~H"""
-    <td class={Enum.join([
+    <td class={build_class([
       "px-6 py-4 text-sm text-gray-500 dark:text-gray-400",
       @class
     ], " ")} {@extra_assigns}>

--- a/lib/petal_components/tabs.ex
+++ b/lib/petal_components/tabs.ex
@@ -1,5 +1,7 @@
 defmodule PetalComponents.Tabs do
   use Phoenix.Component
+
+  import PetalComponents.Class
   import PetalComponents.Link
 
   # prop class, :string
@@ -15,7 +17,7 @@ defmodule PetalComponents.Tabs do
       end)
 
     ~H"""
-    <div {@extra_assigns} class={Enum.join([
+    <div {@extra_assigns} class={build_class([
         "flex gap-x-8 gap-y-2",
         (if @underline, do: "border-b border-gray-200 dark:border-gray-600", else: ""),
         @class
@@ -88,7 +90,7 @@ defmodule PetalComponents.Tabs do
         else:
           "text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 dark:text-gray-400 dark:hover:bg-gray-800 hover:bg-gray-100"
 
-    Enum.join([base_classes, active_classes], " ")
+    build_class([base_classes, active_classes], " ")
   end
 
   # Underline CSS
@@ -106,7 +108,7 @@ defmodule PetalComponents.Tabs do
         do: "",
         else: "hover:border-gray-300"
 
-    Enum.join([base_classes, active_classes, underline_classes], " ")
+    build_class([base_classes, active_classes, underline_classes], " ")
   end
 
   # Underline
@@ -123,7 +125,7 @@ defmodule PetalComponents.Tabs do
         do: "bg-primary-100 dark:bg-primary-600 text-primary-600 dark:text-white",
         else: "bg-gray-100 dark:bg-gray-600 dark:text-white text-gray-500"
 
-    Enum.join([base_classes, active_classes, underline_classes], " ")
+    build_class([base_classes, active_classes, underline_classes], " ")
   end
 
   # Pill
@@ -135,6 +137,6 @@ defmodule PetalComponents.Tabs do
         do: "bg-primary-600 text-white",
         else: "bg-gray-500 dark:bg-gray-600 text-white"
 
-    Enum.join([base_classes, active_classes], " ")
+    build_class([base_classes, active_classes], " ")
   end
 end

--- a/lib/petal_components/tabs.ex
+++ b/lib/petal_components/tabs.ex
@@ -90,7 +90,7 @@ defmodule PetalComponents.Tabs do
         else:
           "text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 dark:text-gray-400 dark:hover:bg-gray-800 hover:bg-gray-100"
 
-    build_class([base_classes, active_classes], " ")
+    build_class([base_classes, active_classes])
   end
 
   # Underline CSS
@@ -108,7 +108,7 @@ defmodule PetalComponents.Tabs do
         do: "",
         else: "hover:border-gray-300"
 
-    build_class([base_classes, active_classes, underline_classes], " ")
+    build_class([base_classes, active_classes, underline_classes])
   end
 
   # Underline
@@ -125,7 +125,7 @@ defmodule PetalComponents.Tabs do
         do: "bg-primary-100 dark:bg-primary-600 text-primary-600 dark:text-white",
         else: "bg-gray-100 dark:bg-gray-600 dark:text-white text-gray-500"
 
-    build_class([base_classes, active_classes, underline_classes], " ")
+    build_class([base_classes, active_classes, underline_classes])
   end
 
   # Pill
@@ -137,6 +137,6 @@ defmodule PetalComponents.Tabs do
         do: "bg-primary-600 text-white",
         else: "bg-gray-500 dark:bg-gray-600 text-white"
 
-    build_class([base_classes, active_classes], " ")
+    build_class([base_classes, active_classes])
   end
 end

--- a/lib/petal_components/typography.ex
+++ b/lib/petal_components/typography.ex
@@ -100,7 +100,7 @@ defmodule PetalComponents.Typography do
   end
 
   defp get_heading_classes(base_classes, assigns) do
-    custom_classes = assigns[:class] || ""
+    custom_classes = assigns[:class]
     color_classes = assigns[:color_class] || "text-gray-900 dark:text-white"
     underline_classes = if assigns[:underline], do: " border-b border-gray-200 pb-2", else: ""
     margin_classes = if assigns[:no_margin], do: "", else: "mb-3"

--- a/lib/petal_components/typography.ex
+++ b/lib/petal_components/typography.ex
@@ -1,6 +1,8 @@
 defmodule PetalComponents.Typography do
   use Phoenix.Component
 
+  import PetalComponents.Class
+
   @moduledoc """
   Everything related to text. Headings, paragraphs and links
   """
@@ -103,8 +105,7 @@ defmodule PetalComponents.Typography do
     underline_classes = if assigns[:underline], do: " border-b border-gray-200 pb-2", else: ""
     margin_classes = if assigns[:no_margin], do: "", else: "mb-3"
 
-    [base_classes, custom_classes, color_classes, underline_classes, margin_classes]
-    |> Enum.join(" ")
+    build_class([base_classes, custom_classes, color_classes, underline_classes, margin_classes])
   end
 
   defp drop_heading_props(assigns) do

--- a/test/petal/class_test.exs
+++ b/test/petal/class_test.exs
@@ -1,0 +1,46 @@
+defmodule PetalComponents.ClassTest do
+  use ExUnit.Case
+
+  import PetalComponents.Class
+
+  test "encode list" do
+    assert "some-class extra-class my-class" ==
+             build_class(["some-class", "extra-class", "my-class"])
+  end
+
+  test "remove whitespace from classes" do
+    assert "some-class extra-class my-class" ==
+             build_class(["         some-class        ", "extra-class    ", "  my-class"])
+  end
+
+  test "remove empty class names" do
+    assert "some-class extra-class my-class" ==
+             build_class([
+               "",
+               "some-class",
+               "",
+               "",
+               "",
+               "extra-class",
+               "",
+               "",
+               "",
+               "",
+               "my-class",
+               "",
+               "",
+               "",
+               "",
+               "",
+               "",
+               "",
+               "",
+               "",
+               "",
+               "",
+               "",
+               "",
+               ""
+             ])
+  end
+end

--- a/test/petal/class_test.exs
+++ b/test/petal/class_test.exs
@@ -43,4 +43,19 @@ defmodule PetalComponents.ClassTest do
                ""
              ])
   end
+
+  test "remove nil class names" do
+    empty_keylist = []
+
+    assert "some-class extra-class my-class" ==
+             build_class([
+               nil,
+               "some-class",
+               empty_keylist[:some_key],
+               "extra-class",
+               nil,
+               "my-class",
+               nil
+             ])
+  end
 end

--- a/test/petal/link_test.exs
+++ b/test/petal/link_test.exs
@@ -73,31 +73,31 @@ defmodule PetalComponents.LinkTest do
     assigns = %{}
 
     assert rendered_to_string(~H"""
-    <.link to="/" label="Press me" />
-    """) =~ ">Press me<"
+           <.link to="/" label="Press me" />
+           """) =~ ">Press me<"
 
     assert rendered_to_string(~H"""
-    <.link to="/" label=" Press me " />
-    """) =~ "> Press me <"
+           <.link to="/" label=" Press me " />
+           """) =~ "> Press me <"
 
     assert rendered_to_string(~H"""
-    <.link link_type="live_patch" to="/" label="Press me" />
-    """) =~ ">Press me<"
+           <.link link_type="live_patch" to="/" label="Press me" />
+           """) =~ ">Press me<"
 
     assert rendered_to_string(~H"""
-    <.link link_type="live_redirect" to="/" label="Press me" />
-    """) =~ ">Press me<"
+           <.link link_type="live_redirect" to="/" label="Press me" />
+           """) =~ ">Press me<"
 
     assert rendered_to_string(~H"""
-    <.link to="/">Press me</.link>
-    """) =~ ">Press me<"
+           <.link to="/">Press me</.link>
+           """) =~ ">Press me<"
 
     assert rendered_to_string(~H"""
-    <.link to="/"> Press me </.link>
-    """) =~ "> Press me <"
+           <.link to="/"> Press me </.link>
+           """) =~ "> Press me <"
 
     assert rendered_to_string(~H"""
-    <.link to="/" label="Press me" />, blah
-    """) =~ "</a>, blah"
+           <.link to="/" label="Press me" />, blah
+           """) =~ "</a>, blah"
   end
 end

--- a/test/petal/table_test.exs
+++ b/test/petal/table_test.exs
@@ -76,47 +76,47 @@ defmodule PetalComponents.TableTest do
     assigns = %{}
 
     assert rendered_to_string(~H"""
-      <.table custom-attr="123"></.table>
-    """) =~ ~s{custom-attr="123"}
+             <.table custom-attr="123"></.table>
+           """) =~ ~s{custom-attr="123"}
 
     assert rendered_to_string(~H"""
-      <.tr custom-attr="123"></.tr>
-    """) =~ ~s{custom-attr="123"}
+             <.tr custom-attr="123"></.tr>
+           """) =~ ~s{custom-attr="123"}
 
     assert rendered_to_string(~H"""
-      <.th custom-attr="123"></.th>
-    """) =~ ~s{custom-attr="123"}
+             <.th custom-attr="123"></.th>
+           """) =~ ~s{custom-attr="123"}
 
     assert rendered_to_string(~H"""
-      <.td custom-attr="123"></.td>
-    """) =~ ~s{custom-attr="123"}
+             <.td custom-attr="123"></.td>
+           """) =~ ~s{custom-attr="123"}
 
     assert rendered_to_string(~H"""
-      <.user_inner_td label="John" sub_label="Smith" custom-attr="123" />
-    """) =~ ~s{custom-attr="123"}
+             <.user_inner_td label="John" sub_label="Smith" custom-attr="123" />
+           """) =~ ~s{custom-attr="123"}
   end
 
   test "components include additional classes" do
     assigns = %{}
 
     assert rendered_to_string(~H"""
-      <.table class="extra-class"></.table>
-    """) =~ "extra-class"
+             <.table class="extra-class"></.table>
+           """) =~ "extra-class"
 
     assert rendered_to_string(~H"""
-      <.tr class="extra-class"></.tr>
-    """) =~ "extra-class"
+             <.tr class="extra-class"></.tr>
+           """) =~ "extra-class"
 
     assert rendered_to_string(~H"""
-      <.th class="extra-class"></.th>
-    """) =~ "extra-class"
+             <.th class="extra-class"></.th>
+           """) =~ "extra-class"
 
     assert rendered_to_string(~H"""
-      <.td class="extra-class"></.td>
-    """) =~ "extra-class"
+             <.td class="extra-class"></.td>
+           """) =~ "extra-class"
 
     assert rendered_to_string(~H"""
-      <.user_inner_td label="John" sub_label="Smith" class="extra-class" />
-    """) =~ "extra-class"
+             <.user_inner_td label="John" sub_label="Smith" class="extra-class" />
+           """) =~ "extra-class"
   end
 end


### PR DESCRIPTION
`build_class/2` is basically `Enum.join/2` with some improvements
for building the class names. For example empty strings are not joined
into the class names and the default joiner is set to a single whitespace to avoid specifying it every time.

Before:
<img width="698" alt="Screenshot 2022-04-28 at 09 54 49" src="https://user-images.githubusercontent.com/792046/165712375-9fa519e2-882f-4373-818e-5b2dda3f0b41.png">

After:
<img width="777" alt="Screenshot 2022-04-28 at 10 33 03" src="https://user-images.githubusercontent.com/792046/165712412-9a9c7646-71d5-4ab5-bb44-f56891fbcf05.png">

