### PR TITLE
Rounds the width of the progress component to 2 decimal places

### DIFF
--- a/lib/petal_components/progress.ex
+++ b/lib/petal_components/progress.ex
@@ -19,7 +19,7 @@ defmodule PetalComponents.Progress do
     <div {@rest} class={["pc-progress--#{@size}", "pc-progress", "pc-progress--#{@color}", @class]}>
       <span
         class={["pc-progress__inner--#{@color}", "pc-progress__inner"]}
-        style={"width: #{round(@value/@max*100)}%"}
+        style={"width: #{Float.round(@value/@max*100, 2)}%"}
       >
         <%= if @size == "xl" do %>
           <span class="pc-progress__label">

--- a/test/petal/progress_test.exs
+++ b/test/petal/progress_test.exs
@@ -73,4 +73,22 @@ defmodule PetalComponents.ProgressTest do
 
     assert html =~ ~s{custom-attrs="123"}
   end
+
+  test "should round width to 2 decimal places" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.progress value={50} max={100} />
+      """)
+
+    assert html =~ "width: 50.0%"
+
+    html =
+      rendered_to_string(~H"""
+      <.progress value={2} max={3} />
+      """)
+
+    assert html =~ "width: 66.67%"
+  end
 end


### PR DESCRIPTION
This PR rounds the width of the progress component to 2 decimal places, as opposed to 0.  2 decimal places seemed like a reasonable precision to me, but I can adjust it if needed.  It's rather arbitrary. 

Examples:

```html
<.progress value={50} max={100} />

<div class="pc-progress--md pc-progress pc-progress--primary ">
  <!-- BEFORE -->
  <span class="pc-progress__inner--primary pc-progress__inner" style="width: 50%">
  
  <!-- AFTER -->
  <span class="pc-progress__inner--primary pc-progress__inner" style="width: 50.0%">
</div>
```

```html
<.progress value={2} max={3} />

<div class="pc-progress--md pc-progress pc-progress--primary ">
  <!-- BEFORE -->
  <span class="pc-progress__inner--primary pc-progress__inner" style="width: 67%">
  
  <!-- AFTER -->
  <span class="pc-progress__inner--primary pc-progress__inner" style="width: 66.67%">
</div>
```

