### PR TITLE
Add support for autocorrect and autocapitalize props in input fields

### DIFF
--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -73,7 +73,7 @@ defmodule PetalComponents.Field do
 
   attr :rest, :global,
     include:
-      ~w(autocomplete disabled form max maxlength min minlength list
+      ~w(autocomplete autocorrect autocapitalize disabled form max maxlength min minlength list
     pattern placeholder readonly required size step value name multiple prompt default year month day hour minute second builder options layout cols rows wrap checked accept),
     doc: "All other props go on the input"
 

--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -4,7 +4,7 @@ defmodule PetalComponents.Form do
   import PetalComponents.Helpers
   alias Phoenix.HTML.Form
 
-  @form_attrs ~w(autocomplete disabled form max maxlength min minlength list
+  @form_attrs ~w(autocomplete autocorrect autocapitalize disabled form max maxlength min minlength list
   pattern placeholder readonly required size step value name multiple prompt selected default year month day hour minute second builder options layout cols rows wrap checked accept)
 
   @moduledoc """

--- a/lib/petal_components/input.ex
+++ b/lib/petal_components/input.ex
@@ -26,7 +26,7 @@ defmodule PetalComponents.Input do
 
   attr :rest, :global,
     include:
-      ~w(autocomplete disabled form max maxlength min minlength list
+      ~w(autocomplete autocorrect autocapitalize disabled form max maxlength min minlength list
     pattern placeholder readonly required size step value name multiple prompt selected default year month day hour minute second builder options layout cols rows wrap checked accept)
 
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do


### PR DESCRIPTION
Prevent showing warnings for supported fields `autocapitalize` and `autocorrect` for input fields.
https://davidwalsh.name/disable-autocorrect