### PR TITLE
Fix basic inputs dropping value, placeholder and other global attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+### Unreleased
+
+#### Fixed
+
+- **`email_input`, `number_input`, `password_input`, `search_input`, `telephone_input` and `url_input` forward global attributes again** (`value`, `placeholder`, `phx-*` bindings, etc.). A 3.0.2 refactor left these six without their own `attr :rest, :global` declarations, and since `attr` only applies to the function directly below it, only `text_input` kept forwarding. Fixes [#488](https://github.com/petalframework/petal_components/issues/488).
+
 ### 4.2.0 - 2026-06-29
 
 A typography pass. The heading and body scale got a proper going-over, and the type set is now complete enough to lay out a full article from components alone. Everything here is additive or a restyle, with no breaking API changes (see Upgrading for the visual shifts).

--- a/lib/petal_components/form.ex
+++ b/lib/petal_components/form.ex
@@ -130,9 +130,7 @@ defmodule PetalComponents.Form do
     ~H"""
     <label class="pc-checkbox-label">
       <.checkbox form={@form} field={@field} {@rest} />
-      <div class={
-        label_classes(%{form: @form, field: @field, type: "checkbox", class: @label_class})
-      }>
+      <div class={label_classes(%{form: @form, field: @field, type: "checkbox", class: @label_class})}>
         {@label}
       </div>
     </label>
@@ -143,9 +141,7 @@ defmodule PetalComponents.Form do
     ~H"""
     <label class="pc-checkbox-label">
       <.switch form={@form} field={@field} {@rest} />
-      <div class={
-        label_classes(%{form: @form, field: @field, type: "checkbox", class: @label_class})
-      }>
+      <div class={label_classes(%{form: @form, field: @field, type: "checkbox", class: @label_class})}>
         {@label}
       </div>
     </label>
@@ -312,11 +308,23 @@ defmodule PetalComponents.Form do
     """
   end
 
+  attr(:form, :any, default: nil, doc: "")
+  attr(:field, :atom, default: nil, doc: "")
+  attr(:label, :string, default: nil, doc: "labels your field")
+  attr(:class, :any, default: nil, doc: "extra classes for the text input")
+  attr(:rest, :global, include: @form_attrs)
+
   def email_input(assigns) do
     ~H"""
     {render_basic_input(&Form.email_input/3, assigns)}
     """
   end
+
+  attr(:form, :any, default: nil, doc: "")
+  attr(:field, :atom, default: nil, doc: "")
+  attr(:label, :string, default: nil, doc: "labels your field")
+  attr(:class, :any, default: nil, doc: "extra classes for the text input")
+  attr(:rest, :global, include: @form_attrs)
 
   def number_input(assigns) do
     ~H"""
@@ -324,11 +332,23 @@ defmodule PetalComponents.Form do
     """
   end
 
+  attr(:form, :any, default: nil, doc: "")
+  attr(:field, :atom, default: nil, doc: "")
+  attr(:label, :string, default: nil, doc: "labels your field")
+  attr(:class, :any, default: nil, doc: "extra classes for the text input")
+  attr(:rest, :global, include: @form_attrs)
+
   def password_input(assigns) do
     ~H"""
     {render_basic_input(&Form.password_input/3, assigns)}
     """
   end
+
+  attr(:form, :any, default: nil, doc: "")
+  attr(:field, :atom, default: nil, doc: "")
+  attr(:label, :string, default: nil, doc: "labels your field")
+  attr(:class, :any, default: nil, doc: "extra classes for the text input")
+  attr(:rest, :global, include: @form_attrs)
 
   def search_input(assigns) do
     ~H"""
@@ -336,11 +356,23 @@ defmodule PetalComponents.Form do
     """
   end
 
+  attr(:form, :any, default: nil, doc: "")
+  attr(:field, :atom, default: nil, doc: "")
+  attr(:label, :string, default: nil, doc: "labels your field")
+  attr(:class, :any, default: nil, doc: "extra classes for the text input")
+  attr(:rest, :global, include: @form_attrs)
+
   def telephone_input(assigns) do
     ~H"""
     {render_basic_input(&Form.telephone_input/3, assigns)}
     """
   end
+
+  attr(:form, :any, default: nil, doc: "")
+  attr(:field, :atom, default: nil, doc: "")
+  attr(:label, :string, default: nil, doc: "labels your field")
+  attr(:class, :any, default: nil, doc: "extra classes for the text input")
+  attr(:rest, :global, include: @form_attrs)
 
   def url_input(assigns) do
     ~H"""

--- a/test/petal/form_test.exs
+++ b/test/petal/form_test.exs
@@ -597,13 +597,15 @@ defmodule PetalComponents.FormTest do
     html =
       rendered_to_string(~H"""
       <.form :let={f} for={%{}} as={:user}>
-        <.number_input form={f} field={:name} />
+        <.number_input form={f} field={:name} value="123" placeholder="eg. 42" />
       </.form>
       """)
 
     assert html =~ "input"
     assert html =~ "number"
     assert html =~ "user[name]"
+    assert html =~ ~s(value="123")
+    assert html =~ ~s(placeholder="eg. 42")
   end
 
   test "email_input" do
@@ -612,13 +614,20 @@ defmodule PetalComponents.FormTest do
     html =
       rendered_to_string(~H"""
       <.form :let={f} for={%{}} as={:user}>
-        <.email_input form={f} field={:name} />
+        <.email_input
+          form={f}
+          field={:name}
+          value="jane@example.com"
+          placeholder="eg. jane@example.com"
+        />
       </.form>
       """)
 
     assert html =~ "input"
     assert html =~ "email"
     assert html =~ "user[name]"
+    assert html =~ ~s(value="jane@example.com")
+    assert html =~ ~s(placeholder="eg. jane@example.com")
   end
 
   test "password_input" do
@@ -627,13 +636,14 @@ defmodule PetalComponents.FormTest do
     html =
       rendered_to_string(~H"""
       <.form :let={f} for={%{}} as={:user}>
-        <.password_input form={f} field={:name} />
+        <.password_input form={f} field={:name} placeholder="Enter password" />
       </.form>
       """)
 
     assert html =~ "input"
     assert html =~ "password"
     assert html =~ "user[name]"
+    assert html =~ ~s(placeholder="Enter password")
   end
 
   test "search_input" do
@@ -642,13 +652,15 @@ defmodule PetalComponents.FormTest do
     html =
       rendered_to_string(~H"""
       <.form :let={f} for={%{}} as={:user}>
-        <.search_input form={f} field={:name} />
+        <.search_input form={f} field={:name} value="abc-123" placeholder="eg. Jane Doe" />
       </.form>
       """)
 
     assert html =~ "input"
     assert html =~ "search"
     assert html =~ "user[name]"
+    assert html =~ ~s(value="abc-123")
+    assert html =~ ~s(placeholder="eg. Jane Doe")
   end
 
   test "telephone_input" do
@@ -657,13 +669,15 @@ defmodule PetalComponents.FormTest do
     html =
       rendered_to_string(~H"""
       <.form :let={f} for={%{}} as={:user}>
-        <.telephone_input form={f} field={:name} />
+        <.telephone_input form={f} field={:name} value="0400 000 000" placeholder="eg. 0400 000 000" />
       </.form>
       """)
 
     assert html =~ "input"
     assert html =~ "tel"
     assert html =~ "user[name]"
+    assert html =~ ~s(value="0400 000 000")
+    assert html =~ ~s(placeholder="eg. 0400 000 000")
   end
 
   test "url_input" do
@@ -672,13 +686,20 @@ defmodule PetalComponents.FormTest do
     html =
       rendered_to_string(~H"""
       <.form :let={f} for={%{}} as={:user}>
-        <.url_input form={f} field={:name} />
+        <.url_input
+          form={f}
+          field={:name}
+          value="https://petal.build"
+          placeholder="eg. https://petal.build"
+        />
       </.form>
       """)
 
     assert html =~ "input"
     assert html =~ "url"
     assert html =~ "user[name]"
+    assert html =~ ~s(value="https://petal.build")
+    assert html =~ ~s(placeholder="eg. https://petal.build")
   end
 
   test "time_input" do

--- a/test/petal/form_test.exs
+++ b/test/petal/form_test.exs
@@ -591,6 +591,29 @@ defmodule PetalComponents.FormTest do
     assert html =~ "Something else"
   end
 
+  test "form_field switch label" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} as={:user} for={%Ecto.Changeset{action: :update, data: %{name: ""}}}>
+        <.form_field type="switch" form={f} field={:name} />
+      </.form>
+      """)
+
+    assert html =~ "Name"
+    assert html =~ "pc-switch"
+
+    html =
+      rendered_to_string(~H"""
+      <.form :let={f} as={:user} for={%Ecto.Changeset{action: :update, data: %{name: ""}}}>
+        <.form_field type="switch" form={f} field={:name} label="Something else" />
+      </.form>
+      """)
+
+    assert html =~ "Something else"
+  end
+
   test "number_input" do
     assigns = %{}
 


### PR DESCRIPTION
Fixes #488.

## The bug

Since 3.0.2, `email_input`, `number_input`, `password_input`, `search_input`, `telephone_input` and `url_input` silently dropped `value`, `placeholder`, `phx-*` bindings and every other `@form_attrs` global. Only `text_input` still forwarded them.

Root cause (well diagnosed in the issue, thanks @pmargreff): the d2f957c refactor collapsed the per-function `attr` blocks, but Phoenix `attr` declarations only apply to the function *directly below* them. So only `text_input` had `attr :rest, :global` in effect; the other six got no `@rest` at all, and `render_basic_input/2` fell back to `%{}`.

Note: `datetime_local_input` and `date_input` (also named in the issue, which was filed against 3.2.2) already have their `attr` blocks back on current `main`, so this PR covers the remaining six.

## The fix

Restore the `attr` block (`form`, `field`, `label`, `class`, `rest`) on each of the six inputs, same shape as `text_input`.

## Tests

Extended each input's existing test to assert forwarded `value` / `placeholder` (the originals only checked type and name, which is why the regression slipped through).

- Without the lib change: 6 failures — the new assertions catch the regression
- With it: full suite passes, 488 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)