### PR TITLE
Update form_attrs with data to stop warnings

### DIFF
--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -5,7 +5,7 @@ defmodule PetalComponents.Form do
   alias Phoenix.HTML.Form
 
   @form_attrs ~w(autocomplete disabled form max maxlength min minlength list
-  pattern placeholder readonly required size step value name multiple prompt selected default year month day hour minute second builder options layout cols rows wrap checked)
+  pattern placeholder readonly required size step value name multiple prompt selected default year month day hour minute second builder options layout cols rows wrap checked icon data)
 
   @moduledoc """
   Everything related to forms: inputs, labels etc

--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -5,7 +5,7 @@ defmodule PetalComponents.Form do
   alias Phoenix.HTML.Form
 
   @form_attrs ~w(autocomplete disabled form max maxlength min minlength list
-  pattern placeholder readonly required size step value name multiple prompt selected default year month day hour minute second builder options layout cols rows wrap checked icon data)
+  pattern placeholder readonly required size step value name multiple prompt selected default year month day hour minute second builder options layout cols rows wrap checked data)
 
   @moduledoc """
   Everything related to forms: inputs, labels etc


### PR DESCRIPTION
While compiling our project with the latest update we started receiving some warnings:

```
warning: undefined attribute "data" for component PetalComponents.Button.button/1
  lib/tool/live/path/show.html.heex:110: (file)

```

This commit adds these attributes to the allow-list to remove such warnings