### PR TITLE
Add `tooltip` to `<.button>`

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -28,6 +28,22 @@
   @apply inline-flex items-center justify-center font-medium transition duration-150 ease-in-out border rounded-md focus:outline-none;
 }
 
+.pc-button__tooltip__group {
+  @apply relative flex flex-col items-center;
+}
+
+.pc-button__tooltip {
+  @apply absolute flex-col items-center invisible mb-6 -translate-y-full -top-1 group-hover/pc-button:flex group-hover/pc-button:visible group-hover/pc-button:opacity-100 opacity-0 transition-opacity duration-300;
+}
+
+.pc-button__tooltip__text {
+  @apply relative z-10 p-2 text-xs leading-none text-white bg-gray-900 shadow-lg whitespace-nowrap dark:bg-gray-700 rounded-sm;
+}
+
+.pc-button__tooltip__arrow {
+  @apply w-3 h-3 -mt-2 rotate-45 bg-gray-900 dark:bg-gray-700;
+}
+
 /* Buttons - sizes */
 
 .pc-button--xs {
@@ -184,18 +200,6 @@
 
 .pc-icon-button {
   @apply inline-block p-2 rounded-full;
-}
-
-.pc-icon-button__tooltip {
-  @apply absolute flex-col items-center invisible mb-6 -translate-y-full -top-1 group-hover/pc-icon-button:flex group-hover/pc-icon-button:visible group-hover/pc-icon-button:opacity-100 opacity-0 transition-opacity duration-300;
-}
-
-.pc-icon-button__tooltip__text {
-  @apply relative z-10 p-2 text-xs leading-none text-white bg-gray-900 shadow-lg whitespace-nowrap dark:bg-gray-700 rounded-sm;
-}
-
-.pc-icon-button__tooltip__arrow {
-  @apply w-3 h-3 -mt-2 rotate-45 bg-gray-900 dark:bg-gray-700;
 }
 
 /* Icon Buttons - colors */

--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -60,7 +60,7 @@ defmodule PetalComponents.Button do
 
     ~H"""
     <Link.a to={@to} link_type={@link_type} class={@classes} disabled={@disabled} {@rest}>
-      <div class={@tooltip && "relative group/pc-icon-button flex flex-col items-center"}>
+      <div class={@tooltip && "pc-button__tooltip__group group/pc-button"}>
         <div class="inline-flex flex-nowrap gap-2">
           <%= if @loading do %>
             <Loading.spinner show={true} size_class={get_spinner_size_classes(@size)} />
@@ -73,11 +73,11 @@ defmodule PetalComponents.Button do
           <%= render_slot(@inner_block) || @label %>
         </div>
 
-        <div :if={@tooltip} role="tooltip" class="pc-icon-button__tooltip">
-          <span class="pc-icon-button__tooltip__text">
+        <div :if={@tooltip} role="tooltip" class="pc-button__tooltip">
+          <span class="pc-button__tooltip__text">
             <%= @tooltip %>
           </span>
-          <div class="pc-icon-button__tooltip__arrow"></div>
+          <div class="pc-button__tooltip__arrow"></div>
         </div>
       </div>
     </Link.a>
@@ -124,17 +124,17 @@ defmodule PetalComponents.Button do
       disabled={@disabled}
       {@rest}
     >
-      <div class={@tooltip && "relative group/pc-icon-button flex flex-col items-center"}>
+      <div class={@tooltip && "pc-button__tooltip__group group/pc-button"}>
         <%= if @loading do %>
           <Loading.spinner show={true} size_class={get_icon_button_spinner_size_classes(@size)} />
         <% else %>
           <%= render_slot(@inner_block) %>
 
-          <div :if={@tooltip} role="tooltip" class="pc-icon-button__tooltip">
-            <span class="pc-icon-button__tooltip__text">
+          <div :if={@tooltip} role="tooltip" class="pc-button__tooltip">
+            <span class="pc-button__tooltip__text">
               <%= @tooltip %>
             </span>
-            <div class="pc-icon-button__tooltip__arrow"></div>
+            <div class="pc-button__tooltip__arrow"></div>
           </div>
         <% end %>
       </div>

--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -45,6 +45,7 @@ defmodule PetalComponents.Button do
 
   attr(:class, :string, default: "", doc: "CSS class")
   attr(:label, :string, default: nil, doc: "labels your button")
+  attr(:tooltip, :string, default: nil, doc: "tooltip text")
 
   attr(:rest, :global,
     include: ~w(method download hreflang ping referrerpolicy rel target type value name)
@@ -59,15 +60,26 @@ defmodule PetalComponents.Button do
 
     ~H"""
     <Link.a to={@to} link_type={@link_type} class={@classes} disabled={@disabled} {@rest}>
-      <%= if @loading do %>
-        <Loading.spinner show={true} size_class={get_spinner_size_classes(@size)} />
-      <% else %>
-        <%= if @icon do %>
-          <Icon.icon name={@icon} mini class={get_spinner_size_classes(@size)} />
-        <% end %>
-      <% end %>
+      <div class={@tooltip && "relative group/pc-icon-button flex flex-col items-center"}>
+        <div class="inline-flex flex-nowrap gap-2">
+          <%= if @loading do %>
+            <Loading.spinner show={true} size_class={get_spinner_size_classes(@size)} />
+          <% else %>
+            <%= if @icon do %>
+              <Icon.icon name={@icon} mini class={get_spinner_size_classes(@size)} />
+            <% end %>
+          <% end %>
 
-      <%= render_slot(@inner_block) || @label %>
+          <%= render_slot(@inner_block) || @label %>
+        </div>
+
+        <div :if={@tooltip} role="tooltip" class="pc-icon-button__tooltip">
+          <span class="pc-icon-button__tooltip__text">
+            <%= @tooltip %>
+          </span>
+          <div class="pc-icon-button__tooltip__arrow"></div>
+        </div>
+      </div>
     </Link.a>
     """
   end

--- a/test/petal/button_test.exs
+++ b/test/petal/button_test.exs
@@ -12,6 +12,7 @@ defmodule PetalComponents.ButtonTest do
 
     assert html =~ "<button"
     assert html =~ "Press me"
+    refute html =~ "tooltip"
   end
 
   test "a" do
@@ -26,6 +27,7 @@ defmodule PetalComponents.ButtonTest do
     assert html =~ "<a"
     assert html =~ "href"
     assert html =~ "phx-click"
+    refute html =~ "tooltip"
   end
 
   test "patch" do
@@ -40,6 +42,7 @@ defmodule PetalComponents.ButtonTest do
     assert html =~ "<a"
     assert html =~ "href"
     assert html =~ "phx-click"
+    refute html =~ "tooltip"
   end
 
   test "redirect" do
@@ -54,6 +57,7 @@ defmodule PetalComponents.ButtonTest do
     assert html =~ "<a"
     assert html =~ "href"
     assert html =~ "phx-click"
+    refute html =~ "tooltip"
   end
 
   test "button with inner_block" do
@@ -66,6 +70,7 @@ defmodule PetalComponents.ButtonTest do
 
     assert html =~ "<button"
     assert html =~ "Press me"
+    refute html =~ "tooltip"
   end
 
   test "button with loading but no size" do
@@ -79,6 +84,7 @@ defmodule PetalComponents.ButtonTest do
     assert html =~ "<button"
     assert html =~ "Press me"
     assert html =~ "<svg"
+    refute html =~ "tooltip"
   end
 
   test "button with shadow" do
@@ -92,6 +98,7 @@ defmodule PetalComponents.ButtonTest do
     assert html =~ "<button"
     assert html =~ "Press me"
     assert html =~ "pc-button--primary-shadow"
+    refute html =~ "tooltip"
   end
 
   test "button with dark mode" do
@@ -105,6 +112,7 @@ defmodule PetalComponents.ButtonTest do
     assert html =~ "<button"
     assert html =~ "Press me"
     assert html =~ "pc-button--primary-shadow"
+    refute html =~ "tooltip"
   end
 
   test "button with custom class" do
@@ -116,6 +124,21 @@ defmodule PetalComponents.ButtonTest do
       """)
 
     assert html =~ "pc-button some-special-class"
+    refute html =~ "tooltip"
+  end
+
+  test "button with tooltip" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.button label="Press me" phx-click="click_event" tooltip="Hello world!" />
+      """)
+
+    assert html =~ "<button"
+    assert html =~ "Press me"
+    assert html =~ "role=\"tooltip"
+    assert html =~ "Hello world!"
   end
 
   test "icon button" do


### PR DESCRIPTION
Second attempt of #190.

Text only:

![image](https://github.com/petalframework/petal_components/assets/31945/d8890ef8-dfd9-4989-8967-dc4cb1fa832a)

With loading:

![image](https://github.com/petalframework/petal_components/assets/31945/3f267cef-e787-4e69-a658-c0b8b5320f8e)

With icon:

![image](https://github.com/petalframework/petal_components/assets/31945/7a676736-a16d-4763-b543-02c6f3093765)

With icon and loading:

![image](https://github.com/petalframework/petal_components/assets/31945/9328773b-63c9-4ddf-b92b-65c453a05baa)
