### PR TITLE
🔖 Release 4.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-### Unreleased
+### 4.9.0 - 2026-07-30
 
 #### Added
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PetalComponents.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/petalframework/petal_components"
-  @version "4.8.1"
+  @version "4.9.0"
 
   def project do
     [


### PR DESCRIPTION
Version bump 4.8.1 → 4.9.0 and CHANGELOG date-stamp for the registry release.

**What ships in 4.9.0** (all merged on main via #512–#517):
- The showcase registry covers the whole library: **36 modules / 86 curated, compile-checked examples / 178 extractor attachments** — playground, petal.build and mcp.petal.build render from one source.
- `tab` declares `link_type="button"` and pins `type="button"` (button tabs inside forms submitted them).
- `color_scheme_switch` icon-sizing specificity fix (consumer-app CSS ordering).
- Example-level teaching corrections (multi-select naming, checkbox-group `[]`, alert dismissal, progress label sizes, stepper map contract).

Post-merge train: tag `v4.9.0` → `mix hex.publish` (Nic, TTY) → marketing dep bump + docs-page conversions → MCP extract + redeploy → changelog entry + comms drafts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)