### PR TITLE
Fix hidden `checkbox-group` input name

### DIFF
--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -237,7 +237,7 @@ defmodule PetalComponents.Field do
       <.field_label required={@required} class={@label_class}>
         {@label}
       </.field_label>
-      <input type="hidden" name={@name} value="" />
+      <input type="hidden" name={@name <> "[]"} value="" />
       <div class={[
         "pc-checkbox-group",
         @group_layout == "row" && "pc-checkbox-group--row",


### PR DESCRIPTION
the hidden input on the checkbox group had a different name then the other inputs on the group - which caused issues with the `used_input?` mechanism. 
attaching an example to reproduce the issue, it has a simple form with a checkbox group, text input and a `used_input?` boolean indicator binded to the checkbox field. go ahead and type something into the text input. 
### expected behavior 
The `used_input?` indicator will change to false. 

```elixir
Mix.install([
  {:phoenix_playground, "~> 0.1.6"}, 
  {:petal_components, "~> 2.8"}, 
  {:phoenix_live_view, "~> 1.0"}
])

defmodule DemoLive do
  use Phoenix.LiveView
  use PetalComponents
  
  def mount(_params, _session, socket) do
    form = to_form(%{"checkbox" => nil, "text" => nil})
    {:ok, assign(socket, form: form)}
  end

  def handle_event("validate", params, socket) do 
    form = to_form(params)
    {:noreply, assign(socket, form: form)}
  end
  
  def render(assigns) do
    ~H"""
    <form phx-change="validate">
    
    <%= Phoenix.Component.used_input?(@form[:checkbox]) %> 
    <.field type="checkbox-group" options={[{"a", "a"}]} field={@form[:checkbox]}/>
    <.field field={@form["text"]} />
    </form>

    <style type="text/css">
      body { padding: 1em; }
      span { font-family: monospace; }
    </style>
    """
  end
end

PhoenixPlayground.start(live: DemoLive)
```