### PR TITLE
Add default_js_lib config

### DIFF
--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -33,4 +33,9 @@ defmodule PetalComponents do
       alias PetalComponents.HeroiconsV1
     end
   end
+
+  @default_js_lib Application.compile_env(:petal_components, :default_js_lib, "alpine_js")
+  def default_js_lib() do
+    @default_js_lib
+  end
 end

--- a/lib/petal_components/accordion.ex
+++ b/lib/petal_components/accordion.ex
@@ -7,7 +7,7 @@ defmodule PetalComponents.Accordion do
   attr(:entries, :list, default: [%{}])
 
   attr(:js_lib, :string,
-    default: "alpine_js",
+    default: PetalComponents.default_js_lib(),
     values: ["alpine_js", "live_view_js"],
     doc: "javascript library used for toggling"
   )

--- a/lib/petal_components/dropdown.ex
+++ b/lib/petal_components/dropdown.ex
@@ -20,7 +20,7 @@ defmodule PetalComponents.Dropdown do
     doc: "any extra CSS class for menu item wrapper container"
 
   attr :js_lib, :string,
-    default: "alpine_js",
+    default: PetalComponents.default_js_lib(),
     values: ["alpine_js", "live_view_js"],
     doc: "javascript library used for toggling"
 

--- a/lib/petal_components/menu.ex
+++ b/lib/petal_components/menu.ex
@@ -129,7 +129,7 @@ defmodule PetalComponents.Menu do
   attr :title, :string, default: nil
 
   attr(:js_lib, :string,
-    default: "alpine_js",
+    default: PetalComponents.default_js_lib(),
     values: ["alpine_js", "live_view_js"],
     doc: "javascript library used for toggling"
   )
@@ -168,7 +168,7 @@ defmodule PetalComponents.Menu do
   attr :title, :string
 
   attr(:js_lib, :string,
-    default: "alpine_js",
+    default: PetalComponents.default_js_lib(),
     values: ["alpine_js", "live_view_js"],
     doc: "javascript library used for toggling"
   )
@@ -206,7 +206,7 @@ defmodule PetalComponents.Menu do
   attr :link_type, :string, default: "live_redirect"
 
   attr(:js_lib, :string,
-    default: "alpine_js",
+    default: PetalComponents.default_js_lib(),
     values: ["alpine_js", "live_view_js"],
     doc: "javascript library used for toggling"
   )


### PR DESCRIPTION
This PR adds `default_js_lib/0` to address the inconvenience of having to set `js_lib` for the component every time it is used.