### PR TITLE
Fix: Icon button setting info to primary

### DIFF
--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -341,7 +341,7 @@ defmodule PetalComponents.Button do
     do: "pc-icon-button--secondary"
 
   defp get_icon_button_color_classes("gray"), do: "pc-icon-button--gray"
-  defp get_icon_button_color_classes("info"), do: "pc-icon-button--primary"
+  defp get_icon_button_color_classes("info"), do: "pc-icon-button--info"
   defp get_icon_button_color_classes("success"), do: "pc-icon-button--success"
   defp get_icon_button_color_classes("warning"), do: "pc-icon-button--warning"
   defp get_icon_button_color_classes("danger"), do: "pc-icon-button--danger"

--- a/test/petal/button_test.exs
+++ b/test/petal/button_test.exs
@@ -133,6 +133,23 @@ defmodule PetalComponents.ButtonTest do
     refute html =~ "tooltip"
   end
 
+  test "icon button with color" do
+    colors = ~w(primary secondary success danger warning info gray)
+
+    Enum.each(colors, fn color ->
+      assigns = %{color: color}
+
+      html =
+        rendered_to_string(~H"""
+        <.icon_button color={@color}>
+          <Heroicons.clock />
+        </.icon_button>
+        """)
+
+      assert html =~ "pc-icon-button-bg--#{color}"
+    end)
+  end
+
   test "icon button with tooltip" do
     assigns = %{}
 


### PR DESCRIPTION
Description
---

The info color arg for icon buttons was being set to the primary class. This PR just makes this small fix and adds some test coverage to ensure the colors are set correctly.