### PR TITLE
Add support for empty states in tables

### DIFF
--- a/lib/petal_components/table.ex
+++ b/lib/petal_components/table.ex
@@ -11,6 +11,7 @@ defmodule PetalComponents.Table do
       <.table id="users" rows={@users}>
         <:col :let={user} label="id"><%= user.id %></:col>
         <:col :let={user} label="username"><%= user.username %></:col>
+        <:empty_state>No data here yet</:empty_state>
       </.table>
   """
   attr :id, :string
@@ -26,6 +27,11 @@ defmodule PetalComponents.Table do
   slot :col do
     attr :label, :string
     attr :class, :string
+    attr :row_class, :string
+  end
+
+  slot :empty_state,
+    doc: "A message to show when the table is empty, to be used together with :col" do
     attr :row_class, :string
   end
 
@@ -48,6 +54,17 @@ defmodule PetalComponents.Table do
           </.tr>
         </thead>
         <tbody id={@id} phx-update={match?(%Phoenix.LiveView.LiveStream{}, @rows) && "stream"}>
+          <%= if length(@empty_state) > 0 do %>
+            <.tr class="hidden only:table-row">
+              <.td
+                :for={empty_state <- @empty_state}
+                colspan={length(@col)}
+                class={empty_state[:row_class]}
+              >
+                <%= render_slot(empty_state) %>
+              </.td>
+            </.tr>
+          <% end %>
           <.tr
             :for={row <- @rows}
             id={@row_id && @row_id.(row)}

--- a/test/petal/table_test.exs
+++ b/test/petal/table_test.exs
@@ -38,6 +38,20 @@ defmodule PetalComponents.TableTest do
       end)
     end
 
+    test "with empty state", assigns do
+      html =
+        rendered_to_string(~H"""
+        <.table class="my-class" id="posts" row_id={fn post -> "row_#{post.id}" end} rows={[]}>
+          <:col :let={post} label="Name" class="col-class" row_class="row-class"><%= post.name %></:col>
+          <:empty_state row_class="empty-class">This table is empty</:empty_state>
+        </.table>
+        """)
+
+      IO.puts(html)
+      assert html =~ "empty-class"
+      assert html =~ "This table is empty"
+    end
+
     test "row_click", assigns do
       html =
         rendered_to_string(~H"""


### PR DESCRIPTION
State with data:
![Screenshot 2024-02-12 at 14 08 44](https://github.com/petalframework/petal_components/assets/404293/8af42abf-4f54-4f86-af18-8a207c6adcb2)

State without data ("empty state"):
![Screenshot 2024-02-12 at 14 08 57](https://github.com/petalframework/petal_components/assets/404293/547f356d-5565-4ec6-83bf-a9917b647448)


Add optional empty states for tables. 

* named slot `:empty_state` 
* always rendered at the top of the table into a cell that spans the whole width (the width is derived from the number of `:col` slots supplied)
* the row that holds the cell has `hidden only:table-row` Tailwind classes so it's only visible if it's the _only_ row
* the slot takes `row_class` that is then forwarded to the cell
* renders multiple cells if more than one `:empty_state` slot is given <- I'm not entirely sure about this, maybe we
  should rather crash if more than one slot is set?
