### PR TITLE
Add missing `list` attr to form input

### DIFF
--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -4,7 +4,7 @@ defmodule PetalComponents.Form do
   import PetalComponents.Helpers
   alias Phoenix.HTML.Form
 
-  @form_attrs ~w(autocomplete disabled form max maxlength min minlength
+  @form_attrs ~w(autocomplete disabled form max maxlength min minlength list
   pattern placeholder readonly required size step value name multiple prompt selected default year month day hour minute second builder options layout cols rows wrap checked)
 
   @moduledoc """


### PR DESCRIPTION
Hello,

I have tried to upgrade petal_components to 0.19.x in my project

the following code:
```elixir
  <.form :let={f} for={:user}>
    <.text_input form={f} field={:city} list="cities" />
    <datalist id="cities">
      <%= for city <- ["New York", "London"] do %>
        <option value={city}><%= city %></option>
      <% end %>
    </datalist>
  </.form>
```
produce the following warning:
```
warning: undefined attribute "list" for component PetalComponents.Form.text_input/1
```

it is a warning doesn't break anything but with `warnings_as_errors` option enabled it can be blocking
not sure how to add a unit test for this thing
