### PR TITLE
Accepts function to define the path in Pagination component

### DIFF
--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -98,15 +98,25 @@ defmodule PetalComponents.Pagination do
     build_class([base_classes, active_classes, rounded_classes])
   end
 
-  defp get_path(path, "previous", current_page) do
-    String.replace(path, ":page", Integer.to_string(current_page - 1))
+  defp get_path(fun, "previous", current_page) when is_function(fun, 1) do
+    (current_page - 1)
+    |> Integer.to_string()
+    |> then(fun)
   end
 
-  defp get_path(path, "next", current_page) do
-    String.replace(path, ":page", Integer.to_string(current_page + 1))
+  defp get_path(fun, "next", current_page) when is_function(fun, 1) do
+    (current_page + 1)
+    |> Integer.to_string()
+    |> then(fun)
   end
 
-  defp get_path(path, page_number, _current_page) do
-    String.replace(path, ":page", Integer.to_string(page_number))
+  defp get_path(fun, page_number, _current_page) when is_function(fun, 1) do
+    page_number
+    |> Integer.to_string()
+    |> then(fun)
+  end
+
+  defp get_path(path, page_number, current_page) when is_binary(path) do
+    get_path(&String.replace(path, ":page", &1), page_number, current_page)
   end
 end

--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -98,25 +98,19 @@ defmodule PetalComponents.Pagination do
     build_class([base_classes, active_classes, rounded_classes])
   end
 
+  defp get_path(path, page_number, current_page) when is_binary(path) do
+    get_path(&String.replace(path, ":page", Integer.to_string(&1)), page_number, current_page)
+  end
+
   defp get_path(fun, "previous", current_page) when is_function(fun, 1) do
-    (current_page - 1)
-    |> Integer.to_string()
-    |> then(fun)
+    get_path(fun, current_page - 1, current_page)
   end
 
   defp get_path(fun, "next", current_page) when is_function(fun, 1) do
-    (current_page + 1)
-    |> Integer.to_string()
-    |> then(fun)
+    get_path(fun, current_page + 1, current_page)
   end
 
   defp get_path(fun, page_number, _current_page) when is_function(fun, 1) do
-    page_number
-    |> Integer.to_string()
-    |> then(fun)
-  end
-
-  defp get_path(path, page_number, current_page) when is_binary(path) do
-    get_path(&String.replace(path, ":page", &1), page_number, current_page)
+    then(page_number, fun)
   end
 end

--- a/test/petal/pagination_test.exs
+++ b/test/petal/pagination_test.exs
@@ -468,4 +468,16 @@ defmodule PetalComponents.PaginationTest do
 
     assert html =~ ~s{data-phx-link="redirect"}
   end
+
+  test "accepts function to define path" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.pagination path={& "/page/#{&1}"} total_pages={3} current_page={1} />
+      """)
+
+    assert html =~ "/page/2"
+    assert html =~ "/page/3"
+  end
 end


### PR DESCRIPTION
Allows the Pagination component to receive a function as a parameter that will define the path of the page.

This change will bring flexibility so that we can use helper functions like the [Phoenix Routing](https://hexdocs.pm/phoenix/routing.html#path-helpers) ones to generate the path:  

```elixir
<.pagination path={fn page -> Routes.user_path(Endpoint, :index, [page: page]) end} current_page={1} total_pages={10} />
```

> The above function should dynamically generate the path `/users?page=#{page}`.
