### PR TITLE
feat(showcase): enrichment pass - nine examples across the six thin modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 #### Added
 
+- Nine new registry examples across six thin modules - toast's remaining
+  severities (warning, loading, neutral), carousel thumbnail navigation
+  and a slides_per_view row, the avatar size ladder + presence dots and
+  the avatar_group team stack, marquee's vertical feed, local_time's
+  threshold flip, and the colour-scheme switch labelled in German plus
+  custom icon slots. petal.build renders these registries directly, so
+  the docs pages inherit every example in the same release.
 - `language_select/1` graduates from Petal Pro: the locale dropdown, now
   a free composition of `dropdown/1`. Plain links carry `?locale=`
   (`&`-joined when the path already has a query - the Pro version broke
@@ -46,6 +53,9 @@
 
 #### Fixed
 
+- `toggle_group` items: `aria-label` is now a declared slot attr.
+  Icon-only items were passing it through with a compile warning - fatal
+  for consumers building with `--warnings-as-errors`.
 - Tall elements no longer inflate into ellipses at `radius="full"`: the
   panel clamp (1rem ceiling) now also covers textareas, multi-selects,
   block input groups (the composer pattern), alerts, the chat composer

--- a/lib/petal_components/showcase/avatar.ex
+++ b/lib/petal_components/showcase/avatar.ex
@@ -29,4 +29,46 @@ defmodule PetalComponents.Showcase.Avatar do
     </div>
     """
   end
+
+  example :sizes_and_presence, "Five sizes, four presence states",
+    description:
+      "The size ladder from xs to xl, and the status dot - online, busy, away, offline - ringed so it reads against any image or placeholder. Presence works on every avatar form." do
+    ~H"""
+    <div class="flex flex-col items-center gap-6">
+      <div class="flex flex-wrap items-end justify-center gap-3">
+        <.avatar name="Sarah Chen" size="xs" random_color />
+        <.avatar name="Sarah Chen" size="sm" random_color />
+        <.avatar name="Sarah Chen" size="md" random_color />
+        <.avatar name="Sarah Chen" size="lg" random_color />
+        <.avatar name="Sarah Chen" size="xl" random_color />
+      </div>
+      <div class="flex flex-wrap items-center justify-center gap-4">
+        <.avatar name="Amelia Ward" size="md" art="mesh" status="online" />
+        <.avatar name="Jonah Reyes" size="md" art="mesh" status="busy" />
+        <.avatar name="Priya Anand" size="md" art="mesh" status="away" />
+        <.avatar name="Tom Hale" size="md" art="mesh" status="offline" />
+      </div>
+    </div>
+    """
+  end
+
+  example :group_stack, "The team stack",
+    description:
+      "avatar_group overlaps your hosted image URLs into the classic team pile; max caps the row and folds the rest into a +N bubble. shape passes through to every avatar and the bubble. The URLs here are inline SVG stand-ins - swap in real photos and nothing else changes." do
+    ~H"""
+    <div class="flex flex-col items-center gap-4">
+      <.avatar_group
+        size="md"
+        max={3}
+        avatars={[
+          "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><rect width='8' height='8' fill='%23f59e0b'/></svg>",
+          "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><rect width='8' height='8' fill='%2310b981'/></svg>",
+          "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><rect width='8' height='8' fill='%236366f1'/></svg>",
+          "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><rect width='8' height='8' fill='%23ec4899'/></svg>",
+          "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><rect width='8' height='8' fill='%2306b6d4'/></svg>"
+        ]}
+      />
+    </div>
+    """
+  end
 end

--- a/lib/petal_components/showcase/carousel.ex
+++ b/lib/petal_components/showcase/carousel.ex
@@ -44,4 +44,43 @@ defmodule PetalComponents.Showcase.Carousel do
     </.carousel>
     """
   end
+
+  example :thumbnails, "Thumbnail navigation",
+    description:
+      "thumbnails swaps the indicators for miniature slides - the media-browser arrangement. Each thumbnail is the slide itself scaled down, so gradient panels, images and custom content all preview correctly." do
+    ~H"""
+    <.carousel
+      id="showcase-carousel-thumbs"
+      thumbnails
+      transition_type="slide"
+      class="max-w-lg mx-auto"
+    >
+      <:slide title="Overview" class="bg-gradient-to-br from-primary-500 to-secondary-500" />
+      <:slide title="Pricing" class="bg-gradient-to-br from-secondary-500 to-primary-700" />
+      <:slide title="Testimonials" class="bg-gradient-to-br from-primary-700 to-secondary-400" />
+      <:slide title="FAQ" class="bg-gradient-to-br from-secondary-400 to-primary-500" />
+    </.carousel>
+    """
+  end
+
+  example :multi_view, "Several slides per view",
+    description:
+      "slides_per_view turns the carousel into a scrolling row - cards, products, team members - with gap between items and loop wrapping the ends. Swipe works on touch; the buttons page a full view at a time." do
+    ~H"""
+    <.carousel
+      id="showcase-carousel-multi"
+      slides_per_view={3}
+      gap="1rem"
+      loop
+      size="small"
+      class="max-w-2xl mx-auto"
+    >
+      <:slide title="Alpha" class="bg-gradient-to-br from-primary-400 to-primary-600" />
+      <:slide title="Beta" class="bg-gradient-to-br from-secondary-400 to-secondary-600" />
+      <:slide title="Gamma" class="bg-gradient-to-br from-primary-600 to-secondary-500" />
+      <:slide title="Delta" class="bg-gradient-to-br from-secondary-600 to-primary-400" />
+      <:slide title="Epsilon" class="bg-gradient-to-br from-primary-500 to-secondary-700" />
+    </.carousel>
+    """
+  end
 end

--- a/lib/petal_components/showcase/carousel.ex
+++ b/lib/petal_components/showcase/carousel.ex
@@ -70,6 +70,7 @@ defmodule PetalComponents.Showcase.Carousel do
     <.carousel
       id="showcase-carousel-multi"
       slides_per_view={3}
+      transition_type="slide"
       gap="1rem"
       loop
       size="small"

--- a/lib/petal_components/showcase/color_scheme_switch.ex
+++ b/lib/petal_components/showcase/color_scheme_switch.ex
@@ -15,4 +15,47 @@ defmodule PetalComponents.Showcase.ColorSchemeSwitch do
     </div>
     """
   end
+
+  example :labels_i18n, "Labelled, in any language",
+    description:
+      "labels puts text next to the icons, and the three label attrs are plain strings - hand them to gettext and the switch speaks your locale. Dropdown and segmented shown here in German." do
+    ~H"""
+    <div class="flex flex-wrap items-center justify-center gap-8">
+      <.color_scheme_switch
+        id="scheme-dropdown-de"
+        variant="dropdown"
+        labels
+        light_label="Hell"
+        dark_label="Dunkel"
+        system_label="System"
+      />
+      <.color_scheme_switch
+        id="scheme-segmented-de"
+        variant="segmented"
+        labels
+        light_label="Hell"
+        dark_label="Dunkel"
+        system_label="System"
+      />
+    </div>
+    """
+  end
+
+  example :custom_icons, "Your icons, same contract",
+    description:
+      "The icon slots replace the sun, moon and monitor with anything - an svg, an emoji, a brand glyph - sized to fill. The no-flash behaviour and persistence don't change." do
+    ~H"""
+    <div class="flex flex-wrap items-center justify-center gap-8">
+      <.color_scheme_switch id="scheme-emoji-toggle">
+        <:light_icon><span class="text-base leading-none">🌞</span></:light_icon>
+        <:dark_icon><span class="text-base leading-none">🌚</span></:dark_icon>
+      </.color_scheme_switch>
+      <.color_scheme_switch id="scheme-emoji-segmented" variant="segmented">
+        <:light_icon><span class="text-sm leading-none">🌞</span></:light_icon>
+        <:dark_icon><span class="text-sm leading-none">🌚</span></:dark_icon>
+        <:system_icon><span class="text-sm leading-none">🖥️</span></:system_icon>
+      </.color_scheme_switch>
+    </div>
+    """
+  end
 end

--- a/lib/petal_components/showcase/local_time.ex
+++ b/lib/petal_components/showcase/local_time.ex
@@ -71,4 +71,24 @@ defmodule PetalComponents.Showcase.LocalTime do
     </div>
     """
   end
+
+  example :threshold, "Where relative gives up",
+    description:
+      "Relative copy is for recency - \"3 days ago\" helps, \"47 weeks ago\" is noise. threshold (seconds, default 7 days) is the cutoff: older than that and the same element renders the absolute form instead. Same timestamp below, two thresholds." do
+    ~H"""
+    <div class="flex flex-col gap-2 text-sm">
+      <.local_time
+        id="showcase-lt-threshold-1"
+        at={DateTime.add(DateTime.utc_now(), -259_200)}
+        format="relative"
+      />
+      <.local_time
+        id="showcase-lt-threshold-2"
+        at={DateTime.add(DateTime.utc_now(), -259_200)}
+        format="relative"
+        threshold={86_400}
+      />
+    </div>
+    """
+  end
 end

--- a/lib/petal_components/showcase/marquee.ex
+++ b/lib/petal_components/showcase/marquee.ex
@@ -70,4 +70,28 @@ defmodule PetalComponents.Showcase.Marquee do
     </div>
     """
   end
+
+  example :vertical_feed, "The vertical feed",
+    description:
+      "vertical scrolls a column instead of a row - activity feeds, changelogs, live signups - capped by max_height (sm through 2xl) with the same edge fade and hover pause. reverse works here too for a bottom-up ticker." do
+    ~H"""
+    <.marquee vertical pause_on_hover duration="25s" gap="0.75rem" max_height="md">
+      <div
+        :for={
+          {name, action} <- [
+            {"Amelia", "upgraded to Pro"},
+            {"Jonah", "deployed to Fly"},
+            {"Priya", "added an org"},
+            {"Tom", "shipped the billing page"},
+            {"Maya", "connected Stripe"},
+            {"Ana", "invited 3 teammates"}
+          ]
+        }
+        class="w-64 rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-600 dark:border-gray-700 dark:text-gray-300"
+      >
+        <span class="font-medium text-gray-900 dark:text-white">{name}</span> {action}
+      </div>
+    </.marquee>
+    """
+  end
 end

--- a/lib/petal_components/showcase/toast.ex
+++ b/lib/petal_components/showcase/toast.ex
@@ -57,4 +57,40 @@ defmodule PetalComponents.Showcase.Toast do
     </div>
     """
   end
+
+  example :severity_set, "The full severity set",
+    description:
+      "Seven kinds: info, success, warning, danger, loading and neutral - plus :error, which normalises to danger so put_flash(:error, ...) lands right. Warning and danger announce assertively (role=alert), the rest politely. The group itself takes position (six corners), max (stack cap) and duration (auto-dismiss default)." do
+    ~H"""
+    <div class="flex flex-wrap items-center justify-center gap-2">
+      <.button
+        color="gray"
+        variant="outline"
+        phx-click={
+          JS.dispatch("petal:toast",
+            detail: %{kind: "warning", title: "Certificate expiring", description: "7 days left."}
+          )
+        }
+      >
+        Warning
+      </.button>
+      <.button
+        color="gray"
+        variant="outline"
+        phx-click={
+          JS.dispatch("petal:toast", detail: %{kind: "loading", title: "Uploading archive..."})
+        }
+      >
+        Loading
+      </.button>
+      <.button
+        color="gray"
+        variant="outline"
+        phx-click={JS.dispatch("petal:toast", detail: %{kind: "neutral", title: "Draft restored"})}
+      >
+        Neutral
+      </.button>
+    </div>
+    """
+  end
 end

--- a/lib/petal_components/toggle_group.ex
+++ b/lib/petal_components/toggle_group.ex
@@ -99,6 +99,9 @@ defmodule PetalComponents.ToggleGroup do
     attr :value, :any, required: true, doc: "the option this item represents"
     attr :disabled, :boolean, doc: "disables this item only"
     attr :class, :any, doc: "extra classes for this item"
+
+    attr :"aria-label", :string,
+      doc: "accessible name for icon-only items - reaches the radio/button itself"
   end
 
   def toggle_group(%{multiple: true} = assigns) do


### PR DESCRIPTION
## What

The 4.10 module-enrichment item. Six modules sat at 1-3 registry examples while the newer pages run 3-6; nine new examples close the API-surface gaps - and because petal.build renders these registries directly, the marketing docs pages inherit all of it in the same release.

| Module | Was | Now | New coverage |
|---|---|---|---|
| toast | 1 | 2 | warning/loading/neutral kinds, error->danger note, group attrs |
| carousel | 2 | 4 | thumbnail navigation; slides_per_view row + gap + loop |
| avatar | 2 | 4 | size ladder, four presence states; avatar_group + the +N bubble |
| marquee | 2 | 3 | vertical feed with max_height |
| local_time | 3 | 4 | the threshold flip (relative -> absolute) |
| color-scheme | 1 | 3 | labels in German (i18n attrs); custom icon slots |

## Two real fixes surfaced by writing them

1. **`toggle_group` icon-only items had no declared accessible name.** The showcase's own icon rails were passing `aria-label` through with a compile warning - fatal for any consumer building with `--warnings-as-errors`. It's now a declared slot attr reaching the radio/button itself. (`validate_attrs: false` doesn't cover hyphenated attrs; declaration does.)
2. The marquee example initially used `max_height="16rem"` - the attr is an enum (`sm`..`2xl`). Caught by the warning gate before ship; example now uses `md` and the description teaches the enum.

## Verification

- 720 tests, 0 failures (registry completeness, per-example render, DOM-id uniqueness all cover the new examples)
- Full recompile under `--warnings-as-errors`: zero warnings
- Marker-level render check on all nine: severity events dispatched, thumbnails render, the group folds 5 avatars into 3 + a `+2` bubble, vertical class + `md` cap land, `threshold` reaches the DOM, German labels and emoji slots render

Also drops the stale pre-4.10 dual-range dev.exs stash (superseded by the shipped slider's `thumbs` mode) - NOW.md's 'next package session rules on it' item, ruled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)