### PR TITLE
implement button_group/1 component

### DIFF
--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -8,6 +8,7 @@ defmodule PetalComponents do
         Badge,
         Breadcrumbs,
         Button,
+        ButtonGroup,
         Card,
         Container,
         Dropdown,

--- a/lib/petal_components/button_group.ex
+++ b/lib/petal_components/button_group.ex
@@ -1,0 +1,153 @@
+defmodule PetalComponents.ButtonGroup do
+  @moduledoc false
+  use Phoenix.Component
+
+  @doc """
+  Renders a button group. Group buttons are configured by defining multiple `:button` slots.
+
+  Note: Phoenix LiveView >= 0.20.17 is required to prevent arbitrary attributes like phx-*
+  given to `:button` slots emitting development warnings.
+
+  ## Examples
+
+  ### Buttons
+
+      <.button_group aria_label="My actions" size="md">
+        <:button phx-click="beep" phx-value-boop="bop">Action 1</:button>
+        <:button phx-click="boop" phx-value-bop="beep">Action 2</:button>
+        <:button label="Action 3" phx-click="bop" phx-value-beep="boop" disabled={@action_disabled?} />
+      </.button_group>
+
+  ### Links
+
+      <.button_group aria_label="My links" size="md">
+        <:button kind="link" patch={~p"/path-one"}>Link 1</:button>
+        <:button kind="link" patch={~p"/path-two"}>Link 2</:button>
+        <:button label="Link 3" kind="link" navigate={~p"/other"} />
+      </.button_group>
+
+  """
+  attr :id, :string, default: nil
+  attr :aria_label, :string, required: true, doc: "the ARIA label for the button group"
+  attr :size, :string, default: "md", values: ["xs", "sm", "md", "lg", "xl"]
+
+  attr :container_class, :string,
+    default: "flex -space-x-px",
+    doc: "class to apply to the group container"
+
+  attr :font_weight_class, :string,
+    default: "font-medium",
+    doc: "the font weight class to apply to all buttons - defaults to font-medium"
+
+  # we mark validate_attrs false so passing phx-click etc. does not emit warnings
+  slot :button, required: true, validate_attrs: false do
+    attr :class, :string, doc: "classes in addition to those already configured"
+    attr :label, :string, doc: "a button label, rendered if you don't provide an inner block"
+
+    attr :kind, :string,
+      values: ["button", "link"],
+      doc: "determines whether we render a button or a <.link />"
+
+    attr :disabled, :boolean,
+      doc: "disables the button - will turn an <a> into a <button> (<a> tags can't be disabled)"
+  end
+
+  def button_group(assigns) do
+    ~H"""
+    <div aria-label={@aria_label} role="group" class={@container_class}>
+      <.group_button
+        :for={{group_btn_assigns, idx} <- Enum.with_index(@button)}
+        idx={idx}
+        last_idx={length(@button) - 1}
+        size={@size}
+        font_weight_class={@font_weight_class}
+        {group_btn_assigns}
+      >
+        <%= if is_function(group_btn_assigns.inner_block) do %>
+          <%= render_slot(group_btn_assigns) %>
+        <% else %>
+          <%= group_btn_assigns.label %>
+        <% end %>
+      </.group_button>
+    </div>
+    """
+  end
+
+  attr :class, :string, default: ""
+  attr :label, :string
+  attr :kind, :string, default: "button", values: ["button", "link"]
+  attr :disabled, :boolean, default: false
+  attr :font_weight_class, :string, required: true
+  attr :size, :string, required: true, values: ["xs", "sm", "md", "lg", "xl"]
+  attr :idx, :integer, required: true
+  attr :last_idx, :integer, required: true
+
+  attr :rest, :global,
+    include:
+      ~w(patch navigate method download hreflang ping referrerpolicy rel target type value name form)
+
+  slot :inner_block, doc: "The inner block of the button.", required: true
+
+  defp group_button(%{kind: "button"} = assigns) do
+    ~H"""
+    <button
+      disabled={@disabled}
+      aria-disabled={@disabled}
+      class={[@class | group_btn_class(assigns)]}
+      {@rest}
+    >
+      <%= render_slot(@inner_block) %>
+    </button>
+    """
+  end
+
+  # anchor tags can't be disabled - renders a disabled button
+  defp group_button(%{kind: "link", disabled: true} = assigns) do
+    assigns = update_in(assigns.rest, &Map.drop(&1, [:"phx-click"]))
+
+    ~H"""
+    <button disabled aria-disabled class={[@class | group_btn_class(assigns)]} {@rest}>
+      <%= render_slot(@inner_block) %>
+    </button>
+    """
+  end
+
+  defp group_button(%{kind: "link"} = assigns) do
+    ~H"""
+    <.link class={[@class | group_btn_class(assigns)]} {@rest}>
+      <%= render_slot(@inner_block) %>
+    </.link>
+    """
+  end
+
+  defp group_btn_class(%{idx: 0, last_idx: 0} = opts),
+    do: ["rounded" | group_btn_base_class(opts)]
+
+  defp group_btn_class(%{idx: 0, last_idx: _length} = opts),
+    do: ["rounded-r-none" | group_btn_base_class(opts)]
+
+  defp group_btn_class(%{idx: last_idx, last_idx: last_idx} = opts),
+    do: ["rounded-l-none" | group_btn_base_class(opts)]
+
+  defp group_btn_class(opts), do: ["rounded-none" | group_btn_base_class(opts)]
+
+  defp group_btn_base_class(opts),
+    do: [
+      opts.font_weight_class,
+      size_classes(opts.size),
+      "transition-colors whitespace-nowrap",
+      "inline-flex rounded-md items-center justify-center",
+      "focus:ring-gray-200 focus:z-10",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2",
+      "disabled:pointer-events-none disabled:opacity-50",
+      "bg-white hover:bg-gray-100 dark:bg-gray-900 dark:hover:bg-gray-800",
+      "text-gray-800 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-300",
+      "border border-gray-200 dark:border-gray-800"
+    ]
+
+  defp size_classes("xs"), do: "text-xs px-2.5 py-1.5 leading-4"
+  defp size_classes("sm"), do: "text-sm px-3 py-2 leading-4"
+  defp size_classes("md"), do: "text-sm px-4 py-2 leading-5"
+  defp size_classes("lg"), do: "text-base px-4 py-2 leading-6"
+  defp size_classes("xl"), do: "text-base px-6 py-3 leading-6"
+end

--- a/lib/petal_components/button_group.ex
+++ b/lib/petal_components/button_group.ex
@@ -1,6 +1,7 @@
 defmodule PetalComponents.ButtonGroup do
   @moduledoc false
   use Phoenix.Component
+  alias PetalComponents.Helpers
 
   @doc """
   Renders a button group. Group buttons are configured by defining multiple `:button` slots.
@@ -54,7 +55,12 @@ defmodule PetalComponents.ButtonGroup do
 
   def button_group(assigns) do
     ~H"""
-    <div aria-label={@aria_label} role="group" class={@container_class}>
+    <div
+      aria-label={@aria_label}
+      role="group"
+      id={@id || Helpers.uniq_id("button-group")}
+      class={@container_class}
+    >
       <.group_button
         :for={{group_btn_assigns, idx} <- Enum.with_index(@button)}
         idx={idx}

--- a/lib/petal_components_web/a11y_live.ex
+++ b/lib/petal_components_web/a11y_live.ex
@@ -25,6 +25,7 @@ defmodule PetalComponentsWeb.A11yLive do
            icon: "hero-key"
          }
        ],
+       group_size: "lg",
        current_page: :current_page,
        sidebar_title: "blah",
        posts: [
@@ -112,6 +113,20 @@ defmodule PetalComponentsWeb.A11yLive do
       />
 
       <.button label="Press me" phx-click="click_event" />
+
+      <.button_group aria_label="My options" size={@group_size}>
+        <:button label="XS" phx-click="change_size" phx-value-size="xs" />
+        <:button label="SM" kind="link" patch="/app/orgs" />
+        <:button label="MD" phx-click="change_size" phx-value-size="md" />
+        <:button phx-click="change_size" phx-value-size="lg">LG</:button>
+        <:button phx-click="change_size" phx-value-size="xl">XL</:button>
+      </.button_group>
+
+      <.button_group aria_label="My links" size="md">
+        <:button kind="link" patch="/path-one">Link 1</:button>
+        <:button kind="link" patch="/path-two">Link 2</:button>
+        <:button label="Link 3" kind="link" navigate="/other" />
+      </.button_group>
 
       <.card>
         <.card_content category="Article" heading="Enhance your Phoenix development">

--- a/test/petal/button_group_test.exs
+++ b/test/petal/button_group_test.exs
@@ -7,14 +7,14 @@ defmodule PetalComponents.ButtonGroupTest do
 
     html =
       rendered_to_string(~H"""
-      <.button_group aria_label="My options">
+      <.button_group id="hello-group" aria_label="My options">
         <:button phx-click="change_size" phx-value-size="md">MD</:button>
         <:button disabled phx-click="change_size" phx-value-size="lg">LG</:button>
         <:button phx-click="change_size" phx-value-size="xl">XL</:button>
       </.button_group>
       """)
 
-    assert html =~ ~s{<div aria-label="My options" role="group"}
+    assert html =~ ~s{<div aria-label="My options" role="group" id="hello-group"}
     assert html =~ ~s{phx-click="change_size" phx-value-size="md">}
     assert html =~ "MD"
     assert html =~ ~s{<button disabled aria-disabled}
@@ -36,7 +36,7 @@ defmodule PetalComponents.ButtonGroupTest do
       </.button_group>
       """)
 
-    assert html =~ ~s{<div aria-label="a11y is good" role="group"}
+    assert html =~ ~s{<div aria-label="a11y is good" role="group" id=}
     assert html =~ ~s{phx-click="change_size" phx-value-size="md">}
     assert html =~ "MD"
     assert html =~ ~s{<button disabled aria-disabled}

--- a/test/petal/button_group_test.exs
+++ b/test/petal/button_group_test.exs
@@ -1,0 +1,106 @@
+defmodule PetalComponents.ButtonGroupTest do
+  use ComponentCase
+  import PetalComponents.ButtonGroup
+
+  test "button_group buttons with inner_block" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.button_group aria_label="My options">
+        <:button phx-click="change_size" phx-value-size="md">MD</:button>
+        <:button disabled phx-click="change_size" phx-value-size="lg">LG</:button>
+        <:button phx-click="change_size" phx-value-size="xl">XL</:button>
+      </.button_group>
+      """)
+
+    assert html =~ ~s{<div aria-label="My options" role="group"}
+    assert html =~ ~s{phx-click="change_size" phx-value-size="md">}
+    assert html =~ "MD"
+    assert html =~ ~s{<button disabled aria-disabled}
+    assert html =~ "LG"
+    assert html =~ ~s{phx-click="change_size" phx-value-size="xl">}
+    assert html =~ "XL"
+    assert html =~ "</div>"
+  end
+
+  test "button_group buttons with labels only" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.button_group aria_label="a11y is good">
+        <:button label="MD" phx-click="change_size" phx-value-size="md" />
+        <:button label="LG" disabled phx-click="change_size" phx-value-size="lg" />
+        <:button label="XL" phx-click="change_size" phx-value-size="xl" />
+      </.button_group>
+      """)
+
+    assert html =~ ~s{<div aria-label="a11y is good" role="group"}
+    assert html =~ ~s{phx-click="change_size" phx-value-size="md">}
+    assert html =~ "MD"
+    assert html =~ ~s{<button disabled aria-disabled}
+    assert html =~ "LG"
+    assert html =~ ~s{phx-click="change_size" phx-value-size="xl">}
+    assert html =~ "XL"
+    assert html =~ "</div>"
+  end
+
+  test "button_group links with inner_block" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.button_group aria_label="links up in here">
+        <:button kind="link" href="/path-one">One</:button>
+        <:button kind="link" patch="/path-two">Two</:button>
+        <:button kind="link" navigate="/path-three">Three</:button>
+        <:button kind="link" disabled navigate="/path-disabled">Disabled as button</:button>
+      </.button_group>
+      """)
+
+    assert html =~ ~s{<div aria-label="links up in here" role="group"}
+    assert html =~ ~s{<a href="/path-one" class=}
+    assert html =~ "One"
+    assert html =~ ~s{<a href="/path-two" data-phx-link="patch" data-phx-link-state="push"}
+    assert html =~ "Two"
+    assert html =~ ~s{<a href="/path-three" data-phx-link="redirect" data-phx-link-state="push"}
+    assert html =~ "Three"
+
+    refute html =~
+             ~s{<a href="/path-disabled" data-phx-link="redirect" data-phx-link-state="push"}
+
+    assert html =~ ~s{<button disabled aria-disabled}
+    assert html =~ "Disabled as button"
+    assert html =~ "</div>"
+  end
+
+  test "button_group links with labels only" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.button_group aria_label="links up in here">
+        <:button label="One" kind="link" href="/path-one" />
+        <:button label="Two" kind="link" patch="/path-two" />
+        <:button label="Three" kind="link" navigate="/path-three" />
+        <:button label="Disabled as button" kind="link" disabled navigate="/path-disabled" />
+      </.button_group>
+      """)
+
+    assert html =~ ~s{<div aria-label="links up in here" role="group"}
+    assert html =~ ~s{<a href="/path-one" class=}
+    assert html =~ "One"
+    assert html =~ ~s{<a href="/path-two" data-phx-link="patch" data-phx-link-state="push"}
+    assert html =~ "Two"
+    assert html =~ ~s{<a href="/path-three" data-phx-link="redirect" data-phx-link-state="push"}
+    assert html =~ "Three"
+
+    refute html =~
+             ~s{<a href="/path-disabled" data-phx-link="redirect" data-phx-link-state="push"}
+
+    assert html =~ ~s{<button disabled aria-disabled}
+    assert html =~ "Disabled as button"
+    assert html =~ "</div>"
+  end
+end


### PR DESCRIPTION
## API

API example:

```heex
<.button_group aria_label="Size options" size={@group_size}>
  <:button phx-click="change_size" phx-value-size="xs">XS</:button>
  <:button phx-click="change_size" phx-value-size="sm">SM</:button>
  <:button phx-click="change_size" phx-value-size="md">MD</:button>
  <:button phx-click="change_size" phx-value-size="lg">LG</:button>
  <:button phx-click="change_size" phx-value-size="xl">XL</:button>
</.button_group>
```

## Demo

https://github.com/user-attachments/assets/a4131347-3901-4d9f-9ff1-25ad0319643c