### PR TITLE
fix(form_field): fixed compilation warning caused by hidden_input not…

### DIFF
--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -59,8 +59,10 @@ defmodule PetalComponents.Form do
     "checkbox",
     "checkbox_group",
     "radio_group",
-    "switch"
+    "switch",
+    "hidden_input"
   ]
+
   attr(:form, :any, doc: "the form object", required: true)
   attr(:field, :atom, doc: "field in changeset / form", required: true)
   attr(:label, :string, doc: "labels your field")
@@ -77,6 +79,12 @@ defmodule PetalComponents.Form do
   attr :rest, :global, include: @form_attrs
 
   @doc "Use this when you want to include the label and some margin."
+  def form_field(%{type: "hidden_input"} = assigns) do
+    ~H"""
+      <.hidden_input form={@form} field={@field} {@rest} />
+    """
+  end
+
   def form_field(assigns) do
     assigns =
       assigns
@@ -118,8 +126,6 @@ defmodule PetalComponents.Form do
         <% "text_input" -> %>
           <.form_label form={@form} field={@field} label={@label} class={@label_class} />
           <.text_input form={@form} field={@field} {@rest} />
-        <% "hidden_input" -> %>
-          <.hidden_input form={@form} field={@field} {@rest} />
         <% "email_input" -> %>
           <.form_label form={@form} field={@field} label={@label} class={@label_class} />
           <.email_input form={@form} field={@field} {@rest} />


### PR DESCRIPTION
I noticed that the docs have an example for using hidden input with `form_field/1`

```
<!-- Explicit option  -->
<.hidden_input form={f} field={:your_field} />

<!-- All inclusive option  -->
<.form_field type="hidden_input" form={f} field={:your_field} />
```

But the `@input_types` module attribute for `PetalComponents.Form` does not include `hidden_input` which causes a compilation warning when trying to use form_field with hidden_input. I also added an extra function clause to `form_field/1` to handle hidden input. My change prevents the wrapper elements from being generated with the hidden input. I realize this is a little opinionated, but `hidden_input` is unique.  It was kind of a surprise to me when I noticed the hidden input showing up in the DOM. If you don't want this change, let me know and I'll drop it from the PR. 