### PR TITLE
🔖 Release 4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-### Unreleased
+### 4.10.0 - 2026-08-04
 
 #### Added
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PetalComponents.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/petalframework/petal_components"
-  @version "4.9.0"
+  @version "4.10.0"
 
   def project do
     [

--- a/rules.md
+++ b/rules.md
@@ -59,7 +59,7 @@ end
 
 ### 5. Register the JS hooks
 
-petal_components v4 ships JS hooks for the password/copyable/clearable inputs, the chat components, the navigation menu (hover mode), the command palette and the aurora backdrop (everything else is CSS + LiveView.JS only). Open `assets/js/app.js`, import the hooks, and merge them into your `LiveSocket`:
+petal_components v4 ships a bundled JS hook set - toasts, the command palette and its trigger, the colour-scheme switch, carousel, charts, local time, sliders, OTP input, the chat family, popover, the navigation menu's hover mode, the effects, and the enhanced inputs (everything else is CSS + LiveView.JS only). You never register hooks individually - spread the whole set once. Open `assets/js/app.js`, import the hooks, and merge them into your `LiveSocket`:
 
 ```js
 import PetalComponents from "../../deps/petal_components/assets/js/petal_components"
@@ -117,7 +117,7 @@ The roles: `primary` is the base action colour and tints every variant of every 
 2. **Do not invent Tailwind soup for things petal_components already does.** No hand-rolled modal divs, no manual dropdown JS, no DIY form labels. There is almost certainly an existing component for it.
 3. **Look up the schema before guessing attrs.** Do not assume attr names from memory. Call `list_components` and `get_component` (see below) to get the real attr/slot signature before writing HEEx.
 4. **Call components as plain HEEx tags after `use PetalComponents`.** `<.button>`, `<.modal>`, `<.table>`, `<.card>`, etc. If you have not imported, qualify with the module: `<PetalComponents.Button.button />`. Note: the `pc-*` prefix you see in source is the CSS class prefix for styling, not part of the function name.
-5. **Components work in both live and dead views.** Interactivity is Phoenix.LiveView.JS only (no Alpine.js as of v4). Some components (password/copyable/clearable inputs, the Chat family, the navigation menu's hover mode, the command palette and aurora) use bundled JS hooks — register them once in your LiveSocket: `import PetalComponents from "../../deps/petal_components/assets/js/petal_components"` then `hooks: { ...PetalComponents }`.
+5. **Components work in both live and dead views.** Interactivity is Phoenix.LiveView.JS only (no Alpine.js as of v4). Many components (toasts, command palette, colour scheme, carousel, charts, chat, enhanced inputs and more) use bundled JS hooks — register the whole set once in your LiveSocket: `import PetalComponents from "../../deps/petal_components/assets/js/petal_components"` then `hooks: { ...PetalComponents }`.
 6. **Form inputs come in two layers, pick deliberately.** Use `<.field type="..." />` when you want label + input + error + help text bundled (the common case in form contexts). Use the standalone primitives (`<.text_input>`, `<.select>`, `<.checkbox>`, etc.) when composing your own field layout.
 
 ## Discovering components


### PR DESCRIPTION
## 4.10.0

The release commit: version bump, CHANGELOG dated, and rules.md's stale hook enumeration rewritten (it named 5 of the 24 shipped hooks - the copy now leads with *register the whole set once* and a representative list that won't rot).

### What ships in 4.10

- **toggle_group** - the segmented family generalised: radiogroup single-select, aria-pressed multiple, three variants on shared geometry (#523)
- **command_trigger** - the ⌘K search pill + icon trigger, hook-based so it works on dead views; LiveView floor moves to ~> 1.1 (#524)
- **language_select** graduates from Petal Pro with query-safe links, text-trigger variants, optional flags, show_chevron (#528)
- **social_button + brand_icon** graduate from Petal Pro - nine providers on pc-button geometry, the bird retired for X (#530)
- **Dropdown consistency pass** - content-width menus, one chevron class, show_chevron on the user menu (#529)
- **Tall-element radius clamp** - textareas, multi-selects, block input-groups, alerts, chat composer and tooltips cap at 1rem; no more full-radius ellipses (#531)
- **Playground: every dial is a toggle_group** - 77 rails dogfooding the new component (#527)
- **Enrichment pass** - nine new registry examples across toast/carousel/avatar/marquee/local-time/color-scheme, plus toggle_group's aria-label slot attr fix (#532)

720 tests green, format clean.

**After merge (Nic):** `git tag v4.10.0 && git push --tags`, then `mix hex.publish` from an up-to-date main checkout (TTY step). The rules.md cascade (MCP INSTALL_INSTRUCTIONS + petal.build hosted copy) and the marketing ride-alongs follow the Hex release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)