### PR TITLE
Dual range slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,21 @@ We’ve released an [official Figma UI kit for Petal](https://www.figma.com/comm
 ## FAQ
 
 **Q: Do I need Alpine JS?**
-A: No we have designed the components to use either Alpine JS or LiveView.JS.
+A: Most components work with either Alpine JS or LiveView.JS. However, some components like the dual range slider require Alpine.js for client-side interactivity. If you're using these components, you'll need to include Alpine.js in your project.
+
+To add Alpine.js via CDN:
+```html
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+```
+
+Or via npm:
+```bash
+npm install alpinejs
+```
+
+**Components that require Alpine.js:**
+- Dual range slider (`type="range-dual"`)
+- Some dropdown variants
 
 **Q: What if I want to use my own components too?**
 A: You can install this library and import only the components you need.

--- a/assets/default.css
+++ b/assets/default.css
@@ -291,7 +291,7 @@
   }
 
   .pc-icon-button__tooltip__text {
-    @apply relative z-10 p-2 text-xs leading-none text-white bg-gray-900 rounded-xs shadow-lg whitespace-nowrap dark:bg-gray-700;
+    @apply relative z-10 p-2 text-xs leading-none text-white bg-gray-900 shadow-lg rounded-xs whitespace-nowrap dark:bg-gray-700;
   }
 
   .pc-icon-button__tooltip__arrow {
@@ -857,7 +857,7 @@
     @apply dark:text-white;
   }
   .pc-switch {
-    @apply relative inline-flex items-center justify-center shrink-0 cursor-pointer;
+    @apply relative inline-flex items-center justify-center cursor-pointer shrink-0;
   }
   .pc-switch--xs {
     @apply w-6 h-3;
@@ -1093,6 +1093,63 @@
     @apply flex items-center justify-center text-left text-gray-900 dark:text-white;
   }
 
+  /* Dual and Numeric Range Styles */
+
+  .pc-slider-input {
+    @apply absolute z-10 w-full h-0 bg-transparent outline-none appearance-none pointer-events-none;
+  }
+
+  .pc-slider-input::-webkit-slider-thumb {
+    @apply appearance-none w-5 h-5 bg-success-500 rounded-full border-0 pointer-events-auto cursor-pointer shadow relative z-20 translate-y-0.5;
+  }
+
+  .pc-slider-input::-moz-range-thumb {
+    @apply w-5 h-5 bg-success-500 rounded-full border-0 pointer-events-auto cursor-pointer shadow relative z-20 translate-y-0.5;
+  }
+
+  .pc-slider-track {
+    @apply absolute z-0 w-full h-1 bg-gray-200 rounded dark:bg-gray-700;
+  }
+
+  .pc-slider-range {
+    @apply absolute z-0 h-1 rounded bg-success-500;
+  }
+
+  /* Customization options for different sizes */
+  .pc-slider-input--sm::-webkit-slider-thumb {
+    @apply w-4 h-4;
+  }
+
+  .pc-slider-input--sm::-moz-range-thumb {
+    @apply w-4 h-4;
+  }
+
+  .pc-slider-input--lg::-webkit-slider-thumb {
+    @apply w-6 h-6;
+  }
+
+  .pc-slider-input--lg::-moz-range-thumb {
+    @apply w-6 h-6;
+  }
+
+  /* Hover and focus states for slider thumbs */
+  .pc-slider-input:hover::-webkit-slider-thumb {
+    @apply bg-success-600;
+  }
+
+  .pc-slider-input:focus::-webkit-slider-thumb {
+    @apply ring-2 ring-success-200 ring-offset-2;
+  }
+
+  .pc-slider-input:hover::-moz-range-thumb {
+    @apply bg-success-600;
+  }
+
+  .pc-slider-input:focus::-moz-range-thumb {
+    @apply ring-2 ring-success-200 ring-offset-2;
+  }
+
+
   /* Radio Card Size Styles */
 
   /* Apply padding to .pc-radio-card__content */
@@ -1285,7 +1342,7 @@
     @apply object-cover rounded-full;
   }
   .pc-avatar--with-placeholder-icon {
-    @apply relative inline-block overflow-hidden bg-gray-100 text-gray-300 rounded-full dark:bg-gray-700;
+    @apply relative inline-block overflow-hidden text-gray-300 bg-gray-100 rounded-full dark:bg-gray-700;
   }
   .pc-avatar--with-placeholder-initials {
     @apply flex items-center justify-center font-semibold text-gray-500 uppercase bg-gray-100 rounded-full dark:bg-gray-700 dark:text-gray-300;
@@ -1562,10 +1619,10 @@
   /* Cards - with media */
 
   .pc-card__image {
-    @apply shrink-0 object-cover w-full;
+    @apply object-cover w-full shrink-0;
   }
   .pc-card__image-placeholder {
-    @apply shrink-0 w-full bg-gray-300 dark:bg-gray-700;
+    @apply w-full bg-gray-300 shrink-0 dark:bg-gray-700;
   }
 
   /* Cards - footer */
@@ -1577,7 +1634,7 @@
   /* Table */
 
   .pc-table--basic {
-    @apply min-w-full overflow-hidden rounded-xs shadow-sm table-auto ring-1 ring-gray-200 dark:ring-gray-800 sm:rounded;
+    @apply min-w-full overflow-hidden shadow-sm table-auto rounded-xs ring-1 ring-gray-200 dark:ring-gray-800 sm:rounded;
   }
   .pc-table--ghost {
     @apply min-w-full overflow-hidden table-auto;
@@ -1631,7 +1688,7 @@
     @apply text-base font-semibold;
   }
   .pc-accordion-item__chevron {
-    @apply shrink-0 w-6 h-6 ml-3 text-gray-400 duration-300 fill-current dark:group-hover:text-gray-300 group-hover:text-gray-500;
+    @apply w-6 h-6 ml-3 text-gray-400 duration-300 fill-current shrink-0 dark:group-hover:text-gray-300 group-hover:text-gray-500;
   }
   .pc-accordion-item__content-container {
     @apply p-5 bg-white border border-gray-200 dark:border-gray-700 dark:bg-gray-900;
@@ -2302,7 +2359,7 @@
 
   /* Indicator */
   .pc-stepper__indicator {
-    @apply grid shrink-0 text-white transition-all duration-200 bg-gray-500 rounded-full place-items-center;
+    @apply grid text-white transition-all duration-200 bg-gray-500 rounded-full shrink-0 place-items-center;
   }
 
   .pc-stepper__node--complete .pc-stepper__indicator {
@@ -2462,7 +2519,7 @@
   }
 
   .pc-vertical-menu-item__icon {
-    @apply shrink-0 w-5 h-5;
+    @apply w-5 h-5 shrink-0;
   }
 
   .pc-vertical-menu-item {
@@ -2511,11 +2568,11 @@
   }
 
   .pc-vertical-menu-item__icon--active {
-    @apply shrink-0 w-5 h-5;
+    @apply w-5 h-5 shrink-0;
   }
 
   .pc-vertical-menu-item__icon--inactive {
-    @apply shrink-0 w-5 h-5;
+    @apply w-5 h-5 shrink-0;
   }
 
   /* Other */

--- a/assets/default.css
+++ b/assets/default.css
@@ -1100,53 +1100,53 @@
   }
 
   .pc-slider-input::-webkit-slider-thumb {
-    @apply appearance-none w-5 h-5 bg-primary-500 rounded-full border-0 pointer-events-auto cursor-pointer shadow relative z-20 translate-y-0.5;
+    @apply appearance-none w-6 h-6 bg-primary-500 rounded-full border-[3px] border-white dark:border-gray-800 pointer-events-auto cursor-pointer shadow-lg relative z-20 translate-y-0.5 transition-transform duration-150 ease-in-out;
   }
 
   .pc-slider-input::-moz-range-thumb {
-    @apply w-5 h-5 bg-primary-500 rounded-full border-0 pointer-events-auto cursor-pointer shadow relative z-20 translate-y-0.5;
+    @apply w-6 h-6 bg-primary-500 rounded-full border-[3px] border-white dark:border-gray-800 pointer-events-auto cursor-pointer shadow-lg relative z-20 translate-y-0.5 transition-transform duration-150 ease-in-out;
   }
 
   .pc-slider-track {
-    @apply absolute z-0 w-full h-1 bg-gray-200 rounded dark:bg-gray-700;
+    @apply absolute z-0 w-full h-1.5 bg-gray-200 rounded-full dark:bg-gray-700;
   }
 
   .pc-slider-range {
-    @apply absolute z-0 h-1 rounded bg-primary-500;
+    @apply absolute z-0 h-1.5 rounded-full bg-primary-500;
   }
 
   /* Customization options for different sizes */
   .pc-slider-input--sm::-webkit-slider-thumb {
-    @apply w-4 h-4;
+    @apply w-5 h-5 border-2;
   }
 
   .pc-slider-input--sm::-moz-range-thumb {
-    @apply w-4 h-4;
+    @apply w-5 h-5 border-2;
   }
 
   .pc-slider-input--lg::-webkit-slider-thumb {
-    @apply w-6 h-6;
+    @apply w-7 h-7 border-4;
   }
 
   .pc-slider-input--lg::-moz-range-thumb {
-    @apply w-6 h-6;
+    @apply w-7 h-7 border-4;
   }
 
   /* Hover and focus states for slider thumbs */
   .pc-slider-input:hover::-webkit-slider-thumb {
-    @apply bg-primary-600;
+    @apply bg-primary-600 scale-110;
   }
 
   .pc-slider-input:focus::-webkit-slider-thumb {
-    @apply ring-2 ring-primary-200 ring-offset-2;
+    @apply ring-4 ring-primary-200 dark:ring-primary-500/30 ring-offset-0 scale-110;
   }
 
   .pc-slider-input:hover::-moz-range-thumb {
-    @apply bg-primary-600;
+    @apply bg-primary-600 scale-110;
   }
 
   .pc-slider-input:focus::-moz-range-thumb {
-    @apply ring-2 ring-primary-200 ring-offset-2;
+    @apply ring-4 ring-primary-200 dark:ring-primary-500/30 ring-offset-0 scale-110;
   }
 
 

--- a/assets/default.css
+++ b/assets/default.css
@@ -1100,11 +1100,11 @@
   }
 
   .pc-slider-input::-webkit-slider-thumb {
-    @apply appearance-none w-6 h-6 bg-primary-500 rounded-full border-[3px] border-white dark:border-gray-800 pointer-events-auto cursor-pointer shadow-lg relative z-20 translate-y-0.5 transition-transform duration-150 ease-in-out;
+    @apply appearance-none w-6 h-6 bg-primary-500 rounded-full border-[3px] border-white dark:border-gray-800 pointer-events-auto cursor-pointer shadow dark:shadow-lg shadow-gray-900/30 relative z-20 translate-y-0.5 transition-transform duration-150 ease-in-out;
   }
 
   .pc-slider-input::-moz-range-thumb {
-    @apply w-6 h-6 bg-primary-500 rounded-full border-[3px] border-white dark:border-gray-800 pointer-events-auto cursor-pointer shadow-lg relative z-20 translate-y-0.5 transition-transform duration-150 ease-in-out;
+    @apply w-6 h-6 bg-primary-500 rounded-full border-[3px] border-white dark:border-gray-800 pointer-events-auto cursor-pointer shadow dark:shadow-lg shadow-gray-900/30 relative z-20 translate-y-0.5 transition-transform duration-150 ease-in-out;
   }
 
   .pc-slider-track {
@@ -1125,28 +1125,28 @@
   }
 
   .pc-slider-input--lg::-webkit-slider-thumb {
-    @apply w-7 h-7 border-4;
+    @apply border-4 w-7 h-7;
   }
 
   .pc-slider-input--lg::-moz-range-thumb {
-    @apply w-7 h-7 border-4;
+    @apply border-4 w-7 h-7;
   }
 
   /* Hover and focus states for slider thumbs */
   .pc-slider-input:hover::-webkit-slider-thumb {
-    @apply bg-primary-600 scale-110;
+    @apply scale-110 bg-primary-600;
   }
 
   .pc-slider-input:focus::-webkit-slider-thumb {
-    @apply ring-4 ring-primary-200 dark:ring-primary-500/30 ring-offset-0 scale-110;
+    @apply scale-110 ring-4 ring-primary-200 dark:ring-primary-500/30 ring-offset-0;
   }
 
   .pc-slider-input:hover::-moz-range-thumb {
-    @apply bg-primary-600 scale-110;
+    @apply scale-110 bg-primary-600;
   }
 
   .pc-slider-input:focus::-moz-range-thumb {
-    @apply ring-4 ring-primary-200 dark:ring-primary-500/30 ring-offset-0 scale-110;
+    @apply scale-110 ring-4 ring-primary-200 dark:ring-primary-500/30 ring-offset-0;
   }
 
 

--- a/assets/default.css
+++ b/assets/default.css
@@ -1100,11 +1100,11 @@
   }
 
   .pc-slider-input::-webkit-slider-thumb {
-    @apply appearance-none w-5 h-5 bg-success-500 rounded-full border-0 pointer-events-auto cursor-pointer shadow relative z-20 translate-y-0.5;
+    @apply appearance-none w-5 h-5 bg-primary-500 rounded-full border-0 pointer-events-auto cursor-pointer shadow relative z-20 translate-y-0.5;
   }
 
   .pc-slider-input::-moz-range-thumb {
-    @apply w-5 h-5 bg-success-500 rounded-full border-0 pointer-events-auto cursor-pointer shadow relative z-20 translate-y-0.5;
+    @apply w-5 h-5 bg-primary-500 rounded-full border-0 pointer-events-auto cursor-pointer shadow relative z-20 translate-y-0.5;
   }
 
   .pc-slider-track {
@@ -1112,7 +1112,7 @@
   }
 
   .pc-slider-range {
-    @apply absolute z-0 h-1 rounded bg-success-500;
+    @apply absolute z-0 h-1 rounded bg-primary-500;
   }
 
   /* Customization options for different sizes */
@@ -1134,19 +1134,19 @@
 
   /* Hover and focus states for slider thumbs */
   .pc-slider-input:hover::-webkit-slider-thumb {
-    @apply bg-success-600;
+    @apply bg-primary-600;
   }
 
   .pc-slider-input:focus::-webkit-slider-thumb {
-    @apply ring-2 ring-success-200 ring-offset-2;
+    @apply ring-2 ring-primary-200 ring-offset-2;
   }
 
   .pc-slider-input:hover::-moz-range-thumb {
-    @apply bg-success-600;
+    @apply bg-primary-600;
   }
 
   .pc-slider-input:focus::-moz-range-thumb {
-    @apply ring-2 ring-success-200 ring-offset-2;
+    @apply ring-2 ring-primary-200 ring-offset-2;
   }
 
 

--- a/lib/petal_components/button_group.ex
+++ b/lib/petal_components/button_group.ex
@@ -94,10 +94,10 @@ defmodule PetalComponents.ButtonGroup do
         button_border_class={@button_border_class}
         {group_btn_assigns}
       >
-        <%= if group_btn_assigns[:inner_block] do %>
+        <%= if Map.has_key?(group_btn_assigns, :inner_block) && group_btn_assigns.inner_block != nil do %>
           {render_slot(group_btn_assigns)}
         <% else %>
-          {group_btn_assigns.label}
+          {Map.get(group_btn_assigns, :label, "")}
         <% end %>
       </.group_button>
     </div>

--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -122,7 +122,7 @@ defmodule PetalComponents.Field do
 
   # When a FormField struct is provided, normalize and delegate rendering.
   def field(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
-    errors = if pc_used_input?(field), do: field.errors, else: []
+    errors = if used_input?(field), do: field.errors, else: []
 
     assigns
     |> assign(field: nil, id: assigns.id || field.id)
@@ -978,8 +978,4 @@ defmodule PetalComponents.Field do
     end
   end
 
-  # Renamed helper to avoid conflict with Phoenix.Component.used_input?/1
-  defp pc_used_input?(field) do
-    field.errors != []
-  end
 end

--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -222,7 +222,7 @@ defmodule PetalComponents.Field do
       <.field_label>{@label}</.field_label>
       <div id={@id} class="relative h-12 mt-4">
         <div class="flex flex-row items-center justify-center space-x-2">
-          <div class="relative w-full h-1">
+          <div class="relative w-full h-1.5">
             <div class="pc-slider-track"></div>
             <div
               class="pc-slider-range"

--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -59,6 +59,8 @@ defmodule PetalComponents.Form do
     "color_input",
     "file_input",
     "range_input",
+    "range_dual",
+    "range_numeric",
     "textarea",
     "select",
     "checkbox",
@@ -222,6 +224,86 @@ defmodule PetalComponents.Form do
         <% "range_input" -> %>
           <.form_label form={@form} field={@field} label={@label} class={@label_class} />
           <.range_input form={@form} field={@field} {@rest} />
+        <% "range_dual" -> %>
+          <.form_label form={@form} field={@field} label={@label} class={@label_class} />
+          <div id={@id || Phoenix.HTML.Form.input_id(@form, @field)} class="relative h-12 mt-4">
+            <div class="flex flex-row items-center justify-center space-x-2">
+              <div class="relative w-full h-1">
+                <div class="pc-slider-track"></div>
+                <div
+                  class="pc-slider-range"
+                  data-slider-id={@id || Phoenix.HTML.Form.input_id(@form, @field)}
+                  id={@id || Phoenix.HTML.Form.input_id(@form, @field) <> "_slider-range"}
+                  style={"left: #{calculate_slider_position(@min_field.value, @range_min, @range_max)}%; right: #{100 - calculate_slider_position(@max_field.value, @range_min, @range_max)}%;"}
+                >
+                </div>
+                <input
+                  type="range"
+                  min={@range_min}
+                  max={@range_max}
+                  step={@step}
+                  name={@min_field.name}
+                  value={@min_field.value}
+                  class="pc-slider-input"
+                  id={@id || Phoenix.HTML.Form.input_id(@form, @field) <> "_min-range"}
+                  phx-hook="DualRangeSliderHook"
+                  data-slider-id={@id || Phoenix.HTML.Form.input_id(@form, @field)}
+                  data-slider-type="min"
+                  data-range-min={@range_min}
+                  data-range-max={@range_max}
+                />
+                <input
+                  type="range"
+                  min={@range_min}
+                  max={@range_max}
+                  step={@step}
+                  name={@max_field.name}
+                  value={@max_field.value}
+                  class="pc-slider-input"
+                  id={@id || Phoenix.HTML.Form.input_id(@form, @field) <> "_max-range"}
+                  phx-hook="DualRangeSliderHook"
+                  data-slider-id={@id || Phoenix.HTML.Form.input_id(@form, @field)}
+                  data-slider-type="max"
+                  data-range-min={@range_min}
+                  data-range-max={@range_max}
+                />
+              </div>
+            </div>
+            # ... rest of the range slider code ...
+          </div>
+          <.form_field_error form={@form} field={@field} />
+          <.form_help_text help_text={@help_text} />
+        <% "range_numeric" -> %>
+          <.form_label form={@form} field={@field} label={@label} class={@label_class} />
+          <div class="flex flex-row gap-2">
+            <.form_field
+              type="number_input"
+              form={@form}
+              field={@min_field.name}
+              label=""
+              placeholder="No Min"
+              min={@range_min}
+              max={@max_field.value}
+              value={@min_field.value}
+              wrapper_classes="w-full"
+            />
+
+            <div class="flex flex-col items-center justify-center">-</div>
+
+            <.form_field
+              type="number_input"
+              form={@form}
+              field={@max_field.name}
+              label=""
+              placeholder="No Max"
+              min={@min_field.value}
+              max={@range_max}
+              value={@max_field.value}
+              wrapper_classes="w-full"
+            />
+          </div>
+          <.form_field_error form={@form} field={@field} />
+          <.form_help_text help_text={@help_text} />
         <% "textarea" -> %>
           <.form_label form={@form} field={@field} label={@label} class={@label_class} />
           <.textarea form={@form} field={@field} {@rest} />
@@ -783,6 +865,24 @@ defmodule PetalComponents.Form do
 
   defp range_input_classes(errors) do
     "#{if errors != [], do: "has-error", else: ""} pc-range-input"
+  end
+
+  # Helper functions for dual range slider
+  defp calculate_slider_position(nil, _range_min, _range_max), do: 0
+
+  defp calculate_slider_position(value, range_min, range_max) when is_integer(value) do
+    round((value - range_min) / (range_max - range_min) * 100)
+  end
+
+  defp calculate_slider_position(value, range_min, range_max) do
+    value =
+      case value do
+        v when is_binary(v) -> String.to_integer(v)
+        v when is_integer(v) -> v
+        _ -> range_min
+      end
+
+    round((value - range_min) / (range_max - range_min) * 100)
   end
 
   defp checkbox_classes(errors) do

--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -72,6 +72,7 @@ defmodule PetalComponents.Form do
 
   attr(:form, :any, doc: "the form object", required: true)
   attr(:field, :atom, doc: "field in changeset / form", required: true)
+  attr(:id, :string, default: nil, doc: "the id of the input")
   attr(:label, :string, doc: "labels your field")
   attr(:label_class, :any, default: nil, doc: "extra CSS for your label")
   attr(:help_text, :string, default: nil, doc: "context/help for your field")
@@ -87,6 +88,26 @@ defmodule PetalComponents.Form do
   attr :no_margin, :boolean,
     default: false,
     doc: "removes the bottom margin from the field wrapper"
+
+  # Range and Dual Range Specific Attributes
+  attr :range_min, :integer, default: 0, doc: "minimum value for range inputs"
+  attr :range_max, :integer, default: 100, doc: "maximum value for range inputs"
+  attr :step, :integer, default: 1, doc: "step value for range inputs"
+
+  attr :min_field, :map,
+    default: nil,
+    doc: "min field for dual range (required for range-dual and range-numeric)"
+
+  attr :max_field, :map,
+    default: nil,
+    doc: "max field for dual range (required for range-dual and range-numeric)"
+
+  attr :range_min_label, :string, default: nil, doc: "optional label for minimum range value"
+  attr :range_max_label, :string, default: nil, doc: "optional label for maximum range value"
+
+  attr :formatter, :any,
+    default: nil,
+    doc: "function to format range values (e.g., Money.to_string!)"
 
   attr :rest, :global, include: @form_attrs
 
@@ -942,6 +963,11 @@ defmodule PetalComponents.Form do
 
   # Helper functions for dual range slider
   defp calculate_slider_position(nil, _range_min, _range_max), do: 0
+
+  # Guard against division by zero when range_min == range_max
+  defp calculate_slider_position(_value, range_min, range_max)
+       when range_min == range_max,
+       do: 0
 
   defp calculate_slider_position(value, range_min, range_max) when is_integer(value) do
     round((value - range_min) / (range_max - range_min) * 100)

--- a/lib/petal_components/input.ex
+++ b/lib/petal_components/input.ex
@@ -40,6 +40,15 @@ defmodule PetalComponents.Input do
   attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
   attr :class, :any, default: nil, doc: "the class to add to the input"
 
+  # Dual range slider attributes
+  attr :min_field, Phoenix.HTML.FormField, doc: "form field for minimum value in range-dual"
+  attr :max_field, Phoenix.HTML.FormField, doc: "form field for maximum value in range-dual"
+  attr :range_min, :integer, default: 0, doc: "minimum value for range-dual slider"
+  attr :range_max, :integer, default: 100, doc: "maximum value for range-dual slider"
+  attr :range_min_label, :string, default: nil, doc: "label for minimum value in range-dual"
+  attr :range_max_label, :string, default: nil, doc: "label for maximum value in range-dual"
+  attr :format_value, :any, default: nil, doc: "function to format displayed values in range-dual"
+
   attr :rest, :global,
     include:
       ~w(autocomplete autocorrect autocapitalize disabled form max maxlength min minlength list
@@ -224,6 +233,16 @@ defmodule PetalComponents.Input do
   end
 
   def input(%{type: "range-dual"} = assigns) do
+    assigns = assign_new(assigns, :format_value, fn -> &to_string/1 end)
+    assigns = assign_new(assigns, :step, fn -> 1 end)
+
+    # Set default values if nil
+    min_value = assigns.min_field.value || assigns.range_min
+    max_value = assigns.max_field.value || assigns.range_max
+
+    assigns = assign(assigns, :min_value, min_value)
+    assigns = assign(assigns, :max_value, max_value)
+
     ~H"""
     <div id={@id} class="relative h-12 mt-4">
       <div class="flex flex-row items-center justify-center space-x-2">
@@ -233,7 +252,7 @@ defmodule PetalComponents.Input do
             class="pc-slider-range"
             data-slider-id={@id}
             id={@id <> "_slider-range"}
-            style={"left: #{calculate_slider_position(@min_field.value, @range_min, @range_max)}%; right: #{100 - calculate_slider_position(@max_field.value, @range_min, @range_max)}%;"}
+            style={"left: #{calculate_slider_position(@min_value, @range_min, @range_max)}%; right: #{100 - calculate_slider_position(@max_value, @range_min, @range_max)}%;"}
           >
           </div>
           <input
@@ -242,7 +261,7 @@ defmodule PetalComponents.Input do
             max={@range_max}
             step={@step}
             name={@min_field.name}
-            value={@min_field.value}
+            value={@min_value}
             class="pc-slider-input"
             id={@id <> "_min-range"}
             phx-hook="DualRangeSliderHook"
@@ -257,7 +276,7 @@ defmodule PetalComponents.Input do
             max={@range_max}
             step={@step}
             name={@max_field.name}
-            value={@max_field.value}
+            value={@max_value}
             class="pc-slider-input"
             id={@id <> "_max-range"}
             phx-hook="DualRangeSliderHook"
@@ -273,7 +292,7 @@ defmodule PetalComponents.Input do
           {@range_min_label || @format_value.(@range_min)}
         </span>
         <span class="flex justify-center text-gray-600 dark:text-gray-300">
-          {@format_value.(@min_field.value) <> " - " <> @format_value.(@max_field.value)}
+          {@format_value.(@min_value) <> " - " <> @format_value.(@max_value)}
         </span>
         <span class="flex items-end justify-end text-gray-500 dark:text-gray-400">
           {@range_max_label || @format_value.(@range_max)}

--- a/lib/petal_components/input.ex
+++ b/lib/petal_components/input.ex
@@ -425,6 +425,10 @@ defmodule PetalComponents.Input do
   # Helper functions for input.ex
   defp calculate_slider_position(nil, _range_min, _range_max), do: 0
 
+  defp calculate_slider_position(_value, range_min, range_max)
+       when range_min == range_max,
+       do: 0
+
   defp calculate_slider_position(value, range_min, range_max) when is_integer(value) do
     round((value - range_min) / (range_max - range_min) * 100)
   end

--- a/test/petal/field_test.exs
+++ b/test/petal/field_test.exs
@@ -1008,4 +1008,214 @@ defmodule PetalComponents.FieldTest do
     # Should have guard clause to prevent division by zero
     assert html =~ "if (this.rangeMax === this.rangeMin)"
   end
+
+  test "dual range slider field with nil values uses range_min/range_max as defaults" do
+    assigns = %{form: to_form(%{}, as: :filter)}
+
+    html =
+      rendered_to_string(~H"""
+      <.form for={@form}>
+        <.field
+          type="range-dual"
+          id="nil_values_range"
+          label="Price Range"
+          range_min={0}
+          range_max={1000}
+          min_field={%{name: "min_price", value: nil}}
+          max_field={%{name: "max_price", value: nil}}
+          field={@form[:price]}
+        />
+      </.form>
+      """)
+
+    # Should use range_min/range_max as defaults
+    assert html =~ "minValue: 0"
+    assert html =~ "maxValue: 1000"
+    assert html =~ ~s|value="0"|
+    assert html =~ ~s|value="1000"|
+  end
+
+  test "dual range slider field with negative ranges" do
+    assigns = %{form: to_form(%{}, as: :filter)}
+
+    html =
+      rendered_to_string(~H"""
+      <.form for={@form}>
+        <.field
+          type="range-dual"
+          id="negative_range"
+          label="Temperature Range"
+          range_min={-100}
+          range_max={100}
+          min_field={%{name: "min_temp", value: -50}}
+          max_field={%{name: "max_temp", value: 50}}
+          field={@form[:temperature]}
+        />
+      </.form>
+      """)
+
+    assert html =~ "Temperature Range"
+    assert html =~ "rangeMin: -100"
+    assert html =~ "rangeMax: 100"
+    assert html =~ "minValue: -50"
+    assert html =~ "maxValue: 50"
+    assert html =~ ~s|min="-100"|
+    assert html =~ ~s|max="100"|
+    assert html =~ ~s|value="-50"|
+    assert html =~ ~s|value="50"|
+  end
+
+  test "dual range slider field with custom step" do
+    assigns = %{form: to_form(%{}, as: :filter)}
+
+    html =
+      rendered_to_string(~H"""
+      <.form for={@form}>
+        <.field
+          type="range-dual"
+          id="step_range"
+          label="Price Range"
+          range_min={0}
+          range_max={1000}
+          step={50}
+          min_field={%{name: "min_price", value: 100}}
+          max_field={%{name: "max_price", value: 500}}
+          field={@form[:price]}
+        />
+      </.form>
+      """)
+
+    assert html =~ ~s|step="50"|
+  end
+
+  test "dual range slider field with custom formatter" do
+    assigns = %{
+      form: to_form(%{}, as: :filter),
+      formatter: fn value -> "$#{value}" end
+    }
+
+    html =
+      rendered_to_string(~H"""
+      <.form for={@form}>
+        <.field
+          type="range-dual"
+          id="formatted_range"
+          label="Price Range"
+          range_min={0}
+          range_max={1000}
+          min_field={%{name: "min_price", value: 100}}
+          max_field={%{name: "max_price", value: 500}}
+          formatter={@formatter}
+          field={@form[:price]}
+        />
+      </.form>
+      """)
+
+    # Check that formatter is applied
+    assert html =~ "$0"
+    assert html =~ "$100"
+    assert html =~ "$500"
+    assert html =~ "$1000"
+  end
+
+  test "dual range slider field with custom labels" do
+    assigns = %{form: to_form(%{}, as: :filter)}
+
+    html =
+      rendered_to_string(~H"""
+      <.form for={@form}>
+        <.field
+          type="range-dual"
+          id="labeled_range"
+          label="Price Range"
+          range_min={0}
+          range_max={1000}
+          min_field={%{name: "min_price", value: 100}}
+          max_field={%{name: "max_price", value: 500}}
+          range_min_label="Minimum"
+          range_max_label="Maximum"
+          field={@form[:price]}
+        />
+      </.form>
+      """)
+
+    assert html =~ "Minimum"
+    assert html =~ "Maximum"
+  end
+
+  test "dual range slider field with help text" do
+    assigns = %{form: to_form(%{}, as: :filter)}
+
+    html =
+      rendered_to_string(~H"""
+      <.form for={@form}>
+        <.field
+          type="range-dual"
+          id="help_range"
+          label="Price Range"
+          range_min={0}
+          range_max={1000}
+          min_field={%{name: "min_price", value: 100}}
+          max_field={%{name: "max_price", value: 500}}
+          help_text="Select your desired price range"
+          field={@form[:price]}
+        />
+      </.form>
+      """)
+
+    assert html =~ "Select your desired price range"
+  end
+
+  test "range-numeric field renders with number inputs" do
+    assigns = %{form: to_form(%{}, as: :filter)}
+
+    html =
+      rendered_to_string(~H"""
+      <.form for={@form}>
+        <.field
+          type="range-numeric"
+          id="numeric_range"
+          label="Price Range"
+          range_min={0}
+          range_max={1000}
+          min_field={%{name: "min_price", value: 100}}
+          max_field={%{name: "max_price", value: 500}}
+          field={@form[:price]}
+        />
+      </.form>
+      """)
+
+    assert html =~ "Price Range"
+    assert html =~ ~s|type="text"|
+    assert html =~ ~s|inputmode="numeric"|
+    refute html =~ ~s|type="range"|
+    refute html =~ "x-data"
+    assert html =~ "No Min"
+    assert html =~ "No Max"
+  end
+
+  test "range-numeric field with nil values" do
+    assigns = %{form: to_form(%{}, as: :filter)}
+
+    html =
+      rendered_to_string(~H"""
+      <.form for={@form}>
+        <.field
+          type="range-numeric"
+          id="numeric_nil"
+          label="Price Range"
+          range_min={0}
+          range_max={1000}
+          min_field={%{name: "min_price", value: nil}}
+          max_field={%{name: "max_price", value: nil}}
+          field={@form[:price]}
+        />
+      </.form>
+      """)
+
+    assert html =~ ~s|type="text"|
+    assert html =~ ~s|inputmode="numeric"|
+    assert html =~ "No Min"
+    assert html =~ "No Max"
+  end
 end

--- a/test/petal/field_test.exs
+++ b/test/petal/field_test.exs
@@ -950,7 +950,7 @@ defmodule PetalComponents.FieldTest do
         field: :price_range,
         id: "price_range",
         form: %Phoenix.HTML.Form{
-          params: %{},
+          params: %{"price_range" => nil},
           source: %{},
           impl: Phoenix.HTML.FormData.Ecto.Changeset,
           name: "filter"

--- a/test/petal/input_test.exs
+++ b/test/petal/input_test.exs
@@ -160,4 +160,160 @@ defmodule PetalComponents.InputTest do
     # Should have guard clause for division by zero
     assert html =~ "if (this.rangeMax === this.rangeMin)"
   end
+
+  test "dual range slider with nil values uses range_min/range_max as defaults" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.input
+        type="range-dual"
+        id="nil_range"
+        range_min={0}
+        range_max={100}
+        min_field={%{name: "min_val", value: nil}}
+        max_field={%{name: "max_val", value: nil}}
+      />
+      """)
+
+    # Should use range_min/range_max as defaults
+    assert html =~ "minValue: 0"
+    assert html =~ "maxValue: 100"
+    assert html =~ ~s|value="0"|
+    assert html =~ ~s|value="100"|
+  end
+
+  test "dual range slider with negative ranges" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.input
+        type="range-dual"
+        id="temp_range"
+        range_min={-100}
+        range_max={100}
+        min_field={%{name: "min_temp", value: -50}}
+        max_field={%{name: "max_temp", value: 50}}
+      />
+      """)
+
+    assert html =~ "rangeMin: -100"
+    assert html =~ "rangeMax: 100"
+    assert html =~ "minValue: -50"
+    assert html =~ "maxValue: 50"
+    assert html =~ ~s|min="-100"|
+    assert html =~ ~s|max="100"|
+    assert html =~ ~s|value="-50"|
+    assert html =~ ~s|value="50"|
+  end
+
+  test "dual range slider with custom step" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.input
+        type="range-dual"
+        id="price_range"
+        range_min={0}
+        range_max={1000}
+        step={50}
+        min_field={%{name: "min", value: 100}}
+        max_field={%{name: "max", value: 500}}
+      />
+      """)
+
+    assert html =~ ~s|step="50"|
+  end
+
+  test "dual range slider with custom labels" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.input
+        type="range-dual"
+        id="price_range"
+        range_min={0}
+        range_max={1000}
+        min_field={%{name: "min", value: 100}}
+        max_field={%{name: "max", value: 500}}
+        range_min_label="Minimum"
+        range_max_label="Maximum"
+      />
+      """)
+
+    assert html =~ "Minimum"
+    assert html =~ "Maximum"
+  end
+
+  test "dual range slider calculates slider position correctly" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.input
+        type="range-dual"
+        id="position_test"
+        range_min={0}
+        range_max={100}
+        min_field={%{name: "min", value: 25}}
+        max_field={%{name: "max", value: 75}}
+      />
+      """)
+
+    # Check that style attribute contains calculated positions
+    # 25 out of 0-100 = 25% left
+    # 75 out of 0-100 = 25% right (100 - 75)
+    assert html =~ ~r/style="[^"]*left: 25%/
+    assert html =~ ~r/right: 25%/
+  end
+
+  test "range-numeric renders with number inputs" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.input
+        type="range-numeric"
+        id="numeric_range"
+        range_min={0}
+        range_max={1000}
+        min_field={%{name: "min_price", value: 100}}
+        max_field={%{name: "max_price", value: 500}}
+      />
+      """)
+
+    # Should have number inputs
+    assert html =~ ~s|type="number"|
+    assert html =~ ~s|inputmode="numeric"|
+    refute html =~ ~s|type="range"|
+    refute html =~ "x-data"
+
+    # Check for placeholders
+    assert html =~ "No Min"
+    assert html =~ "No Max"
+  end
+
+  test "range-numeric with nil values" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.input
+        type="range-numeric"
+        id="numeric_nil"
+        range_min={0}
+        range_max={1000}
+        min_field={%{name: "min_price", value: nil}}
+        max_field={%{name: "max_price", value: nil}}
+      />
+      """)
+
+    assert html =~ ~s|type="number"|
+    assert html =~ ~s|inputmode="numeric"|
+    assert html =~ "No Min"
+    assert html =~ "No Max"
+  end
 end

--- a/test/petal/input_test.exs
+++ b/test/petal/input_test.exs
@@ -60,4 +60,104 @@ defmodule PetalComponents.InputTest do
 
     assert html =~ "rounted-r-none"
   end
+
+  test "dual range slider renders with Alpine.js directives" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.input
+        type="range-dual"
+        id="test_range"
+        range_min={0}
+        range_max={100}
+        min_field={%{name: "min_val", value: 20}}
+        max_field={%{name: "max_val", value: 80}}
+      />
+      """)
+
+    # Check for Alpine.js directives
+    assert html =~ "x-data"
+    assert html =~ "x-ref=\"minSlider\""
+    assert html =~ "x-ref=\"maxSlider\""
+    assert html =~ "x-ref=\"rangeTrack\""
+    assert html =~ "@input=\"updateMinValue"
+    assert html =~ "@input=\"updateMaxValue"
+
+    # Check for phx-update="ignore" to prevent LiveView conflicts
+    assert html =~ ~s|phx-update="ignore"|
+
+    # Check for two range inputs
+    assert html =~ ~s|type="range"|
+    assert html =~ ~s|name="min_val"|
+    assert html =~ ~s|name="max_val"|
+
+    # Check for values
+    assert html =~ ~s|value="20"|
+    assert html =~ ~s|value="80"|
+
+    # Check for range bounds
+    assert html =~ ~s|min="0"|
+    assert html =~ ~s|max="100"|
+
+    # Check for slider CSS classes
+    assert html =~ "pc-slider-input"
+    assert html =~ "pc-slider-track"
+    assert html =~ "pc-slider-range"
+
+    # Check for value display with x-text
+    assert html =~ "x-text"
+  end
+
+  test "dual range slider with custom formatter" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.input
+        type="range-dual"
+        id="price_range"
+        range_min={0}
+        range_max={500}
+        range_min_label="$0"
+        range_max_label="$500"
+        min_field={%{name: "min_price", value: 50}}
+        max_field={%{name: "max_price", value: 200}}
+        format_value={&("$#{&1}")}
+      />
+      """)
+
+    # Check that formatter is used for initial render
+    assert html =~ "$50"
+    assert html =~ "$200"
+    assert html =~ "$0"
+    assert html =~ "$500"
+
+    # Check that Alpine formatValue function detects $ format
+    assert html =~ "formatValue"
+  end
+
+  test "dual range slider handles edge case when range_min equals range_max" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.input
+        type="range-dual"
+        id="edge_case_range"
+        range_min={100}
+        range_max={100}
+        min_field={%{name: "min_val", value: 100}}
+        max_field={%{name: "max_val", value: 100}}
+      />
+      """)
+
+    # Should render without crashing
+    assert html =~ "x-data"
+    assert html =~ ~s|min="100"|
+    assert html =~ ~s|max="100"|
+
+    # Should have guard clause for division by zero
+    assert html =~ "if (this.rangeMax === this.rangeMin)"
+  end
 end


### PR DESCRIPTION
  ### Core Implementation
  - Added dual range slider component (`type="range-dual"`) using Alpine.js for client-side interactivity
  - Implemented in `input.ex`, `field.ex`, and `form.ex` for consistent API across component variants
  - Works seamlessly in both LiveView and controller-rendered (dead) views

  ### Technical Improvements
  - Added `phx-update="ignore"` to prevent LiveView/Alpine.js DOM conflicts
  - Implemented `$nextTick()` wrapper for proper Alpine initialization timing
  - Added `Jason.encode!()` for safe JavaScript string interpolation (prevents injection)
  - Added division by zero guard clauses when `range_min == range_max`
  - Proper error state handling and display with field wrapper integration

  ### Features
  - Support for custom formatters (e.g., currency: `format_value={&("$#{&1}")}`)
  - Configurable min/max labels, step values, and range bounds
  - Real-time visual feedback with sliding track indicator
  - Form submission with standard `name` attributes (no special handling required)
  - Accessible markup with proper ARIA attributes