### PR TITLE
Add tooltip to `icon_button`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - New: Add `separator_class` option to `<.breadcrumb>`
+- New: Add `tooltip` option to `<.icon_button>`
 
 ### 1.0.5 - 2023-04-03 09:33:31
 

--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -102,6 +102,7 @@ defmodule PetalComponents.Button do
       link_type={@link_type}
       class={
         build_class([
+          "group",
           "pc-icon-button",
           get_disabled_classes(@disabled),
           get_icon_button_background_color_classes(@color),
@@ -119,17 +120,17 @@ defmodule PetalComponents.Button do
       <% else %>
         <%= render_slot(@inner_block) %>
       <% end %>
-    </Link.a>
 
-    <%= unless is_nil(@tooltip) do %>
-      <div
-        id={"tooltip-" <> Macro.underscore(@label || "")}
-        role="tooltip"
-        class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-900 rounded-lg shadow-sm opacity-0 tooltip dark:bg-gray-700"
-      >
-        <%= @tooltip %>
-      </div>
-    <% end %>
+      <%= unless is_nil(@tooltip) do %>
+        <div
+          id={"tooltip-" <> Macro.underscore(@label || "")}
+          role="tooltip"
+          class="group-hover:visible group-hover:opacity-100 absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-900 rounded-lg shadow-sm opacity-0 tooltip dark:bg-gray-700"
+        >
+          <%= @tooltip %>
+        </div>
+      <% end %>
+    </Link.a>
     """
   end
 

--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -112,7 +112,7 @@ defmodule PetalComponents.Button do
         ])
       }
       disabled={@disabled}
-      data-tooltip-target={"tooltip-" <> Macro.underscore(@label || "")}
+      data-tooltip-target={unless is_nil(@tooltip), do: "tooltip-" <> Macro.underscore(@label || "")}
       {@rest}
     >
       <%= if @loading do %>

--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -91,6 +91,7 @@ defmodule PetalComponents.Button do
 
   attr(:class, :string, default: "", doc: "CSS class")
   attr(:label, :string, default: nil, doc: "label your button")
+  attr(:tooltip, :string, default: nil, doc: "tooltip text, requires label to be set")
   attr(:rest, :global, include: ~w(method download hreflang ping referrerpolicy rel target type))
   slot(:inner_block, required: false)
 
@@ -110,6 +111,7 @@ defmodule PetalComponents.Button do
         ])
       }
       disabled={@disabled}
+      data-tooltip-target={"tooltip-" <> Macro.underscore(@label || "")}
       {@rest}
     >
       <%= if @loading do %>
@@ -118,6 +120,16 @@ defmodule PetalComponents.Button do
         <%= render_slot(@inner_block) %>
       <% end %>
     </Link.a>
+
+    <%= unless is_nil(@tooltip) do %>
+      <div
+        id={"tooltip-" <> Macro.underscore(@label || "")}
+        role="tooltip"
+        class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-900 rounded-lg shadow-sm opacity-0 tooltip dark:bg-gray-700"
+      >
+        <%= @tooltip %>
+      </div>
+    <% end %>
     """
   end
 

--- a/test/petal/button_test.exs
+++ b/test/petal/button_test.exs
@@ -130,6 +130,31 @@ defmodule PetalComponents.ButtonTest do
 
     assert html =~ "<svg"
     assert html =~ "pc-icon-button-bg--primary"
+    refute html =~ "id=\"tooltip-"
+  end
+
+  test "icon button with tooltip" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.icon_button
+        to="/"
+        link_type="button"
+        size="xs"
+        color="primary"
+        tooltip="Hello world!"
+        label="hello"
+      >
+        <Heroicons.clock solid />
+      </.icon_button>
+      """)
+
+    assert html =~ "<svg"
+    assert html =~ "pc-icon-button-bg--primary"
+    assert html =~ "data-tooltip-target=\"tooltip-hello\""
+    assert html =~ "id=\"tooltip-hello\""
+    assert html =~ "Hello world!"
   end
 
   test "should include additional assigns" do


### PR DESCRIPTION
An icon button sometimes isn't very useful as the user might recognise what it is or does. So let's allow for a tooltip.

This is what it looks like:
![image](https://user-images.githubusercontent.com/31945/233036272-4af9b57e-62a2-4c2e-821b-49a61542ab3f.png)
![image](https://user-images.githubusercontent.com/31945/233036565-7866b463-80b8-4475-8510-5c1af7525797.png)
