### PR TITLE
Fix radio group's state

### DIFF
--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -216,7 +216,14 @@ defmodule PetalComponents.Field do
         <input type="hidden" name={@name} value="" />
         <%= for {label, value} <- @options do %>
           <label class="pc-checkbox-label">
-            <input type="radio" name={@name} value={value} class="pc-radio" {@rest} />
+            <input
+              type="radio"
+              name={@name}
+              value={value}
+              checked={to_string(value) == @value}
+              class="pc-radio"
+              {@rest}
+            />
             <%= label %>
           </label>
         <% end %>


### PR DESCRIPTION
So the radio group doesn't actually remember the state, so this PR fixes it.

However, there are currently no tests to test the form's state behaviour, I'm not sure what the best way to do it is. @mplatts @nhobes 