### PR TITLE
Pagination support encoded path

### DIFF
--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -127,7 +127,9 @@ defmodule PetalComponents.Pagination do
   end
 
   defp get_path(path, page_number, current_page) when is_binary(path) do
-    get_path(&String.replace(path, ":page", Integer.to_string(&1)), page_number, current_page)
+    # replace on `%3Apage` or `:page` in case we receive an URI encoded path
+    fun = &String.replace(path, ~r/%3Apage|:page/, Integer.to_string(&1))
+    get_path(fun, page_number, current_page)
   end
 
   defp get_path(fun, "previous", current_page) when is_function(fun, 1) do

--- a/test/petal/pagination_test.exs
+++ b/test/petal/pagination_test.exs
@@ -519,4 +519,18 @@ defmodule PetalComponents.PaginationTest do
 
     refute html =~ "phx-target"
   end
+
+  test "accept an encoded path URI to work with phoenix sigil_p and path with dynamics params" do
+    assigns = %{
+      params: %{"filter" => "test", "page" => ":page"}
+    }
+
+    html =
+      rendered_to_string(~H"""
+      <.pagination path={"/page?#{URI.encode_query(@params)}"} total_pages={2} current_page={1} />
+      """)
+
+    assert html =~ "filter=test"
+    assert html =~ "page=2"
+  end
 end


### PR DESCRIPTION
Following #262 
Finally it's not a good idea to encode the path first you have to split the query from the path and encode.
Something like
```
uri = URI.new!("/team?page=:page")
iex(7)> URI.decode_query(uri.query)
%{"page" => ":page"}
iex(8)> query = URI.decode_query(uri.query) |> URI.encode_query()
"page=%3Apage"
iex(9)> %{uri | query: query} |> to_string()
""/team?page=%3Apage""
```
Instead I use a simple regex with a OR.