### PR TITLE
Generate list of heroicons if the dependency exists

### DIFF
--- a/lib/petal_components/icon.ex
+++ b/lib/petal_components/icon.ex
@@ -3,56 +3,76 @@ defmodule PetalComponents.Icon do
 
   require Logger
 
-  attr :rest, :global,
-    doc: "the arbitrary HTML attributes for the svg container",
-    include: ~w(role aria-hidden)
-
-  attr :name, :any, required: true
-  attr :class, :any, default: nil, doc: "svg class"
-
-  defp heroicon(%{name: "hero-" <> _} = assigns) do
-    ~H"""
-    <span class={[@name, @class]} {@rest} />
-    """
-  end
-
-  @icons [
-    {"", "/24/outline"},
-    {"-solid", "/24/solid"},
-    {"-mini", "/20/solid"},
-    {"-micro", "/16/solid"}
-  ]
-
   deps_paths = Mix.Project.deps_paths()
   heroicons_path = deps_paths[:heroicons]
 
-  heroicon_names =
-    for {suffix, dir} <- @icons do
-      path =
-        Path.join(heroicons_path, dir)
-        |> Path.expand()
-
-      # Read folder
-      case File.ls(path) do
-        {:ok, file_names} ->
-          for file_name <- file_names, do: Path.rootname(file_name) <> suffix
-
-        {:error, _reason} ->
-          []
-      end
-    end
-    |> Enum.flat_map(fn x -> x end)
-
-  quote do
+  # Heroicons aren't available when pushing to hex
+  if !heroicons_path do
     attr :rest, :global,
-      doc: "the arbitrary HTML attributes for the svg container",
+      doc: "the arbitrary HTML attributes for the heroicon container",
       include: ~w(role aria-hidden)
 
     attr :name, :any, required: true
-    attr :class, :any, default: nil, doc: "svg class"
+    attr :class, :any, default: nil, doc: "class applied to heroicon container"
+
+    def icon(%{name: "hero-" <> _} = assigns) do
+      ~H"""
+      <span class={[@name, @class]} {@rest} />
+      """
+    end
   end
 
-  for heroicon_name <- heroicon_names do
-    def icon(%{name: "hero-" <> unquote(heroicon_name)} = assigns), do: heroicon(assigns)
+  # If heroicons are included as a dependency (either in :dev or in the
+  # calling application), then generate a function per heroicon variant
+  if heroicons_path do
+    attr :rest, :global,
+      doc: "the arbitrary HTML attributes for the heroicon container",
+      include: ~w(role aria-hidden)
+
+    attr :name, :any, required: true
+    attr :class, :any, default: nil, doc: "class applied to heroicon container"
+
+    defp heroicon(%{name: "hero-" <> _} = assigns) do
+      ~H"""
+      <span class={[@name, @class]} {@rest} />
+      """
+    end
+
+    @icons [
+      {"", "/24/outline"},
+      {"-solid", "/24/solid"},
+      {"-mini", "/20/solid"},
+      {"-micro", "/16/solid"}
+    ]
+
+    heroicon_names =
+      for {suffix, dir} <- @icons do
+        path =
+          Path.join(heroicons_path, dir)
+          |> Path.expand()
+
+        # Read folder
+        case File.ls(path) do
+          {:ok, file_names} ->
+            for file_name <- file_names, do: Path.rootname(file_name) <> suffix
+
+          {:error, _reason} ->
+            []
+        end
+      end
+      |> Enum.flat_map(fn x -> x end)
+
+    quote do
+      attr :rest, :global,
+        doc: "the arbitrary HTML attributes for the svg container",
+        include: ~w(role aria-hidden)
+
+      attr :name, :any, required: true
+      attr :class, :any, default: nil, doc: "svg class"
+    end
+
+    for heroicon_name <- heroicon_names do
+      def icon(%{name: "hero-" <> unquote(heroicon_name)} = assigns), do: heroicon(assigns)
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,8 @@ defmodule PetalComponents.MixProject do
        tag: "v2.1.5",
        app: false,
        compile: false,
-       sparse: "optimized"}
+       sparse: "optimized",
+       only: [:dev, :test]}
     ]
   end
 


### PR DESCRIPTION
The `:heroicons` dependency cannot be part of deployment to hex (you can't include a dependency that refers to a GitHub repo). So I've adjusted the code to work when there is no `:heroicons` dependency/folder. The original code will still work in `:dev` mode or if the calling app includes the `:heroicons` dependency...