### PR TITLE
Fix bg colour for input checkbox

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -496,6 +496,9 @@
 :not(.phx-no-feedback).pc-form-field-wrapper--error textarea {
   @apply border-danger-500 focus:border-danger-500 text-danger-900 placeholder-danger-700 bg-danger-50 dark:text-danger-100 dark:placeholder-danger-300 dark:bg-danger-900 focus:ring-danger-500;
 }
+:not(.phx-no-feedback).pc-form-field-wrapper--error input[type=checkbox] {
+  @apply bg-danger-700;
+}
 :not(.phx-no-feedback).pc-form-field-wrapper--error
   .pc-switch
   .pc-switch__fake-input {


### PR DESCRIPTION
This PR fixes the bg colour of the checked checkboxes.

Dark mode works fine:

![Screenshot 2023-07-16 at 5 30 24 pm](https://github.com/petalframework/petal_components/assets/31945/5f675a8e-a493-4bd1-b98c-6f1e0479882a)

However, light mode currently looks like this, note that the first three boxes are checked, the last one is not, but they all look the same:

![Screenshot 2023-07-16 at 5 30 14 pm](https://github.com/petalframework/petal_components/assets/31945/fac260f7-9ccf-40cc-b87d-dfb1383950af)

With this PR:

![Screenshot 2023-07-16 at 5 29 57 pm](https://github.com/petalframework/petal_components/assets/31945/8973b083-cb5b-4bc1-b3b6-f073b155e626)

Took me a while to realise this was caused by styling. I was going crazy thinking my auto-checking plugin was broken. 🙈 