### PR TITLE
Fix table id

### DIFF
--- a/lib/petal_components/table.ex
+++ b/lib/petal_components/table.ex
@@ -46,7 +46,7 @@ defmodule PetalComponents.Table do
     assigns = assign_new(assigns, :id, fn -> "table_#{Ecto.UUID.generate()}" end)
 
     ~H"""
-    <table class={["pc-table", @class]} {@rest}>
+    <table id={@id} class={["pc-table", @class]} {@rest}>
       <%= if length(@col) > 0 do %>
         <thead>
           <.tr>

--- a/test/petal/table_test.exs
+++ b/test/petal/table_test.exs
@@ -21,13 +21,14 @@ defmodule PetalComponents.TableTest do
     test "plain", assigns do
       html =
         rendered_to_string(~H"""
-        <.table class="my-class" id="posts" row_id={fn post -> "row_#{post.id}" end} rows={@posts}>
+        <.table class="my-class" id="my-id" row_id={fn post -> "row_#{post.id}" end} rows={@posts}>
           <:col :let={post} label="Name" class="col-class" row_class="row-class"><%= post.name %></:col>
         </.table>
         """)
 
       assert html =~ "<table"
       assert html =~ "pc-table"
+      assert html =~ "my-id"
       assert html =~ "my-class"
       assert html =~ "col-class"
       assert html =~ "row-class"
@@ -47,7 +48,6 @@ defmodule PetalComponents.TableTest do
         </.table>
         """)
 
-      IO.puts(html)
       assert html =~ "empty-class"
       assert html =~ "This table is empty"
     end
@@ -78,11 +78,12 @@ defmodule PetalComponents.TableTest do
 
     html =
       rendered_to_string(~H"""
-      <.table></.table>
+      <.table id="my-id"></.table>
       """)
 
     assert html =~ "<table"
     assert html =~ "pc-table"
+    assert html =~ "my-id"
   end
 
   test "tr" do


### PR DESCRIPTION
Recent changes to the `<.table>` component broke the `id` attribute.