### PR TITLE
Allow heroicon names containing "-"

### DIFF
--- a/lib/mix/tasks/heroicons/generate.ex
+++ b/lib/mix/tasks/heroicons/generate.ex
@@ -16,11 +16,12 @@ defmodule Mix.Tasks.Heroicons.Generate do
     defmodule PetalComponents.#{namespace} do
       @moduledoc \"\"\"
       Icon name can be the function or passed in as a type eg.
-      <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
-      <PetalComponents.Heroicons.Solid.render icon="home" class="w-5 h-5" />
 
-      <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
-      <PetalComponents.Heroicons.Outline.render icon="home" class="w-6 h-6" />
+          <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
+          <PetalComponents.Heroicons.Solid.render icon="home" class="w-5 h-5" />
+
+          <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
+          <PetalComponents.Heroicons.Outline.render icon="home" class="w-6 h-6" />
       \"\"\"
       use Phoenix.Component
 

--- a/lib/mix/tasks/heroicons/generate.ex
+++ b/lib/mix/tasks/heroicons/generate.ex
@@ -29,7 +29,10 @@ defmodule Mix.Tasks.Heroicons.Generate do
       end
 
       def render(%{icon: icon_name} = assigns) do
-        icon_name = String.to_existing_atom(icon_name)
+        icon_name = 
+          icon_name
+          |> String.replace("-", "_")
+          |> String.to_existing_atom()
         apply(__MODULE__, icon_name, [assigns])
       end
     """

--- a/lib/mix/tasks/heroicons/generate.ex
+++ b/lib/mix/tasks/heroicons/generate.ex
@@ -29,10 +29,11 @@ defmodule Mix.Tasks.Heroicons.Generate do
       end
 
       def render(%{icon: icon_name} = assigns) do
-        icon_name = 
+        icon_name =
           icon_name
           |> String.replace("-", "_")
           |> String.to_existing_atom()
+
         apply(__MODULE__, icon_name, [assigns])
       end
     """

--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -494,7 +494,7 @@ defmodule PetalComponents.Form do
   end
 
   defp checkbox_classes(has_error) do
-    "#{if has_error, do: "has-error", else: ""} border-gray-300 text-primary-700 rounded w-5 h-5 ease-linear transition-all duration-150 dark:bg-gray-800 dark:border-gray-300"
+    "#{if has_error, do: "has-error", else: ""} border-gray-300 text-primary-700 rounded w-5 h-5 ease-linear transition-all duration-150 dark:bg-gray-800 dark:border-gray-600"
   end
 
   defp checkbox_group_layout_classes(assigns) do
@@ -542,7 +542,7 @@ defmodule PetalComponents.Form do
   end
 
   defp radio_classes(has_error) do
-    "#{if has_error, do: "has-error", else: ""} border-gray-300 h-4 w-4 cursor-pointer text-primary-600 focus:ring-primary-500 dark:bg-gray-800 dark:border-gray-300"
+    "#{if has_error, do: "has-error", else: ""} border-gray-300 h-4 w-4 cursor-pointer text-primary-600 focus:ring-primary-500 dark:bg-gray-800 dark:border-gray-600"
   end
 
   defp field_has_errors?(%{form: form, field: field}) do

--- a/lib/petal_components/icons/heroicons/outline.ex
+++ b/lib/petal_components/icons/heroicons/outline.ex
@@ -14,7 +14,10 @@ defmodule PetalComponents.Heroicons.Outline do
   end
 
   def render(%{icon: icon_name} = assigns) do
-    icon_name = String.to_existing_atom(icon_name)
+    icon_name = 
+      icon_name
+      |> String.replace("-", "_")
+      |> String.to_existing_atom()
     apply(__MODULE__, icon_name, [assigns])
   end
 

--- a/lib/petal_components/icons/heroicons/outline.ex
+++ b/lib/petal_components/icons/heroicons/outline.ex
@@ -1,11 +1,12 @@
 defmodule PetalComponents.Heroicons.Outline do
   @moduledoc """
   Icon name can be the function or passed in as a type eg.
-  <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
-  <PetalComponents.Heroicons.Solid.render icon="home" class="w-5 h-5" />
 
-  <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
-  <PetalComponents.Heroicons.Outline.render icon="home" class="w-6 h-6" />
+      <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
+      <PetalComponents.Heroicons.Solid.render icon="home" class="w-5 h-5" />
+
+      <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
+      <PetalComponents.Heroicons.Outline.render icon="home" class="w-6 h-6" />
   """
   use Phoenix.Component
 

--- a/lib/petal_components/icons/heroicons/outline.ex
+++ b/lib/petal_components/icons/heroicons/outline.ex
@@ -14,10 +14,11 @@ defmodule PetalComponents.Heroicons.Outline do
   end
 
   def render(%{icon: icon_name} = assigns) do
-    icon_name = 
+    icon_name =
       icon_name
       |> String.replace("-", "_")
       |> String.to_existing_atom()
+
     apply(__MODULE__, icon_name, [assigns])
   end
 

--- a/lib/petal_components/icons/heroicons/solid.ex
+++ b/lib/petal_components/icons/heroicons/solid.ex
@@ -1,11 +1,12 @@
 defmodule PetalComponents.Heroicons.Solid do
   @moduledoc """
   Icon name can be the function or passed in as a type eg.
-  <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
-  <PetalComponents.Heroicons.Solid.render icon="home" class="w-5 h-5" />
 
-  <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
-  <PetalComponents.Heroicons.Outline.render icon="home" class="w-6 h-6" />
+      <PetalComponents.Heroicons.Solid.home class="w-5 h-5" />
+      <PetalComponents.Heroicons.Solid.render icon="home" class="w-5 h-5" />
+
+      <PetalComponents.Heroicons.Outline.home class="w-6 h-6" />
+      <PetalComponents.Heroicons.Outline.render icon="home" class="w-6 h-6" />
   """
   use Phoenix.Component
 

--- a/lib/petal_components/icons/heroicons/solid.ex
+++ b/lib/petal_components/icons/heroicons/solid.ex
@@ -14,7 +14,10 @@ defmodule PetalComponents.Heroicons.Solid do
   end
 
   def render(%{icon: icon_name} = assigns) do
-    icon_name = String.to_existing_atom(icon_name)
+    icon_name = 
+      icon_name
+      |> String.replace("-", "_")
+      |> String.to_existing_atom()
     apply(__MODULE__, icon_name, [assigns])
   end
 

--- a/lib/petal_components/icons/heroicons/solid.ex
+++ b/lib/petal_components/icons/heroicons/solid.ex
@@ -14,10 +14,11 @@ defmodule PetalComponents.Heroicons.Solid do
   end
 
   def render(%{icon: icon_name} = assigns) do
-    icon_name = 
+    icon_name =
       icon_name
       |> String.replace("-", "_")
       |> String.to_existing_atom()
+
     apply(__MODULE__, icon_name, [assigns])
   end
 

--- a/test/petal/heroicons_test.exs
+++ b/test/petal/heroicons_test.exs
@@ -19,15 +19,28 @@ defmodule PetalComponents.HeroiconsTest do
 
     html =
       rendered_to_string(~H"""
-      <Heroicons.Solid.render icon="home" />
+      <Heroicons.Solid.render icon="document_text" />
       """)
 
     assert html =~ "<svg class="
     assert html =~ "currentColor"
 
+    also_html =
+      rendered_to_string(~H"""
+      <Heroicons.Solid.render icon={:document_text} />
+      """)
+
+    assert also_html == html
+    assert also_html =~ "<svg class="
+    assert also_html =~ "currentColor"
+  end
+
+  test "it renders heroicons solid with dash" do
+    assigns = %{}
+
     html =
       rendered_to_string(~H"""
-      <Heroicons.Solid.render icon={:home} />
+      <Heroicons.Solid.render icon="document-text" />
       """)
 
     assert html =~ "<svg class="
@@ -51,15 +64,28 @@ defmodule PetalComponents.HeroiconsTest do
 
     html =
       rendered_to_string(~H"""
-      <Heroicons.Outline.render icon="home" />
+      <Heroicons.Outline.render icon="document_text" />
       """)
 
     assert html =~ "<svg class="
     assert html =~ "none"
 
+    also_html =
+      rendered_to_string(~H"""
+      <Heroicons.Outline.render icon={:document_text} />
+      """)
+
+    assert also_html == html
+    assert also_html =~ "<svg class="
+    assert also_html =~ "none"
+  end
+
+  test "it renders heroicons outline with dash" do
+    assigns = %{}
+
     html =
       rendered_to_string(~H"""
-      <Heroicons.Outline.render icon={:home} />
+      <Heroicons.Outline.render icon="document-text" />
       """)
 
     assert html =~ "<svg class="


### PR DESCRIPTION
In #44 I fixed the render method for heroicons to work with strings. Before the names of the icons were atoms and the dashes in their names were replaced with underscores, but since we're using strings now there is no reason to use underscores.

This PR uses `String.replace` to replace all "-" with "_" before calling the function which makes the names from heroicons.com work out of the box, but icon names with underscores should keep working.

Edit: 
Regarding the atoms existing in the last PR
> I just assumed they were since module names are atoms too, and it seems to work (I tested it with a project that uses a lot of different icons and they all showed up correctly using the new syntax for render).

Function names do not count as atoms. I think they all exist because they are created in the generator.
