### PR TITLE
Ensure css transitions don't cause flaky tests

### DIFF
--- a/lib/petal_components_web/a11y_live.ex
+++ b/lib/petal_components_web/a11y_live.ex
@@ -52,11 +52,17 @@ defmodule PetalComponentsWeb.A11yLive do
     <script defer src="https://cdn.tailwindcss.com">
     </script>
     <style type="text/css">
+      /* css transitions can cause flaky a11y tests */
+      .env-test {
+        *, *::before, *::after {
+          transition: unset !important;
+        }
+      }
       svg {
         height: 1em; width: 1em;
       }
     </style>
-    <main role="main">
+    <main role="main" class="env-test">
       <.h1>Petal Components A11y Audit</.h1>
       <.h2>Heading 2</.h2>
       <.h3>Heading 3</.h3>


### PR DESCRIPTION
The a11y tests have been failing intermittently. @nhobes found [the culprit](https://github.com/angelikatyborska/a11y-audit-elixir/commit/b56c1439c680276c1e4972a9c4e6d879eec836b0). This implements the fix outlined there.