### PR TITLE
showcase: live toggle_group example + alert page leads with outline ramps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 - **`hide_header` on `<.modal>` - headerless confirmation dialogs without an accessibility trade-off.** Confirmation-style modals (think "unsubscribed successfully") carry their heading centered in the content, but the component always rendered its header bar, so an empty strip sat above the content unless you hand-rolled CSS to hide it. `hide_header` now does it properly: the header collapses to a screen-reader-only box (sr-only, never `display: none`) because the dialog's `aria-labelledby` points at the title inside it - pass a real `title` and the dialog keeps its accessible name while showing none of the bar. It also skips the corner close button (an invisible button you can still tab to is a keyboard trap, not a feature), so give the content its own way out - escape and click-away still work by default. New "Headerless confirmation" example in the showcase registry.
 - **`tailwind-gray.css` - stock Tailwind gray back in one import.** The `gray` role deliberately ships zinc values under the gray name, which also decides what an app's own `text-gray-*` utilities render as - and since the stock values only ever lived under that name, no `var()` can reach them once zinc holds it. This file restores them verbatim: import it after `default.css` and every gray in the app is Tailwind's original again. Any other neutral (slate, stone, neutral) never needed it - those remain live variables you can remap a role to in one line per stop.
+- **The toggle group gets a live example.** Every toggle_group registry example rendered inert, so the docs pages read as screenshots. The new "Try it - this one is live" example is the exception on purpose: the single rail is native radios, so the browser moves the pressed chip with no JavaScript and no server, and the multiple rail toggles each chip client-side through `JS.toggle_attribute` on `on_change`. The description says out loud what a real app would do instead (send the event, let the server own the value).
+
+#### Changed
+
+- **The alert page leads with the semantic ramps in outline.** Same first example, same anchor, but the four alerts now carry `variant="outline"` - the coloured border and glyph on a calm surface reads better at first glance than four filled light bars. The description points out that dropping the variant gives you light, the component default, which is unchanged.
 
 #### Fixed
 

--- a/lib/petal_components/showcase/alert.ex
+++ b/lib/petal_components/showcase/alert.ex
@@ -6,13 +6,17 @@ defmodule PetalComponents.Showcase.Alert do
 
   example :semantic_colors, "Semantic colours",
     description:
-      "A prominent message tied to state. Danger and warning announce as role=\"alert\" (assertive); info, success and gray as polite status - the same kind split the toast uses. with_icon adds the matching glyph." do
+      "A prominent message tied to state, shown here in the outline variant - the coloured border and glyph on a calm surface. Danger and warning announce as role=\"alert\" (assertive); info, success and gray as polite status - the same kind split the toast uses. with_icon adds the matching glyph. Drop the variant attribute and you get light, the filled default." do
     ~H"""
     <div class="w-full space-y-3">
-      <.alert color="info" with_icon>A new version of this page is available.</.alert>
-      <.alert color="success" with_icon>Your changes were saved.</.alert>
-      <.alert color="warning" with_icon>Your trial ends in 3 days.</.alert>
-      <.alert color="danger" with_icon>Payment failed. Check your card details.</.alert>
+      <.alert color="info" variant="outline" with_icon>
+        A new version of this page is available.
+      </.alert>
+      <.alert color="success" variant="outline" with_icon>Your changes were saved.</.alert>
+      <.alert color="warning" variant="outline" with_icon>Your trial ends in 3 days.</.alert>
+      <.alert color="danger" variant="outline" with_icon>
+        Payment failed. Check your card details.
+      </.alert>
     </div>
     """
   end

--- a/lib/petal_components/showcase/toggle_group.ex
+++ b/lib/petal_components/showcase/toggle_group.ex
@@ -4,6 +4,8 @@ defmodule PetalComponents.Showcase.ToggleGroup do
     component: PetalComponents.ToggleGroup,
     title: "Toggle group"
 
+  alias Phoenix.LiveView.JS
+
   example :single, "Single select",
     inert: true,
     description:
@@ -32,6 +34,30 @@ defmodule PetalComponents.Showcase.ToggleGroup do
       <:item value="italic" aria-label="Italic"><.icon name="hero-italic" /></:item>
       <:item value="underline" aria-label="Underline"><.icon name="hero-underline" /></:item>
     </.toggle_group>
+    """
+  end
+
+  example :try_it, "Try it - this one is live",
+    description:
+      "Click around. The single rail needs nothing from you: it renders native radios, so the browser moves the chip itself - no JavaScript, no server. The multiple rail toggles each chip with a client-side LiveView.JS command on on_change. In a real app you would usually send an event and let the server own the value instead; these two are here to show the pressed states are real, not screenshots." do
+    ~H"""
+    <div class="flex flex-col items-start gap-4">
+      <.toggle_group aria_label="View" value="grid">
+        <:item value="list"><.icon name="hero-list-bullet" /> List</:item>
+        <:item value="grid"><.icon name="hero-squares-2x2" /> Grid</:item>
+        <:item value="board"><.icon name="hero-view-columns" /> Board</:item>
+      </.toggle_group>
+      <.toggle_group
+        multiple
+        aria_label="Formatting"
+        value={["bold"]}
+        on_change={JS.toggle_attribute({"aria-pressed", "true", "false"})}
+      >
+        <:item value="bold" aria-label="Bold"><.icon name="hero-bold" /></:item>
+        <:item value="italic" aria-label="Italic"><.icon name="hero-italic" /></:item>
+        <:item value="underline" aria-label="Underline"><.icon name="hero-underline" /></:item>
+      </.toggle_group>
+    </div>
     """
   end
 


### PR DESCRIPTION
Two showcase-registry changes aimed at the petal.build docs pages (they land there at the next release + marketing bump).

## Live toggle_group example

Every toggle_group example rendered `inert`, so the docs page reads as screenshots. The new **"Try it - this one is live"** example (placed after the two canonical wiring examples) is interactive without any server state, which keeps the registry rule that examples render deterministically:

- The single rail is native radios - the browser moves the pressed chip itself, no JavaScript, no LiveView round trip.
- The multiple rail toggles each chip's `aria-pressed` client-side with `JS.toggle_attribute` on `on_change` (LiveView 1.0+; we pin 1.2.7).
- The description says explicitly what a real app would do instead (send the event, let the server own the value), so nobody copies the demo wiring into production.

## Alert page leads with outline semantic ramps

Same first example, same `:semantic_colors` id and anchor, but the four alerts now carry `variant="outline"` - the coloured border and glyph on a calm surface read better at first glance than four filled light bars. The description notes that dropping the attribute gives `light`, the unchanged component default. No component code changes.

## Verified

- `mix test` 725 green, credo/format clean (the toggle_group credo hit is the pre-existing missing `@moduledoc`).
- Rendered both examples through the registry and screenshotted against the compiled stylesheet: Grid pressed in the single rail, Bold pressed in the multiple rail, four outline alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)