### PR TITLE
fix(css): toggle-item and alert-glyph icon sizing join the !important contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+### Unreleased
+
+#### Fixed
+
+- **Two icon-geometry sites the 4.11.1 sweep missed join the `!important` contract.** 4.11.1 restored the bangs at the sites the 4.11.0 audit had de-banged - but two rules were never in that audit because they never had bangs to begin with, and both lose the same cascade fight (consumer hero-* geometry from the utilities layer or unlayered): the toggle group's icon-only item sizing (on petal.build the pressed chip stretched to 24x20 and the rail read non-uniform, icon riding left) and the alert kind-glyph fill inside its 20px container. Both banged, both verified with the same compiled-CSS probe against unlayered consumer hero rules: 16x16 icons, uniform 36x28 chips.
+
 ### 4.11.1 - 2026-08-05
 
 #### Fixed

--- a/assets/default.css
+++ b/assets/default.css
@@ -1124,8 +1124,11 @@
     @apply self-start shrink-0 pt-0.5 w-5 h-5;
   }
 
+  /* !important per the icon sizing contract (see pagination previous
+     chevron): the kind glyph must fill the 20px container even when consumer
+     hero-* geometry arrives from the utilities layer or unlayered. */
   .pc-alert__icon-container > * {
-    @apply w-full h-full;
+    @apply w-full! h-full!;
   }
 
   /* Forms */
@@ -5336,12 +5339,17 @@
     @apply px-3.5 py-2 text-sm;
   }
 
-  /* Icon-only items keep a square hit target per size. */
+  /* Icon-only items keep a square hit target per size. !important per the
+     icon sizing contract (see pagination previous chevron): consumer hero-*
+     geometry can arrive from the utilities layer or unlayered, both of which
+     beat this rule's (0,2,0) without the bangs - petal.build's unlayered
+     hero CSS stretched pressed icon chips to 24x20 and the rail read
+     non-uniform. */
   .pc-toggle-group__item > [class^="hero-"],
   .pc-toggle-group__item > [class*=" hero-"],
   .pc-toggle-group__content > [class^="hero-"],
   .pc-toggle-group__content > [class*=" hero-"] {
-    @apply w-4 h-4;
+    @apply w-4! h-4!;
   }
 
   /* Confetti mount point */


### PR DESCRIPTION
Two icon-geometry sites the 4.11.1 sweep missed — never part of the 4.11.0 audit because they never had bangs to begin with, but they lose the identical cascade fight (consumer hero-* geometry arriving from the utilities layer or unlayered):

1. **Toggle group icon-only items** (`.pc-toggle-group__item > [class^="hero-"]` family) — on petal.build, whose hero CSS is unlayered, the plugin's `24px × 1lh` beat the `w-4 h-4` sizing: pressed icon chips stretched to 24×20 and the rail read non-uniform, glyph riding left. This is the regression Nic spotted on the live /components/toggle-group page.
2. **Alert kind-glyph fill** (`.pc-alert__icon-container > *`) — same fight, the glyph must fill its 20px container.

Both now `!important` per the corrected contract (canonical comment at the pagination previous chevron). Verified by rebuilding the playground CSS and appending petal.build's actual unlayered hero rules last: icons back to 16×16, chips a uniform 36×28 — matching the playground's correct rendering.

`mix test` 725 green. Ship as **4.11.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)