### PR TITLE
feat(showcase): marquee gets the striking spread; review_card works photo-less

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **`review_card` works without a photo.** `img` is optional now: leave it off and the card hashes a deterministic gradient monogram from the reviewer's name - testimonial walls with zero photo assets. With `img` set, nothing changes.
+- **Showcase registry: marquee grows the striking spread.** The logo strip (styled wordmarks - swap in your `<img>` logos and nothing else changes) and the testimonial wall (two counter-rotating rows of photo-less review cards). The playground marquee page renders both.
+
+#### Fixed
+
+- **Playground: dark mode paints the overscroll.** `html` and `body` carry the scheme backgrounds and `theme-color` metas, so iOS rubber-banding no longer flashes white above and below a dark page. (Deployed playground only - no package change.)
+
 ### 4.9.0 - 2026-07-30
 
 #### Added

--- a/dev.exs
+++ b/dev.exs
@@ -5379,14 +5379,6 @@ defmodule Dev.PlaygroundLive do
         <.showcase_example example={ex} />
       </div>
 
-      <div :for={ex <- PetalComponents.Showcase.Marquee.examples()} class="mt-10">
-        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
-        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
-          {ex.description}
-        </p>
-        <.showcase_example example={ex} />
-      </div>
-
       <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
       <.showcase_props component={PetalComponents.Marquee} function={:marquee} />
 

--- a/dev.exs
+++ b/dev.exs
@@ -37,10 +37,16 @@ defmodule Dev.Layouts do
   def root(assigns) do
     ~H"""
     <!DOCTYPE html>
-    <html lang="en">
+    <%!-- html AND body carry the scheme backgrounds: iOS paints rubber-band
+    overscroll from them (roughly html above the page, body below), so a
+    bg-white body under a dark app flashes white at both boundaries.
+    theme-color keeps the browser chrome matching. --%>
+    <html lang="en" class="bg-white dark:bg-gray-950">
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#030712" media="(prefers-color-scheme: dark)" />
         <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
         <.live_title>Petal Components Playground</.live_title>
         <PetalComponents.ColorSchemeSwitch.color_scheme_script />
@@ -66,7 +72,7 @@ defmodule Dev.Layouts do
         >
         </script>
       </head>
-      <body class="bg-white antialiased">
+      <body class="bg-white dark:bg-gray-950 antialiased">
         <script>
           // Hidden webviews (Claude preview, headless CDP) never fire
           // requestAnimationFrame - Chrome pauses it while document.hidden.
@@ -5365,6 +5371,14 @@ defmodule Dev.PlaygroundLive do
           </div>
         </div>
       </div>
+      <div :for={ex <- PetalComponents.Showcase.Marquee.examples()} class="mt-10">
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
       <div :for={ex <- PetalComponents.Showcase.Marquee.examples()} class="mt-10">
         <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
         <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">

--- a/lib/petal_components/card.ex
+++ b/lib/petal_components/card.ex
@@ -115,7 +115,13 @@ defmodule PetalComponents.Card do
 
   attr(:name, :string, required: true, doc: "The reviewer's name")
   attr(:username, :string, required: true, doc: "The reviewer's username")
-  attr(:img, :string, required: true, doc: "URL of the reviewer's avatar")
+
+  attr(:img, :string,
+    default: nil,
+    doc:
+      "URL of the reviewer's avatar; without one, a deterministic gradient monogram is hashed from the name - no photo assets required"
+  )
+
   attr(:body, :string, required: true, doc: "The review text content")
   attr(:class, :string, default: "", doc: "Additional classes")
   attr(:rest, :global)
@@ -124,7 +130,7 @@ defmodule PetalComponents.Card do
     ~H"""
     <figure class={["pc-review-card", @class]} {@rest}>
       <div class="pc-review-header">
-        <.avatar src={@img} alt={@name} size="md" />
+        <.avatar src={@img} name={@name} random_gradient alt={@name} size="md" />
         <div class="pc-review-meta">
           <figcaption>
             <.p no_margin class="text-sm pc-review-name">{@name}</.p>

--- a/lib/petal_components/showcase/marquee.ex
+++ b/lib/petal_components/showcase/marquee.ex
@@ -2,19 +2,72 @@ defmodule PetalComponents.Showcase.Marquee do
   @moduledoc false
   use PetalComponents.Showcase, component: PetalComponents.Marquee, title: "Marquee"
 
-  example :logos, "An infinite scroller",
+  example :logos, "The logo strip",
     description:
-      "Logos, testimonials, anything - pure CSS animation with edge fade, pausing under the pointer with pause_on_hover. repeat controls how many copies keep the loop seamless; duration and gap tune the feel; reverse and vertical change direction. Holds still under prefers-reduced-motion." do
+      "The trusted-by row: an infinite scroller with edge fade, pausing under the pointer with pause_on_hover. Wordmarks here are plain styled text - swap in your logos as <img> tags and nothing else changes. repeat controls how many copies keep the loop seamless; duration and gap tune the feel. Holds still under prefers-reduced-motion." do
     ~H"""
-    <.marquee pause_on_hover duration="24s">
-      <div
-        :for={name <- ~w(Phoenix LiveView Tailwind Elixir Postgres Oban Ecto)}
-        class="flex items-center gap-2 px-5 py-3 mx-2 border border-gray-200 rounded-xl dark:border-gray-700"
+    <.marquee pause_on_hover duration="30s" gap="4rem">
+      <span
+        :for={
+          {name, style} <- [
+            {"ACME", "font-black tracking-tighter"},
+            {"Globex", "font-serif italic font-bold"},
+            {"INITECH", "font-mono font-semibold tracking-widest"},
+            {"Umbra", "font-extrabold tracking-tight"},
+            {"Vandelay", "font-serif font-medium tracking-wide"},
+            {"hooli", "font-black tracking-wide"}
+          ]
+        }
+        class={["text-3xl text-gray-400 dark:text-gray-500", style]}
       >
-        <.icon name="hero-bolt" class="w-4 h-4 text-gray-400" />
-        <span class="text-sm font-medium">{name}</span>
-      </div>
+        {name}
+      </span>
     </.marquee>
+    """
+  end
+
+  example :testimonials, "The testimonial wall",
+    description:
+      "Two counter-rotating rows of review cards - the social-proof wall from two marquees and one card component. No photo assets: review_card without img hashes a deterministic gradient monogram from each name. reverse sends the second row the other way; hover either row and it pauses for reading." do
+    ~H"""
+    <div class="flex w-full flex-col gap-4">
+      <.marquee pause_on_hover duration="45s">
+        <.review_card
+          :for={
+            {name, username, body} <- [
+              {"Amelia Ward", "@ameliabuilds",
+               "Shipped our whole settings area in an afternoon. The form components alone paid for the switch."},
+              {"Jonah Reyes", "@jonahdev",
+               "The dark mode just works. Every component, first try, no audit pass needed."},
+              {"Priya Anand", "@priya_a",
+               "Our AI assistant generates petal code that compiles. That was the moment for me."}
+            ]
+          }
+          name={name}
+          username={username}
+          body={body}
+          class="w-80 mx-2"
+        />
+      </.marquee>
+      <.marquee pause_on_hover reverse duration="45s">
+        <.review_card
+          :for={
+            {name, username, body} <- [
+              {"Maya Okafor", "@mayacodes",
+               "Radius token, colour dials, done. The whole app restyled without touching a component."},
+              {"Tom Hale", "@tomhale",
+               "Went from Figma to a working LiveView in a day. The stepper and slide-over are exactly right."},
+              {"Ana Silva", "@anasilva",
+               "put_flash renders as toasts now. Deleted a hundred lines of notification code."}
+            ]
+          }
+          name={name}
+          username={username}
+          body={body}
+          class="w-80 mx-2"
+        />
+      </.marquee>
+    </div>
     """
   end
 end

--- a/test/petal/card_test.exs
+++ b/test/petal/card_test.exs
@@ -250,12 +250,8 @@ defmodule PetalComponents.CardTest do
   end
 
   describe "validation" do
-    test "raises error when required attributes are missing" do
-      base_assigns = %{rest: %{}, __changed__: nil, class: "", __given__: %{__changed__: nil}}
-
-      message = "key :img not found in: " <> inspect(base_assigns, pretty: true)
-
-      assert_raise KeyError, message, fn ->
+    test "raises when required attributes are missing (img is optional now)" do
+      assert_raise KeyError, ~r/key :name not found/, fn ->
         assigns = %{}
 
         rendered_to_string(~H"""
@@ -263,15 +259,7 @@ defmodule PetalComponents.CardTest do
         """)
       end
 
-      assigns_with_name =
-        Map.merge(base_assigns, %{
-          name: "John",
-          __given__: %{name: "John", __changed__: nil}
-        })
-
-      message = "key :img not found in: " <> inspect(assigns_with_name, pretty: true)
-
-      assert_raise KeyError, message, fn ->
+      assert_raise KeyError, ~r/key :username not found/, fn ->
         assigns = %{name: "John"}
 
         rendered_to_string(~H"""
@@ -279,40 +267,27 @@ defmodule PetalComponents.CardTest do
         """)
       end
 
-      assigns_with_username =
-        Map.merge(base_assigns, %{
-          name: "John",
-          username: "@john",
-          __given__: %{name: "John", username: "@john", __changed__: nil}
-        })
-
-      message = "key :img not found in: " <> inspect(assigns_with_username, pretty: true)
-
-      assert_raise KeyError, message, fn ->
+      assert_raise KeyError, ~r/key :body not found/, fn ->
         assigns = %{name: "John", username: "@john"}
 
         rendered_to_string(~H"""
         <.review_card name={@name} username={@username} />
         """)
       end
+    end
 
-      assigns_with_img =
-        Map.merge(base_assigns, %{
-          name: "John",
-          username: "@john",
-          img: "test.jpg",
-          __given__: %{name: "John", username: "@john", img: "test.jpg", __changed__: nil}
-        })
+    test "review_card without img falls back to the name-hashed gradient monogram" do
+      assigns = %{}
 
-      message = "key :body not found in: " <> inspect(assigns_with_img, pretty: true)
-
-      assert_raise KeyError, message, fn ->
-        assigns = %{name: "John", username: "@john", img: "test.jpg"}
-
+      html =
         rendered_to_string(~H"""
-        <.review_card name={@name} username={@username} img={@img} />
+        <.review_card name="Amelia Ward" username="@ameliabuilds" body="Great components." />
         """)
-      end
+
+      refute html =~ "<img"
+      assert html =~ "pc-avatar"
+      # deterministic initials from the name
+      assert html =~ "AW"
     end
   end
 


### PR DESCRIPTION
## What

First slice of the 4.10 enrichment queue, prompted by Nic's review of the marketing marquee page: its logo strip and testimonial wall are the striking, real-world examples - this reproduces both in the shared registry, **asset-free**, plus fixes the mobile dark-mode overscroll he spotted.

- **The logo strip**: styled text wordmarks (fictional brands). The marketing page hotlinks wikimedia SVGs of Google/Apple/Netflix - fine on a marketing page, wrong for examples agents copy into user apps (hotlinks + trademarks). Swap in `<img>` logos and nothing else changes.
- **The testimonial wall**: two counter-rotating rows of review cards. Needed a component fix: **`review_card.img` was required**, forcing stock photos. It's optional now - the card falls through to the petal avatar chain with a deterministic per-name gradient monogram, so the wall is colourful with zero photo assets. Existing `img` callers are pixel-identical; the required-attrs regression test is updated to the new contract and a monogram-fallback test added.
- **Playground dark overscroll** (mobile find): `html` and `body` carry the scheme backgrounds plus `theme-color` metas, so iOS rubber-banding no longer flashes white above and below dark pages. Playground-only.

## Verification

- 679 tests, 0 failures; format + `--warnings-as-errors` clean.
- Real MCP extract: `marquee -> 2` (logo strip, testimonial wall), attachment scoping correct.
- Playground booted: marquee page renders both frames (48 gradient monograms server-side), `html`/`body` verified carrying `dark:bg-gray-950`, testimonial wall visually verified in dark mode.

Rides the next release (4.9.1/4.10); marketing's marquee page harmonises then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)