### PR TITLE
Add pagination attribute allowing always shown prev and next buttons

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -843,13 +843,13 @@
   @apply inline-flex items-center justify-center leading-5 px-3.5 py-2 border border-gray-200 dark:border-gray-700;
 }
 .pc-pagination__item__previous {
-  @apply mr-2 inline-flex items-center justify-center rounded leading-5 px-2.5 py-2 bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800 border dark:border-gray-700 border-gray-200 text-gray-600 hover:text-gray-800;
+  @apply mr-2 inline-flex items-center justify-center rounded leading-5 px-2.5 py-2 bg-white enabled:hover:bg-gray-50 dark:bg-gray-900 enabled:dark:hover:bg-gray-800 border dark:border-gray-700 border-gray-200 text-gray-600 enabled:hover:text-gray-800 disabled:opacity-50;
 }
 .pc-pagination__item__previous__chevron {
   @apply w-5 h-5 text-gray-600 dark:text-gray-400;
 }
 .pc-pagination__item__next {
-  @apply ml-2 inline-flex items-center justify-center rounded leading-5 px-2.5 py-2 bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800 dark:border-gray-700 border border-gray-200 text-gray-600 hover:text-gray-800;
+  @apply ml-2 inline-flex items-center justify-center rounded leading-5 px-2.5 py-2 bg-white enabled:hover:bg-gray-50 dark:bg-gray-900 enabled:dark:hover:bg-gray-800 dark:border-gray-700 border border-gray-200 text-gray-600 enabled:hover:text-gray-800 disabled:opacity-50;
 }
 .pc-pagination__item__next__chevron {
   @apply w-5 h-5 text-gray-600 dark:text-gray-400;
@@ -1182,11 +1182,11 @@
 }
 
 .pc-vertical-menu__menu-group__wrapper {
-  @apply  divide-y divide-gray-300;
+  @apply divide-y divide-gray-300;
 }
 
 .pc-vertical-menu__menu-group {
-  @apply  space-y-1;
+  @apply space-y-1;
 }
 
 .pc-vertical-menu__menu-group__title {

--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -26,6 +26,7 @@ defmodule PetalComponents.Pagination do
   attr :current_page, :integer, default: nil, doc: "sets the current page"
   attr :sibling_count, :integer, default: 1, doc: "sets a sibling count"
   attr :boundary_count, :integer, default: 1, doc: "sets a boundary count"
+  attr :show_boundary_chevrons, :boolean, default: false, doc: "whether to show prev & next buttons at boundary pages"
   attr :rest, :global
 
   @doc """
@@ -38,7 +39,7 @@ defmodule PetalComponents.Pagination do
     <div {@rest} class={"#{@class} pc-pagination"}>
       <ul class="pc-pagination__inner">
         <%= for item <- get_pagination_items(@total_pages, @current_page, @sibling_count, @boundary_count) do %>
-          <%= if item.type == "prev" and item.enabled? do %>
+          <%= if item.type == "prev" and (item.enabled? or @show_boundary_chevrons) do %>
             <div>
               <Link.a
                 phx-click={if @event, do: "goto-page"}
@@ -47,6 +48,7 @@ defmodule PetalComponents.Pagination do
                 link_type={if @event, do: "button", else: @link_type}
                 to={if not @event, do: get_path(@path, item.number, @current_page)}
                 class="pc-pagination__item__previous"
+                disabled={!item.enabled?}
               >
                 <Heroicons.chevron_left solid class="pc-pagination__item__previous__chevron" />
               </Link.a>
@@ -80,7 +82,7 @@ defmodule PetalComponents.Pagination do
             </li>
           <% end %>
 
-          <%= if item.type == "next" and item.enabled? do %>
+          <%= if item.type == "next" and (item.enabled? or @show_boundary_chevrons) do %>
             <div>
               <Link.a
                 phx-click={if @event, do: "goto-page"}
@@ -89,6 +91,7 @@ defmodule PetalComponents.Pagination do
                 link_type={if @event, do: "button", else: @link_type}
                 to={if not @event, do: get_path(@path, item.number, @current_page)}
                 class="pc-pagination__item__next"
+                disabled={!item.enabled?}
               >
                 <Heroicons.chevron_right solid class="pc-pagination__item__next__chevron" />
               </Link.a>

--- a/test/petal/pagination_test.exs
+++ b/test/petal/pagination_test.exs
@@ -344,6 +344,17 @@ defmodule PetalComponents.PaginationTest do
     refute html =~ "/page/0"
   end
 
+  test "previous shows on page 1 as disabled if show boundary chevrons true" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.pagination path="/page/:page" total_pages={10} current_page={1} show_boundary_chevrons={true} />
+      """)
+
+    assert html =~ "button class=\"pc-pagination__item__previous\" disabled"
+  end
+
   test "next doesn't show on last page" do
     assigns = %{}
 
@@ -353,6 +364,17 @@ defmodule PetalComponents.PaginationTest do
       """)
 
     refute html =~ "/page/11"
+  end
+
+  test "next shows on last page as disabled if show boundary chevrons true" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.pagination path="/page/:page" total_pages={10} current_page={10} show_boundary_chevrons={true} />
+      """)
+
+    assert html =~ "button class=\"pc-pagination__item__next\" disabled"
   end
 
   test "show front ellipsis if current page is greater than the boundary count" do
@@ -503,7 +525,7 @@ defmodule PetalComponents.PaginationTest do
 
     html =
       rendered_to_string(~H"""
-      <.pagination event={true} target={"some-component-id"} total_pages={3} current_page={1} />
+      <.pagination event={true} target="some-component-id" total_pages={3} current_page={1} />
       """)
 
     assert html =~ "phx-target"
@@ -514,7 +536,7 @@ defmodule PetalComponents.PaginationTest do
 
     html =
       rendered_to_string(~H"""
-      <.pagination target={"some-component-id"} total_pages={3} current_page={1} />
+      <.pagination target="some-component-id" total_pages={3} current_page={1} />
       """)
 
     refute html =~ "phx-target"


### PR DESCRIPTION
Adds a boolean attribute to the pagination component allowing the previous & next buttons to always be shown on the boundary pages. Defaults to current behavior (prev not shown on page 1, next not shown on last page).

Buttons shown on those boundary pages are disabled and reduced opacity.

[Loom of the live boilerplate page](https://www.loom.com/share/15f0d94008874bc58ae7cc007fe41a7a?sid=59d436c3-537c-4c4f-b933-fade87bb7dfe)

<img src="https://github.com/petalframework/petal_components/assets/2649893/a7dd99a4-a66c-47ac-9746-bee8a9772054" width="400" />


Resolves #140 