### PR TITLE
Fixed pagination control if users set sibling_count to less than 1

### DIFF
--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -33,7 +33,7 @@ defmodule PetalComponents.Pagination do
     <div {@rest} class={"#{@class} flex"}>
       <ul class="inline-flex -space-x-px text-sm font-medium">
         <%= for item <- get_items(@total_pages, @current_page, @sibling_count, @boundary_count) do %>
-          <%= if item.type == "previous" do %>
+          <%= if item.type == "previous" and item.enabled? do %>
             <div>
               <Link.link link_type={@link_type} to={get_path(@path, item.number, @current_page)} class="mr-2 inline-flex items-center justify-center rounded leading-5 px-2.5 py-2 bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800 border dark:border-gray-700 border-gray-200 text-gray-600 hover:text-gray-800">
                 <Heroicons.Solid.chevron_left class="w-5 h-5 text-gray-600 dark:text-gray-400" />
@@ -43,8 +43,8 @@ defmodule PetalComponents.Pagination do
 
           <%= if item.type == "page" do %>
             <li>
-              <%= if item.number == @current_page do %>
-                <span class={get_box_class(item, true)}><%= item.number %></span>
+              <%= if item.current? do %>
+                <span class={get_box_class(item)}><%= item.number %></span>
               <% else %>
                 <Link.link link_type={@link_type} to={get_path(@path, item.number, @current_page)} class={get_box_class(item)}>
                   <%= item.number %>
@@ -59,7 +59,7 @@ defmodule PetalComponents.Pagination do
             </li>
           <% end %>
 
-          <%= if item.type == "next" do %>
+          <%= if item.type == "next" and item.enabled? do %>
             <div>
               <Link.link link_type={@link_type} to={get_path(@path, item.number, @current_page)} class="ml-2 inline-flex items-center justify-center rounded leading-5 px-2.5 py-2 bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800 dark:border-gray-700 border border-gray-200 text-gray-600 hover:text-gray-800">
                 <Heroicons.Solid.chevron_right class="w-5 h-5 text-gray-600 dark:text-gray-400" />
@@ -73,108 +73,132 @@ defmodule PetalComponents.Pagination do
   end
 
   defp get_items(total_pages, current_page, sibling_count, boundary_count) do
-    start_pages = 1..min(boundary_count, total_pages) |> Enum.to_list()
-    end_pages_start = max(total_pages - boundary_count + 1, boundary_count + 1)
-    end_pages_end = total_pages
-    end_pages = end_pages_start..end_pages_end |> Enum.to_list()
+    total_pages = max(1, total_pages)
+    current_page = max(1, min(current_page, total_pages))
+    boundary_count = max(0, min(boundary_count, total_pages))
+    sibling_count = max(0, sibling_count)
 
-    siblings_start =
-      max(
-        min(current_page - sibling_count, total_pages - boundary_count - sibling_count * 2 - 1),
-        boundary_count + 2
-      )
+    siblings_size = 1 + 2 * sibling_count
+    start_siblings = max(1, min(current_page - sibling_count, total_pages - siblings_size - boundary_count + 1))
+    end_siblings = min(max(current_page + sibling_count, siblings_size + boundary_count), total_pages)
 
-    siblings_end =
-      min(
-        max(current_page + sibling_count, boundary_count + sibling_count * 2 + 2),
-        if(length(end_pages) > 0, do: List.first(end_pages) - 2, else: total_pages - 1)
-      )
-
-    items = []
-
-    # Previous button
-    items =
-      if current_page > 1,
-        do: items ++ [%{type: "previous", number: current_page - 1}],
-        else: items
-
-    # Start pages
-    items =
-      Enum.reduce(start_pages, items, fn i, acc ->
-        acc ++ [%{type: "page", number: i, first: i == 1, only: total_pages == 1}]
-      end)
-
-    # First ellipsis
-    items =
-      if siblings_start > boundary_count + 2,
-        do: items ++ [%{type: "ellipsis"}],
-        else:
-          if(boundary_count + 1 < total_pages - boundary_count,
-            do: items ++ [%{type: "page", number: boundary_count + 1}],
-            else: items
-          )
-
-    # Siblings
-    items =
-      if siblings_start <= siblings_end do
-        Enum.reduce(siblings_start..siblings_end, items, fn i, acc ->
-          acc ++ [%{type: "page", number: i}]
-        end)
+    boundary_start =
+      if boundary_count > 0 do
+        1..min(boundary_count, start_siblings) |> Enum.to_list()
       else
-        items
+        [start_siblings]
       end
 
-    # Second ellipsis
-    items =
-      if siblings_end < total_pages - boundary_count - 1,
-        do: items ++ [%{type: "ellipsis"}],
-        else:
-          if(total_pages - boundary_count > boundary_count,
-            do: items ++ [%{type: "page", number: total_pages - boundary_count}],
-            else: items
-          )
+    siblings = start_siblings..end_siblings |> Enum.to_list()
 
-    # End pages
-    items =
-      if end_pages_start <= end_pages_end do
-        Enum.reduce(end_pages, items, fn i, acc ->
-          acc ++ [%{type: "page", number: i, last: i == total_pages}]
-        end)
+    boundary_end =
+      if boundary_count > 0 do
+        max(total_pages - boundary_count + 1, end_siblings)..total_pages |> Enum.to_list()
       else
-        items
+        [end_siblings]
       end
 
-    # Next button
-    items =
-      if current_page < total_pages,
-        do: items ++ [%{type: "next", number: current_page + 1}],
-        else: items
+    pages =
+      Enum.concat([boundary_start, siblings, boundary_end])
+      |> Enum.sort()
+      |> Enum.dedup()
+      |> Enum.to_list()
 
-    items
+    first_page = List.first(pages)
+    last_page = List.last(pages)
+
+    pages_next =
+      Enum.drop(pages, 1)
+      |> Enum.concat([List.last(pages) + 1])
+      |> Enum.to_list()
+
+    Enum.zip(pages, pages_next)
+    |> Enum.flat_map(fn t ->
+      case t do
+        {page, next} when next - page == 1 ->
+          [%{type: "page", number: page}]
+
+        {page, next} when next - page > 1 ->
+          [%{type: "page", number: page}, %{type: "ellipsis"}]
+
+        _ ->
+          []
+      end
+    end)
+    |> Enum.map(fn item ->
+      case item do
+        %{type: "page"} ->
+          item
+          |> Map.put(:first?, item.number == first_page)
+          |> Map.put(:current?, item.number == current_page)
+          |> Map.put(:last?, item.number == last_page)
+
+        _ ->
+          item
+      end
+    end)
+    |> Enum.flat_map(fn item ->
+      case item do
+        %{first?: true, current?: true, last?: true} when total_pages > 1 ->
+          [
+            get_prev_item(current_page, total_pages),
+            item,
+            get_next_item(current_page, total_pages)
+          ]
+
+        %{first?: true, last?: false} when total_pages > 1 ->
+          [
+            get_prev_item(current_page, total_pages),
+            item
+          ]
+
+        %{first?: false, last?: true} when total_pages > 1 ->
+          [
+            item,
+            get_next_item(current_page, total_pages)
+          ]
+
+        _ ->
+          [item]
+      end
+    end)
   end
 
-  defp get_box_class(item, is_active \\ false) do
+  defp get_prev_item(current_page, _total_pages) do
+    %{
+      type: "previous",
+      number: max(1, current_page - 1),
+      enabled?: current_page > 1
+    }
+  end
+
+  defp get_next_item(current_page, total_pages) do
+    %{
+      type: "next",
+      number: min(current_page + 1, total_pages),
+      enabled?: current_page < total_pages
+    }
+  end
+
+  defp get_box_class(item) do
     base_classes =
       "inline-flex items-center justify-center leading-5 px-3.5 py-2 border border-gray-200 dark:border-gray-700"
 
     active_classes =
-      if is_active,
+      if item.current?,
         do: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300",
         else:
           "bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-800 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-400"
 
     rounded_classes =
-      cond do
-        item[:only] ->
+      case item do
+        %{first?: true, last?: true} ->
           "rounded"
-
-        item[:first] ->
+        %{first?: true, last?: false} ->
           "rounded-l "
-
-        item[:last] ->
+        %{first?: false, last?: true} ->
           "rounded-r"
-
-        true ->
+        _ ->
           ""
       end
 

--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -5,6 +5,7 @@ defmodule PetalComponents.Pagination do
   alias PetalComponents.Link
 
   import PetalComponents.Helpers
+  import PetalComponents.PaginationInternal
 
   # prop path, :string
   # prop class, :string
@@ -32,8 +33,8 @@ defmodule PetalComponents.Pagination do
     ~H"""
     <div {@rest} class={"#{@class} flex"}>
       <ul class="inline-flex -space-x-px text-sm font-medium">
-        <%= for item <- get_items(@total_pages, @current_page, @sibling_count, @boundary_count) do %>
-          <%= if item.type == "previous" and item.enabled? do %>
+        <%= for item <- get_pagination_items(@total_pages, @current_page, @sibling_count, @boundary_count) do %>
+          <%= if item.type == "prev" and item.enabled? do %>
             <div>
               <Link.link link_type={@link_type} to={get_path(@path, item.number, @current_page)} class="mr-2 inline-flex items-center justify-center rounded leading-5 px-2.5 py-2 bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800 border dark:border-gray-700 border-gray-200 text-gray-600 hover:text-gray-800">
                 <Heroicons.Solid.chevron_left class="w-5 h-5 text-gray-600 dark:text-gray-400" />
@@ -53,7 +54,7 @@ defmodule PetalComponents.Pagination do
             </li>
           <% end %>
 
-          <%= if item.type == "ellipsis" do %>
+          <%= if item.type == "..." do %>
             <li>
               <span class="inline-flex items-center justify-center leading-5 px-3.5 py-2 bg-white border dark:bg-gray-900 dark:border-gray-700 border-gray-200 text-gray-400">...</span>
             </li>
@@ -70,114 +71,6 @@ defmodule PetalComponents.Pagination do
       </ul>
     </div>
     """
-  end
-
-  defp get_items(total_pages, current_page, sibling_count, boundary_count) do
-    total_pages = max(1, total_pages)
-    current_page = max(1, min(current_page, total_pages))
-    boundary_count = max(0, min(boundary_count, total_pages))
-    sibling_count = max(0, sibling_count)
-
-    siblings_size = 1 + 2 * sibling_count
-    start_siblings = max(1, min(current_page - sibling_count, total_pages - siblings_size - boundary_count + 1))
-    end_siblings = min(max(current_page + sibling_count, siblings_size + boundary_count), total_pages)
-
-    boundary_start =
-      if boundary_count > 0 do
-        1..min(boundary_count, start_siblings) |> Enum.to_list()
-      else
-        [start_siblings]
-      end
-
-    siblings = start_siblings..end_siblings |> Enum.to_list()
-
-    boundary_end =
-      if boundary_count > 0 do
-        max(total_pages - boundary_count + 1, end_siblings)..total_pages |> Enum.to_list()
-      else
-        [end_siblings]
-      end
-
-    pages =
-      Enum.concat([boundary_start, siblings, boundary_end])
-      |> Enum.sort()
-      |> Enum.dedup()
-      |> Enum.to_list()
-
-    first_page = List.first(pages)
-    last_page = List.last(pages)
-
-    pages_next =
-      Enum.drop(pages, 1)
-      |> Enum.concat([List.last(pages) + 1])
-      |> Enum.to_list()
-
-    Enum.zip(pages, pages_next)
-    |> Enum.flat_map(fn t ->
-      case t do
-        {page, next} when next - page == 1 ->
-          [%{type: "page", number: page}]
-
-        {page, next} when next - page > 1 ->
-          [%{type: "page", number: page}, %{type: "ellipsis"}]
-
-        _ ->
-          []
-      end
-    end)
-    |> Enum.map(fn item ->
-      case item do
-        %{type: "page"} ->
-          item
-          |> Map.put(:first?, item.number == first_page)
-          |> Map.put(:current?, item.number == current_page)
-          |> Map.put(:last?, item.number == last_page)
-
-        _ ->
-          item
-      end
-    end)
-    |> Enum.flat_map(fn item ->
-      case item do
-        %{first?: true, current?: true, last?: true} when total_pages > 1 ->
-          [
-            get_prev_item(current_page, total_pages),
-            item,
-            get_next_item(current_page, total_pages)
-          ]
-
-        %{first?: true, last?: false} when total_pages > 1 ->
-          [
-            get_prev_item(current_page, total_pages),
-            item
-          ]
-
-        %{first?: false, last?: true} when total_pages > 1 ->
-          [
-            item,
-            get_next_item(current_page, total_pages)
-          ]
-
-        _ ->
-          [item]
-      end
-    end)
-  end
-
-  defp get_prev_item(current_page, _total_pages) do
-    %{
-      type: "previous",
-      number: max(1, current_page - 1),
-      enabled?: current_page > 1
-    }
-  end
-
-  defp get_next_item(current_page, total_pages) do
-    %{
-      type: "next",
-      number: min(current_page + 1, total_pages),
-      enabled?: current_page < total_pages
-    }
   end
 
   defp get_box_class(item) do

--- a/lib/petal_components/pagination_internal.ex
+++ b/lib/petal_components/pagination_internal.ex
@@ -103,7 +103,7 @@ defmodule PetalComponents.PaginationInternal do
 
   defp get_prev_item(current_page, _total_pages) do
     %{
-      type: "prevs",
+      type: "prev",
       number: max(1, current_page - 1),
       enabled?: current_page > 1
     }

--- a/lib/petal_components/pagination_internal.ex
+++ b/lib/petal_components/pagination_internal.ex
@@ -1,13 +1,21 @@
 defmodule PetalComponents.PaginationInternal do
   @doc """
-  get_items computes the pagination buttons based on
+  get_items computes the pagination button information based on
   - total number of pages,
   - current page,
   - sibling count (pages left and right of current page)
   - boundary count (pages at start, and at end of the page range)
 
-  As this receives user input, possibly from the internet
-  the result is computed ignoring invalid values and a valid result is always returned.
+  As this control receives user input, possibly from the internet
+  a reasonable result is computed despite invalid input values and
+  at least one page item is returned always.
+
+  * The resulting items list always has 1 + max(0, sibling_count) + max(0, boundary_count) page items
+  * The resulting items may/will contains ellipsis items only if boundary_count > 0
+  * The previous item has `:enabled?` false if page 1 is current
+  * The next item has `:enabled?` false if the last page is current
+
+  please see the unit tests for examples
   """
   def get_pagination_items(total_pages, current_page, sibling_count, boundary_count) do
     total_pages = max(1, total_pages)

--- a/lib/petal_components/pagination_internal.ex
+++ b/lib/petal_components/pagination_internal.ex
@@ -1,0 +1,119 @@
+defmodule PetalComponents.PaginationInternal do
+  @doc """
+  get_items computes the pagination buttons based on
+  - total number of pages,
+  - current page,
+  - sibling count (pages left and right of current page)
+  - boundary count (pages at start, and at end of the page range)
+
+  As this receives user input, possibly from the internet
+  the result is computed ignoring invalid values and a valid result is always returned.
+  """
+  def get_pagination_items(total_pages, current_page, sibling_count, boundary_count) do
+    total_pages = max(1, total_pages)
+    current_page = max(1, min(current_page, total_pages))
+    boundary_count = max(0, min(boundary_count, total_pages))
+    sibling_count = max(0, sibling_count)
+
+    siblings_size = 1 + 2 * sibling_count
+    start_siblings = max(1, min(current_page - sibling_count, total_pages - siblings_size - boundary_count + 1))
+    end_siblings = min(max(current_page + sibling_count, siblings_size + boundary_count), total_pages)
+
+    boundary_start =
+      if boundary_count > 0 do
+        1..min(boundary_count, start_siblings) |> Enum.to_list()
+      else
+        [start_siblings]
+      end
+
+    siblings = start_siblings..end_siblings |> Enum.to_list()
+
+    boundary_end =
+      if boundary_count > 0 do
+        max(total_pages - boundary_count + 1, end_siblings)..total_pages |> Enum.to_list()
+      else
+        [end_siblings]
+      end
+
+    pages =
+      Enum.concat([boundary_start, siblings, boundary_end])
+      |> Enum.sort()
+      |> Enum.dedup()
+      |> Enum.to_list()
+
+    first_page = List.first(pages)
+    last_page = List.last(pages)
+
+    pages_next =
+      Enum.drop(pages, 1)
+      |> Enum.concat([List.last(pages) + 1])
+      |> Enum.to_list()
+
+    Enum.zip(pages, pages_next)
+    |> Enum.flat_map(fn t ->
+      case t do
+        {page, next} when next - page == 1 ->
+          [%{type: "page", number: page}]
+
+        {page, next} when next - page > 1 ->
+          [%{type: "page", number: page}, %{type: "..."}]
+
+        _ ->
+          []
+      end
+    end)
+    |> Enum.map(fn item ->
+      case item do
+        %{type: "page"} ->
+          item
+          |> Map.put(:first?, item.number == first_page)
+          |> Map.put(:current?, item.number == current_page)
+          |> Map.put(:last?, item.number == last_page)
+
+        _ ->
+          item
+      end
+    end)
+    |> Enum.flat_map(fn item ->
+      case item do
+        %{first?: true, current?: true, last?: true} when total_pages > 1 ->
+          [
+            get_prev_item(current_page, total_pages),
+            item,
+            get_next_item(current_page, total_pages)
+          ]
+
+        %{first?: true, last?: false} when total_pages > 1 ->
+          [
+            get_prev_item(current_page, total_pages),
+            item
+          ]
+
+        %{first?: false, last?: true} when total_pages > 1 ->
+          [
+            item,
+            get_next_item(current_page, total_pages)
+          ]
+
+        _ ->
+          [item]
+      end
+    end)
+  end
+
+  defp get_prev_item(current_page, _total_pages) do
+    %{
+      type: "prevs",
+      number: max(1, current_page - 1),
+      enabled?: current_page > 1
+    }
+  end
+
+  defp get_next_item(current_page, total_pages) do
+    %{
+      type: "next",
+      number: min(current_page + 1, total_pages),
+      enabled?: current_page < total_pages
+    }
+  end
+end

--- a/test/petal/pagination_test.exs
+++ b/test/petal/pagination_test.exs
@@ -1,6 +1,326 @@
 defmodule PetalComponents.PaginationTest do
   use ComponentCase
   import PetalComponents.Pagination
+  import PetalComponents.PaginationInternal
+
+  test "pager for negative number of pages, current page, siblings and boundary" <>
+         " shows only the first (supposedly empty) page, no prev or next" do
+    items = get_pagination_items(-1, -1, -1, -1)
+    assert [%{type: "page", number: 1}] = items
+  end
+
+  test "pager for zero number of pages, current page, siblings and boundary" <>
+         " shows only a single page, no prev or next" do
+    items = get_pagination_items(0, 0, 0, 0)
+    assert [%{type: "page", number: 1}] = items
+  end
+
+  test "pager for 2 pages, current page 1, siblings and boundary at zero" <>
+         " shows only a single page and next, no prev" do
+    items = get_pagination_items(2, 1, 0, 0)
+
+    assert [
+             %{type: "prev", number: 1, enabled?: false},
+             %{type: "page", number: 1, current?: true},
+             %{type: "next", number: 2, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 2 pages, current page 2, siblings and boundary at zero" <>
+  " shows: only a single page and prev, no next" do
+    items = get_pagination_items(2, 2, 0, 0)
+
+    assert [
+             %{type: "prev", number: 1, enabled?: true},
+             %{type: "page", number: 2, current?: true},
+             %{type: "next", number: 2, enabled?: false}
+           ] = items
+  end
+
+  test "pager for 5 pages, current page 2, 0 siblings and boundary" <>
+  " shows: prev, [2], next" do
+    items = get_pagination_items(5, 2, 0, 0)
+
+    assert [
+             %{type: "prev", number: 1, enabled?: true},
+             %{type: "page", number: 2, current?: true},
+             %{type: "next", number: 3, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 5 pages, current page 1, 0 siblings and 1 boundary" <>
+  " shows: [1], 2, ..., 5, next" do
+    items = get_pagination_items(5, 1, 0, 1)
+
+    assert [
+             %{type: "prev", number: 1, enabled?: false},
+             %{type: "page", number: 1, current?: true},
+             %{type: "page", number: 2, current?: false},
+             %{type: "...",  },
+             %{type: "page", number: 5, current?: false},
+             %{type: "next", number: 2, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 5 pages, current page 2, 0 siblings and 1 boundary" <>
+  " shows: prev, 1, [2], ..., 5, next" do
+    items = get_pagination_items(5, 2, 0, 1)
+
+    assert [
+             %{type: "prev", number: 1, enabled?: true},
+             %{type: "page", number: 1, current?: false},
+             %{type: "page", number: 2, current?: true},
+             %{type: "...",  },
+             %{type: "page", number: 5, current?: false},
+             %{type: "next", number: 3, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 5 pages, current page 3, 0 siblings and 1 boundary" <>
+  " shows: prev, 1, ,..., [3], ..., 5, next" do
+    items = get_pagination_items(5, 3, 0, 1)
+
+    assert [
+             %{type: "prev", number: 2, enabled?: true},
+             %{type: "page", number: 1, current?: false},
+             %{type: "...",  },
+             %{type: "page", number: 3, current?: true},
+             %{type: "...",  },
+             %{type: "page", number: 5, current?: false},
+             %{type: "next", number: 4, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 5 pages, current page 4, 0 siblings and 1 boundary" <>
+  " shows: prev, 1,... , [4], 5, next" do
+    items = get_pagination_items(5, 4, 0, 1)
+
+    assert [
+             %{type: "prev", number: 3, enabled?: true},
+             %{type: "page", number: 1, current?: false},
+             %{type: "...",  },
+             %{type: "page", number: 4, current?: true},
+             %{type: "page", number: 5, current?: false},
+             %{type: "next", number: 5, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 5 pages, current page 5, 0 siblings and 1 boundary" <>
+  " shows: prev, 1,... , 4, [5]" do
+    items = get_pagination_items(5, 5, 0, 1)
+
+    assert [
+             %{type: "prev", number: 4, enabled?: true},
+             %{type: "page", number: 1, current?: false},
+             %{type: "...",  },
+             %{type: "page", number: 4, current?: false},
+             %{type: "page", number: 5, current?: true},
+             %{type: "next", number: 5, enabled?: false}
+           ] = items
+  end
+
+  test "pager for 5 pages, current page 1, 1 sibling and 0 boundary" <>
+  " shows: [1], 2, 3, next" do
+    items = get_pagination_items(5, 1, 1, 0)
+
+    assert [
+             %{type: "prev", number: 1, enabled?: false},
+             %{type: "page", number: 1, current?: true},
+             %{type: "page", number: 2, current?: false},
+             %{type: "page", number: 3, current?: false},
+             %{type: "next", number: 2, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 5 pages, current page 2, 1 sibling and 0 boundary" <>
+  " shows: prev, 1, [2], 3, next" do
+    items = get_pagination_items(5, 2, 1, 0)
+
+    assert [
+             %{type: "prev", number: 1, enabled?: true},
+             %{type: "page", number: 1, current?: false},
+             %{type: "page", number: 2, current?: true},
+             %{type: "page", number: 3, current?: false},
+             %{type: "next", number: 3, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 5 pages, current page 3, 1 sibling and 0 boundary" <>
+  " shows: prev, 2, [3], 4, next" do
+    items = get_pagination_items(5, 3, 1, 0)
+
+    assert [
+             %{type: "prev", number: 2, enabled?: true},
+             %{type: "page", number: 2, current?: false},
+             %{type: "page", number: 3, current?: true},
+             %{type: "page", number: 4, current?: false},
+             %{type: "next", number: 4, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 5 pages, current page 4, 1 sibling and 0 boundary" <>
+  " shows: prev, 3, [4], 5, next" do
+    items = get_pagination_items(5, 4, 1, 0)
+
+    assert [
+             %{type: "prev", number: 3, enabled?: true},
+             %{type: "page", number: 3, current?: false},
+             %{type: "page", number: 4, current?: true},
+             %{type: "page", number: 5, current?: false},
+             %{type: "next", number: 5, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 5 pages, current page 5, 1 sibling and 0 boundary" <>
+  " shows: prev, 3, 4, [5]" do
+    items = get_pagination_items(5, 5, 1, 0)
+
+    assert [
+             %{type: "prev", number: 4, enabled?: true},
+             %{type: "page", number: 3, current?: false},
+             %{type: "page", number: 4, current?: false},
+             %{type: "page", number: 5, current?: true},
+             %{type: "next", number: 5, enabled?: false}
+           ] = items
+  end
+
+  test "pager for 100 pages, current page 1, 2 siblings and 2 boundary pages" <>
+  " shows: [1], 2, 3, 4, ... , 98, 99, 100, next" do
+    items = get_pagination_items(100, 1, 2, 2)
+
+    assert [
+             %{type: "prev", number: 1, enabled?: false},
+             # current page
+             %{type: "page", number: 1, current?: true},
+             # start boundary pages
+             %{type: "page", number: 2, current?: false},
+             %{type: "page", number: 3, current?: false},
+             # start sibling pages
+             %{type: "page", number: 4, current?: false},
+             %{type: "page", number: 5, current?: false},
+             # end sibling pages
+             %{type: "page", number: 6, current?: false},
+             %{type: "page", number: 7, current?: false},
+             # ellipsis
+             %{type: "...",  },
+             # end boundary pages
+             %{type: "page", number: 99, current?: false},
+             %{type: "page", number: 100, current?: false},
+             %{type: "next", number: 2, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 100 pages, current page 5, 2 siblings and 2 boundary pages" <>
+  " shows: prev, 1, 2, 3, 4, [5], 6, 7 ... , 98, 99, 100, next" do
+    items = get_pagination_items(100, 5, 2, 2)
+
+    assert [
+             %{type: "prev", number: 4, enabled?: true},
+             # start boundary pages
+             %{type: "page", number: 1, current?: false},
+             %{type: "page", number: 2, current?: false},
+             # start sibling pages
+             %{type: "page", number: 3, current?: false},
+             %{type: "page", number: 4, current?: false},
+             # current page
+             %{type: "page", number: 5, current?: true},
+             # end sibling pages
+             %{type: "page", number: 6, current?: false},
+             %{type: "page", number: 7, current?: false},
+             # ellipsis
+             %{type: "...",  },
+             # end boundary pages
+             %{type: "page", number: 99, current?: false},
+             %{type: "page", number: 100, current?: false},
+             %{type: "next", number: 6, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 100 pages, current page 6, 2 siblings and 2 boundary pages" <>
+  " shows: prev, 1, 2, .., 4, 5, [6], 7, 8, ... , 98, 99, 100, next" do
+    items = get_pagination_items(100, 6, 2, 2)
+
+    assert [
+             %{type: "prev", number: 5, enabled?: true},
+             # start boundary pages
+             %{type: "page", number: 1, current?: false},
+             %{type: "page", number: 2, current?: false},
+             # ellipsis
+             %{type: "...",  },
+             # start sibling pages
+             %{type: "page", number: 4, current?: false},
+             %{type: "page", number: 5, current?: false},
+             # current page
+             %{type: "page", number: 6, current?: true},
+             # end sibling pages
+             %{type: "page", number: 7, current?: false},
+             %{type: "page", number: 8, current?: false},
+             # ellipsis
+             %{type: "...",  },
+             # end boundary pages
+             %{type: "page", number: 99, current?: false},
+             %{type: "page", number: 100, current?: false},
+             %{type: "next", number: 7, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 100 pages, current page 7, 2 siblings and 2 boundary pages" <>
+  " shows prev, [1], 2, 3, 4, ... , 98, 99, 100, next" do
+    items = get_pagination_items(100, 7, 2, 2)
+
+    assert [
+             #prev page 6
+             %{type: "prev", number: 6, enabled?: true},
+             # start boundary pages
+             %{type: "page", number: 1, current?: false},
+             %{type: "page", number: 2, current?: false},
+             # ellipsis
+             %{type: "...",  },
+             # start sibling pages
+             %{type: "page", number: 5, current?: false},
+             %{type: "page", number: 6, current?: false},
+             # current page
+             %{type: "page", number: 7, current?: true},
+             # end sibling pages
+             %{type: "page", number: 8, current?: false},
+             %{type: "page", number: 9, current?: false},
+             # ellipsis
+             %{type: "...",  },
+             # end boundary pages
+             %{type: "page", number: 99, current?: false},
+             %{type: "page", number: 100, current?: false},
+             # next page 8
+             %{type: "next", number: 8, enabled?: true}
+           ] = items
+  end
+
+  test "pager for 100 pages, current page 100, 2 siblings and 2 boundary pages" <>
+  " shows prev, 1, 2, ... 94, 95, 96, 97, 98, 99, [100]" do
+    items = get_pagination_items(100, 100, 2, 2)
+
+    assert [
+             #prev page 6
+             %{type: "prev", number: 99, enabled?: true},
+             # start boundary pages
+             %{type: "page", number: 1, current?: false},
+             %{type: "page", number: 2, current?: false},
+             # ellipsis
+             %{type: "...",  },
+             # start sibling pages
+             %{type: "page", number: 94, current?: false},
+             %{type: "page", number: 95, current?: false},
+             # end sibling pages
+             %{type: "page", number: 96, current?: false},
+             %{type: "page", number: 97, current?: false},
+             # end boundary pages
+             %{type: "page", number: 98, current?: false},
+             %{type: "page", number: 99, current?: false},
+             # current page
+             %{type: "page", number: 100, current?: true},
+             # next page 8
+             %{type: "next", number: 100, enabled?: false}
+           ] = items
+  end
 
   test "test less than 5 pages" do
     assigns = %{}
@@ -36,6 +356,13 @@ defmodule PetalComponents.PaginationTest do
   end
 
   test "show front ellipsis if current page is greater than the boundary count" do
+    # bc: 1, sib: 1
+    # 10 no [1], 2, 3, 4, 5,
+    # 10 no 1, [2], 3, 4, 5,
+    # 10 no 1, 2, [3], 4, 5,
+    # 10 no 1, ..., 3, [4], 5,
+    # 10 no 1, ..., 4, [5],6,
+
     assigns = %{}
 
     html =
@@ -68,7 +395,7 @@ defmodule PetalComponents.PaginationTest do
       """)
 
     ellipis_count = (html |> String.split("...") |> length()) - 1
-    assert ellipis_count == 1
+    assert ellipis_count == 2
 
     html =
       rendered_to_string(~H"""


### PR DESCRIPTION
 or boundary_count less than 1.

if boundary count is set to zero, no ellipsis or boundary pages are shown.
if sibling count is set to zero only the current page is shown.
if total_pages is 1 or less only the button for page one is shown.

The behavior is such that the number of page buttons shown is always `boundary_count * 2 + sibling_count * 2 + 1`
unless the total_pages count doesn't allow for that.

If this pull request need work, please let me know.