### PR TITLE
Fathom analytics on the deployed playground

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -23,6 +23,17 @@ end
 defmodule Dev.Layouts do
   use Phoenix.Component
 
+  # Fathom (cookieless, no personal data, nothing to consent to) on the
+  # PUBLIC deployment only: PLAYGROUND_DEPLOY gates it so a local
+  # `mix run dev.exs` never phones home, and the site id comes from the
+  # environment so anyone forking this repo and deploying their own
+  # playground doesn't report into ours. data-spa="auto" because choosing
+  # a component is a push_patch, not a page load - without it we'd record
+  # one pageview per session no matter how much of the library you browse.
+  defp fathom_site do
+    if System.get_env("PLAYGROUND_DEPLOY") == "true", do: System.get_env("FATHOM_SITE_ID")
+  end
+
   def root(assigns) do
     ~H"""
     <!DOCTYPE html>
@@ -45,6 +56,15 @@ defmodule Dev.Layouts do
         </script>
         <meta name="pg-rev" content="alert-badge-1" />
         <link rel="stylesheet" href="/assets/app.css" />
+        <script
+          :if={fathom_site()}
+          src="https://cdn.usefathom.com/script.js"
+          data-site={fathom_site()}
+          data-spa="auto"
+          data-canonical="false"
+          defer
+        >
+        </script>
       </head>
       <body class="bg-white antialiased">
         <script>


### PR DESCRIPTION
playground.petal.build shipped without any measurement, so we currently cannot tell whether it gets used at all.

Adds Fathom (cookieless, no personal data collected, nothing to consent to), **double-gated**:
- `PLAYGROUND_DEPLOY=true` - a local `mix run dev.exs` never phones home
- `FATHOM_SITE_ID` from the environment - the id isn't baked into this open-source repo, so anyone forking and deploying their own playground doesn't report into ours

`data-spa="auto"` is load-bearing rather than cargo-culted: picking a component is a `push_patch` (dev.exs:1504), not a page load. Without it, a visitor browsing thirty components registers a single pageview - and per-component interest is precisely the signal worth having.

## Verified locally, all three states
| PLAYGROUND_DEPLOY | FATHOM_SITE_ID | script rendered |
|---|---|---|
| true | set | yes, `data-site="RZGYGJEV"` |
| true | unset | no |
| unset (local dev) | set | **no** |

Deploy side (separate from this PR): `fly secrets set FATHOM_SITE_ID=... -a petal-components-demo`. The Fathom site is the existing "Petal Components Playground" (RZGYGJEV) - the same site that already covered petal-components-demo.fly.dev, which is the very app the playground now runs on, with multi-domains enabled so both hostnames count.