### PR TITLE
Remove `for` attribute in `radio-group` label

### DIFF
--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -256,7 +256,7 @@ defmodule PetalComponents.Field do
 
     ~H"""
     <.field_wrapper errors={@errors} name={@name} class={@wrapper_class}>
-      <.field_label required={@required} for={@id} class={@label_class}>
+      <.field_label required={@required} class={@label_class}>
         <%= @label %>
       </.field_label>
       <div class={[


### PR DESCRIPTION
The `for` attribute in `label` is supposed to match the `id` of a visible `input` element on the page. 
Since the `radio-group` component renders multiple `radio` inputs, it's not possible to have the label match a single element with a unique ID.

Having the `label` unmatched with an `input` causes an accessibility issue to show up on the Chrome dev tools.

<img width="1512" alt="Screenshot 2024-08-14 at 15 58 09" src="https://github.com/user-attachments/assets/edb79761-7b03-427e-aad3-fa6ce8fb5da8">
