### PR TITLE
Add `empty_message` attr for `checkbox-group` and `radio-group`

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -596,6 +596,10 @@
 .pc-radio-group__item--col {
   @apply inline-flex items-center gap-3 cursor-pointer;
 }
+.pc-checkbox-group--empty-message,
+.pc-radio-group--empty-message {
+  @apply text-sm;
+}
 
 /* Dropdown */
 

--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -54,6 +54,11 @@ defmodule PetalComponents.Field do
     default: "row",
     doc: "the layout of the inputs in a group (checkbox-group or radio-group)"
 
+  attr :empty_message, :string,
+    default: nil,
+    doc:
+      "the message to display when there are no options available, for checkbox-group or radio-group"
+
   attr :rows, :string, default: "4", doc: "rows for textarea"
 
   attr :class, :string, default: nil, doc: "the class to add to the input"
@@ -202,6 +207,12 @@ defmodule PetalComponents.Field do
             <%= label %>
           </label>
         <% end %>
+
+        <%= if @empty_message && Enum.empty?(@options) do %>
+          <div class="pc-checkbox-group--empty-message">
+            <%= @empty_message %>
+          </div>
+        <% end %>
       </div>
       <.field_error :for={msg <- @errors}><%= msg %></.field_error>
       <.field_help_text help_text={@help_text} />
@@ -236,6 +247,12 @@ defmodule PetalComponents.Field do
             />
             <%= label %>
           </label>
+        <% end %>
+
+        <%= if @empty_message && Enum.empty?(@options) do %>
+          <div class="pc-checkbox-group--empty-message">
+            <%= @empty_message %>
+          </div>
         <% end %>
       </div>
       <.field_error :for={msg <- @errors}><%= msg %></.field_error>

--- a/test/petal/field_test.exs
+++ b/test/petal/field_test.exs
@@ -348,6 +348,42 @@ defmodule PetalComponents.FieldTest do
     assert html =~ "pc-checkbox-group--row"
   end
 
+  test "field checkbox-group empty options" do
+    assigns = %{form: to_form(%{}, as: :user)}
+
+    html =
+      rendered_to_string(~H"""
+      <.form for={@form}>
+        <.field
+          type="checkbox-group"
+          checked={["read"]}
+          field={@form[:roles]}
+          options={[]}
+          empty_message="No options"
+        />
+      </.form>
+      """)
+
+    assert html =~ "No options"
+
+    assigns = %{form: to_form(%{}, as: :user)}
+
+    html =
+      rendered_to_string(~H"""
+      <.form for={@form}>
+        <.field
+          type="checkbox-group"
+          checked={["read"]}
+          field={@form[:roles]}
+          options={[{"Read", "read"}, {"Write", "write"}]}
+          empty_message="No options"
+        />
+      </.form>
+      """)
+
+    refute html =~ "No options"
+  end
+
   test "field radio-group" do
     assigns = %{form: to_form(%{}, as: :user)}
 
@@ -426,6 +462,42 @@ defmodule PetalComponents.FieldTest do
       """)
 
     assert html =~ ~s|value="write" checked|
+  end
+
+  test "field radio-group empty options" do
+    assigns = %{form: to_form(%{}, as: :user)}
+
+    html =
+      rendered_to_string(~H"""
+      <.form for={@form}>
+        <.field
+          class="custom-class"
+          type="radio-group"
+          field={@form[:roles]}
+          options={[]}
+          empty_message="No options"
+        />
+      </.form>
+      """)
+
+    assert html =~ "No options"
+
+    assigns = %{form: to_form(%{}, as: :user)}
+
+    html =
+      rendered_to_string(~H"""
+      <.form for={@form}>
+        <.field
+          class="custom-class"
+          type="radio-group"
+          field={@form[:roles]}
+          options={[{"Read", "read"}, {"Write", "write"}]}
+          empty_message="No options"
+        />
+      </.form>
+      """)
+
+    refute html =~ "No options"
   end
 
   test "field switch" do


### PR DESCRIPTION
When there's no options it'll be great if we could add a message (different to error label).