### PR TITLE
Bubble event when input is cleared

### DIFF
--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -512,7 +512,7 @@ defmodule PetalComponents.Field do
           x-on:click="
             $refs.clearInput.value = '';
             showClearButton = false;
-            $refs.clearInput.dispatchEvent(new Event('input'));
+            $refs.clearInput.dispatchEvent(new Event('input', { bubbles: true }));
           "
           style="display: none;"
           aria-label="Clear input"


### PR DESCRIPTION
**Current behavior**

Clearable form field does not trigger form's `phx-change` when clicking the clear button and the LiveView doesn't receive the updated form state.

**Expected behavior**

`phx-change` is triggered on the form just as it is when typing in something in the input.

**Fix**

Updated the clear button logic to dispatch the 'input' event with `{ bubbles: true }`, allowing the event to propagate up to the form and properly trigger `phx-change`.