### PR TITLE
CSS to fix size of datetime inputs in Safari.

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -2544,3 +2544,12 @@ input[type="file_input"].has-error {
 [x-cloak=""] {
   display: none;
 }
+
+/*
+  Needed for datetime inputs to have the correct size in Safari
+  See: https://github.com/twbs/bootstrap/issues/34433#issuecomment-1831467352
+*/
+input::-webkit-datetime-edit {
+  display: block;
+  padding: 0;
+}


### PR DESCRIPTION
Before:

![datetime-before](https://github.com/user-attachments/assets/e3bf8c82-909f-4b98-8a9b-b0f86174cd38)

After:

![datetime-after](https://github.com/user-attachments/assets/62aafb1d-6d75-481e-b0f4-b911a879b28c)
