### PR TITLE
revert(playground): remove footer credit, README acknowledgements are enough

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -2417,17 +2417,6 @@ defmodule Dev.PlaygroundLive do
 
         <main class="flex-1 overflow-y-auto">
           {render_page(assigns)}
-          <footer class="max-w-3xl px-4 pb-8 mx-auto sm:px-8 text-xs text-gray-400 dark:text-gray-500">
-            Built on
-            <a
-              href="https://github.com/phoenix-playground/phoenix_playground"
-              target="_blank"
-              class="underline underline-offset-2 decoration-gray-300 dark:decoration-gray-600 hover:text-gray-600 dark:hover:text-gray-300"
-            >
-              phoenix_playground
-            </a>
-            by Wojtek Mach. Petal Components is open source, MIT licensed.
-          </footer>
         </main>
       </div>
     </div>


### PR DESCRIPTION
## What

Removes the playground footer credit added in #521. The README Acknowledgements section stays — that's the durable credit surface.

## Why

Nic's call: the playground chrome stays clean; a per-page footer is overkill when the README already carries the acknowledgements.

## Verification

- `mix format --check-formatted` clean.
- Pure deletion of the footer block added in #521; `<main>` returns to exactly its pre-#521 markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)