### PR TITLE
Typography polish: list styling, text-balance, demo table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 #### Changed
 
-- **Refined the typography scale.** More readable body line-height, tighter heading tracking, softened the heaviest heading weights, and `h5` is now sized distinctly from `h4`. Existing `h1`-`h5` and `p` will look slightly different (a deliberate polish pass) — no API changes.
+- **Refined the typography scale.** More readable body line-height, tighter heading tracking with balanced multi-line headings (`text-wrap: balance`), softened the heaviest heading weights, and `h5` is now sized distinctly from `h4`. Existing `h1`-`h5` and `p` will look slightly different (a deliberate polish pass) — no API changes.
+- **`ul` / `ol` lists now look considered out of the box.** Markers sit outside with consistent indentation (ordered and unordered match), and there is built-in vertical spacing between items, so a list reads well without adding spacing utilities yourself.
 
 ### 4.1.2 - 2026-06-17
 

--- a/assets/default.css
+++ b/assets/default.css
@@ -506,16 +506,16 @@
   /* Typography */
 
   .pc-h1 {
-    @apply text-4xl font-extrabold tracking-tight leading-tight sm:text-5xl lg:text-6xl;
+    @apply text-4xl font-extrabold tracking-tight text-balance leading-tight sm:text-5xl lg:text-6xl;
   }
   .pc-h2 {
-    @apply text-3xl font-bold tracking-tight leading-tight;
+    @apply text-3xl font-bold tracking-tight text-balance leading-tight;
   }
   .pc-h3 {
-    @apply text-2xl font-bold tracking-tight leading-snug;
+    @apply text-2xl font-bold tracking-tight text-balance leading-snug;
   }
   .pc-h4 {
-    @apply text-xl font-semibold tracking-tight leading-snug;
+    @apply text-xl font-semibold tracking-tight text-balance leading-snug;
   }
   .pc-h5 {
     @apply text-base font-semibold leading-snug;

--- a/dev.exs
+++ b/dev.exs
@@ -1100,8 +1100,11 @@ defmodule Dev.PlaygroundLive do
             </.lead>
             <.p>
               Petal Components gives you a refined set of headings, body copy and inline elements
-              out of the box. Drop in a <.inline_code>&lt;.button&gt;</.inline_code> or a
-              <.inline_code>&lt;.modal&gt;</.inline_code> and it already matches.
+              out of the box. Drop in a
+              <.inline_code>&lt;.button&gt;</.inline_code>
+              or a
+              <.inline_code>&lt;.modal&gt;</.inline_code>
+              and it already matches.
             </.p>
 
             <.h2 class="mt-10">Built for reading</.h2>
@@ -1116,18 +1119,36 @@ defmodule Dev.PlaygroundLive do
             </.blockquote>
 
             <.h3 class="mt-8">What you get</.h3>
-            <.ul class="my-4 space-y-1">
-              <li>Headings from <.inline_code>h1</.inline_code> to <.inline_code>h5</.inline_code></li>
+            <.ul>
+              <li>
+                Headings from
+                <.inline_code>h1</.inline_code>
+                to
+                <.inline_code>h5</.inline_code>
+              </li>
               <li>Lead, body, blockquote and inline code</li>
               <li>Muted, large and small text helpers</li>
             </.ul>
 
             <.h4 class="mt-8">Three steps</.h4>
-            <.ol class="my-4 space-y-1">
+            <.ol>
               <li>Add the dependency</li>
               <li>Import the styles</li>
               <li>Start composing</li>
             </.ol>
+
+            <.h4 class="mt-8">A table, too</.h4>
+            <.table
+              id="typography-table"
+              rows={[
+                %{tier: "Puns", price: "5 gold coins"},
+                %{tier: "Jokes", price: "10 gold coins"},
+                %{tier: "One-liners", price: "20 gold coins"}
+              ]}
+            >
+              <:col :let={row} label="Joke tier">{row.tier}</:col>
+              <:col :let={row} label="Tax">{row.price}</:col>
+            </.table>
 
             <.hr />
 

--- a/lib/petal_components/typography.ex
+++ b/lib/petal_components/typography.ex
@@ -145,7 +145,7 @@ defmodule PetalComponents.Typography do
 
   def ul(assigns) do
     ~H"""
-    <ul class={["pc-text", "list-disc list-inside", @class]} {@rest}>
+    <ul class={["pc-text", "my-4 ml-6 list-disc [&>li]:mt-2", @class]} {@rest}>
       {render_slot(@inner_block)}
     </ul>
     """
@@ -165,7 +165,7 @@ defmodule PetalComponents.Typography do
 
   def ol(assigns) do
     ~H"""
-    <ol class={["pc-text", "list-decimal list-inside", @class]} {@rest}>
+    <ol class={["pc-text", "my-4 ml-6 list-decimal [&>li]:mt-2", @class]} {@rest}>
       {render_slot(@inner_block)}
     </ol>
     """


### PR DESCRIPTION
Follow-up to #489 addressing review feedback.

- **Lists** — `ul`/`ol` now use outside markers with consistent `ml-6` indentation (ordered and unordered match) and built-in `[&>li]:mt-2` spacing between items. Fixes the over-indented bullets and uneven gaps vs shadcn's lists.
- **`text-balance`** on `h1`-`h4` so multi-line headings break evenly (Baseline, degrades gracefully).
- **Demo** rounded out with a table via the existing `<.table>`.

Verified in the playground: ul/ol both 24px indent, markers outside, 8px between items. 16 typography tests pass.