### PR TITLE
Make compatible with liveview 0.18

### DIFF
--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -3,9 +3,9 @@ defmodule PetalComponents.Button do
 
   alias PetalComponents.Loading
   alias PetalComponents.Heroicons
+  alias PetalComponents.Link
 
   import PetalComponents.Class
-  import PetalComponents.Link
 
   # prop class, :string
   # prop color, :string, options: ["primary", "secondary", "info", "success", "warning", "danger", "gray"]
@@ -31,7 +31,7 @@ defmodule PetalComponents.Button do
       |> assign_new(:to, fn -> nil end)
 
     ~H"""
-    <.link to={@to} link_type={@link_type} class={@classes} disabled={@disabled} {@extra_assigns}>
+    <Link.link to={@to} link_type={@link_type} class={@classes} disabled={@disabled} {@extra_assigns}>
       <%= if @loading do %>
         <Loading.spinner show={true} size_class={get_spinner_size_classes(@size)} />
       <% end %>
@@ -41,7 +41,7 @@ defmodule PetalComponents.Button do
       <% else %>
         <%= @label %>
       <% end %>
-    </.link>
+    </Link.link>
     """
   end
 
@@ -69,7 +69,7 @@ defmodule PetalComponents.Button do
       |> assign_new(:color, fn -> "gray" end)
 
     ~H"""
-    <.link
+    <Link.link
       to={@to}
       link_type={@link_type}
       class={build_class(
@@ -91,7 +91,7 @@ defmodule PetalComponents.Button do
             get_icon_button_size_classes(@size)
           ])}/>
       <% end %>
-    </.link>
+    </Link.link>
     """
   end
 

--- a/lib/petal_components/dropdown.ex
+++ b/lib/petal_components/dropdown.ex
@@ -2,7 +2,7 @@ defmodule PetalComponents.Dropdown do
   use Phoenix.Component
   alias Phoenix.LiveView.JS
   alias PetalComponents.Heroicons
-  import PetalComponents.Link
+  alias PetalComponents.Link
 
   @transition_in_base "transition transform ease-out duration-100"
   @transition_in_start "transform opacity-0 scale-95"
@@ -103,13 +103,13 @@ defmodule PetalComponents.Dropdown do
       end)
 
     ~H"""
-    <.link link_type={@link_type} to={@to} class={@classes} {@extra_assigns}>
+    <Link.link link_type={@link_type} to={@to} class={@classes} {@extra_assigns}>
       <%= if @inner_block do %>
         <%= render_slot(@inner_block) %>
       <% else %>
         <%= @label %>
       <% end %>
-    </.link>
+    </Link.link>
     """
   end
 

--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -2,9 +2,9 @@ defmodule PetalComponents.Pagination do
   use Phoenix.Component
 
   alias PetalComponents.Heroicons
+  alias PetalComponents.Link
 
   import PetalComponents.Class
-  import PetalComponents.Link
 
   # prop path, :string
   # prop class, :string
@@ -43,9 +43,9 @@ defmodule PetalComponents.Pagination do
         <%= for item <- get_items(@total_pages, @current_page, @sibling_count, @boundary_count) do %>
           <%= if item.type == "previous" do %>
             <div>
-              <.link link_type={@link_type} to={get_path(@path, item.number, @current_page)} class="mr-2 inline-flex items-center justify-center rounded leading-5 px-2.5 py-2 bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800 border dark:border-gray-700 border-gray-200 text-gray-600 hover:text-gray-800">
+              <Link.link link_type={@link_type} to={get_path(@path, item.number, @current_page)} class="mr-2 inline-flex items-center justify-center rounded leading-5 px-2.5 py-2 bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800 border dark:border-gray-700 border-gray-200 text-gray-600 hover:text-gray-800">
                 <Heroicons.Solid.chevron_left class="w-5 h-5 text-gray-600 dark:text-gray-400" />
-              </.link>
+              </Link.link>
             </div>
           <% end %>
 
@@ -54,9 +54,9 @@ defmodule PetalComponents.Pagination do
               <%= if item.number == @current_page do %>
                 <span class={get_box_class(item, true)}><%= item.number %></span>
               <% else %>
-                <.link link_type={@link_type} to={get_path(@path, item.number, @current_page)} class={get_box_class(item)}>
+                <Link.link link_type={@link_type} to={get_path(@path, item.number, @current_page)} class={get_box_class(item)}>
                   <%= item.number %>
-                </.link>
+                </Link.link>
               <% end %>
             </li>
           <% end %>
@@ -69,9 +69,9 @@ defmodule PetalComponents.Pagination do
 
           <%= if item.type == "next" do %>
             <div>
-              <.link link_type={@link_type} to={get_path(@path, item.number, @current_page)} class="ml-2 inline-flex items-center justify-center rounded leading-5 px-2.5 py-2 bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800 dark:border-gray-700 border border-gray-200 text-gray-600 hover:text-gray-800">
+              <Link.link link_type={@link_type} to={get_path(@path, item.number, @current_page)} class="ml-2 inline-flex items-center justify-center rounded leading-5 px-2.5 py-2 bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800 dark:border-gray-700 border border-gray-200 text-gray-600 hover:text-gray-800">
                 <Heroicons.Solid.chevron_right class="w-5 h-5 text-gray-600 dark:text-gray-400" />
-              </.link>
+              </Link.link>
             </div>
           <% end %>
         <% end %>

--- a/lib/petal_components/tabs.ex
+++ b/lib/petal_components/tabs.ex
@@ -1,8 +1,9 @@
 defmodule PetalComponents.Tabs do
   use Phoenix.Component
 
+  alias PetalComponents.Link
+
   import PetalComponents.Class
-  import PetalComponents.Link
 
   # prop class, :string
   # prop underline, :boolean, default: false
@@ -56,7 +57,7 @@ defmodule PetalComponents.Tabs do
       end)
 
     ~H"""
-    <.link link_type={@link_type} label={@label} to={@to} class={[get_tab_class(@is_active, @underline), @class]} {@extra_assigns}>
+    <Link.link link_type={@link_type} label={@label} to={@to} class={[get_tab_class(@is_active, @underline), @class]} {@extra_assigns}>
       <%= if @number do %>
         <.render_label_or_slot {assigns} />
 
@@ -66,7 +67,7 @@ defmodule PetalComponents.Tabs do
       <% else %>
         <.render_label_or_slot {assigns} />
       <% end %>
-    </.link>
+    </Link.link>
     """
   end
 

--- a/test/petal/form_test.exs
+++ b/test/petal/form_test.exs
@@ -518,8 +518,7 @@ defmodule PetalComponents.FormTest do
       </.form>
       """)
 
-    assert html =~ "input"
-    assert html =~ "select"
+      assert html =~ "select"
     assert html =~ "user[name]"
   end
 

--- a/test/petal/link_test.exs
+++ b/test/petal/link_test.exs
@@ -1,13 +1,13 @@
 defmodule PetalComponents.LinkTest do
   use ComponentCase
-  import PetalComponents.Link
+  alias PetalComponents.Link
 
   test "a link with label" do
     assigns = %{}
 
     html =
       rendered_to_string(~H"""
-      <.link link_type="a" to="/" label="Press me" phx-click="click_event" />
+      <Link.link link_type="a" to="/" label="Press me" phx-click="click_event" />
       """)
 
     assert html =~ "Press me"
@@ -20,7 +20,7 @@ defmodule PetalComponents.LinkTest do
 
     html =
       rendered_to_string(~H"""
-      <.link link_type="live_patch" to="/" label="Press me" phx-click="click_event" />
+      <Link.link link_type="live_patch" to="/" label="Press me" phx-click="click_event" />
       """)
 
     assert html =~ "Press me"
@@ -33,7 +33,7 @@ defmodule PetalComponents.LinkTest do
 
     html =
       rendered_to_string(~H"""
-      <.link link_type="live_redirect" to="/" label="Press me" phx-click="click_event" />
+      <Link.link link_type="live_redirect" to="/" label="Press me" phx-click="click_event" />
       """)
 
     assert html =~ "Press me"
@@ -46,9 +46,9 @@ defmodule PetalComponents.LinkTest do
 
     html =
       rendered_to_string(~H"""
-      <.link link_type="a" to="/" phx-click="click_event">
+      <Link.link link_type="a" to="/" phx-click="click_event">
         Press me
-      </.link>
+      </Link.link>
       """)
 
     assert html =~ "Press me"
@@ -60,9 +60,9 @@ defmodule PetalComponents.LinkTest do
 
     html =
       rendered_to_string(~H"""
-      <.link to="/" method={:put}>
+      <Link.link to="/" method={:put}>
         Press me
-      </.link>
+      </Link.link>
       """)
 
     assert html =~ "Press me"
@@ -73,31 +73,31 @@ defmodule PetalComponents.LinkTest do
     assigns = %{}
 
     assert rendered_to_string(~H"""
-           <.link to="/" label="Press me" />
+           <Link.link to="/" label="Press me" />
            """) =~ ">Press me<"
 
     assert rendered_to_string(~H"""
-           <.link to="/" label=" Press me " />
+           <Link.link to="/" label=" Press me " />
            """) =~ "> Press me <"
 
     assert rendered_to_string(~H"""
-           <.link link_type="live_patch" to="/" label="Press me" />
+           <Link.link link_type="live_patch" to="/" label="Press me" />
            """) =~ ">Press me<"
 
     assert rendered_to_string(~H"""
-           <.link link_type="live_redirect" to="/" label="Press me" />
+           <Link.link link_type="live_redirect" to="/" label="Press me" />
            """) =~ ">Press me<"
 
     assert rendered_to_string(~H"""
-           <.link to="/">Press me</.link>
+           <Link.link to="/">Press me</Link.link>
            """) =~ ">Press me<"
 
     assert rendered_to_string(~H"""
-           <.link to="/"> Press me </.link>
+           <Link.link to="/"> Press me </Link.link>
            """) =~ "> Press me <"
 
     assert rendered_to_string(~H"""
-           <.link to="/" label="Press me" />, blah
+           <Link.link to="/" label="Press me" />, blah
            """) =~ "</a>, blah"
   end
 end


### PR DESCRIPTION
The next version of liveview introduces a `link` component, not sure if this can be used here, but this PR makes it compatible with the next version by not importing the `Link` module.

Fixes #42 