### PR TITLE
Fix avatar passing src as empty string and name together

### DIFF
--- a/lib/petal_components/avatar.ex
+++ b/lib/petal_components/avatar.ex
@@ -26,7 +26,7 @@ defmodule PetalComponents.Avatar do
         <Heroicons.Solid.user class="relative w-full h-full text-gray-300 dark:text-gray-300 dark:bg-gray-700 top-[12%] scale-[1.15] transform" />
       </div>
     <% else %>
-      <%= if !@src && @name do %>
+      <%= if src_blank?(@src) && @name do %>
         <div {@rest}
           style={maybe_generate_random_color(@random_color, @name)}
           class={build_class([


### PR DESCRIPTION
If you pass `src` and `name` to avatar and `src` is `""` then it will still try to render the avatar with an img tag instead of a div with initials.

E.g. this is broken when `src == ""`:
```
<.avatar size="sm" src={@user.avatar_url} name={@user.name} />
```