### PR TITLE
Add support for disabled attribute on dropdown menu items

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -496,7 +496,7 @@
 :not(.phx-no-feedback).pc-form-field-wrapper--error textarea {
   @apply border-danger-500 focus:border-danger-500 text-danger-900 placeholder-danger-700 bg-danger-50 dark:text-danger-100 dark:placeholder-danger-300 dark:bg-danger-900 focus:ring-danger-500;
 }
-:not(.phx-no-feedback).pc-form-field-wrapper--error input[type=checkbox] {
+:not(.phx-no-feedback).pc-form-field-wrapper--error input[type="checkbox"] {
   @apply bg-danger-700;
 }
 :not(.phx-no-feedback).pc-form-field-wrapper--error
@@ -643,6 +643,9 @@
 }
 .pc-dropdown__trigger-button--with-label-and-trigger-element {
   @apply align-middle;
+}
+.pc-dropdown__menu-item--disabled {
+  @apply text-gray-500 hover:bg-transparent;
 }
 .pc-dropdown__ellipsis {
   @apply w-5 h-5;

--- a/lib/petal_components/button.ex
+++ b/lib/petal_components/button.ex
@@ -8,15 +8,14 @@ defmodule PetalComponents.Button do
   import PetalComponents.Helpers
   require Logger
 
-  attr(:size, :string, default: "md", values: ["xs", "sm", "md", "lg", "xl"], doc: "button sizes")
+  attr :size, :string, default: "md", values: ["xs", "sm", "md", "lg", "xl"], doc: "button sizes"
 
-  attr(:variant, :string,
+  attr :variant, :string,
     default: "solid",
     values: ["solid", "outline", "inverted", "shadow"],
     doc: "button variant"
-  )
 
-  attr(:color, :string,
+  attr :color, :string,
     default: "primary",
     values: [
       "primary",
@@ -31,27 +30,24 @@ defmodule PetalComponents.Button do
       "light"
     ],
     doc: "button color"
-  )
 
-  attr(:to, :string, default: nil, doc: "link path")
-  attr(:loading, :boolean, default: false, doc: "indicates a loading state")
-  attr(:disabled, :boolean, default: false, doc: "indicates a disabled state")
-  attr(:icon, :atom, default: nil, doc: "name of a Heroicon at the front of the button")
-  attr(:with_icon, :boolean, default: false, doc: "adds some icon base classes")
+  attr :to, :string, default: nil, doc: "link path"
+  attr :loading, :boolean, default: false, doc: "indicates a loading state"
+  attr :disabled, :boolean, default: false, doc: "indicates a disabled state"
+  attr :icon, :atom, default: nil, doc: "name of a Heroicon at the front of the button"
+  attr :with_icon, :boolean, default: false, doc: "adds some icon base classes"
 
-  attr(:link_type, :string,
+  attr :link_type, :string,
     default: "button",
     values: ["a", "live_patch", "live_redirect", "button"]
-  )
 
-  attr(:class, :string, default: "", doc: "CSS class")
-  attr(:label, :string, default: nil, doc: "labels your button")
+  attr :class, :string, default: "", doc: "CSS class"
+  attr :label, :string, default: nil, doc: "labels your button"
 
-  attr(:rest, :global,
+  attr :rest, :global,
     include: ~w(method download hreflang ping referrerpolicy rel target type value name form)
-  )
 
-  slot(:inner_block, required: false)
+  slot :inner_block, required: false
 
   def button(assigns) do
     assigns =
@@ -73,31 +69,28 @@ defmodule PetalComponents.Button do
     """
   end
 
-  attr(:size, :string, default: "sm", values: ["xs", "sm", "md", "lg", "xl"])
+  attr :size, :string, default: "sm", values: ["xs", "sm", "md", "lg", "xl"]
 
-  attr(:color, :string,
+  attr :color, :string,
     default: "gray",
     values: ["primary", "secondary", "info", "success", "warning", "danger", "gray"]
-  )
 
-  attr(:to, :string, default: nil, doc: "link path")
-  attr(:loading, :boolean, default: false, doc: "indicates a loading state")
-  attr(:disabled, :boolean, default: false, doc: "indicates a disabled state")
-  attr(:with_icon, :boolean, default: false, doc: "adds some icon base classes")
+  attr :to, :string, default: nil, doc: "link path"
+  attr :loading, :boolean, default: false, doc: "indicates a loading state"
+  attr :disabled, :boolean, default: false, doc: "indicates a disabled state"
+  attr :with_icon, :boolean, default: false, doc: "adds some icon base classes"
 
-  attr(:link_type, :string,
+  attr :link_type, :string,
     default: "button",
     values: ["a", "live_patch", "live_redirect", "button"]
-  )
 
-  attr(:class, :string, default: "", doc: "CSS class")
-  attr(:tooltip, :string, default: nil, doc: "tooltip text")
+  attr :class, :string, default: "", doc: "CSS class"
+  attr :tooltip, :string, default: nil, doc: "tooltip text"
 
-  attr(:rest, :global,
+  attr :rest, :global,
     include: ~w(method download hreflang ping referrerpolicy rel target type value name form)
-  )
 
-  slot(:inner_block, required: false)
+  slot :inner_block, required: false
 
   def icon_button(assigns) do
     ~H"""

--- a/lib/petal_components/dropdown.ex
+++ b/lib/petal_components/dropdown.ex
@@ -11,25 +11,25 @@ defmodule PetalComponents.Dropdown do
   @transition_out_start "transform opacity-100 scale-100"
   @transition_out_end "transform opacity-0 scale-95"
 
-  attr(:options_container_id, :string)
-  attr(:label, :string, default: nil, doc: "labels your dropdown option")
-  attr(:class, :string, default: "", doc: "any extra CSS class for the parent container")
+  attr :options_container_id, :string
+  attr :label, :string, default: nil, doc: "labels your dropdown option"
+  attr :class, :string, default: "", doc: "any extra CSS class for the parent container"
+  attr :disabled, :boolean, default: false
 
-  attr(:menu_items_wrapper_class, :string,
+  attr :menu_items_wrapper_class, :string,
     default: "",
     doc: "any extra CSS class for menu item wrapper container"
-  )
 
-  attr(:js_lib, :string,
+  attr :js_lib, :string,
     default: "alpine_js",
     values: ["alpine_js", "live_view_js"],
     doc: "javascript library used for toggling"
-  )
 
-  attr(:placement, :string, default: "left", values: ["left", "right"])
-  attr(:rest, :global)
-  slot(:trigger_element)
-  slot(:inner_block, required: false)
+  attr :placement, :string, default: "left", values: ["left", "right"]
+  attr :rest, :global
+
+  slot :trigger_element
+  slot :inner_block, required: false
 
   @doc """
     <.dropdown label="Dropdown" js_lib="alpine_js|live_view_js">
@@ -38,6 +38,7 @@ defmodule PetalComponents.Dropdown do
         Button item with icon
       </.dropdown_menu_item>
       <.dropdown_menu_item link_type="a" to="/" label="a item" />
+      <.dropdown_menu_item link_type="a" to="/" disabled label="disabled item" />
       <.dropdown_menu_item link_type="live_patch" to="/" label="Live Patch item" />
       <.dropdown_menu_item link_type="live_redirect" to="/" label="Live Redirect item" />
     </.dropdown>
@@ -56,9 +57,10 @@ defmodule PetalComponents.Dropdown do
       <div>
         <button
           type="button"
-          class={trigger_button_classes(@label, @trigger_element)}
+          class={[trigger_button_classes(@label, @trigger_element), @disabled && "pc-dropdown__menu-item--disabled"]}
           {js_attributes("button", @js_lib, @options_container_id)}
           aria-haspopup="true"
+          disabled={@disabled}
         >
           <span class="sr-only">Open options</span>
 
@@ -92,17 +94,16 @@ defmodule PetalComponents.Dropdown do
     """
   end
 
-  attr(:to, :string, default: nil, doc: "link path")
-  attr(:label, :string, doc: "link label")
-  attr(:class, :string, default: "", doc: "any additional CSS classes")
+  attr :to, :string, default: nil, doc: "link path"
+  attr :label, :string, doc: "link label"
+  attr :class, :string, default: "", doc: "any additional CSS classes"
 
-  attr(:link_type, :string,
+  attr :link_type, :string,
     default: "button",
     values: ["a", "live_patch", "live_redirect", "button"]
-  )
 
-  attr(:rest, :global, include: ~w(method download hreflang ping referrerpolicy rel target type))
-  slot(:inner_block, required: false)
+  attr :rest, :global, include: ~w(method download hreflang ping referrerpolicy rel target type)
+  slot :inner_block, required: false
 
   def dropdown_menu_item(assigns) do
     ~H"""

--- a/lib/petal_components/dropdown.ex
+++ b/lib/petal_components/dropdown.ex
@@ -109,7 +109,7 @@ defmodule PetalComponents.Dropdown do
     <Link.a
       link_type={@link_type}
       to={@to}
-      class={"#{@class} pc-dropdown__menu-item #{get_disabled_classes(@disabled)}"}
+      class={[@class, "pc-dropdown__menu-item", get_disabled_classes(@disabled)]}
       disabled={@disabled}
       {@rest}
     >

--- a/lib/petal_components/dropdown.ex
+++ b/lib/petal_components/dropdown.ex
@@ -14,7 +14,6 @@ defmodule PetalComponents.Dropdown do
   attr :options_container_id, :string
   attr :label, :string, default: nil, doc: "labels your dropdown option"
   attr :class, :string, default: "", doc: "any extra CSS class for the parent container"
-  attr :disabled, :boolean, default: false
 
   attr :menu_items_wrapper_class, :string,
     default: "",
@@ -57,10 +56,9 @@ defmodule PetalComponents.Dropdown do
       <div>
         <button
           type="button"
-          class={[trigger_button_classes(@label, @trigger_element), @disabled && "pc-dropdown__menu-item--disabled"]}
+          class={trigger_button_classes(@label, @trigger_element)}
           {js_attributes("button", @js_lib, @options_container_id)}
           aria-haspopup="true"
-          disabled={@disabled}
         >
           <span class="sr-only">Open options</span>
 
@@ -97,6 +95,7 @@ defmodule PetalComponents.Dropdown do
   attr :to, :string, default: nil, doc: "link path"
   attr :label, :string, doc: "link label"
   attr :class, :string, default: "", doc: "any additional CSS classes"
+  attr :disabled, :boolean, default: false
 
   attr :link_type, :string,
     default: "button",
@@ -107,7 +106,13 @@ defmodule PetalComponents.Dropdown do
 
   def dropdown_menu_item(assigns) do
     ~H"""
-    <Link.a link_type={@link_type} to={@to} class={"#{@class} pc-dropdown__menu-item"} {@rest}>
+    <Link.a
+      link_type={@link_type}
+      to={@to}
+      class={"#{@class} pc-dropdown__menu-item #{get_disabled_classes(@disabled)}"}
+      disabled={@disabled}
+      {@rest}
+    >
       <%= render_slot(@inner_block) || @label %>
     </Link.a>
     """
@@ -181,4 +186,7 @@ defmodule PetalComponents.Dropdown do
 
   defp placement_class("left"), do: "pc-dropdown__menu-items-wrapper-placement--left"
   defp placement_class("right"), do: "pc-dropdown__menu-items-wrapper-placement--right"
+
+  defp get_disabled_classes(true), do: "pc-dropdown__menu-item--disabled"
+  defp get_disabled_classes(false), do: ""
 end

--- a/lib/petal_components/link.ex
+++ b/lib/petal_components/link.ex
@@ -1,13 +1,13 @@
 defmodule PetalComponents.Link do
   use Phoenix.Component
 
-  attr(:class, :string, default: "", doc: "CSS class for link")
-  attr(:link_type, :string, default: "a", values: ["a", "live_patch", "live_redirect", "button"])
-  attr(:label, :string, default: nil, doc: "label your link")
-  attr(:to, :string, default: nil, doc: "link path")
-  attr(:disabled, :boolean, default: false, doc: "disables your link")
-  attr(:rest, :global, include: ~w(method download))
-  slot(:inner_block, required: false)
+  attr :class, :any, default: "", doc: "CSS class for link (either a string or list)"
+  attr :link_type, :string, default: "a", values: ["a", "live_patch", "live_redirect", "button"]
+  attr :label, :string, default: nil, doc: "label your link"
+  attr :to, :string, default: nil, doc: "link path"
+  attr :disabled, :boolean, default: false, doc: "disables your link"
+  attr :rest, :global, include: ~w(method download)
+  slot :inner_block, required: false
 
   def a(%{link_type: "button", disabled: true} = assigns) do
     assigns = update_in(assigns.rest, &Map.drop(&1, [:"phx-click"]))

--- a/lib/petal_components/rating.ex
+++ b/lib/petal_components/rating.ex
@@ -22,7 +22,10 @@ defmodule PetalComponents.Rating do
     doc: "Whether to include an automatically generated rating label"
   )
 
-  attr(:label_class, :string, default: nil, doc: "Any additional CSS classes for the rating label")
+  attr(:label_class, :string,
+    default: nil,
+    doc: "Any additional CSS classes for the rating label"
+  )
 
   def rating(assigns) do
     assigns =

--- a/test/petal/dropdown_test.exs
+++ b/test/petal/dropdown_test.exs
@@ -54,6 +54,20 @@ defmodule PetalComponents.DropdownTest do
            """) =~ "pc-dropdown__menu-items-wrapper-placement--right"
   end
 
+  test "the disabled attribute works" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.dropdown>
+        <.dropdown_menu_item disabled>Option</.dropdown_menu_item>
+      </.dropdown>
+      """)
+
+    assert html =~ "pc-dropdown__menu-item--disabled"
+    assert html =~ " disabled" # the attribute itself
+  end
+
   test "it works with a custom trigger" do
     assigns = %{}
 


### PR DESCRIPTION
Hi! I added support for the `disabled` attribute on the `dropdown_menu_item` component.

I don't know whether this is the correct way to apply styling. I tried to mirror the approach that the `button` component uses.

Also, sorry for the giant diff! I removed the annoying brackets the formatter adds everywhere. Btw, that has been fixed a while ago in ElixirLS, see elixir-lsp/elixir-ls#526.