### PR TITLE
Add `disabled` attribute to Tab component

### DIFF
--- a/lib/petal_components/tabs.ex
+++ b/lib/petal_components/tabs.ex
@@ -40,8 +40,9 @@ defmodule PetalComponents.Tabs do
 
   attr(:to, :string, default: nil, doc: "link path")
   attr(:number, :integer, default: nil, doc: "indicates a number next to your tab")
-  attr(:underline, :boolean, default: false, doc: "underlines your your tab")
+  attr(:underline, :boolean, default: false, doc: "underlines your tab")
   attr(:is_active, :boolean, default: false, doc: "indicates the current tab")
+  attr(:disabled, :boolean, default: false, doc: "disabled your tab")
   attr(:rest, :global, include: ~w(method download hreflang ping referrerpolicy rel target type))
   slot(:inner_block, required: false)
 
@@ -52,6 +53,7 @@ defmodule PetalComponents.Tabs do
       label={@label}
       to={@to}
       class={"#{get_tab_class(@is_active, @underline)} #{@class}"}
+      disabled={@disabled}
       {@rest}
     >
       <%= if @number do %>

--- a/lib/petal_components/tabs.ex
+++ b/lib/petal_components/tabs.ex
@@ -42,7 +42,7 @@ defmodule PetalComponents.Tabs do
   attr(:number, :integer, default: nil, doc: "indicates a number next to your tab")
   attr(:underline, :boolean, default: false, doc: "underlines your tab")
   attr(:is_active, :boolean, default: false, doc: "indicates the current tab")
-  attr(:disabled, :boolean, default: false, doc: "disabled your tab")
+  attr(:disabled, :boolean, default: false, doc: "disables your tab")
   attr(:rest, :global, include: ~w(method download hreflang ping referrerpolicy rel target type))
   slot(:inner_block, required: false)
 


### PR DESCRIPTION
Sorry for the delay on this, following up on the quick change referenced in https://github.com/petalframework/petal_components/issues/254. Passes through a `disabled` attribute to the `Link` component for `Tab`s.

(I also fixed a small doc typo I noticed while I was in there for the underline attribute.)