### PR TITLE
docs: acknowledgements in README + playground footer credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,16 @@ There is also a [Phoenix umbrella app](https://github.com/petalframework/petal_d
 - [Figma UI kit](https://www.figma.com/community/file/1374192831096114078/official-petal-ui-kit) - official Figma kit for designing against petal_components.
 - [VSCode snippets](https://marketplace.visualstudio.com/items?itemName=petalframework.vscode-petal-components-snippets) - 65+ snippets for the components.
 
+## Acknowledgements
+
+Petal Components stands on other people's work:
+
+- [phoenix_playground](https://github.com/phoenix-playground/phoenix_playground) by [Wojtek Mach](https://github.com/wojtekmach) - boots the dev server and [playground.petal.build](https://playground.petal.build) from a single script.
+- [Phoenix](https://www.phoenixframework.org/) and [LiveView](https://github.com/phoenixframework/phoenix_live_view) - the platform everything here renders on.
+- [Tailwind CSS](https://tailwindcss.com/) - every component is styled with Tailwind v4.
+- [Apache ECharts](https://echarts.apache.org/) - the engine under `<.chart>`.
+- [Heroicons](https://heroicons.com/) - the icon set under `<.icon>`.
+
 ## License
 
 MIT.

--- a/dev.exs
+++ b/dev.exs
@@ -2417,6 +2417,17 @@ defmodule Dev.PlaygroundLive do
 
         <main class="flex-1 overflow-y-auto">
           {render_page(assigns)}
+          <footer class="max-w-3xl px-4 pb-8 mx-auto sm:px-8 text-xs text-gray-400 dark:text-gray-500">
+            Built on
+            <a
+              href="https://github.com/phoenix-playground/phoenix_playground"
+              target="_blank"
+              class="underline underline-offset-2 decoration-gray-300 dark:decoration-gray-600 hover:text-gray-600 dark:hover:text-gray-300"
+            >
+              phoenix_playground
+            </a>
+            by Wojtek Mach. Petal Components is open source, MIT licensed.
+          </footer>
         </main>
       </div>
     </div>


### PR DESCRIPTION
## What

Adds durable credit for the projects petal_components is built on, in the two places that don't scroll away:

- **README**: new *Acknowledgements* section (above License) crediting phoenix_playground (Wojtek Mach), Phoenix/LiveView, Tailwind CSS, Apache ECharts, and Heroicons.
- **Playground footer**: a one-line credit inside `<main>` after each page's content: "Built on phoenix_playground by Wojtek Mach. Petal Components is open source, MIT licensed." Styled in the playground's gray idiom (text-xs, gray-400/500), link to the phoenix_playground repo.

## Why

Nothing is legally required (MIT travels with the deps), but the playground's whole existence rides on phoenix_playground and we credited it nowhere. Durable credit in README + footer beats a one-off social post.

## Verification

- `mix format --check-formatted` clean on both files.
- Booted the playground from this branch in deploy mode (PLAYGROUND_DEPLOY=true): root page 200, footer renders under the page content with the correct link, checked visually in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)