### PR TITLE
fixed field_has_errors?

### DIFF
--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -563,8 +563,10 @@ defmodule PetalComponents.Form do
   end
 
   defp field_has_errors?(%{form: form, field: field}) do
-    length(Keyword.get_values(form.errors, field)) > 0
+    case Keyword.get_values(form.errors, field) do
+      [] -> false
+      _ -> true
+    end
   end
 
-  defp field_has_errors?(_), do: false
 end

--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -569,4 +569,6 @@ defmodule PetalComponents.Form do
     end
   end
 
+  defp field_has_errors?(_), do: false
+
 end


### PR DESCRIPTION
Checking the length of the list means always traversing the whole list,
matching on the empty list is (in this case marginally) faster, and more
idiomatic.