### PR TITLE
Fix slide-over wrapper/overlay not hiding on close

### DIFF
--- a/lib/petal_components/slide_over.ex
+++ b/lib/petal_components/slide_over.ex
@@ -136,6 +136,7 @@ defmodule PetalComponents.SlideOver do
         },
         to: "#slide-over-content"
       )
+      |> JS.hide(to: "#slide-over")
 
     if close_slide_over_target do
       JS.push(js, "close_slide_over", target: close_slide_over_target)


### PR DESCRIPTION
When closing the slide over component, the main wrapper's `display: block` rule from `JS.show` doesn't get removed, leading to underlying content being blocked.

This PR fixes it by also hiding the wrapper at the other end of the chain.