### PR TITLE
Remove for attribute in checkbox-group label

### DIFF
--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -209,7 +209,7 @@ defmodule PetalComponents.Field do
 
     ~H"""
     <.field_wrapper errors={@errors} name={@name} class={@wrapper_class}>
-      <.field_label required={@required} for={@id} class={@label_class}>
+      <.field_label required={@required} class={@label_class}>
         <%= @label %>
       </.field_label>
       <input type="hidden" name={@name} value="" />

--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -366,9 +366,15 @@ defmodule PetalComponents.Field do
 
   def field_label(assigns) do
     ~H"""
-    <label for={@for} class={["pc-label", @class, @required && "pc-label--required"]} {@rest}>
-      <%= render_slot(@inner_block) %>
-    </label>
+    <%= if @for do %>
+      <label for={@for} class={["pc-label", @class, @required && "pc-label--required"]} {@rest}>
+        <%= render_slot(@inner_block) %>
+      </label>
+    <% else %>
+      <span class={["pc-label", @class, @required && "pc-label--required"]} {@rest}>
+        <%= render_slot(@inner_block) %>
+      </span>
+    <% end %>
     """
   end
 

--- a/lib/petal_components/menu.ex
+++ b/lib/petal_components/menu.ex
@@ -136,7 +136,6 @@ defmodule PetalComponents.Menu do
 
   def vertical_menu(%{menu_items: []} = assigns) do
     ~H"""
-
     """
   end
 

--- a/lib/petal_components/skeleton.ex
+++ b/lib/petal_components/skeleton.ex
@@ -1,7 +1,11 @@
 defmodule PetalComponents.Skeleton do
   use Phoenix.Component
 
-  attr(:kind, :atom, default: :default, doc: "skeleton", values: [:default, :image, :video, :text, :card, :widget, :list, :testimonial])
+  attr(:kind, :atom,
+    default: :default,
+    doc: "skeleton",
+    values: [:default, :image, :video, :text, :card, :widget, :list, :testimonial]
+  )
 
   def skeleton(%{kind: :default} = assigns) do
     ~H"""

--- a/test/petal/field_test.exs
+++ b/test/petal/field_test.exs
@@ -253,7 +253,6 @@ defmodule PetalComponents.FieldTest do
       """)
 
     assert html =~ "checkbox"
-    assert html =~ "user_roles"
     assert html =~ "user[roles][]"
     assert html =~ "Read"
     assert html =~ "phx-feedback-for"
@@ -403,7 +402,6 @@ defmodule PetalComponents.FieldTest do
       """)
 
     assert html =~ "radio"
-    assert html =~ "user_roles"
     assert html =~ "user[roles]"
     assert html =~ "Read"
     assert html =~ "phx-feedback-for"

--- a/test/petal/menu_test.exs
+++ b/test/petal/menu_test.exs
@@ -48,7 +48,7 @@ defmodule PetalComponents.MenuTest do
           %{
             name: :sign_in,
             label: "Path",
-            path: "/path",
+            path: "/path"
           }
         ],
         current_page: :current_page,


### PR DESCRIPTION
Also, avoid creating a `label` that does not refer to a legitimate `input` element - removes warning.

See https://github.com/petalframework/petal_components/issues/328 for original change to radio-group