### PR TITLE
feat: add conditional to JS.push event for slide over to accommodate live_co…

### DIFF
--- a/lib/petal_components/slide_over.ex
+++ b/lib/petal_components/slide_over.ex
@@ -113,7 +113,12 @@ defmodule PetalComponents.SlideOver do
       },
       to: "#slide-over-content"
     )
-    |> JS.push("close_slide_over")
+
+    if close_slide_over_target do
+      JS.push(js, "close_slide_over", target: close_slide_over_target)
+    else
+      JS.push(js, "close_slide_over")
+    end
   end
 
   defp get_classes(max_width, origin, class) do

--- a/lib/petal_components/slide_over.ex
+++ b/lib/petal_components/slide_over.ex
@@ -53,8 +53,8 @@ defmodule PetalComponents.SlideOver do
         <div
           id="slide-over-content"
           class={get_classes(@max_width, @origin, @class)}
-          phx-click-away={hide_slide_over(@close_slide_over_target || @origin)}
-          phx-window-keydown={hide_slide_over(@close_slide_over_target || @origin)}
+          phx-click-away={hide_slide_over(@close_slide_over_target, @origin)}
+          phx-window-keydown={hide_slide_over(@close_slide_over_target, @origin)}
           phx-key="escape"
         >
           <!-- Header -->
@@ -64,7 +64,7 @@ defmodule PetalComponents.SlideOver do
                 <%= @title %>
               </div>
 
-              <button phx-click={hide_slide_over(@close_slide_over_target || @origin)} class="pc-slideover__header__button">
+              <button phx-click={hide_slide_over(@close_slide_over_target, @origin)} class="pc-slideover__header__button">
                 <div class="sr-only">Close</div>
                 <svg class="pc-slideover__header__close-svg">
                   <path d="M7.95 6.536l4.242-4.243a1 1 0 111.415 1.414L9.364 7.95l4.243 4.242a1 1 0 11-1.415 1.415L7.95 9.364l-4.243 4.243a1 1 0 01-1.414-1.415L6.536 7.95 2.293 3.707a1 1 0 011.414-1.414L7.95 6.536z" />
@@ -86,7 +86,7 @@ defmodule PetalComponents.SlideOver do
   # def handle_event("close_slide_over", _, socket) do
   #   {:noreply, push_patch(socket, to: Routes.moderate_users_path(socket, :index))}
   # end
-  def hide_slide_over(close_slide_over_target \\ nil, origin) do
+  def hide_slide_over(close_slide_over_target, origin) do
     origin_class =
       case origin do
         x when x in ["left", "right"] -> "translate-x-0"

--- a/lib/petal_components/slide_over.ex
+++ b/lib/petal_components/slide_over.ex
@@ -11,6 +11,12 @@ defmodule PetalComponents.SlideOver do
     doc: "slideover point of origin"
   )
 
+  attr(:close_slide_over_target, :string,
+  default: nil,
+  doc:
+    "close_slide_over_target allows you to target a specific live component for the close event to go to. eg: close_slide_over_target={@myself}"
+)
+
   attr(:title, :string, default: nil, doc: "slideover title")
 
   attr(:max_width, :string,
@@ -47,8 +53,8 @@ defmodule PetalComponents.SlideOver do
         <div
           id="slide-over-content"
           class={get_classes(@max_width, @origin, @class)}
-          phx-click-away={hide_slide_over(@origin)}
-          phx-window-keydown={hide_slide_over(@origin)}
+          phx-click-away={hide_slide_over(@close_slide_over_target || @origin)}
+          phx-window-keydown={hide_slide_over(@close_slide_over_target || @origin)}
           phx-key="escape"
         >
           <!-- Header -->
@@ -58,7 +64,7 @@ defmodule PetalComponents.SlideOver do
                 <%= @title %>
               </div>
 
-              <button phx-click={hide_slide_over(@origin)} class="pc-slideover__header__button">
+              <button phx-click={hide_slide_over(@close_slide_over_target || @origin)} class="pc-slideover__header__button">
                 <div class="sr-only">Close</div>
                 <svg class="pc-slideover__header__close-svg">
                   <path d="M7.95 6.536l4.242-4.243a1 1 0 111.415 1.414L9.364 7.95l4.243 4.242a1 1 0 11-1.415 1.415L7.95 9.364l-4.243 4.243a1 1 0 01-1.414-1.415L6.536 7.95 2.293 3.707a1 1 0 011.414-1.414L7.95 6.536z" />
@@ -80,7 +86,7 @@ defmodule PetalComponents.SlideOver do
   # def handle_event("close_slide_over", _, socket) do
   #   {:noreply, push_patch(socket, to: Routes.moderate_users_path(socket, :index))}
   # end
-  def hide_slide_over(js \\ %JS{}, origin) do
+  def hide_slide_over(close_slide_over_target \\ nil, origin) do
     origin_class =
       case origin do
         x when x in ["left", "right"] -> "translate-x-0"


### PR DESCRIPTION
I am running into an issue where I created a `live_component` for the slide over,  however I am getting a handle_event error saying the "close_slide_over" event is being looked for in the parent, which I don't want. 

I am hoping for the same functionality achieved used with the modal component here: 

```
Close modal target
If you’re nesting a modal inside a live component, the close event will go to the parent live view, instead of the component.

To fix this, you can change the target to be the live component:

<.modal title="Modal" close_modal_target={@myself}>
  <.p>Content</.p>
</.modal>
Underneath the hood, this gets forwarded to the JS.push function. Here’s what it looks like:

# in petal_components/modal.ex
JS.push(js, "close_modal", target: close_modal_target)
```