### PR TITLE
Theming + typography foundation: zinc grays, refined scale, full type set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+### Unreleased (targeting 4.2.0)
+
+#### Added
+
+- **Typography: `lead`, `blockquote`, `inline_code`, `text_muted` / `text_large` / `text_small`, and `hr`.** Rounds out the type set so a full article composes without dropping to raw HTML.
+
+#### Changed
+
+- **Refined the typography scale.** More readable body line-height, tighter heading tracking, softened the heaviest heading weights, and `h5` is now sized distinctly from `h4`. Existing `h1`-`h5` and `p` will look slightly different (a deliberate polish pass) — no API changes.
+
 ### 4.1.2 - 2026-06-17
 
 #### Fixed

--- a/assets/default.css
+++ b/assets/default.css
@@ -506,34 +506,57 @@
   /* Typography */
 
   .pc-h1 {
-    @apply text-4xl font-extrabold leading-10 sm:leading-none sm:text-5xl sm:tracking-tight lg:text-6xl;
+    @apply text-4xl font-extrabold tracking-tight leading-tight sm:text-5xl lg:text-6xl;
   }
   .pc-h2 {
-    @apply text-2xl font-extrabold leading-9 sm:leading-10 sm:text-3xl;
+    @apply text-3xl font-bold tracking-tight leading-tight;
   }
   .pc-h3 {
-    @apply text-xl font-bold leading-7 sm:text-2xl;
+    @apply text-2xl font-bold tracking-tight leading-snug;
   }
   .pc-h4 {
-    @apply text-lg font-bold leading-6;
+    @apply text-xl font-semibold tracking-tight leading-snug;
   }
   .pc-h5 {
-    @apply text-lg font-medium leading-6;
+    @apply text-base font-semibold leading-snug;
   }
   .pc-heading--color {
     @apply text-gray-900 dark:text-white;
   }
   .pc-heading--underline {
-    @apply pb-2 border-b border-gray-200;
+    @apply pb-2 border-b border-gray-200 dark:border-gray-800;
   }
   .pc-heading--margin {
     @apply mb-3;
   }
   .pc-text {
-    @apply leading-5 text-gray-700 dark:text-gray-300;
+    @apply text-base leading-7 text-gray-700 dark:text-gray-300;
   }
   .pc-p--margin {
-    @apply mb-2;
+    @apply mb-4;
+  }
+
+  /* Extended typography */
+  .pc-lead {
+    @apply text-xl leading-relaxed text-gray-600 dark:text-gray-400;
+  }
+  .pc-blockquote {
+    @apply mt-4 border-l-2 border-gray-300 pl-6 italic text-gray-700 dark:border-gray-700 dark:text-gray-300;
+  }
+  .pc-inline-code {
+    @apply relative rounded bg-gray-100 px-[0.4rem] py-[0.2rem] font-mono text-sm font-semibold text-gray-900 dark:bg-gray-800 dark:text-gray-100;
+  }
+  .pc-text-muted {
+    @apply text-sm text-gray-500 dark:text-gray-400;
+  }
+  .pc-text-large {
+    @apply text-lg font-semibold text-gray-900 dark:text-white;
+  }
+  .pc-text-small {
+    @apply text-sm font-medium leading-none text-gray-900 dark:text-white;
+  }
+  .pc-hr {
+    @apply my-8 border-gray-200 dark:border-gray-800;
   }
 
   /* Badges */

--- a/dev.exs
+++ b/dev.exs
@@ -1089,16 +1089,55 @@ defmodule Dev.PlaygroundLive do
       <%!-- LAYOUT TAB                                                   --%>
       <%!-- ============================================================ --%>
       <div :if={@active_tab == "layout"} class="space-y-8">
-        <section>
-          <.h2 class="mb-4">Typography</.h2>
-          <div class="space-y-2">
-            <.h1>Heading 1</.h1>
-            <.h2>Heading 2</.h2>
-            <.h3>Heading 3</.h3>
-            <.h4>Heading 4</.h4>
-            <.h5>Heading 5</.h5>
-            <.p>A paragraph of text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</.p>
-          </div>
+        <%!-- Realistic article showing every element in context (the example bar). --%>
+        <section class="max-w-2xl">
+          <.h2 class="mb-6">Typography</.h2>
+          <article>
+            <.h1>The quiet power of Phoenix</.h1>
+            <.lead>
+              A considered type scale does more for "looks finished" than any single component.
+              Here is every element, in the kind of context you would actually ship.
+            </.lead>
+            <.p>
+              Petal Components gives you a refined set of headings, body copy and inline elements
+              out of the box. Drop in a <.inline_code>&lt;.button&gt;</.inline_code> or a
+              <.inline_code>&lt;.modal&gt;</.inline_code> and it already matches.
+            </.p>
+
+            <.h2 class="mt-10">Built for reading</.h2>
+            <.p>
+              Body text uses a comfortable line height and a sensible measure, so paragraphs are
+              actually pleasant to read rather than cramped. Headings carry tight tracking and
+              balanced weight.
+            </.p>
+
+            <.blockquote class="my-6">
+              "We shipped our marketing site in a weekend. The defaults just look right."
+            </.blockquote>
+
+            <.h3 class="mt-8">What you get</.h3>
+            <.ul class="my-4 space-y-1">
+              <li>Headings from <.inline_code>h1</.inline_code> to <.inline_code>h5</.inline_code></li>
+              <li>Lead, body, blockquote and inline code</li>
+              <li>Muted, large and small text helpers</li>
+            </.ul>
+
+            <.h4 class="mt-8">Three steps</.h4>
+            <.ol class="my-4 space-y-1">
+              <li>Add the dependency</li>
+              <li>Import the styles</li>
+              <li>Start composing</li>
+            </.ol>
+
+            <.hr />
+
+            <div class="space-y-2">
+              <.text_large>Large — emphasised body text.</.text_large>
+              <.p>Default — the standard paragraph.</.p>
+              <.text_muted>Muted — captions, hints and metadata.</.text_muted>
+              <.text_small>Small — tight label text.</.text_small>
+            </div>
+          </article>
         </section>
 
         <section>

--- a/dev/colors.css
+++ b/dev/colors.css
@@ -71,15 +71,15 @@
   --color-info-900: var(--color-sky-900);
   --color-info-950: var(--color-sky-950);
 
-  --color-gray-50: var(--color-slate-50);
-  --color-gray-100: var(--color-slate-100);
-  --color-gray-200: var(--color-slate-200);
-  --color-gray-300: var(--color-slate-300);
-  --color-gray-400: var(--color-slate-400);
-  --color-gray-500: var(--color-slate-500);
-  --color-gray-600: var(--color-slate-600);
-  --color-gray-700: var(--color-slate-700);
-  --color-gray-800: var(--color-slate-800);
-  --color-gray-900: var(--color-slate-900);
-  --color-gray-950: var(--color-slate-950);
+  --color-gray-50: var(--color-zinc-50);
+  --color-gray-100: var(--color-zinc-100);
+  --color-gray-200: var(--color-zinc-200);
+  --color-gray-300: var(--color-zinc-300);
+  --color-gray-400: var(--color-zinc-400);
+  --color-gray-500: var(--color-zinc-500);
+  --color-gray-600: var(--color-zinc-600);
+  --color-gray-700: var(--color-zinc-700);
+  --color-gray-800: var(--color-zinc-800);
+  --color-gray-900: var(--color-zinc-900);
+  --color-gray-950: var(--color-zinc-950);
 }

--- a/lib/petal_components/typography.ex
+++ b/lib/petal_components/typography.ex
@@ -170,4 +170,92 @@ defmodule PetalComponents.Typography do
     </ol>
     """
   end
+
+  attr(:class, :any, default: nil, doc: "CSS class")
+  attr(:rest, :global)
+  slot(:inner_block, required: false)
+
+  @doc """
+  A larger, muted introductory paragraph for the top of a page or section.
+
+      <.lead>Petal Components is a set of HEEx components for Phoenix.</.lead>
+  """
+  def lead(assigns) do
+    ~H"""
+    <p class={["pc-lead", @class]} {@rest}>{render_slot(@inner_block)}</p>
+    """
+  end
+
+  attr(:class, :any, default: nil, doc: "CSS class")
+  attr(:rest, :global)
+  slot(:inner_block, required: false)
+
+  @doc """
+  A styled blockquote with a left border.
+
+      <.blockquote>"This library shipped our marketing site in a weekend."</.blockquote>
+  """
+  def blockquote(assigns) do
+    ~H"""
+    <blockquote class={["pc-blockquote", @class]} {@rest}>{render_slot(@inner_block)}</blockquote>
+    """
+  end
+
+  attr(:class, :any, default: nil, doc: "CSS class")
+  attr(:rest, :global)
+  slot(:inner_block, required: false)
+
+  @doc """
+  Inline code styling for snippets within a sentence.
+
+      Run <.inline_code>mix deps.get</.inline_code> to install.
+  """
+  def inline_code(assigns) do
+    ~H"""
+    <code class={["pc-inline-code", @class]} {@rest}>{render_slot(@inner_block)}</code>
+    """
+  end
+
+  attr(:class, :any, default: nil, doc: "CSS class")
+  attr(:rest, :global)
+  slot(:inner_block, required: false)
+
+  @doc "Muted secondary text, e.g. a caption or helper line."
+  def text_muted(assigns) do
+    ~H"""
+    <p class={["pc-text-muted", @class]} {@rest}>{render_slot(@inner_block)}</p>
+    """
+  end
+
+  attr(:class, :any, default: nil, doc: "CSS class")
+  attr(:rest, :global)
+  slot(:inner_block, required: false)
+
+  @doc "Slightly larger, emphasised body text."
+  def text_large(assigns) do
+    ~H"""
+    <div class={["pc-text-large", @class]} {@rest}>{render_slot(@inner_block)}</div>
+    """
+  end
+
+  attr(:class, :any, default: nil, doc: "CSS class")
+  attr(:rest, :global)
+  slot(:inner_block, required: false)
+
+  @doc "Small, tight label text."
+  def text_small(assigns) do
+    ~H"""
+    <small class={["pc-text-small", @class]} {@rest}>{render_slot(@inner_block)}</small>
+    """
+  end
+
+  attr(:class, :any, default: nil, doc: "CSS class")
+  attr(:rest, :global)
+
+  @doc "A horizontal rule with sensible vertical spacing."
+  def hr(assigns) do
+    ~H"""
+    <hr class={["pc-hr", @class]} {@rest} />
+    """
+  end
 end

--- a/test/petal/typography_test.exs
+++ b/test/petal/typography_test.exs
@@ -161,4 +161,46 @@ defmodule PetalComponents.TypographyTest do
     assert html =~ "pc-text"
     assert html =~ "random-attribute"
   end
+
+  test ".lead" do
+    assigns = %{}
+    html = rendered_to_string(~H"<.lead>Intro</.lead>")
+    assert html =~ "Intro"
+    assert html =~ "pc-lead"
+    assert html =~ "<p class="
+  end
+
+  test ".blockquote" do
+    assigns = %{}
+    html = rendered_to_string(~H"<.blockquote>A quote</.blockquote>")
+    assert html =~ "A quote"
+    assert html =~ "pc-blockquote"
+    assert html =~ "<blockquote"
+  end
+
+  test ".inline_code" do
+    assigns = %{}
+    html = rendered_to_string(~H"<.inline_code>mix deps.get</.inline_code>")
+    assert html =~ "mix deps.get"
+    assert html =~ "pc-inline-code"
+    assert html =~ "<code"
+  end
+
+  test ".text_muted / .text_large / .text_small" do
+    assigns = %{}
+    assert rendered_to_string(~H"<.text_muted>m</.text_muted>") =~ "pc-text-muted"
+    assert rendered_to_string(~H"<.text_large>l</.text_large>") =~ "pc-text-large"
+
+    small = rendered_to_string(~H"<.text_small>s</.text_small>")
+    assert small =~ "pc-text-small"
+    assert small =~ "<small"
+  end
+
+  test ".hr" do
+    assigns = %{}
+    html = rendered_to_string(~H|<.hr class="mt-10" />|)
+    assert html =~ "<hr"
+    assert html =~ "pc-hr"
+    assert html =~ "mt-10"
+  end
 end


### PR DESCRIPTION
First PR in the 'make it look more shadcn' track.

**What's here**
- **Zinc grays** — remap `--color-gray-*` from slate (the cold/blue gray) to **zinc** (neutral). Trivially revertible to Neutral if preferred.
- **Refined type scale** — body `leading-5 → leading-7` (the main 'cramped/clunky' cause), `tracking-tight` on headings, softened the heaviest weights, fixed h5 being the same size as h4.
- **Completed the type set** (all additive, zero breakage) — `lead`, `blockquote`, `inline_code`, `text_muted` / `text_large` / `text_small`, `hr`.
- **Realistic demo article** — replaces the vanilla atoms-list with a real article showing every element in context (the shadcn-grade example bar).
- Tests for all new elements. **488 tests, 0 failures.**

**Deliberate follow-ups** (kept out to keep this reviewable)
- Dark-surface `900 → 950` sweep across components.
- Rolling 'realistic example' upgrade for other components (floating_div/popover, slide_over, dropdown, …).

Screenshot of the new typography demo is in the linked Slack message.