### PR TITLE
Only send close_modal event to target if provided

### DIFF
--- a/lib/petal_components/modal.ex
+++ b/lib/petal_components/modal.ex
@@ -90,12 +90,11 @@ defmodule PetalComponents.Modal do
         },
         to: "#modal-content"
       )
-      |> JS.push("close_modal")
 
     if close_modal_target do
       JS.push(js, "close_modal", target: close_modal_target)
     else
-      js
+      JS.push(js, "close_modal")
     end
   end
 


### PR DESCRIPTION
Seems related to #30 and some recent changes that were added to support modals in components. As-is, this was still sending the `close_modal` event to the LiveView page when used inside a component and a specific target is passed, as well as to the target. This'll make it so only the target gets the event