### PR TITLE
Make progress bars look nicer in dark mode

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -735,25 +735,25 @@
 /* Progress - colors */
 
 .pc-progress--primary {
-  @apply bg-primary-100;
+  @apply bg-primary-100 dark:bg-primary-900;
 }
 .pc-progress--secondary {
-  @apply bg-secondary-100;
+  @apply bg-secondary-100 dark:bg-secondary-900;
 }
 .pc-progress--info {
-  @apply bg-info-100;
+  @apply bg-info-100 dark:bg-info-900;
 }
 .pc-progress--success {
-  @apply bg-green-100;
+  @apply bg-green-100 dark:bg-green-900;
 }
 .pc-progress--warning {
-  @apply bg-yellow-100;
+  @apply bg-yellow-100 dark:bg-yellow-900;
 }
 .pc-progress--danger {
-  @apply bg-red-100;
+  @apply bg-red-100 dark:bg-red-900;
 }
 .pc-progress--gray {
-  @apply bg-gray-100;
+  @apply bg-gray-100 dark:bg-gray-900;
 }
 .pc-progress__inner--primary {
   @apply bg-primary-500;


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/31945/236400402-d7e9bf6d-0b42-4097-b45a-de8afbc96412.png)


After:

![image](https://user-images.githubusercontent.com/31945/236400254-e945b02d-3eb3-42ff-b9cc-521656843c7d.png)
