### PR TITLE
Allow disabling the modal transition animation

### DIFF
--- a/test/petal/modal_test.exs
+++ b/test/petal/modal_test.exs
@@ -108,4 +108,22 @@ defmodule PetalComponents.ModalTest do
 
     refute html =~ "<svg"
   end
+
+  test "enable_transition" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.modal></.modal>
+      """)
+
+    assert html =~ "transition-all"
+
+    html =
+      rendered_to_string(~H"""
+      <.modal enable_transition={false}></.modal>
+      """)
+
+    refute html =~ "transition-all"
+  end
 end


### PR DESCRIPTION
I use Wallaby for feature tests. Despite using `find`, the animation still makes the test brittle for some reason. Disabling the animation resolves it.