### PR TITLE
Switch should use primary colour instead of blue

### DIFF
--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -374,7 +374,7 @@ defmodule PetalComponents.Form do
         class: @classes,
         phx_feedback_for: input_name(@form, @field)] ++ @extra_assigns
       %>
-      <span class="absolute h-6 mx-auto transition-colors duration-200 ease-in-out bg-gray-200 border rounded-full pointer-events-none w-11 dark:bg-gray-700 dark:border-gray-600 peer-checked:bg-blue-500"></span>
+      <span class="absolute h-6 mx-auto transition-colors duration-200 ease-in-out bg-gray-200 border rounded-full pointer-events-none w-11 dark:bg-gray-700 dark:border-gray-600 peer-checked:bg-primary-500"></span>
       <span class="absolute left-0 inline-block w-5 h-5 transition-transform duration-200 ease-in-out transform translate-x-0 bg-white rounded-full shadow pointer-events-none peer-checked:translate-x-5 ring-0 "></span>
     </label>
     """


### PR DESCRIPTION
The form switch component is currently using a hardcoded colour blue rather than the configured primary colour.