### PR TITLE
fix the date inputs icon overlap in safari 

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -906,7 +906,7 @@
 /* Date and Time Field Styles */
 .pc-date-input {
   @apply pc-text-input;
-  @apply [-webkit-appearance:none] [&::-webkit-datetime-edit-fields-wrapper]:p-0 [&::-webkit-date-and-time-value]:text-black dark:[&::-webkit-date-and-time-value]:text-white;
+  @apply [-webkit-appearance:none] [&::-webkit-datetime-edit-fields-wrapper]:p-0 [&::-webkit-date-and-time-value]:text-black dark:[&::-webkit-date-and-time-value]:text-white pe-[40px];
 }
 
 .pc-date-input-wrapper {


### PR DESCRIPTION
fixes the date input icon overlap on safari. 
https://github.com/petalframework/petal_components/issues/372

the issue - 
<img width="500" alt="Screenshot 2024-11-15 at 14 28 57" src="https://github.com/user-attachments/assets/d85a4c8d-e3e9-4567-a0dc-f358a1a7ef49">

the fix - 
<img width="471" alt="Screenshot 2024-11-15 at 14 25 06" src="https://github.com/user-attachments/assets/2fd2f9fd-8f56-4f3a-a59a-18a7b64282e2">
