### PR TITLE
Tooltip tweaks

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -187,7 +187,7 @@
 }
 
 .pc-icon-button__tooltip {
-  @apply absolute flex-col items-center invisible mb-6 -translate-y-full -top-1 group-hover:flex group-hover:visible group-hover:opacity-100 opacity-0 transition-opacity duration-300;
+  @apply absolute flex-col items-center invisible mb-6 -translate-y-full -top-1 group-hover/pc-icon-button:flex group-hover/pc-icon-button:visible group-hover/pc-icon-button:opacity-100 opacity-0 transition-opacity duration-300;
 }
 
 .pc-icon-button__tooltip__text {

--- a/assets/default.css
+++ b/assets/default.css
@@ -187,7 +187,7 @@
 }
 
 .pc-icon-button__tooltip {
-  @apply absolute flex-col items-center hidden mb-6 -translate-y-full -top-1 group-hover:flex;
+  @apply absolute flex-col items-center invisible mb-6 -translate-y-full -top-1 group-hover:flex group-hover:visible group-hover:opacity-100 opacity-0 transition-opacity duration-300;
 }
 
 .pc-icon-button__tooltip__text {

--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -102,7 +102,6 @@ defmodule PetalComponents.Button do
       class={
         build_class([
           "pc-icon-button",
-          @tooltip && "relative group flex flex-col items-center",
           get_disabled_classes(@disabled),
           get_icon_button_background_color_classes(@color),
           get_icon_button_color_classes(@color),
@@ -113,18 +112,20 @@ defmodule PetalComponents.Button do
       disabled={@disabled}
       {@rest}
     >
-      <%= if @loading do %>
-        <Loading.spinner show={true} size_class={get_icon_button_spinner_size_classes(@size)} />
-      <% else %>
-        <%= render_slot(@inner_block) %>
+      <div class={@tooltip && "relative group flex flex-col items-center"}>
+        <%= if @loading do %>
+          <Loading.spinner show={true} size_class={get_icon_button_spinner_size_classes(@size)} />
+        <% else %>
+          <%= render_slot(@inner_block) %>
 
-        <div :if={@tooltip} role="tooltip" class="pc-icon-button__tooltip">
-          <span class="pc-icon-button__tooltip__text">
-            <%= @tooltip %>
-          </span>
-          <div class="pc-icon-button__tooltip__arrow"></div>
-        </div>
-      <% end %>
+          <div :if={@tooltip} role="tooltip" class="pc-icon-button__tooltip">
+            <span class="pc-icon-button__tooltip__text">
+              <%= @tooltip %>
+            </span>
+            <div class="pc-icon-button__tooltip__arrow"></div>
+          </div>
+        <% end %>
+      </div>
     </Link.a>
     """
   end

--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -112,7 +112,7 @@ defmodule PetalComponents.Button do
       disabled={@disabled}
       {@rest}
     >
-      <div class={@tooltip && "relative group flex flex-col items-center"}>
+      <div class={@tooltip && "relative group/pc-icon-button flex flex-col items-center"}>
         <%= if @loading do %>
           <Loading.spinner show={true} size_class={get_icon_button_spinner_size_classes(@size)} />
         <% else %>

--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -90,8 +90,7 @@ defmodule PetalComponents.Button do
   )
 
   attr(:class, :string, default: "", doc: "CSS class")
-  attr(:label, :string, default: nil, doc: "label your button")
-  attr(:tooltip, :string, default: nil, doc: "tooltip text, requires label to be set")
+  attr(:tooltip, :string, default: nil, doc: "tooltip text")
   attr(:rest, :global, include: ~w(method download hreflang ping referrerpolicy rel target type))
   slot(:inner_block, required: false)
 

--- a/test/petal/button_test.exs
+++ b/test/petal/button_test.exs
@@ -138,14 +138,7 @@ defmodule PetalComponents.ButtonTest do
 
     html =
       rendered_to_string(~H"""
-      <.icon_button
-        to="/"
-        link_type="button"
-        size="xs"
-        color="primary"
-        tooltip="Hello world!"
-        label="hello"
-      >
+      <.icon_button to="/" link_type="button" size="xs" color="primary" tooltip="Hello world!">
         <Heroicons.clock solid />
       </.icon_button>
       """)


### PR DESCRIPTION
- Add fade-in transition to make it nicer
- Remove the unneeded `label`
- Make it more portable by self-contain the `flex` class
- Make the grouping isolated so it can be nested in parent groups