### PR TITLE
🔖 Release 4.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-### Unreleased
+### 4.8.1 - 2026-07-28
 
 #### Fixed
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PetalComponents.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/petalframework/petal_components"
-  @version "4.8.0"
+  @version "4.8.1"
 
   def project do
     [


### PR DESCRIPTION
Patch release: the two toast fixes that landed on main since 4.8.0, both found on the live playground within hours of it going public.

- **Toast timers wedging on touch after X-dismiss** (#506) - touch taps synthesize `mouseenter` but never the matching `mouseleave`, so one tap latched hover-to-pause permanently: every later toast mounted unarmed, progress frozen at 100% until a page refresh. Real user-facing bug on the mobile half of the web, in 4.8's flagship component. Hover-to-pause is now mouse-only (`pointerType`-gated); touch gets press-and-hold; gestures are window-scoped and pointerId-keyed.
- **Duplicate toasts with a second `toast_group`** (#505) - ownership election (first mounted wins, extras warn + stay inert) and the internal `Showcase.Toast` example no longer renders its own group.

Shipping this ahead of the 4.8 announcement thread, which will point mobile-heavy X traffic at the toast page.

CHANGELOG: Unreleased section rolled to `4.8.1 - 2026-07-28`. Version bump only otherwise - all substantive changes were reviewed in #505/#506 (both ended Greptile 5/5, every spec mutation-checked).

Verified on this branch: `mix test` 676/676, `npm test` 12/12, `mix hex.build` packages clean as 4.8.1.