### PR TITLE
Use `spans` instead of `labels` if there is no `for` attribute

### DIFF
--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -32,9 +32,9 @@ defmodule PetalComponents.Form do
         <%= render_slot(@inner_block) || @label || Form.humanize(@field) %>
       <% end %>
     <% else %>
-      <label class={@classes} {@rest}>
+      <span class={@classes} {@rest}>
         <%= render_slot(@inner_block) || @label || Form.humanize(@field) %>
-      </label>
+      </span>
     <% end %>
     """
   end
@@ -120,10 +120,10 @@ defmodule PetalComponents.Form do
             </div>
           </label>
         <% "checkbox_group" -> %>
-          <.form_label form={@form} field={@field} label={@label} class={@label_class} />
+          <.form_label form={@form} label={@label} class={@label_class} />
           <.checkbox_group form={@form} field={@field} {@rest} />
         <% "radio_group" -> %>
-          <.form_label form={@form} field={@field} label={@label} class={@label_class} />
+          <.form_label form={@form} label={@label} class={@label_class} />
           <.radio_group form={@form} field={@field} {@rest} />
         <% "text_input" -> %>
           <.form_label form={@form} field={@field} label={@label} class={@label_class} />
@@ -150,16 +150,16 @@ defmodule PetalComponents.Form do
           <.form_label form={@form} field={@field} label={@label} class={@label_class} />
           <.time_input form={@form} field={@field} {@rest} />
         <% "time_select" -> %>
-          <.form_label form={@form} field={@field} label={@label} class={@label_class} />
+          <.form_label form={@form} label={@label} class={@label_class} />
           <.time_select form={@form} field={@field} {@rest} />
         <% "datetime_select" -> %>
-          <.form_label form={@form} field={@field} label={@label} class={@label_class} />
+          <.form_label form={@form} label={@label} class={@label_class} />
           <.datetime_select form={@form} field={@field} {@rest} />
         <% "datetime_local_input" -> %>
           <.form_label form={@form} field={@field} label={@label} class={@label_class} />
           <.datetime_local_input form={@form} field={@field} {@rest} />
         <% "date_select" -> %>
-          <.form_label form={@form} field={@field} label={@label} class={@label_class} />
+          <.form_label form={@form} label={@label} class={@label_class} />
           <.date_select form={@form} field={@field} {@rest} />
         <% "date_input" -> %>
           <.form_label form={@form} field={@field} label={@label} class={@label_class} />

--- a/test/petal/form_test.exs
+++ b/test/petal/form_test.exs
@@ -315,14 +315,7 @@ defmodule PetalComponents.FormTest do
     html =
       rendered_to_string(~H"""
       <.form :let={f} as={:user} for={%Ecto.Changeset{action: :update, data: %{name: ""}}}>
-        <.form_field
-          type="text_input"
-          form={f}
-          field={:name}
-          placeholder="eg. John"
-          label_class="label-class-test"
-          help_text="Help!"
-        />
+        <.form_field type="text_input" form={f} field={:name} label_class="label-class-test" />
       </.form>
       """)
 
@@ -361,6 +354,145 @@ defmodule PetalComponents.FormTest do
     assert html =~ "pc-form-field-wrapper"
     assert html =~ "pc-text-input"
     assert html =~ "w-max"
+  end
+
+  test "form_fields generate appropriate label and inputs" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} as={:user} for={%{}}>
+        <.form_field type="text_input" form={f} field={:name} />
+      </.form>
+      """)
+
+    assert Floki.find(html, "label.pc-label") != []
+    assert Floki.find(html, "input[type='text']") != []
+
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} for={%{}} as={:user}>
+        <.form_field type="time_input" form={f} field={:name} />
+      </.form>
+      """)
+
+    assert Floki.find(html, "label.pc-label") != []
+    assert Floki.find(html, "input[type='time']") != []
+
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} for={%{}} as={:user}>
+        <.form_field
+          type="checkbox_group"
+          form={f}
+          field={:roles}
+          options={[{"Read", "read"}, {"Write", "write"}]}
+        />
+      </.form>
+      """)
+
+    assert Floki.find(html, "span.pc-label") != []
+    assert Floki.find(html, "input[type='checkbox']") != []
+
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} for={%{}} as={:user}>
+        <.form_field
+          type="radio_group"
+          form={f}
+          field={:roles}
+          options={[{"Read", "read"}, {"Write", "write"}]}
+        />
+      </.form>
+      """)
+
+    assert Floki.find(html, "span.pc-label") != []
+    assert Floki.find(html, "input[type='radio']") != []
+
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} for={%{}} as={:user}>
+        <.form_field type="time_select" form={f} field={:time} />
+      </.form>
+      """)
+
+    assert Floki.find(html, "span.pc-label") != []
+    html =~ "<select"
+
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} for={%{}} as={:user}>
+        <.form_field type="datetime_select" form={f} field={:date_time} />
+      </.form>
+      """)
+
+    assert Floki.find(html, "span.pc-label") != []
+    html =~ "<select"
+
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} for={%{}} as={:user}>
+        <.form_field type="datetime_local_input" form={f} field={:date_time} />
+      </.form>
+      """)
+
+    assert Floki.find(html, "label.pc-label") != []
+    assert Floki.find(html, "input[type='datetime-local']") != []
+
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} for={%{}} as={:user}>
+        <.form_field type="date_select" form={f} field={:date} />
+      </.form>
+      """)
+
+    assert Floki.find(html, "span.pc-label") != []
+    html =~ "<select"
+
+    # Date input
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} for={%{}} as={:user}>
+        <.form_field type="date_input" form={f} field={:date} />
+      </.form>
+      """)
+
+    assert Floki.find(html, "label.pc-label") != []
+    assert Floki.find(html, "input[type='date']") != []
+  end
+
+  test "form_field checkbox_group label" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} for={%{}} as={:user}>
+        <.form_field
+          type="checkbox_group"
+          form={f}
+          field={:roles}
+          options={[{"Read", "read"}, {"Write", "write"}]}
+        />
+      </.form>
+      """)
+
+    assert html =~ "span"
+    assert html =~ "Roles"
+
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} for={%{}} as={:user}>
+        <.form_field
+          type="checkbox_group"
+          form={f}
+          field={:roles}
+          label="Something else"
+          options={[{"Read", "read"}, {"Write", "write"}]}
+        />
+      </.form>
+      """)
+
+    assert html =~ "Something else"
   end
 
   test "form_field checkbox label" do


### PR DESCRIPTION
Following on from PR https://github.com/petalframework/petal_components/pull/336 and PR https://github.com/petalframework/petal_components/pull/333, this removes errors/warnings for date and time select form components