### PR TITLE
Add `type=button` to close slide over button

### DIFF
--- a/lib/petal_components/slide_over.ex
+++ b/lib/petal_components/slide_over.ex
@@ -60,6 +60,7 @@ defmodule PetalComponents.SlideOver do
               </div>
 
               <button
+                type="button"
                 phx-click={hide_slide_over(@origin, @close_slide_over_target)}
                 class="pc-slideover__header__button"
               >


### PR DESCRIPTION
Ideally `button` elements should always specify a `type` attribute to avoid unexpected behavior, since each browser might implement a different default.

In our app, we do HTML forms inside slide overs. When the user clicks to close a slide over, the form ends up being submitted, given that the close button is inside the form. Setting the button's type prevents this issue.