### PR TITLE
Make textarea v2's height the same as v1

### DIFF
--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -120,7 +120,7 @@ defmodule PetalComponents.Field do
     ~H"""
     <.field_wrapper errors={@errors} name={@name} class={@wrapper_class}>
       <.field_label for={@id}><%= @label %></.field_label>
-      <textarea id={@id} name={@name} class={["pc-text-input", @class]} {@rest}><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
+      <textarea id={@id} name={@name} class={["pc-text-input", @class]} rows="4" {@rest}><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
       <.field_error :for={msg <- @errors}><%= msg %></.field_error>
       <.field_help_text help_text={@help_text} />
     </.field_wrapper>


### PR DESCRIPTION
Please feel free to close this PR, but I was hoping v2 and v1's default styling are consistent. So adding `rows="4"` to match v1's.