### PR TITLE
Add `tooltip` to `<.button>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 ### 1.2.2 - 2023-05-17 02:26:44
 
 - Updated: checkbox_group now supports `disabled_options` attr

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,4 @@
 RELEASE_TYPE: patch
 
 - Updated: Move custom css classes to last so they can potentially override default ones (button, loading)
+- Added: `tooltip` option to `<.button>`

--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -45,6 +45,7 @@ defmodule PetalComponents.Button do
 
   attr(:class, :string, default: "", doc: "CSS class")
   attr(:label, :string, default: nil, doc: "labels your button")
+  attr(:tooltip, :string, default: nil, doc: "tooltip text")
 
   attr(:rest, :global,
     include: ~w(method download hreflang ping referrerpolicy rel target type value name)
@@ -59,15 +60,24 @@ defmodule PetalComponents.Button do
 
     ~H"""
     <Link.a to={@to} link_type={@link_type} class={@classes} disabled={@disabled} {@rest}>
-      <%= if @loading do %>
-        <Loading.spinner show={true} size_class={get_spinner_size_classes(@size)} />
-      <% else %>
-        <%= if @icon do %>
-          <Icon.icon name={@icon} mini class={get_spinner_size_classes(@size)} />
+      <div class={@tooltip && "relative group/pc-icon-button flex flex-col items-center"}>
+        <%= if @loading do %>
+          <Loading.spinner show={true} size_class={get_spinner_size_classes(@size)} />
+        <% else %>
+          <%= if @icon do %>
+            <Icon.icon name={@icon} mini class={get_spinner_size_classes(@size)} />
+          <% end %>
         <% end %>
-      <% end %>
 
-      <%= render_slot(@inner_block) || @label %>
+        <%= render_slot(@inner_block) || @label %>
+
+        <div :if={@tooltip} role="tooltip" class="pc-icon-button__tooltip">
+          <span class="pc-icon-button__tooltip__text">
+            <%= @tooltip %>
+          </span>
+          <div class="pc-icon-button__tooltip__arrow"></div>
+        </div>
+      </div>
     </Link.a>
     """
   end

--- a/test/petal/button_test.exs
+++ b/test/petal/button_test.exs
@@ -12,6 +12,7 @@ defmodule PetalComponents.ButtonTest do
 
     assert html =~ "<button"
     assert html =~ "Press me"
+    refute html =~ "tooltip"
   end
 
   test "a" do
@@ -26,6 +27,7 @@ defmodule PetalComponents.ButtonTest do
     assert html =~ "<a"
     assert html =~ "href"
     assert html =~ "phx-click"
+    refute html =~ "tooltip"
   end
 
   test "patch" do
@@ -40,6 +42,7 @@ defmodule PetalComponents.ButtonTest do
     assert html =~ "<a"
     assert html =~ "href"
     assert html =~ "phx-click"
+    refute html =~ "tooltip"
   end
 
   test "redirect" do
@@ -54,6 +57,7 @@ defmodule PetalComponents.ButtonTest do
     assert html =~ "<a"
     assert html =~ "href"
     assert html =~ "phx-click"
+    refute html =~ "tooltip"
   end
 
   test "button with inner_block" do
@@ -66,6 +70,7 @@ defmodule PetalComponents.ButtonTest do
 
     assert html =~ "<button"
     assert html =~ "Press me"
+    refute html =~ "tooltip"
   end
 
   test "button with loading but no size" do
@@ -79,6 +84,7 @@ defmodule PetalComponents.ButtonTest do
     assert html =~ "<button"
     assert html =~ "Press me"
     assert html =~ "<svg"
+    refute html =~ "tooltip"
   end
 
   test "button with shadow" do
@@ -92,6 +98,7 @@ defmodule PetalComponents.ButtonTest do
     assert html =~ "<button"
     assert html =~ "Press me"
     assert html =~ "pc-button--primary-shadow"
+    refute html =~ "tooltip"
   end
 
   test "button with dark mode" do
@@ -105,6 +112,7 @@ defmodule PetalComponents.ButtonTest do
     assert html =~ "<button"
     assert html =~ "Press me"
     assert html =~ "pc-button--primary-shadow"
+    refute html =~ "tooltip"
   end
 
   test "button with custom class" do
@@ -116,6 +124,21 @@ defmodule PetalComponents.ButtonTest do
       """)
 
     assert html =~ "pc-button some-special-class"
+    refute html =~ "tooltip"
+  end
+
+  test "button with tooltip" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.button label="Press me" phx-click="click_event" tooltip="Hello world!" />
+      """)
+
+    assert html =~ "<button"
+    assert html =~ "Press me"
+    assert html =~ "role=\"tooltip"
+    assert html =~ "Hello world!"
   end
 
   test "icon button" do


### PR DESCRIPTION
Ported the same tooltip from `icon_button` to `button`.