### PR TITLE
Fix modal class

### DIFF
--- a/lib/petal_components/modal.ex
+++ b/lib/petal_components/modal.ex
@@ -6,6 +6,7 @@ defmodule PetalComponents.Modal do
   attr :id, :string, default: "modal", doc: "modal id"
   attr :hide, :boolean, default: false, doc: "modal is hidden"
   attr :title, :string, default: nil, doc: "modal title"
+  attr :class, :string, default: nil, doc: "modal class"
 
   attr :close_modal_target, :string,
     default: nil,

--- a/test/petal/modal_test.exs
+++ b/test/petal/modal_test.exs
@@ -108,4 +108,15 @@ defmodule PetalComponents.ModalTest do
 
     refute html =~ "<svg"
   end
+
+  test "class" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.modal class="h-full"></.modal>
+      """)
+
+    assert html =~ "pc-modal__box--md pc-modal__box h-full"
+  end
 end

--- a/test/petal/modal_test.exs
+++ b/test/petal/modal_test.exs
@@ -117,6 +117,13 @@ defmodule PetalComponents.ModalTest do
       <.modal class="h-full"></.modal>
       """)
 
-    assert html =~ "pc-modal__box--md pc-modal__box h-full"
+    assert html =~ "\"pc-modal__box--md pc-modal__box h-full\""
+
+    html =
+      rendered_to_string(~H"""
+      <.modal></.modal>
+      """)
+
+    assert html =~ "\"pc-modal__box--md pc-modal__box \""
   end
 end


### PR DESCRIPTION
Currently, the `class` passed into the modal component is part of the `rest` global attr, since it's not explicitly declared, which causes `custom_classes` in `get_classes/1` to always be `""`.