### PR TITLE
Scheme-switch icon sizing must beat consumer heroicon CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+### Unreleased
+
+#### Fixed
+
+- **`color_scheme_switch` - icons no longer ride high in consumer apps.** The controls' icon-fill rule tied on specificity with the host app's own heroicon CSS, so whichever stylesheet loaded last won - petal.build's heroicon rules loaded after the package CSS and pushed the glyphs to 20x24 inside the 20px icon boxes. The fill rule now carries (0,2,0) specificity and forces `display: block`, so the wrapper is the sizing contract regardless of the consumer's heroicon setup or import order. Playground and custom icon slots verified unchanged.
+
 ### 4.8.1 - 2026-07-28
 
 #### Fixed

--- a/assets/default.css
+++ b/assets/default.css
@@ -4915,12 +4915,19 @@
   }
 
   /* Icon wrappers size whatever they hold - the default Heroicon or any
-     svg dropped in via the light_icon/dark_icon/system_icon slots. */
-  .pc-scheme-toggle__sun > *,
-  .pc-scheme-toggle__moon > *,
-  .pc-scheme-segmented__icon > *,
-  .pc-scheme-dropdown__item-icon > * {
-    @apply w-full h-full;
+     svg dropped in via the light_icon/dark_icon/system_icon slots. The
+     selectors are doubled ON PURPOSE: consumer heroicon CSS also sizes
+     bare hero-* spans by single class, and at equal specificity whichever
+     stylesheet loads LAST wins - petal.build's heroicon rules loaded after
+     this file and pushed the glyphs to 20x24 inside these 20px boxes, so
+     every icon rode high. (0,2,0) beats any single-class consumer rule
+     regardless of import order; `block` also neutralises consumer
+     display/vertical-align choices inside the flex-centered wrappers. */
+  .pc-scheme-toggle .pc-scheme-toggle__sun > *,
+  .pc-scheme-toggle .pc-scheme-toggle__moon > *,
+  .pc-scheme-segmented .pc-scheme-segmented__icon > *,
+  .pc-scheme-dropdown__item .pc-scheme-dropdown__item-icon > * {
+    @apply block w-full h-full;
   }
 
   .pc-scheme-toggle__sun {


### PR DESCRIPTION
Found via petal.build (first real consumer surface): every scheme-control icon rode high because the package's icon-fill rule tied at (0,1,0) specificity with the host's own heroicon CSS - whichever stylesheet loads last wins, and marketing's heroicon rules load after the package's, computing 20x24 glyphs inside the 20px icon boxes.

The playground never showed it: its generated heroicons.css is imported `layer(base)`, and layered rules lose to the package's unlayered fill rule regardless of order - which is exactly why the playground isn't a faithful consumer testbed for CSS-order bugs.

Fix: doubled selectors carry (0,2,0) - beats any single-class consumer rule in either import order - plus `block` to neutralise consumer display/vertical-align choices inside the flex-centered wrappers. No markup changes.

Verified on the playground: toggle / segmented / open dropdown items / custom slot svgs all 20x20 and nested, toggle still flips the scheme. petal.build carries a matching temp override (marked for removal) until this ships in the next release.