### PR TITLE
feat(showcase): button joins the example registry (first 4.9 conversion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ### Unreleased
 
+#### Added
+
+- **Showcase registry: `button` joins.** The playground's button sections (variants, semantic colours, sizes, states, icon button) become registry examples - shown code is the rendered code, captured at compile time - so the playground, petal.build and the curated examples mcp.petal.build serves to AI assistants all document buttons from one source. The playground page keeps its interactive dials, and the states example now also shows `icon_placement="right"`.
+
 #### Fixed
 
 - **`color_scheme_switch` - icons no longer ride high in consumer apps.** The controls' icon-fill rule tied on specificity with the host app's own heroicon CSS, so whichever stylesheet loaded last won - petal.build's heroicon rules loaded after the package CSS and pushed the glyphs to 20x24 inside the 20px icon boxes. The fill rule now carries (0,2,0) specificity and forces `display: block`, so the wrapper is the sizing contract regardless of the consumer's heroicon setup or import order. Playground and custom icon slots verified unchanged.

--- a/dev.exs
+++ b/dev.exs
@@ -2512,57 +2512,22 @@ defmodule Dev.PlaygroundLive do
         class="p-4 mt-2 overflow-x-auto text-sm text-gray-100 bg-gray-900 rounded-xl dark:border dark:border-gray-800"
       ><code>{button_snippet(assigns)}</code></pre>
 
-      <div class="mt-12 mb-3 text-xs font-medium text-gray-400 dark:text-gray-500">Variants</div>
-      <div class="flex flex-wrap items-center justify-center gap-3 px-6 py-10 border border-gray-200 rounded-xl dark:border-gray-800">
-        <.button>Solid</.button>
-        <.button variant="soft">Soft</.button>
-        <.button variant="light">Light</.button>
-        <.button variant="outline">Outline</.button>
-        <.button variant="ghost">Ghost</.button>
-      </div>
-
-      <div class="mt-10 mb-3 text-xs font-medium text-gray-400 dark:text-gray-500">
-        Semantic colours
-      </div>
-      <div class="flex flex-wrap items-center justify-center gap-3 px-6 py-8 border border-gray-200 rounded-xl dark:border-gray-800">
-        <.button color="info" variant={@variant}>Info</.button>
-        <.button color="success" variant={@variant}>Success</.button>
-        <.button color="warning" variant={@variant}>Warning</.button>
-        <.button color="danger" variant={@variant}>Danger</.button>
-      </div>
-
-      <div class="mt-10 mb-3 text-xs font-medium text-gray-400 dark:text-gray-500">Sizes</div>
-      <div class="flex flex-wrap items-center justify-center gap-3 px-6 py-8 border border-gray-200 rounded-xl dark:border-gray-800">
-        <.button size="xs">Extra small</.button>
-        <.button size="sm">Small</.button>
-        <.button size="md">Medium</.button>
-        <.button size="lg">Large</.button>
-        <.button size="xl">Extra large</.button>
-      </div>
-
-      <div class="mt-10 mb-3 text-xs font-medium text-gray-400 dark:text-gray-500">States</div>
-      <div class="flex flex-wrap items-center justify-center gap-3 px-6 py-8 border border-gray-200 rounded-xl dark:border-gray-800">
-        <.button>Default</.button>
-        <.button icon="hero-rocket-launch">With icon</.button>
-        <.button loading>Loading</.button>
-        <.button disabled>Disabled</.button>
-      </div>
-
-      <div class="mt-10 mb-3 text-xs font-medium text-gray-400 dark:text-gray-500">Icon button</div>
-      <div class="flex flex-wrap items-center justify-center gap-3 px-6 py-8 border border-gray-200 rounded-xl dark:border-gray-800">
-        <.button size="icon" aria-label="Submit">
-          <.icon name="hero-arrow-up" class="w-5 h-5" />
-        </.button>
-        <.button variant="outline" size="icon" aria-label="Add">
-          <.icon name="hero-plus" class="w-5 h-5" />
-        </.button>
-        <.button variant="ghost" size="icon" aria-label="Settings">
-          <.icon name="hero-cog-6-tooth" class="w-5 h-5" />
-        </.button>
+      <div :for={ex <- PetalComponents.Showcase.Button.examples()} class="mt-10">
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
       </div>
 
       <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
       <.showcase_props component={PetalComponents.Button} functions={[:button, :icon_button]} />
+
+      <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        These examples render from the shared <code>PetalComponents.Showcase.Button</code>
+        registry - the same source petal.build renders, so the playground and the marketing
+        docs can't drift.
+      </div>
     </div>
     """
   end

--- a/lib/petal_components/showcase/button.ex
+++ b/lib/petal_components/showcase/button.ex
@@ -1,0 +1,80 @@
+defmodule PetalComponents.Showcase.Button do
+  @moduledoc false
+  use PetalComponents.Showcase,
+    component: PetalComponents.Button,
+    title: "Button",
+    functions: [:button, :icon_button]
+
+  example :variants, "Variants",
+    description:
+      "Five fill styles, one per action weight: solid carries the primary action, soft and light tint the surface (soft adapts its tint to dark mode, light stays light in both), outline and ghost recede to chrome. inverted and shadow still render but are legacy - prefer outline." do
+    ~H"""
+    <div class="flex flex-wrap items-center justify-center gap-3">
+      <.button>Solid</.button>
+      <.button variant="soft">Soft</.button>
+      <.button variant="light">Light</.button>
+      <.button variant="outline">Outline</.button>
+      <.button variant="ghost">Ghost</.button>
+    </div>
+    """
+  end
+
+  example :semantic_colors, "Semantic colours",
+    description:
+      "For actions that carry meaning: info, success, warning and danger tint every variant - solid shown here; soften the signal with variant=\"soft\" or \"outline\". primary, secondary and gray cover everything else." do
+    ~H"""
+    <div class="flex flex-wrap items-center justify-center gap-3">
+      <.button color="info">Info</.button>
+      <.button color="success">Success</.button>
+      <.button color="warning">Warning</.button>
+      <.button color="danger">Danger</.button>
+    </div>
+    """
+  end
+
+  example :sizes, "Sizes",
+    description:
+      "Five sizes, xs to xl, md the default. Padding, type and icon scale together, so a size change never needs a class override." do
+    ~H"""
+    <div class="flex flex-wrap items-center justify-center gap-3">
+      <.button size="xs">Extra small</.button>
+      <.button size="sm">Small</.button>
+      <.button size="md">Medium</.button>
+      <.button size="lg">Large</.button>
+      <.button size="xl">Extra large</.button>
+    </div>
+    """
+  end
+
+  example :states, "States",
+    description:
+      "icon renders a Heroicon beside the label; icon_placement=\"right\" moves it after, for arrows and continues. loading swaps the icon's side for a spinner so the button never reflows mid-submit, and disabled mutes the button and blocks the click." do
+    ~H"""
+    <div class="flex flex-wrap items-center justify-center gap-3">
+      <.button>Default</.button>
+      <.button icon="hero-rocket-launch">With icon</.button>
+      <.button icon="hero-arrow-right" icon_placement="right">Continue</.button>
+      <.button loading>Loading</.button>
+      <.button disabled>Disabled</.button>
+    </div>
+    """
+  end
+
+  example :icon_button, "Icon button",
+    description:
+      "size=\"icon\" renders a square, md-height button for a lone glyph - toolbars, composers, close affordances. A glyph is not a name, so pair it with an aria-label. Every variant and colour applies." do
+    ~H"""
+    <div class="flex flex-wrap items-center justify-center gap-3">
+      <.button size="icon" aria-label="Submit">
+        <.icon name="hero-arrow-up" class="w-5 h-5" />
+      </.button>
+      <.button variant="outline" size="icon" aria-label="Add">
+        <.icon name="hero-plus" class="w-5 h-5" />
+      </.button>
+      <.button variant="ghost" size="icon" aria-label="Settings">
+        <.icon name="hero-cog-6-tooth" class="w-5 h-5" />
+      </.button>
+    </div>
+    """
+  end
+end

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -13,6 +13,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.Aurora,
     PetalComponents.Showcase.Avatar,
     PetalComponents.Showcase.BorderBeam,
+    PetalComponents.Showcase.Button,
     PetalComponents.Showcase.Carousel,
     PetalComponents.Showcase.Chart,
     PetalComponents.Showcase.Chat,


### PR DESCRIPTION
## What

Converts the playground's legacy button page to the shared showcase registry - the first of the 4.9 registry conversions, prioritised as AI-channel supply: every converted component means mcp.petal.build serves curated, compile-checked examples for the components AI assistants write most often, and button is the most-written one.

- **New `PetalComponents.Showcase.Button`** with five examples converting the page's five static sections: variants, semantic colours, sizes, states, icon button. Shown code is the rendered code, captured at compile time.
- **Registered in `Showcase.Registry`** (the completeness test enforces this).
- **The playground page** (`?c=button` / `/`) now renders the registry loop + props table + registry footer note, exactly like the already-converted pages (avatar, accordion, carousel). The interactive dials (colour / variant / size / icon / state) and the live snippet stay - they are playground-only and not part of the registry.

## Conversion notes

- **Extractor attachment verified end-to-end** (the petal_components#508 lesson): the MCP extractor attaches an example to a component function only if the example's code renders its tag (`example_uses?/2`). Ran the real `extract_schemas.exs` against this tree: `button -> 5 examples`, each containing `<.button`. `icon_button` stays attrs-only on purpose - it is the legacy path and no curated example should teach it.
- **States now also shows `icon_placement="right"`** (the 4.8 addition), so the curated set covers both icon sides and the no-reflow loading contract.
- **Semantic colours was dial-linked** (`variant={@variant}`); registry examples are static by contract, so it pins the solid default and the description points at `variant="soft"` / `"outline"` for softer signals.

## Verification

- `mix test`: 676 tests, 0 failures (registry completeness, render, highlight, unique-id checks all cover the new module).
- `mix format --check-formatted` and `mix compile --warnings-as-errors` clean.
- Real MCP extract run against this branch via a scratch mix project pointing at the worktree: all five examples attach to `button`, none leak to `icon_button` or `button_group`.
- Playground booted in deploy mode (`PLAYGROUND_DEPLOY=true ... PORT=4108`): all five `pcsx-*` frames render with lumis-highlighted code panels and copy buttons, both props tables render, dials verified live in the browser (colour dial round-trips, hero button restyles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)