### PR TITLE
Fix heroicons render method

### DIFF
--- a/lib/mix/tasks/heroicons/generate.ex
+++ b/lib/mix/tasks/heroicons/generate.ex
@@ -17,22 +17,21 @@ defmodule Mix.Tasks.Heroicons.Generate do
       @moduledoc \"\"\"
       Icon name can be the function or passed in as a type eg.
       <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
-      <PetalComponents.Heroicons.Solid.render type="home" class="w-5 h-5" />
+      <PetalComponents.Heroicons.Solid.render icon="home" class="w-5 h-5" />
 
       <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
-      <PetalComponents.Heroicons.Outline.render type="home" class="w-6 h-6" />
+      <PetalComponents.Heroicons.Outline.render icon="home" class="w-6 h-6" />
       \"\"\"
       use Phoenix.Component
 
-      def render(%{type: icon_name} = assigns) do
-        icon_name = String.to_existing_atom(icon_name)
+      def render(%{icon: icon_name} = assigns) when is_atom(icon_name) do
         apply(__MODULE__, icon_name, [assigns])
       end
 
       def render(%{icon: icon_name} = assigns) do
+        icon_name = String.to_existing_atom(icon_name)
         apply(__MODULE__, icon_name, [assigns])
       end
-
     """
 
     functions_content =

--- a/lib/mix/tasks/heroicons/generate.ex
+++ b/lib/mix/tasks/heroicons/generate.ex
@@ -14,7 +14,6 @@ defmodule Mix.Tasks.Heroicons.Generate do
 
     file_content = """
     defmodule PetalComponents.#{namespace} do
-      use Phoenix.Component
       @moduledoc \"\"\"
       Icon name can be the function or passed in as a type eg.
       <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
@@ -23,9 +22,10 @@ defmodule Mix.Tasks.Heroicons.Generate do
       <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
       <PetalComponents.Heroicons.Outline.render type="home" class="w-6 h-6" />
       \"\"\"
+      use Phoenix.Component
 
       def render(assigns) do
-        icon_name = assigns.icon
+        icon_name = String.to_existing_atom(assigns.type)
         apply(__MODULE__, icon_name, [assigns])
       end
 

--- a/lib/mix/tasks/heroicons/generate.ex
+++ b/lib/mix/tasks/heroicons/generate.ex
@@ -24,8 +24,12 @@ defmodule Mix.Tasks.Heroicons.Generate do
       \"\"\"
       use Phoenix.Component
 
-      def render(assigns) do
-        icon_name = String.to_existing_atom(assigns.type)
+      def render(%{type: icon_name} = assigns) do
+        icon_name = String.to_existing_atom(icon_name)
+        apply(__MODULE__, icon_name, [assigns])
+      end
+
+      def render(%{icon: icon_name} = assigns) do
         apply(__MODULE__, icon_name, [assigns])
       end
 

--- a/lib/petal_components/class.ex
+++ b/lib/petal_components/class.ex
@@ -29,6 +29,7 @@ defmodule PetalComponents.Class do
   defp join_non_empty_list(["" | rest], joiner, acc) do
     join_non_empty_list(rest, joiner, acc)
   end
+
   defp join_non_empty_list([nil | rest], joiner, acc) do
     join_non_empty_list(rest, joiner, acc)
   end

--- a/lib/petal_components/icons/heroicons/outline.ex
+++ b/lib/petal_components/icons/heroicons/outline.ex
@@ -2,19 +2,19 @@ defmodule PetalComponents.Heroicons.Outline do
   @moduledoc """
   Icon name can be the function or passed in as a type eg.
   <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
-  <PetalComponents.Heroicons.Solid.render type="home" class="w-5 h-5" />
+  <PetalComponents.Heroicons.Solid.render icon="home" class="w-5 h-5" />
 
   <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
-  <PetalComponents.Heroicons.Outline.render type="home" class="w-6 h-6" />
+  <PetalComponents.Heroicons.Outline.render icon="home" class="w-6 h-6" />
   """
   use Phoenix.Component
 
-  def render(%{type: icon_name} = assigns) do
-    icon_name = String.to_existing_atom(icon_name)
+  def render(%{icon: icon_name} = assigns) when is_atom(icon_name) do
     apply(__MODULE__, icon_name, [assigns])
   end
 
   def render(%{icon: icon_name} = assigns) do
+    icon_name = String.to_existing_atom(icon_name)
     apply(__MODULE__, icon_name, [assigns])
   end
 

--- a/lib/petal_components/icons/heroicons/outline.ex
+++ b/lib/petal_components/icons/heroicons/outline.ex
@@ -9,8 +9,12 @@ defmodule PetalComponents.Heroicons.Outline do
   """
   use Phoenix.Component
 
-  def render(assigns) do
-    icon_name = String.to_existing_atom(assigns.type)
+  def render(%{type: icon_name} = assigns) do
+    icon_name = String.to_existing_atom(icon_name)
+    apply(__MODULE__, icon_name, [assigns])
+  end
+
+  def render(%{icon: icon_name} = assigns) do
     apply(__MODULE__, icon_name, [assigns])
   end
 

--- a/lib/petal_components/icons/heroicons/outline.ex
+++ b/lib/petal_components/icons/heroicons/outline.ex
@@ -1,6 +1,4 @@
 defmodule PetalComponents.Heroicons.Outline do
-  use Phoenix.Component
-
   @moduledoc """
   Icon name can be the function or passed in as a type eg.
   <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
@@ -9,9 +7,10 @@ defmodule PetalComponents.Heroicons.Outline do
   <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
   <PetalComponents.Heroicons.Outline.render type="home" class="w-6 h-6" />
   """
+  use Phoenix.Component
 
   def render(assigns) do
-    icon_name = assigns.icon
+    icon_name = String.to_existing_atom(assigns.type)
     apply(__MODULE__, icon_name, [assigns])
   end
 

--- a/lib/petal_components/icons/heroicons/solid.ex
+++ b/lib/petal_components/icons/heroicons/solid.ex
@@ -9,8 +9,12 @@ defmodule PetalComponents.Heroicons.Solid do
   """
   use Phoenix.Component
 
-  def render(assigns) do
-    icon_name = String.to_existing_atom(assigns.type)
+  def render(%{type: icon_name} = assigns) do
+    icon_name = String.to_existing_atom(icon_name)
+    apply(__MODULE__, icon_name, [assigns])
+  end
+
+  def render(%{icon: icon_name} = assigns) do
     apply(__MODULE__, icon_name, [assigns])
   end
 

--- a/lib/petal_components/icons/heroicons/solid.ex
+++ b/lib/petal_components/icons/heroicons/solid.ex
@@ -1,6 +1,4 @@
 defmodule PetalComponents.Heroicons.Solid do
-  use Phoenix.Component
-
   @moduledoc """
   Icon name can be the function or passed in as a type eg.
   <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
@@ -9,9 +7,10 @@ defmodule PetalComponents.Heroicons.Solid do
   <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
   <PetalComponents.Heroicons.Outline.render type="home" class="w-6 h-6" />
   """
+  use Phoenix.Component
 
   def render(assigns) do
-    icon_name = assigns.icon
+    icon_name = String.to_existing_atom(assigns.type)
     apply(__MODULE__, icon_name, [assigns])
   end
 

--- a/lib/petal_components/icons/heroicons/solid.ex
+++ b/lib/petal_components/icons/heroicons/solid.ex
@@ -2,19 +2,19 @@ defmodule PetalComponents.Heroicons.Solid do
   @moduledoc """
   Icon name can be the function or passed in as a type eg.
   <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
-  <PetalComponents.Heroicons.Solid.render type="home" class="w-5 h-5" />
+  <PetalComponents.Heroicons.Solid.render icon="home" class="w-5 h-5" />
 
   <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
-  <PetalComponents.Heroicons.Outline.render type="home" class="w-6 h-6" />
+  <PetalComponents.Heroicons.Outline.render icon="home" class="w-6 h-6" />
   """
   use Phoenix.Component
 
-  def render(%{type: icon_name} = assigns) do
-    icon_name = String.to_existing_atom(icon_name)
+  def render(%{icon: icon_name} = assigns) when is_atom(icon_name) do
     apply(__MODULE__, icon_name, [assigns])
   end
 
   def render(%{icon: icon_name} = assigns) do
+    icon_name = String.to_existing_atom(icon_name)
     apply(__MODULE__, icon_name, [assigns])
   end
 

--- a/test/petal/heroicons_test.exs
+++ b/test/petal/heroicons_test.exs
@@ -14,12 +14,36 @@ defmodule PetalComponents.HeroiconsTest do
     assert html =~ "currentColor"
   end
 
+  test "it renders heroicons solid icon and color correctly via render component" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <Heroicons.Solid.render type="home" />
+      """)
+
+    assert html =~ "<svg class="
+    assert html =~ "currentColor"
+  end
+
   test "it renders heroicons outline icon and color correctly" do
     assigns = %{}
 
     html =
       rendered_to_string(~H"""
       <Heroicons.Outline.home />
+      """)
+
+    assert html =~ "<svg class="
+    assert html =~ "none"
+  end
+
+  test "it renders heroicons outline icon and color correctly via render component" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <Heroicons.Outline.render type="home" />
       """)
 
     assert html =~ "<svg class="

--- a/test/petal/heroicons_test.exs
+++ b/test/petal/heroicons_test.exs
@@ -19,7 +19,15 @@ defmodule PetalComponents.HeroiconsTest do
 
     html =
       rendered_to_string(~H"""
-      <Heroicons.Solid.render type="home" />
+      <Heroicons.Solid.render icon="home" />
+      """)
+
+    assert html =~ "<svg class="
+    assert html =~ "currentColor"
+
+    html =
+      rendered_to_string(~H"""
+      <Heroicons.Solid.render icon={:home} />
       """)
 
     assert html =~ "<svg class="
@@ -43,7 +51,15 @@ defmodule PetalComponents.HeroiconsTest do
 
     html =
       rendered_to_string(~H"""
-      <Heroicons.Outline.render type="home" />
+      <Heroicons.Outline.render icon="home" />
+      """)
+
+    assert html =~ "<svg class="
+    assert html =~ "none"
+
+    html =
+      rendered_to_string(~H"""
+      <Heroicons.Outline.render icon={:home} />
       """)
 
     assert html =~ "<svg class="


### PR DESCRIPTION
In 538f2b1348e31537b6f41d68b044d5655d2edd2e the docs for the Heroicons component were updated to use `type="icon_name"` instead of `icon={:icon_name}`:

```heex
<PetalComponents.Heroicons.Solid.render icon={:home} class="w-6 h-6" />
<PetalComponents.Heroicons.Solid.render type="home" class="w-6 h-6" />
```

But it doesn't work since the render function wasn't updated.