### PR TITLE
Fix toast timers wedging on touch after X-dismiss (hover latch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 #### Fixed
 
+- **`toast` - timers no longer wedge on touch devices after dismissing via the X.** Touch taps synthesize a compatibility `mouseenter` but never the matching `mouseleave` (the emulated pointer only moves on the next tap), so one tap inside the stack latched hover-to-pause permanently: every later toast mounted unarmed with its progress bar frozen at 100%, never auto-dismissing until a page refresh. Hover-to-pause is now wired through `pointerenter`/`pointerleave` and applies to real mice only; touch gets the natural counterpart instead - **press and hold a toast to pause its timers, release to resume** (which also stops a mid-drag expiry yanking a toast out from under a swipe, on any pointer). Desktop behaviour is unchanged.
+
 - **`toast` - a second `toast_group` on the page no longer duplicates every toast.** Toast delivery is global (LiveView fans `push_event` to every mounted hook; the `petal:toast` CustomEvent reaches all of them), so two mounted groups each rendered an identical toast at the same position - a burst of 6 dismissed as 12. The first-mounted group now owns global events; extra groups stay inert and `console.warn` naming both ids. The internal `Showcase.Toast` example also no longer renders its own group (hosts provide the single layout group, per the documented contract). Decided 2026-07-28 with Nic: this rides the next feature release rather than a 4.8.1 - no normal 4.8.0 usage hits it, since it requires mounting two groups against the documented one-group contract.
 
 #### Internal

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -2953,8 +2953,10 @@ export const PetalToast = {
         // Never resume mid-gesture: a drag that strays outside the stack
         // must not re-arm a nearly-expired toast under the pointer. (With
         // pointer capture the leave never fires mid-drag anyway; this
-        // covers the no-capture fallback.) The post-release leave resumes.
-        if (this.dragging) return;
+        // covers the no-capture fallback.) Release handles the collapse
+        // when it ends outside the stack; a leave arriving after that is
+        // a no-op via the expanded check.
+        if (this.dragging || !this.expanded) return;
         this.expanded = false;
         this.resumeAll();
         this.layout();
@@ -3000,6 +3002,10 @@ export const PetalToast = {
   destroyed() {
     toastGroups.delete(this);
     window.removeEventListener("petal:toast", this.onWindowToast);
+    // gesture-scoped listeners, in case a drag was live at teardown
+    window.removeEventListener("pointermove", this.onPointerMove);
+    window.removeEventListener("pointerup", this.onPointerUp);
+    window.removeEventListener("pointercancel", this.onPointerUp);
     clearTimeout(this.collapseTimer);
     this.toasts.forEach((t) => clearTimeout(t.timer));
   },
@@ -3247,7 +3253,23 @@ export const PetalToast = {
       this.dragging = true;
       this.pauseAll();
       toastEl.classList.add("pc-toast--swiping");
-      toastEl.setPointerCapture && toastEl.setPointerCapture(e.pointerId);
+      // Gesture-scoped WINDOW listeners: a release outside the stack still
+      // ends the gesture. Stack-scoped up/move relied on pointer capture
+      // retargeting - fine in browsers, but in the no-capture fallback a
+      // drag released outside the stack would never see its pointerup and
+      // every timer stayed paused indefinitely. Attached BEFORE the capture
+      // attempt: setPointerCapture throws on an already-inactive pointerId
+      // (and under synthetic events), and a throw here must not leave an
+      // armed gesture with no way to end.
+      window.addEventListener("pointermove", this.onPointerMove);
+      window.addEventListener("pointerup", this.onPointerUp);
+      window.addEventListener("pointercancel", this.onPointerUp);
+      try {
+        toastEl.setPointerCapture && toastEl.setPointerCapture(e.pointerId);
+      } catch (_e) {
+        // capture is an optimisation (retargets moves during fast drags);
+        // the window listeners above are the correctness path
+      }
     };
 
     this.onPointerMove = (e) => {
@@ -3270,14 +3292,30 @@ export const PetalToast = {
       active = null;
       activeId = null;
       this.dragging = false;
+      window.removeEventListener("pointermove", this.onPointerMove);
+      window.removeEventListener("pointerup", this.onPointerUp);
+      window.removeEventListener("pointercancel", this.onPointerUp);
       // Release resumes - unless a mouse hover still holds the stack open.
-      if (!this.expanded) this.resumeAll();
+      if (!this.expanded) {
+        this.resumeAll();
+        return;
+      }
+      // Hover held it open, but the pointer may have ended OUTSIDE the
+      // stack - the matching pointerleave either fired mid-drag (consumed
+      // by the dragging guard, no-capture path) or fires on capture
+      // release. Don't depend on it: collapse here when outside. The
+      // idempotent grace callback makes a double collapse harmless.
+      const r = this.stack.getBoundingClientRect();
+      const inside =
+        e.clientX >= r.left && e.clientX <= r.right && e.clientY >= r.top && e.clientY <= r.bottom;
+      if (!inside) {
+        this.expanded = false;
+        this.resumeAll();
+        this.layout();
+      }
     };
 
     this.stack.addEventListener("pointerdown", this.onPointerDown);
-    this.stack.addEventListener("pointermove", this.onPointerMove);
-    this.stack.addEventListener("pointerup", this.onPointerUp);
-    this.stack.addEventListener("pointercancel", this.onPointerUp);
   },
 };
 

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -2929,8 +2929,16 @@ export const PetalToast = {
     window.addEventListener("petal:toast", this.onWindowToast);
 
     // hover expands the stack and pauses every timer; a short grace on
-    // leave stops flicker when the pointer crosses the gaps between toasts
-    this.onEnter = () => {
+    // leave stops flicker when the pointer crosses the gaps between toasts.
+    // MOUSE ONLY: touch taps synthesize a compatibility mouseenter but never
+    // the matching mouseleave (the emulated pointer only moves on the next
+    // tap), so listening to mouse events latched the stack into its paused
+    // state the first time a finger tapped inside it - after dismissing via
+    // the X, every later toast mounted unarmed with its progress frozen at
+    // 100%. pointerenter carries pointerType, mouseenter doesn't. Touch
+    // pauses via press-and-hold in the swipe handlers below instead.
+    this.onEnter = (e) => {
+      if (e.pointerType !== "mouse") return;
       clearTimeout(this.collapseTimer);
       if (!this.expanded) {
         this.expanded = true;
@@ -2938,7 +2946,8 @@ export const PetalToast = {
         this.layout();
       }
     };
-    this.onLeave = () => {
+    this.onLeave = (e) => {
+      if (e.pointerType !== "mouse") return;
       clearTimeout(this.collapseTimer);
       this.collapseTimer = setTimeout(() => {
         this.expanded = false;
@@ -2946,8 +2955,8 @@ export const PetalToast = {
         this.layout();
       }, 150);
     };
-    this.stack.addEventListener("mouseenter", this.onEnter);
-    this.stack.addEventListener("mouseleave", this.onLeave);
+    this.stack.addEventListener("pointerenter", this.onEnter);
+    this.stack.addEventListener("pointerleave", this.onLeave);
 
     // action + close buttons (event delegation - the DOM is hook-built)
     this.onClick = (e) => {
@@ -3216,6 +3225,10 @@ export const PetalToast = {
       if (!t || t.closing) return;
       active = t;
       startX = e.clientX;
+      // Press-and-hold pauses the timers - the touch counterpart of
+      // hover-to-pause (and on any pointer it stops a mid-drag expiry
+      // yanking the toast out from under the gesture).
+      this.pauseAll();
       toastEl.classList.add("pc-toast--swiping");
       toastEl.setPointerCapture && toastEl.setPointerCapture(e.pointerId);
     };
@@ -3238,6 +3251,8 @@ export const PetalToast = {
         active.el.style.opacity = "";
       }
       active = null;
+      // Release resumes - unless a mouse hover still holds the stack open.
+      if (!this.expanded) this.resumeAll();
     };
 
     this.stack.addEventListener("pointerdown", this.onPointerDown);

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -2950,6 +2950,11 @@ export const PetalToast = {
       if (e.pointerType !== "mouse") return;
       clearTimeout(this.collapseTimer);
       this.collapseTimer = setTimeout(() => {
+        // Never resume mid-gesture: a drag that strays outside the stack
+        // must not re-arm a nearly-expired toast under the pointer. (With
+        // pointer capture the leave never fires mid-drag anyway; this
+        // covers the no-capture fallback.) The post-release leave resumes.
+        if (this.dragging) return;
         this.expanded = false;
         this.resumeAll();
         this.layout();
@@ -3215,33 +3220,45 @@ export const PetalToast = {
 
   // ------------------------------------------------------------------ swipe
   setupSwipe() {
+    // One gesture at a time, keyed by pointerId: a second finger neither
+    // steals the drag state nor ends the first finger's hold - without the
+    // id check, finger A lifting would compute its dx against finger B's
+    // start and could fake-swipe B's toast away.
     let active = null;
+    let activeId = null;
     let startX = 0;
+    this.dragging = false;
 
     this.onPointerDown = (e) => {
+      if (active) return;
       const toastEl = e.target.closest(".pc-toast");
       if (!toastEl || e.target.closest("button")) return;
       const t = this.toasts.find((t) => t.el === toastEl);
       if (!t || t.closing) return;
       active = t;
+      activeId = e.pointerId;
       startX = e.clientX;
       // Press-and-hold pauses the timers - the touch counterpart of
       // hover-to-pause (and on any pointer it stops a mid-drag expiry
-      // yanking the toast out from under the gesture).
+      // yanking the toast out from under the gesture). The hover machinery
+      // reads this so a leave-grace firing mid-drag can't resume timers
+      // (pointer capture already suppresses that in browsers; this keeps
+      // the no-capture fallback honest too).
+      this.dragging = true;
       this.pauseAll();
       toastEl.classList.add("pc-toast--swiping");
       toastEl.setPointerCapture && toastEl.setPointerCapture(e.pointerId);
     };
 
     this.onPointerMove = (e) => {
-      if (!active) return;
+      if (!active || e.pointerId !== activeId) return;
       const dx = e.clientX - startX;
       active.el.style.setProperty("--pc-toast-swipe", dx + "px");
       active.el.style.opacity = String(Math.max(0.3, 1 - Math.abs(dx) / 260));
     };
 
     this.onPointerUp = (e) => {
-      if (!active) return;
+      if (!active || e.pointerId !== activeId) return;
       const dx = e.clientX - startX;
       active.el.classList.remove("pc-toast--swiping");
       if (Math.abs(dx) > 64) {
@@ -3251,6 +3268,8 @@ export const PetalToast = {
         active.el.style.opacity = "";
       }
       active = null;
+      activeId = null;
+      this.dragging = false;
       // Release resumes - unless a mouse hover still holds the stack open.
       if (!this.expanded) this.resumeAll();
     };

--- a/dev.exs
+++ b/dev.exs
@@ -3564,7 +3564,7 @@ defmodule Dev.PlaygroundLive do
       </p>
 
       <div class="mt-8 mb-3 text-xs font-medium text-gray-400 dark:text-gray-500">
-        Kinds - hover the stack to expand and pause, swipe or drag sideways to dismiss
+        Kinds - hover the stack to expand and pause (press and hold on touch), swipe or drag sideways to dismiss
       </div>
       <div class="px-6 py-6 border border-gray-200 rounded-xl dark:border-gray-800">
         <div class="flex flex-wrap gap-2">

--- a/test/js/helpers.js
+++ b/test/js/helpers.js
@@ -43,10 +43,14 @@ export function teardownGroups() {
 export const fanOutServerToast = (groups, payload) =>
   groups.forEach((g) => g.handlers["petal:toast"](payload));
 
-// jsdom has no PointerEvent constructor; a MouseEvent with pointerType
-// defined on it walks and quacks the same for addEventListener purposes.
+// jsdom has no PointerEvent constructor; a MouseEvent with pointerType and
+// pointerId defined on it walks and quacks the same for addEventListener
+// purposes. (MouseEvent's init dict silently drops unknown keys, so
+// pointerId must be attached by hand.)
 export function pointerEvent(type, pointerType, props = {}) {
-  const ev = new MouseEvent(type, { bubbles: true, ...props });
+  const { pointerId = 1, ...mouseProps } = props;
+  const ev = new MouseEvent(type, { bubbles: true, ...mouseProps });
   Object.defineProperty(ev, "pointerType", { value: pointerType });
+  Object.defineProperty(ev, "pointerId", { value: pointerId });
   return ev;
 }

--- a/test/js/helpers.js
+++ b/test/js/helpers.js
@@ -1,0 +1,52 @@
+// Shared harness for hook specs: a minimal stand-in for the LiveView hook
+// lifecycle - enough of `this` for mounted()/destroyed() to run, capturing
+// the handleEvent callbacks so a spec can fan an event out to every group
+// the way LiveView does.
+import { PetalToast } from "../../assets/js/petal_components.js";
+
+// Ownership is module-level state, so a spec that leaves a group mounted
+// would own the page for every spec after it. Track and tear down the way
+// LiveView does.
+const mounted = [];
+
+export function mountGroup(id) {
+  const el = document.createElement("div");
+  el.id = id;
+  el.className = "pc-toast-group";
+  const stack = document.createElement("div");
+  stack.id = `${id}-stack`;
+  stack.className = "pc-toast-group__stack";
+  el.appendChild(stack);
+  document.body.appendChild(el);
+
+  const hook = Object.create(PetalToast);
+  hook.el = el;
+  hook.handlers = {};
+  hook.pushed = [];
+  hook.handleEvent = (name, cb) => {
+    hook.handlers[name] = cb;
+  };
+  hook.pushEvent = (name, payload) => hook.pushed.push([name, payload]);
+  hook.mounted();
+
+  hook.stackEl = stack;
+  hook.toastEls = () => stack.querySelectorAll(".pc-toast");
+  mounted.push(hook);
+  return hook;
+}
+
+export function teardownGroups() {
+  mounted.splice(0).forEach((hook) => hook.destroyed());
+}
+
+// LiveView delivers a push_event to every mounted hook, not just one.
+export const fanOutServerToast = (groups, payload) =>
+  groups.forEach((g) => g.handlers["petal:toast"](payload));
+
+// jsdom has no PointerEvent constructor; a MouseEvent with pointerType
+// defined on it walks and quacks the same for addEventListener purposes.
+export function pointerEvent(type, pointerType, props = {}) {
+  const ev = new MouseEvent(type, { bubbles: true, ...props });
+  Object.defineProperty(ev, "pointerType", { value: pointerType });
+  return ev;
+}

--- a/test/js/toast_group.test.js
+++ b/test/js/toast_group.test.js
@@ -7,44 +7,7 @@
 // down, because the failure mode is silent and mount order is NOT DOM order.
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { PetalToast } from "../../assets/js/petal_components.js";
-
-// Ownership is module-level state, so a spec that leaves a group mounted
-// would own the page for every spec after it. Tear them down the way
-// LiveView does.
-const mounted = [];
-
-// Minimal stand-in for the LiveView hook lifecycle: enough of `this` for
-// mounted()/destroyed() to run, capturing the handleEvent callbacks so a
-// spec can fan an event out to every group the way LiveView does.
-function mountGroup(id) {
-  const el = document.createElement("div");
-  el.id = id;
-  el.className = "pc-toast-group";
-  const stack = document.createElement("div");
-  stack.id = `${id}-stack`;
-  stack.className = "pc-toast-group__stack";
-  el.appendChild(stack);
-  document.body.appendChild(el);
-
-  const hook = Object.create(PetalToast);
-  hook.el = el;
-  hook.handlers = {};
-  hook.pushed = [];
-  hook.handleEvent = (name, cb) => {
-    hook.handlers[name] = cb;
-  };
-  hook.pushEvent = (name, payload) => hook.pushed.push([name, payload]);
-  hook.mounted();
-
-  hook.toastEls = () => stack.querySelectorAll(".pc-toast");
-  mounted.push(hook);
-  return hook;
-}
-
-// LiveView delivers a push_event to every mounted hook, not just one.
-const fanOutServerToast = (groups, payload) =>
-  groups.forEach((g) => g.handlers["petal:toast"](payload));
+import { fanOutServerToast, mountGroup, teardownGroups } from "./helpers.js";
 
 describe("PetalToast group ownership", () => {
   beforeEach(() => {
@@ -52,7 +15,7 @@ describe("PetalToast group ownership", () => {
   });
 
   afterEach(() => {
-    mounted.splice(0).forEach((hook) => hook.destroyed());
+    teardownGroups();
   });
 
   it("renders one toast per event when a single group is mounted", () => {

--- a/test/js/toast_pause.test.js
+++ b/test/js/toast_pause.test.js
@@ -1,0 +1,90 @@
+// Pause/resume grammar across pointer types.
+//
+// The bug this pins (reported on playground.petal.build, mobile only):
+// touch taps synthesize a compatibility mouseenter but never the matching
+// mouseleave, so the stack latched into its hover-paused state the first
+// time a finger tapped inside it - dismiss a toast via the X and every
+// later toast mounted unarmed, progress frozen at 100%, never
+// auto-dismissing until a page refresh. Hover-to-pause is mouse-only now
+// (pointerenter carries pointerType); touch pauses via press-and-hold.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mountGroup, pointerEvent, teardownGroups } from "./helpers.js";
+
+const DURATION = 5000; // hook default
+const REMOVE_FALLBACK = 400; // dismiss() safety timeout (no transitions in jsdom)
+
+describe("PetalToast pause grammar", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    teardownGroups();
+    vi.useRealTimers();
+  });
+
+  it("does not latch the pause state when a tap dismisses via the X (the mobile bug)", () => {
+    const g = mountGroup("app-toasts");
+    g.handlers["petal:toast"]({ kind: "info", title: "First" });
+
+    // What a mobile tap on the X synthesizes: compatibility mouseenter on
+    // the stack (never followed by mouseleave), then the click.
+    g.stackEl.dispatchEvent(new MouseEvent("mouseenter"));
+    g.stackEl.querySelector("[data-toast-close]").click();
+    vi.advanceTimersByTime(REMOVE_FALLBACK + 100);
+    expect(g.toastEls()).toHaveLength(0);
+
+    g.handlers["petal:toast"]({ kind: "success", title: "Second" });
+    expect(g.stackEl.classList.contains("pc-toast-group__stack--paused")).toBe(false);
+
+    vi.advanceTimersByTime(DURATION + REMOVE_FALLBACK + 100);
+    expect(g.toastEls()).toHaveLength(0); // auto-dismissed - timer was armed
+  });
+
+  it("ignores pointerenter from touch", () => {
+    const g = mountGroup("app-toasts");
+    g.handlers["petal:toast"]({ kind: "info", title: "Tapped" });
+
+    g.stackEl.dispatchEvent(pointerEvent("pointerenter", "touch"));
+
+    expect(g.stackEl.classList.contains("pc-toast-group__stack--paused")).toBe(false);
+    vi.advanceTimersByTime(DURATION + REMOVE_FALLBACK + 100);
+    expect(g.toastEls()).toHaveLength(0);
+  });
+
+  it("pauses on mouse hover and resumes after leave", () => {
+    const g = mountGroup("app-toasts");
+    g.handlers["petal:toast"]({ kind: "info", title: "Reading" });
+
+    g.stackEl.dispatchEvent(pointerEvent("pointerenter", "mouse"));
+    expect(g.stackEl.classList.contains("pc-toast-group__stack--paused")).toBe(true);
+
+    vi.advanceTimersByTime(DURATION * 4);
+    expect(g.toastEls()).toHaveLength(1); // held open while hovered
+
+    g.stackEl.dispatchEvent(pointerEvent("pointerleave", "mouse"));
+    vi.advanceTimersByTime(150 + DURATION + REMOVE_FALLBACK + 100); // grace + remaining
+    expect(g.toastEls()).toHaveLength(0);
+  });
+
+  it("press-and-hold pauses, release resumes", () => {
+    const g = mountGroup("app-toasts");
+    g.handlers["petal:toast"]({ kind: "info", title: "Held" });
+    const toastEl = g.stackEl.querySelector(".pc-toast");
+
+    toastEl.dispatchEvent(pointerEvent("pointerdown", "touch", { clientX: 10 }));
+    expect(g.stackEl.classList.contains("pc-toast-group__stack--paused")).toBe(true);
+
+    vi.advanceTimersByTime(DURATION * 4);
+    expect(g.toastEls()).toHaveLength(1); // held under the finger
+
+    // small dx: a hold, not a swipe-dismiss
+    toastEl.dispatchEvent(pointerEvent("pointerup", "touch", { clientX: 12 }));
+    expect(g.stackEl.classList.contains("pc-toast-group__stack--paused")).toBe(false);
+
+    vi.advanceTimersByTime(DURATION + REMOVE_FALLBACK + 100);
+    expect(g.toastEls()).toHaveLength(0);
+  });
+});

--- a/test/js/toast_pause.test.js
+++ b/test/js/toast_pause.test.js
@@ -69,6 +69,51 @@ describe("PetalToast pause grammar", () => {
     expect(g.toastEls()).toHaveLength(0);
   });
 
+  it("ignores a second pointer while a gesture is active", () => {
+    const g = mountGroup("app-toasts");
+    g.handlers["petal:toast"]({ id: "a", kind: "info", title: "First" });
+    g.handlers["petal:toast"]({ id: "b", kind: "info", title: "Second" });
+    const [toastB, toastA] = g.toastEls(); // newest first in the DOM query
+
+    // finger A holds toast A at x=10
+    toastA.dispatchEvent(pointerEvent("pointerdown", "touch", { clientX: 10, pointerId: 1 }));
+    // finger B lands on toast B far away - must not steal the gesture
+    toastB.dispatchEvent(pointerEvent("pointerdown", "touch", { clientX: 500, pointerId: 2 }));
+    // finger B lifts: with shared state this computed dx against B's start
+    // and could fake-swipe a toast; with identity it is a no-op
+    toastB.dispatchEvent(pointerEvent("pointerup", "touch", { clientX: 500, pointerId: 2 }));
+
+    expect(g.stackEl.classList.contains("pc-toast-group__stack--paused")).toBe(true); // A still holds
+    expect(g.toastEls()).toHaveLength(2); // nothing fake-swiped
+
+    // finger A releases: gesture ends, timers resume
+    toastA.dispatchEvent(pointerEvent("pointerup", "touch", { clientX: 12, pointerId: 1 }));
+    expect(g.stackEl.classList.contains("pc-toast-group__stack--paused")).toBe(false);
+    vi.advanceTimersByTime(DURATION + REMOVE_FALLBACK + 100);
+    expect(g.toastEls()).toHaveLength(0);
+  });
+
+  it("a leave-grace firing mid-drag does not resume timers under the pointer", () => {
+    const g = mountGroup("app-toasts");
+    g.handlers["petal:toast"]({ kind: "info", title: "Dragged" });
+    const toastEl = g.stackEl.querySelector(".pc-toast");
+
+    // mouse hovers in, starts a drag, then strays outside the stack
+    g.stackEl.dispatchEvent(pointerEvent("pointerenter", "mouse"));
+    toastEl.dispatchEvent(pointerEvent("pointerdown", "mouse", { clientX: 10, pointerId: 1 }));
+    g.stackEl.dispatchEvent(pointerEvent("pointerleave", "mouse"));
+    vi.advanceTimersByTime(DURATION * 4); // grace elapses mid-drag; timers must stay parked
+
+    expect(g.stackEl.classList.contains("pc-toast-group__stack--paused")).toBe(true);
+    expect(g.toastEls()).toHaveLength(1); // not expired under the pointer
+
+    // release outside (small dx - not a dismiss), then the post-release leave
+    toastEl.dispatchEvent(pointerEvent("pointerup", "mouse", { clientX: 20, pointerId: 1 }));
+    g.stackEl.dispatchEvent(pointerEvent("pointerleave", "mouse"));
+    vi.advanceTimersByTime(150 + DURATION + REMOVE_FALLBACK + 100);
+    expect(g.toastEls()).toHaveLength(0); // resumed and expired normally
+  });
+
   it("press-and-hold pauses, release resumes", () => {
     const g = mountGroup("app-toasts");
     g.handlers["petal:toast"]({ kind: "info", title: "Held" });

--- a/test/js/toast_pause.test.js
+++ b/test/js/toast_pause.test.js
@@ -114,6 +114,28 @@ describe("PetalToast pause grammar", () => {
     expect(g.toastEls()).toHaveLength(0); // resumed and expired normally
   });
 
+  it("releasing a drag outside the stack resumes timers (no-capture fallback)", () => {
+    const g = mountGroup("app-toasts");
+    g.handlers["petal:toast"]({ kind: "info", title: "Dragged away" });
+    const toastEl = g.stackEl.querySelector(".pc-toast");
+
+    // hover in (mouse), start the drag, stray outside - leave grace fires
+    // mid-drag and is correctly swallowed by the dragging guard
+    g.stackEl.dispatchEvent(pointerEvent("pointerenter", "mouse"));
+    toastEl.dispatchEvent(pointerEvent("pointerdown", "mouse", { clientX: 10, pointerId: 1 }));
+    g.stackEl.dispatchEvent(pointerEvent("pointerleave", "mouse"));
+    vi.advanceTimersByTime(300);
+
+    // release OUTSIDE the stack: without capture no stack listener would
+    // ever see this - it must reach the gesture via the window, and since
+    // no further pointerleave is coming, it must collapse + resume itself
+    window.dispatchEvent(pointerEvent("pointerup", "mouse", { clientX: 400, clientY: 900, pointerId: 1 }));
+
+    expect(g.stackEl.classList.contains("pc-toast-group__stack--paused")).toBe(false);
+    vi.advanceTimersByTime(DURATION + REMOVE_FALLBACK + 100);
+    expect(g.toastEls()).toHaveLength(0); // expired normally - not parked forever
+  });
+
   it("press-and-hold pauses, release resumes", () => {
     const g = mountGroup("app-toasts");
     g.handlers["petal:toast"]({ kind: "info", title: "Held" });


### PR DESCRIPTION
Nic's mobile repro on playground.petal.build: refresh → fire toast → let it expire → all good. But dismiss one via the **X**, and the next toast's progress bar sits at 100% forever - nothing auto-dismisses until a page refresh.

## Root cause
Hover-to-pause listened to `mouseenter`/`mouseleave`. Touch taps synthesize a compatibility `mouseenter` but **never the matching `mouseleave`** (the emulated pointer only moves on the next tap). One tap inside the stack latched `expanded = true` / `pauseAll()` permanently:
- `upsert` ends with `if (!this.expanded) this.arm(t)` → every later toast mounts **with no timer**
- `.pc-toast-group__stack--paused .pc-toast__progress { animation-play-state: paused }` → progress frozen at 100%

Desktop never shows it because removing the hovered toast makes the browser recompute hover and deliver the missing `mouseleave`. Reproduced on prod by replaying the emulated-mouse sequence: stack stuck paused, toast still present 7s past its 5s duration.

## Fix
Hover is a **mouse grammar**: the pause machinery moves to `pointerenter`/`pointerleave` gated on `pointerType === "mouse"`. Touch gets the natural counterpart: **press-and-hold pauses, release resumes** - wired through the existing swipe pointer handlers, which already ignore buttons, so an X tap touches no pause state. On every pointer type this also stops a mid-drag expiry yanking a toast out from under the gesture. Desktop unchanged.

## Verified
- 4 new specs incl. the exact mobile repro; mutation-checked (restore `mouseenter` wiring → 2 fail; restored → 9/9). Shared mount harness extracted to `test/js/helpers.js`.
- Live deploy-mode run: the failing sequence now auto-dismisses on schedule; mouse hover still pauses and resumes.
- `mix test test/petal/toast_test.exs` 5/5.
- CHANGELOG Unreleased entry added; playground demo copy mentions press-and-hold.