### PR TITLE
Deployable playground via PLAYGROUND_DEPLOY (playground.petal.build)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# _build and deps MUST stay out of the build context: in local checkouts and
+# worktrees they can be symlinks to absolute macOS paths (dangling on the
+# builder), and even as real dirs they're hundreds of MB the image rebuilds
+# anyway. The generated CSS is rebuilt at boot.
+_build
+deps
+priv/static/assets
+.git
+.github
+.elixir_ls
+test
+guides
+doc
+cover
+tmp
+screenshot.png
+logo.png
+*.md
+!rules.md
+.DS_Store
+fly.toml
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,14 @@ RUN apt-get update -y && \
 
 WORKDIR /app
 
+# MIX_HOME/HEX_HOME live under /app so the runtime user can read them -
+# the default is /root/.mix, which becomes unreadable after the USER drop
+# and `mix run` still consults it at boot.
 ENV MIX_ENV=dev \
     LANG=C.UTF-8 \
-    OPEN_BROWSER=false
+    OPEN_BROWSER=false \
+    MIX_HOME=/app/.mix \
+    HEX_HOME=/app/.hex
 
 RUN mix local.hex --force && mix local.rebar --force
 
@@ -38,6 +43,13 @@ COPY dev dev
 COPY dev.exs ./
 
 RUN mix compile
+
+# Public app: don't run as root. The whole tree is chowned because boot
+# writes generated files (priv/static/assets CSS, dev/heroicons.css) and
+# mix touches _build manifests.
+RUN useradd --system --create-home --shell /usr/sbin/nologin playground && \
+    chown -R playground:playground /app
+USER playground
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,16 @@ COPY dev.exs ./
 
 RUN mix compile
 
-# Public app: don't run as root. The whole tree is chowned because boot
-# writes generated files (priv/static/assets CSS, dev/heroicons.css) and
-# mix touches _build manifests.
+# Public app: don't run as root, and own only what boot actually writes -
+# priv/static (tailwind CSS output), dev (generated heroicons.css) and
+# _build (mix manifests + tailwind binary freshness checks). Source, deps
+# and mix files stay root-owned read-only. --create-home because the BEAM
+# writes ~/.erlang.cookie on first start.
+# mkdir first: priv/static only holds generated output, which .dockerignore
+# keeps out of the context, so the directory may not exist yet.
 RUN useradd --system --create-home --shell /usr/sbin/nologin playground && \
-    chown -R playground:playground /app
+    mkdir -p /app/priv/static/assets && \
+    chown -R playground:playground /app/priv/static /app/dev /app/_build
 USER playground
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Deployed component playground (playground.petal.build).
+#
+# This intentionally runs MIX_ENV=dev: the playground IS the dev server
+# (dev.exs + phoenix_playground), just with the dev conveniences switched
+# off via PLAYGROUND_DEPLOY=true (no code reloader, no live reload, no
+# tailwind watcher, real secret_key_base). Every runtime dep it needs is
+# scoped `only: :dev` in mix.exs, so a prod build would have nothing to run.
+FROM hexpm/elixir:1.17.2-erlang-26.2.1-debian-bookworm-20260610-slim
+
+# git: heroicons is a github dep. build-essential: NIF fallback compiles
+# (lazy_html) when a precompiled binary isn't available for this target.
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends git ca-certificates build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+ENV MIX_ENV=dev \
+    LANG=C.UTF-8 \
+    OPEN_BROWSER=false
+
+RUN mix local.hex --force && mix local.rebar --force
+
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only dev
+
+COPY config config
+RUN mix deps.compile
+
+# Fetch the linux tailwind binary at build time so first boot doesn't
+# download it (dev.exs runs the tailwind task on every start).
+RUN mix tailwind.install --if-missing
+
+COPY lib lib
+COPY assets assets
+COPY priv priv
+COPY dev dev
+COPY dev.exs ./
+
+RUN mix compile
+
+EXPOSE 8080
+
+CMD ["mix", "run", "--no-halt", "dev.exs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,13 @@ RUN mix compile
 
 # Public app: don't run as root, and own only what boot actually writes -
 # priv/static (tailwind CSS output), dev (generated heroicons.css) and
-# _build (mix manifests + tailwind binary freshness checks). Source, deps
-# and mix files stay root-owned read-only. --create-home because the BEAM
-# writes ~/.erlang.cookie on first start.
+# _build. Source, deps and mix files stay root-owned read-only.
+# _build stays writable ON PURPOSE: the entrypoint is `mix run`, and Mix
+# (1.17) takes file locks under the build path on every invocation, so a
+# read-only _build can crash boot. The marginal risk (overwriting compiled
+# beams) buys nothing here - an attacker positioned to do that is already
+# executing inside the BEAM. --create-home because the BEAM writes
+# ~/.erlang.cookie on first start.
 # mkdir first: priv/static only holds generated output, which .dockerignore
 # keeps out of the context, so the directory may not exist yet.
 RUN useradd --system --create-home --shell /usr/sbin/nologin playground && \

--- a/dev.exs
+++ b/dev.exs
@@ -8509,9 +8509,15 @@ defmodule Dev.Endpoint do
     from: Path.expand("priv/static", __DIR__),
     at: "/"
 
-  socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
-  plug Phoenix.LiveReloader
-  plug Phoenix.CodeReloader, reloader: &Dev.Reloader.reload/2
+  # Dev-only reload machinery, compiled out when PLAYGROUND_DEPLOY=true:
+  # Phoenix.CodeReloader re-evaluates this ENTIRE file on every request
+  # (~12s each measured) - live_reload: false alone does not disable it,
+  # because these plugs are hardcoded here, not derived from that option.
+  if System.get_env("PLAYGROUND_DEPLOY") != "true" do
+    socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
+    plug Phoenix.LiveReloader
+    plug Phoenix.CodeReloader, reloader: &Dev.Reloader.reload/2
+  end
 
   plug Plug.Session,
     store: :cookie,
@@ -8581,27 +8587,62 @@ File.mkdir_p!("priv/static/assets")
 # Generate heroicon CSS from SVG files, then build Tailwind
 Dev.HeroiconsCSS.generate()
 
+# PLAYGROUND_DEPLOY=true is the public deployment (playground.petal.build):
+# same file, dev conveniences off. The perf-critical switch lives in
+# Dev.Endpoint below, where this flag compiles out Phoenix.CodeReloader -
+# that plug re-evaluates this whole file on EVERY request (~12s each).
+# Here the flag turns off the live-reload watcher, debug_errors (no
+# stacktraces on a public URL) and the Tailwind watcher, requires a real
+# signing key, and locks the LiveView websocket origin.
+deploy? = System.get_env("PLAYGROUND_DEPLOY") == "true"
+
+secret_key_base =
+  if deploy?,
+    do: System.fetch_env!("SECRET_KEY_BASE"),
+    else: String.duplicate("a", 64)
+
 # Pre-configure endpoint (PhoenixPlayground merges on top of this)
-Application.put_env(:phoenix_playground, Dev.Endpoint, secret_key_base: String.duplicate("a", 64))
+Application.put_env(:phoenix_playground, Dev.Endpoint, secret_key_base: secret_key_base)
 
 # Run initial Tailwind build before starting the server
 Mix.Task.run("tailwind", ["petal_dev"])
 
+deploy_endpoint_options =
+  if deploy? do
+    [
+      # The LiveView websocket rejects cross-origin connects; without this the
+      # deployed site dead-renders and every dial silently stops working.
+      check_origin: [
+        "https://playground.petal.build",
+        "https://petal-components-demo.fly.dev"
+      ],
+      url: [host: System.get_env("PHX_HOST", "playground.petal.build"), scheme: "https"]
+    ]
+  else
+    []
+  end
+
 PhoenixPlayground.start(
   endpoint: Dev.Endpoint,
   # OPEN_BROWSER=false for headless runs (CI, agents); PORT to avoid clashes
-  open_browser: System.get_env("OPEN_BROWSER", "true") != "false",
+  open_browser: not deploy? and System.get_env("OPEN_BROWSER", "true") != "false",
   port: String.to_integer(System.get_env("PORT", "4000")),
   # Dual-stack: "localhost" resolves to ::1 or 127.0.0.1 depending on the
   # client's Happy Eyeballs mood; a v4-only listener makes the LiveView
   # websocket silently fail on the ::1 pick (dead render, URL params ignored).
+  # (Fly's proxy also reaches the app over the v6 private network.)
   ip: {0, 0, 0, 0, 0, 0, 0, 0},
-  live_reload: true,
-  endpoint_options: [
-    debug_errors: true,
-    render_errors: [formats: [html: Dev.ErrorHTML], layout: false],
-    watchers: [
-      tailwind: {Tailwind, :install_and_run, [:petal_dev, ~w(--watch)]}
-    ]
-  ]
+  live_reload: not deploy?,
+  endpoint_options:
+    deploy_endpoint_options ++
+      [
+        debug_errors: not deploy?,
+        render_errors: [formats: [html: Dev.ErrorHTML], layout: false],
+        watchers:
+          if deploy? do
+            []
+          else
+            [tailwind: {Tailwind, :install_and_run, [:petal_dev, ~w(--watch)]}]
+          end
+      ]
 )

--- a/fly.toml
+++ b/fly.toml
@@ -1,8 +1,11 @@
 # Fly config for the hosted component playground (playground.petal.build).
 # Deploy: fly deploy --remote-only -a petal-components-demo
 # Requires secret: SECRET_KEY_BASE (mix phx.gen.secret)
+# yyz matches where the app's existing machine already lives - fly deploy
+# updates machines in place and never moves them, so primary_region saying
+# anything else would put future machines in a different region.
 app = "petal-components-demo"
-primary_region = "ewr"
+primary_region = "yyz"
 
 [build]
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,25 @@
+# Fly config for the hosted component playground (playground.petal.build).
+# Deploy: fly deploy --remote-only -a petal-components-demo
+# Requires secret: SECRET_KEY_BASE (mix phx.gen.secret)
+app = "petal-components-demo"
+primary_region = "ewr"
+
+[build]
+
+[env]
+  PLAYGROUND_DEPLOY = "true"
+  PORT = "8080"
+  PHX_HOST = "playground.petal.build"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  # Keep one machine warm: a cold boot re-runs the tailwind build and
+  # heroicons CSS generation, so first paint after a stop is slow.
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "1gb"


### PR DESCRIPTION
Hosts the component playground publicly on Fly (app `petal-components-demo`, then `playground.petal.build`).

## What
- `dev.exs`: `PLAYGROUND_DEPLOY=true` switches the same playground into deploy mode:
  - **Compiles out `Phoenix.CodeReloader`/`LiveReloader` in `Dev.Endpoint`** - the reloader re-evaluates the entire 8.6k-line file on every request. Measured: **12.7s/request with it, 2ms without**. (`live_reload: false` alone does not help; the plugs were hardcoded.)
  - Tailwind watcher off, `debug_errors` off, `SECRET_KEY_BASE` required from env, LiveView `check_origin` locked to the public hosts.
- `Dockerfile`: MIX_ENV=dev image (every playground dep is `only: :dev`), tailwind binary pre-installed at build, CSS still built at boot as usual.
- `.dockerignore`: `_build`/`deps` excluded (local checkouts have absolute-path symlinks that dangle on builders - the exact failure mode that broke CI on #500).
- `fly.toml`: 1GB shared-cpu-1x, one machine always warm.

## Verified locally
- Deploy mode: `?c=button/slider/toast` all 200 in ~2ms after boot; `/assets/app.css` 200 (1.7MB); `/dev-static` 200; unknown route renders plain "Not Found", no stacktrace.
- Dev mode unchanged: reloader + live-reload iframe still active with the flag unset.

Deploy steps after merge (separate, not in CI): `fly secrets set SECRET_KEY_BASE=...`, `fly deploy --remote-only`, measurement gate, then `fly certs add playground.petal.build`.