### PR TITLE
Pagination: variant="simple" - Previous/Next outline buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **`pagination` gains `variant="simple"`** - Previous/Next outline buttons
+  with disabled boundary states, instead of the numbered page window. The
+  right form when a list is short or a total is unreliable (cursor-style
+  paging), and the footer grammar the upcoming `data_table` uses when
+  `total` is unknown. `previous_label`/`next_label` attrs make the copy
+  localizable; link and event modes work unchanged. The numbered layout is
+  untouched and stays the default (`variant="numbered"`).
+
 ### 4.11.3 - 2026-08-05
 
 #### Fixed

--- a/assets/default.css
+++ b/assets/default.css
@@ -2558,6 +2558,26 @@
     border-end-end-radius: var(--pc-radius, 0.625rem);
   }
 
+  /* Pagination - simple variant: Previous/Next outline buttons. Plain
+     hover: (not enabled:hover:) because in link mode these render as
+     anchors, which never match :enabled; disabled renders as a real
+     disabled button (Link.a converts), so disabled: variants apply and
+     pointer-events-none stops hover styling on it. */
+  .pc-pagination__simple {
+    @apply inline-flex items-center gap-2;
+  }
+  .pc-pagination__simple-button {
+    @apply inline-flex h-9 items-center justify-center gap-1.5 border border-gray-300 bg-transparent px-3.5 text-sm font-medium text-gray-700 shadow-xs transition-colors duration-150 hover:bg-gray-100 hover:text-gray-900 disabled:pointer-events-none disabled:opacity-40 dark:border-gray-400/25 dark:text-gray-300 dark:hover:bg-gray-400/17 dark:hover:text-gray-200;
+    border-radius: var(--pc-radius, 0.625rem);
+  }
+  .pc-pagination__simple-chevron {
+    @apply text-gray-500 dark:text-gray-400;
+  }
+  /* Doubled selector + !important: icon sizing contract (see pagination previous chevron). */
+  .pc-pagination__simple-chevron.pc-pagination__simple-chevron {
+    @apply w-4! h-4!;
+  }
+
   /* Tabs */
 
   .pc-tabs {

--- a/dev.exs
+++ b/dev.exs
@@ -6154,7 +6154,7 @@ defmodule Dev.PlaygroundLive do
       </div>
 
       <div
-        :for={ex <- examples_for(PetalComponents.Showcase.Pagination, ~w(link_mode)a)}
+        :for={ex <- examples_for(PetalComponents.Showcase.Pagination, ~w(link_mode simple)a)}
         class="mt-10"
       >
         <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>

--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -77,7 +77,7 @@ defmodule PetalComponents.Pagination do
           phx-value-page={@current_page - 1}
           link_type={if @event, do: "button", else: @link_type}
           to={if not @event, do: get_path(@path, "previous", @current_page)}
-          type={if @event, do: "button"}
+          type={if @event or @link_type == "button", do: "button"}
           class="pc-pagination__simple-button"
           disabled={!@prev_enabled?}
         >
@@ -91,7 +91,7 @@ defmodule PetalComponents.Pagination do
           phx-value-page={@current_page + 1}
           link_type={if @event, do: "button", else: @link_type}
           to={if not @event, do: get_path(@path, "next", @current_page)}
-          type={if @event, do: "button"}
+          type={if @event or @link_type == "button", do: "button"}
           class="pc-pagination__simple-button"
           disabled={!@next_enabled?}
         >

--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -12,6 +12,15 @@ defmodule PetalComponents.Pagination do
   attr :path, :string, default: "/:page", doc: "page path"
   attr :class, :any, default: nil, doc: "parent div CSS class"
 
+  attr :variant, :string,
+    default: "numbered",
+    values: ["numbered", "simple"],
+    doc:
+      "numbered renders the windowed page list; simple renders Previous/Next outline buttons only - fewer decisions on short lists, and the honest form when a total is unreliable"
+
+  attr :previous_label, :string, default: "Previous", doc: "simple variant: label for the previous button"
+  attr :next_label, :string, default: "Next", doc: "simple variant: label for the next button"
+
   attr :link_type, :string,
     default: "a",
     values: ["a", "live_patch", "live_redirect", "button"]
@@ -41,6 +50,45 @@ defmodule PetalComponents.Pagination do
   In the `path` param you can specify :page as the place your page number will appear.
   e.g "/posts/:page" => "/posts/1"
   """
+
+  def pagination(%{variant: "simple"} = assigns) do
+    assigns =
+      assigns
+      |> assign(:prev_enabled?, assigns.current_page > 1)
+      |> assign(:next_enabled?, assigns.current_page < assigns.total_pages)
+
+    ~H"""
+    <div {@rest} class={["pc-pagination", @class]}>
+      <nav class="pc-pagination__simple" aria-label="Pagination">
+        <Link.a
+          phx-click={if @event, do: "goto-page"}
+          phx-target={if @event, do: @target}
+          phx-value-page={@current_page - 1}
+          link_type={if @event, do: "button", else: @link_type}
+          to={if not @event, do: get_path(@path, "previous", @current_page)}
+          class="pc-pagination__simple-button"
+          disabled={!@prev_enabled?}
+        >
+          <.icon name="hero-chevron-left-mini" class="pc-pagination__simple-chevron" />
+          {@previous_label}
+        </Link.a>
+
+        <Link.a
+          phx-click={if @event, do: "goto-page"}
+          phx-target={if @event, do: @target}
+          phx-value-page={@current_page + 1}
+          link_type={if @event, do: "button", else: @link_type}
+          to={if not @event, do: get_path(@path, "next", @current_page)}
+          class="pc-pagination__simple-button"
+          disabled={!@next_enabled?}
+        >
+          {@next_label}
+          <.icon name="hero-chevron-right-mini" class="pc-pagination__simple-chevron" />
+        </Link.a>
+      </nav>
+    </div>
+    """
+  end
 
   def pagination(assigns) do
     ~H"""

--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -18,7 +18,10 @@ defmodule PetalComponents.Pagination do
     doc:
       "numbered renders the windowed page list; simple renders Previous/Next outline buttons only - fewer decisions on short lists, and the honest form when a total is unreliable"
 
-  attr :previous_label, :string, default: "Previous", doc: "simple variant: label for the previous button"
+  attr :previous_label, :string,
+    default: "Previous",
+    doc: "simple variant: label for the previous button"
+
   attr :next_label, :string, default: "Next", doc: "simple variant: label for the next button"
 
   attr :link_type, :string,
@@ -52,10 +55,18 @@ defmodule PetalComponents.Pagination do
   """
 
   def pagination(%{variant: "simple"} = assigns) do
+    # Normalize like the numbered branch does via get_pagination_items:
+    # nil/zero totals become one page, current clamps into range - so the
+    # neighbour links can never point outside 1..total_pages.
+    total_pages = max(assigns.total_pages || 1, 1)
+    current_page = (assigns.current_page || 1) |> max(1) |> min(total_pages)
+
     assigns =
       assigns
-      |> assign(:prev_enabled?, assigns.current_page > 1)
-      |> assign(:next_enabled?, assigns.current_page < assigns.total_pages)
+      |> assign(:total_pages, total_pages)
+      |> assign(:current_page, current_page)
+      |> assign(:prev_enabled?, current_page > 1)
+      |> assign(:next_enabled?, current_page < total_pages)
 
     ~H"""
     <div {@rest} class={["pc-pagination", @class]}>
@@ -66,6 +77,7 @@ defmodule PetalComponents.Pagination do
           phx-value-page={@current_page - 1}
           link_type={if @event, do: "button", else: @link_type}
           to={if not @event, do: get_path(@path, "previous", @current_page)}
+          type={if @event, do: "button"}
           class="pc-pagination__simple-button"
           disabled={!@prev_enabled?}
         >
@@ -79,6 +91,7 @@ defmodule PetalComponents.Pagination do
           phx-value-page={@current_page + 1}
           link_type={if @event, do: "button", else: @link_type}
           to={if not @event, do: get_path(@path, "next", @current_page)}
+          type={if @event, do: "button"}
           class="pc-pagination__simple-button"
           disabled={!@next_enabled?}
         >

--- a/lib/petal_components/showcase/pagination.ex
+++ b/lib/petal_components/showcase/pagination.ex
@@ -10,6 +10,17 @@ defmodule PetalComponents.Showcase.Pagination do
     """
   end
 
+  example :simple, "Simple variant",
+    description:
+      "variant=\"simple\" trades the page window for Previous/Next outline buttons with disabled boundary states - fewer decisions on short lists, and the honest form when a total is unreliable (cursor-style paging). previous_label/next_label are attrs, so localization is a prop away; link and event modes work unchanged. The second rail sits on page 1, so Previous renders disabled." do
+    ~H"""
+    <div class="flex flex-col items-center gap-5">
+      <.pagination variant="simple" path="/users/:page" total_pages={12} current_page={5} />
+      <.pagination variant="simple" path="/users/:page" total_pages={12} current_page={1} />
+    </div>
+    """
+  end
+
   example :event_mode, "Event mode",
     description:
       "event mode skips links and fires goto-page with phx-value-page instead - for LiveViews that page in place without URL changes." do

--- a/test/petal/pagination_test.exs
+++ b/test/petal/pagination_test.exs
@@ -664,6 +664,18 @@ defmodule PetalComponents.PaginationTest do
       refute html =~ ~s|type="submit"|
     end
 
+    test "explicit link_type=button controls are also type=button" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.pagination variant="simple" link_type="button" total_pages={12} current_page={5} />
+        """)
+
+      assert html =~ ~s|type="button"|
+      refute html =~ ~s|type="submit"|
+    end
+
     test "labels are overridable" do
       assigns = %{}
 

--- a/test/petal/pagination_test.exs
+++ b/test/petal/pagination_test.exs
@@ -629,6 +629,41 @@ defmodule PetalComponents.PaginationTest do
       refute html =~ "href="
     end
 
+    test "out-of-range and nil pages normalize instead of building invalid links" do
+      assigns = %{}
+
+      # current past the total clamps to the last page
+      html =
+        rendered_to_string(~H"""
+        <.pagination variant="simple" path="/users/:page" total_pages={12} current_page={15} />
+        """)
+
+      assert html =~ ~s|href="/users/11"|
+      refute html =~ ~s|href="/users/14"|
+      refute html =~ ~s|href="/users/16"|
+
+      # no attrs at all renders one page with both boundaries disabled
+      html =
+        rendered_to_string(~H"""
+        <.pagination variant="simple" path="/users/:page" />
+        """)
+
+      refute html =~ "href="
+      assert html =~ "disabled"
+    end
+
+    test "event-mode controls are type=button so they never submit a form" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.pagination variant="simple" event total_pages={12} current_page={5} />
+        """)
+
+      assert html =~ ~s|type="button"|
+      refute html =~ ~s|type="submit"|
+    end
+
     test "labels are overridable" do
       assigns = %{}
 

--- a/test/petal/pagination_test.exs
+++ b/test/petal/pagination_test.exs
@@ -570,4 +570,83 @@ defmodule PetalComponents.PaginationTest do
     refute html =~ ~r{<div>\s*<a[^>]*class="pc-pagination__item__previous"}s
     refute html =~ ~r{<div>\s*<a[^>]*class="pc-pagination__item__next"}s
   end
+
+  describe "variant=simple" do
+    test "renders Previous and Next as links with the neighbour pages" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.pagination variant="simple" path="/users/:page" total_pages={12} current_page={5} />
+        """)
+
+      assert html =~ "pc-pagination__simple"
+      assert html =~ "Previous"
+      assert html =~ "Next"
+      assert html =~ ~s|href="/users/4"|
+      assert html =~ ~s|href="/users/6"|
+      refute html =~ "pc-pagination__inner"
+    end
+
+    test "Previous is a disabled button on page 1" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.pagination variant="simple" path="/users/:page" total_pages={12} current_page={1} />
+        """)
+
+      # Link.a converts a disabled link into a disabled <button>
+      assert html =~ "disabled"
+      refute html =~ ~s|href="/users/0"|
+      assert html =~ ~s|href="/users/2"|
+    end
+
+    test "Next is a disabled button on the last page" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.pagination variant="simple" path="/users/:page" total_pages={12} current_page={12} />
+        """)
+
+      assert html =~ "disabled"
+      assert html =~ ~s|href="/users/11"|
+      refute html =~ ~s|href="/users/13"|
+    end
+
+    test "event mode fires goto-page with the neighbour page numbers" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.pagination variant="simple" event total_pages={12} current_page={5} />
+        """)
+
+      assert html =~ ~s|phx-click="goto-page"|
+      assert html =~ ~s|phx-value-page="4"|
+      assert html =~ ~s|phx-value-page="6"|
+      refute html =~ "href="
+    end
+
+    test "labels are overridable" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.pagination
+          variant="simple"
+          path="/users/:page"
+          total_pages={3}
+          current_page={2}
+          previous_label="Zurück"
+          next_label="Weiter"
+        />
+        """)
+
+      assert html =~ "Zurück"
+      assert html =~ "Weiter"
+      refute html =~ "Previous"
+    end
+  end
 end


### PR DESCRIPTION
First deliverable of the approved data-table/combobox plan (workspace: tasks/data-table-combobox-plan.md §3.5, Matt-approved 6 Aug).

## What
`variant="simple"` renders Previous/Next outline buttons instead of the numbered page window - the right form for short lists, and the only honest one for cursor-style paging where a total is unreliable. It's the footer grammar the upcoming `data_table` auto-picks when `total` is unknown.

- Same link/event mechanics as numbered: path templates resolve neighbour pages; event mode fires `goto-page` with `phx-value-page`
- Real disabled boundary states (Link.a converts disabled links to disabled buttons; `pointer-events-none` keeps hover off them; plain `hover:` because enabled anchors never match `:enabled`)
- `previous_label`/`next_label` attrs for localization
- Buttons ride the radius token + outline-button surface recipe; chevrons join the doubled-selector icon sizing contract
- Registry example (page 5 + page 1 teaching the disabled state), playground page renders it
- `variant="numbered"` stays the default; existing markup byte-identical

**Naming**: `simple` over `compact` (collides with the density axis) and `minimal` (vague) - Ant Design's "simple pagination" is the established term for this exact form, so humans and AI agents pattern-match it.

## Verification
- `mix compile --warnings-as-errors` clean; 42 pagination tests green (5 new: link hrefs, both disabled boundaries, event payloads, label override)
- Rendered against the compiled stylesheet in headless Chrome, light + dark: outline surface, radius token, disabled fade all correct