### PR TITLE
Fix the empty value for a checkbox group

### DIFF
--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -566,7 +566,7 @@ defmodule PetalComponents.Form do
 
     ~H"""
     <div class={checkbox_group_layout_classes(%{layout: @layout})}>
-      <%= Form.hidden_input(@form, @field, name: Form.input_name(@form, @field), value: "") %>
+      <%= Form.hidden_input(@form, @field, name: Form.input_name(@form, @field) <> "[]", value: "") %>
       <%= for {label, value} <- @options do %>
         <label class={checkbox_group_layout_item_classes(%{layout: @layout})}>
           <.checkbox


### PR DESCRIPTION
Currently, when nothing's checked it produces this param:

```elixir
"tags" => ""
```

In this case, tags should be an array, so this fix makes it:

```elixir
"tags" => [""]
```