### PR TITLE
Form help text

### DIFF
--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -63,6 +63,7 @@ defmodule PetalComponents.Form do
   attr(:form, :any, doc: "the form object", required: true)
   attr(:field, :atom, doc: "field in changeset / form", required: true)
   attr(:label, :string, default: nil, doc: "labels your field")
+  attr(:help_text, :string, default: nil, doc: "context/help for your field")
 
   attr(:type, :string,
     default: "text_input",
@@ -165,6 +166,7 @@ defmodule PetalComponents.Form do
       <% end %>
 
       <.form_field_error class="mt-1" form={@form} field={@field} />
+      <.form_help_text class="mt-1" help_text={@help_text} />
     </div>
     """
   end
@@ -670,6 +672,23 @@ defmodule PetalComponents.Form do
     """
   end
 
+  attr(:class, :string, default: "", doc: "extra classes for the help text")
+  attr(:help_text, :string, default: nil, doc: "context/help for your field")
+  slot(:inner_block, required: false)
+  attr(:rest, :global)
+
+  def form_help_text(assigns) do
+    assigns = assign_defaults(assigns, help_text_classes(assigns))
+
+    ~H"""
+    <%= if @inner_block || @help_text do %>
+      <p class={@classes} {@rest}>
+        <%= render_slot(@inner_block) || @help_text %>
+      </p>
+    <% end %>
+    """
+  end
+
   defp generated_translated_errors(form, field) do
     translate_error = translator_from_config() || (&translate_error/1)
 
@@ -731,6 +750,10 @@ defmodule PetalComponents.Form do
       end
 
     "#{if field_has_errors?(assigns), do: "has-error", else: ""} #{type_classes} text-sm block text-gray-900 dark:text-gray-200"
+  end
+
+  defp help_text_classes(_assigns) do
+    "text-xs block text-gray-900 dark:text-gray-300"
   end
 
   defp text_input_classes(has_error) do

--- a/test/petal/form_test.exs
+++ b/test/petal/form_test.exs
@@ -218,6 +218,32 @@ defmodule PetalComponents.FormTest do
     assert html =~ "mt-1"
   end
 
+  test "form_help_text" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.form_help_text help_text="Inline" />
+      """)
+
+    assert html =~ "Inline"
+
+    html =
+      rendered_to_string(~H"""
+      <.form_help_text>Utilising slot</.form_help_text>
+      """)
+
+    assert html =~ "Utilising slot"
+
+    html =
+      rendered_to_string(~H"""
+      <.form_help_text class="mt-1" help_text="Test class" />
+      """)
+
+    assert html =~ "Test class"
+    assert html =~ "mt-1"
+  end
+
   test "form_field wrapper_classes" do
     assigns = %{}
 

--- a/test/petal/form_test.exs
+++ b/test/petal/form_test.exs
@@ -269,6 +269,7 @@ defmodule PetalComponents.FormTest do
           field={:name}
           placeholder="eg. John"
           wrapper_classes="wrapper-test"
+          help_text="Help!"
         />
       </.form>
       """)
@@ -280,6 +281,7 @@ defmodule PetalComponents.FormTest do
     assert html =~ "too long"
     assert html =~ "blank"
     assert html =~ "<div class=\"wrapper-test\""
+    assert html =~ "Help!"
   end
 
   test "form_field text_input" do


### PR DESCRIPTION
To resolve #103. Adds ability to add help text to form fields. Inline, you can do the following.

```elixir
<.form_help_text help_text="Help text" />
```

Here's the same example, but using a slot (so you can add more than text):

```elixir
<.form_help_text>
  Help text<br />
  With some html
</.form_help_text>
```

Finally, you can add `help_text` to `form_field` (at this stage, there is no slot option):

```elixir
<.form_field
  type="text_input"
  form={f}
  field={:text_input}
  placeholder="Placeholder"
  help_text="Help text"
/>
```