### PR TITLE
Add ID to table row containing empty state slot

### DIFF
--- a/lib/petal_components/table.ex
+++ b/lib/petal_components/table.ex
@@ -55,7 +55,7 @@ defmodule PetalComponents.Table do
         </thead>
         <tbody id={@id} phx-update={match?(%Phoenix.LiveView.LiveStream{}, @rows) && "stream"}>
           <%= if length(@empty_state) > 0 do %>
-            <.tr class="hidden only:table-row">
+            <.tr id={@id <> "-empty"} class="hidden only:table-row">
               <.td
                 :for={empty_state <- @empty_state}
                 colspan={length(@col)}


### PR DESCRIPTION
Running tests on an app that passes stream to the table component produces the following error:
```
** (ArgumentError) setting phx-update to "stream" requires setting an ID on each child. No ID was found on:

     <tr class="pc-table__tr hidden only:table-row"><td class="pc-table__td " colspan="2">
```
because the row that contains the empty state slot has no ID.

Based on https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#stream/4-handling-the-empty-case, the row with the empty state should also have an ID.

Versions used:
elixir          1.17.2-otp-27
phoenix_live_view          0.20.14