### PR TITLE
Add value when closing modal to support nested modal

### DIFF
--- a/lib/petal_components/modal.ex
+++ b/lib/petal_components/modal.ex
@@ -104,9 +104,9 @@ defmodule PetalComponents.Modal do
       |> JS.remove_class("overflow-hidden", to: "body")
 
     if close_modal_target do
-      JS.push(js, "close_modal", target: close_modal_target)
+      JS.push(js, "close_modal", target: close_modal_target, value: %{id: id})
     else
-      JS.push(js, "close_modal")
+      JS.push(js, "close_modal", value: %{id: id})
     end
   end
 


### PR DESCRIPTION
This PR will send close_modal event with modal id as a params when closing. This will help to detect nested modal closing.