### PR TITLE
Keep the toast showcase example attached to toast_group (MCP extractor)

### DIFF
--- a/lib/petal_components/showcase/toast.ex
+++ b/lib/petal_components/showcase/toast.ex
@@ -16,6 +16,7 @@ defmodule PetalComponents.Showcase.Toast do
     description:
       "One toast_group in the layout catches everything: Toast.send_toast/3 from the server, put_flash for free, or - as here - a plain petal:toast CustomEvent from the client. Fire a few and hover the stack." do
     ~H"""
+    <%!-- once, in your root layout: <.toast_group flash={@flash} /> --%>
     <div class="flex flex-wrap items-center justify-center gap-2">
       <.button
         color="gray"


### PR DESCRIPTION
One-line follow-up to #505, caught during the 4.8.1 MCP schema sync: the extractor attaches showcase examples to a component only when the example's code uses its tag (`example_uses?/2`). Removing the inline `<.toast_group>` meant toast's only curated example no longer matched - `examples: []` in schemas.json for the flagship component.

Fix: a HEEx comment as the example's first line - renders nothing (no second group mounted, the #505 contract holds) but keeps the tag in the captured code, so the example attaches AND explicitly teaches where the group goes, which the old inline-group version actively mis-taught.

Plan: merge inside Hex's one-hour replace window and re-publish 4.8.1 via `mix hex.publish --replace` (zero runtime change - showcase example content only), then re-run the MCP extract.