### PR TITLE
combo_box: the searchable select (combobox M1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **`combo_box` - the searchable select, milestone 1 of the combobox arc**
+  (tasks/data-table-combobox-plan.md §6, Matt-approved). Type to filter,
+  arrow keys to move, Enter to choose: the command palette's proven
+  keyboard + scoring machinery (`PetalComboBox` forks `PetalCommand`)
+  wired to a real hidden native `<select>`. The select IS the form
+  control - name/value from a `field` or manual attrs, bubbling
+  input/change on selection - so changesets, `phx-change` and LiveView
+  form recovery behave exactly like a plain select. No
+  `phx-update="ignore"` island, no Tom Select, zero JS dependencies.
+  Options accept the `select` shapes: strings, `{label, value}`,
+  `{label, value, disabled: true}` and `{group_label, options}` groups
+  (headed in the listbox, `optgroup` in the select, hidden when filtered
+  empty). ARIA done properly for a combobox: `aria-selected` marks the
+  CHOSEN option (with the check mark); the keyboard highlight is virtual
+  (`data-highlighted` + `aria-activedescendant`), focus never leaves the
+  input. The control carries the field surface (input_group doctrine:
+  ring on the wrapper, borderless inner input); the panel follows the
+  dropdown grammar with the 1rem radius clamp. Single select, static
+  options; multiple/chips, free-text autocomplete and the remote-search
+  contract land in the next milestones.
+
 ### 4.11.3 - 2026-08-05
 
 #### Fixed

--- a/assets/default.css
+++ b/assets/default.css
@@ -2129,6 +2129,78 @@
     }
   }
 
+  /* Combo box - a searchable select. The control carries the field surface
+     (input_group doctrine: border + focus-within ring live on the wrapper,
+     the inner input is borderless); the panel follows the dropdown grammar
+     with the 1rem radius clamp; options follow the command item recipe.
+     aria-selected marks the CHOSEN option (check mark); data-highlighted is
+     the virtual keyboard highlight. */
+
+  .pc-combo-box {
+    @apply relative w-full;
+  }
+  /* the real form control: submits + recovers like any select, never seen */
+  .pc-combo-box__select {
+    @apply sr-only;
+  }
+  .pc-combo-box__control {
+    @apply flex items-center w-full bg-white border border-gray-300 shadow-xs transition-[color,box-shadow] duration-200 ease-out focus-within:border-primary-500 focus-within:ring-2 focus-within:ring-primary-500/50 dark:bg-gray-400/8 dark:border-gray-400/25;
+    border-radius: var(--pc-radius, 0.625rem);
+  }
+  .pc-combo-box__control:has(.pc-combo-box__input:disabled) {
+    @apply opacity-50;
+  }
+  .pc-combo-box__input {
+    @apply w-full min-w-0 bg-transparent border-0 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed dark:text-gray-100 dark:placeholder-gray-500;
+    border-radius: inherit;
+  }
+  .pc-combo-box__chevron {
+    @apply mr-2.5 shrink-0 text-gray-400 dark:text-gray-500;
+  }
+  /* Doubled selector + !important: icon sizing contract (see pagination previous chevron). */
+  .pc-combo-box__chevron.pc-combo-box__chevron {
+    @apply w-4! h-4!;
+  }
+
+  .pc-combo-box__panel {
+    @apply absolute left-0 top-full z-30 mt-1 w-full bg-white shadow-lg border border-gray-200 dark:bg-gray-900 dark:border-gray-400/17;
+    border-radius: min(var(--pc-radius, 0.625rem), 1rem);
+  }
+  .pc-combo-box__list {
+    @apply max-h-64 overflow-y-auto p-1;
+  }
+  .pc-combo-box__group-heading {
+    @apply px-2 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400;
+  }
+  .pc-combo-box__option {
+    @apply relative flex w-full cursor-default items-center gap-2 px-2 py-1.5 text-left text-sm text-gray-700 outline-none select-none dark:text-gray-200;
+    /* Derived from the clamped panel like dropdown/command items - raw-token
+       rounding pills options inside a clamped panel at large tokens. */
+    border-radius: max(calc(min(var(--pc-radius, 0.625rem), 1rem) - 0.25rem), 0px);
+  }
+  .pc-combo-box__option[data-highlighted] {
+    @apply bg-gray-100 text-gray-900 dark:bg-gray-400/17 dark:text-white;
+  }
+  .pc-combo-box__option[data-disabled] {
+    @apply pointer-events-none opacity-50;
+  }
+  .pc-combo-box__option-label {
+    @apply flex-1 truncate;
+  }
+  .pc-combo-box__check {
+    @apply invisible ml-auto shrink-0 text-gray-900 dark:text-white;
+  }
+  .pc-combo-box__option[aria-selected="true"] .pc-combo-box__check {
+    @apply visible;
+  }
+  /* Doubled selector + !important: icon sizing contract (see pagination previous chevron). */
+  .pc-combo-box__check.pc-combo-box__check {
+    @apply w-4! h-4!;
+  }
+  .pc-combo-box__empty {
+    @apply px-2 py-6 text-center text-sm text-gray-500 dark:text-gray-400;
+  }
+
   /* Tooltip */
 
   .pc-tooltip {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3373,10 +3373,17 @@ export const PetalComboBox = {
     // keep focus on the input while clicking inside the panel, or the
     // focusout close would swallow the click before it lands
     this.onPanelPointerDown = (e) => e.preventDefault();
-    this.onControlClick = () => {
+    this.onControlClick = (e) => {
       if (this.input.disabled) return;
-      this.panel.hidden ? this.openPanel() : this.closePanel();
-      this.input.focus();
+      if (this.panel.hidden) {
+        this.openPanel();
+        this.input.focus();
+      } else if (e.target !== this.input) {
+        // chevron / control chrome toggles; a click on the input itself is
+        // caret work - closing here would discard the active query
+        this.closePanel();
+        this.input.focus();
+      }
     };
     this.onFocusOut = (e) => {
       if (!this.el.contains(e.relatedTarget)) this.closePanel();

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3337,6 +3337,245 @@ export const PetalToast = {
   },
 };
 
+
+// Combo box: the command palette's filter + keyboard core wired to a real
+// hidden <select>. The select IS the form control - choosing an option sets
+// its value and dispatches bubbling input/change events, so phx-change and
+// LiveView form recovery behave exactly like a native select. Options are
+// hidden, never reordered - the server owns DOM order. aria-selected tracks
+// the CHOSEN option (the check mark); the keyboard highlight is virtual:
+// data-highlighted + aria-activedescendant.
+export const PetalComboBox = {
+  mounted() {
+    this.select = this.el.querySelector(".pc-combo-box__select");
+    this.input = this.el.querySelector(".pc-combo-box__input");
+    this.control = this.el.querySelector(".pc-combo-box__control");
+    this.panel = this.el.querySelector("[data-pc-combo-panel]");
+    this.list = this.el.querySelector(".pc-combo-box__list");
+    if (!this.select || !this.input || !this.panel || !this.list) return;
+
+    this.query = "";
+
+    this.onInput = () => {
+      this.query = this.input.value.trim().toLowerCase();
+      if (this.panel.hidden) this.openPanel({ keepQuery: true });
+      this.filter();
+    };
+    this.onKeydown = (e) => this.keydown(e);
+    this.onPointerOver = (e) => {
+      const item = e.target.closest("[data-pc-combo-item]");
+      if (item && !item.hasAttribute("data-disabled") && !item.hidden) this.highlight(item, false);
+    };
+    this.onListClick = (e) => {
+      const item = e.target.closest("[data-pc-combo-item]");
+      if (item && !item.hasAttribute("data-disabled")) this.choose(item);
+    };
+    // keep focus on the input while clicking inside the panel, or the
+    // focusout close would swallow the click before it lands
+    this.onPanelPointerDown = (e) => e.preventDefault();
+    this.onControlClick = () => {
+      if (this.input.disabled) return;
+      this.panel.hidden ? this.openPanel() : this.closePanel();
+      this.input.focus();
+    };
+    this.onFocusOut = (e) => {
+      if (!this.el.contains(e.relatedTarget)) this.closePanel();
+    };
+
+    this.input.addEventListener("input", this.onInput);
+    this.input.addEventListener("keydown", this.onKeydown);
+    this.list.addEventListener("pointerover", this.onPointerOver);
+    this.list.addEventListener("click", this.onListClick);
+    this.panel.addEventListener("pointerdown", this.onPanelPointerDown);
+    this.control.addEventListener("click", this.onControlClick);
+    this.el.addEventListener("focusout", this.onFocusOut);
+
+    this.syncFromSelect();
+  },
+
+  updated() {
+    // LiveView patched the component - the select (server state) wins.
+    this.syncFromSelect();
+    if (!this.panel.hidden) this.filter();
+  },
+
+  destroyed() {
+    if (!this.input) return;
+    this.input.removeEventListener("input", this.onInput);
+    this.input.removeEventListener("keydown", this.onKeydown);
+    this.list.removeEventListener("pointerover", this.onPointerOver);
+    this.list.removeEventListener("click", this.onListClick);
+    this.panel.removeEventListener("pointerdown", this.onPanelPointerDown);
+    this.control.removeEventListener("click", this.onControlClick);
+    this.el.removeEventListener("focusout", this.onFocusOut);
+  },
+
+  items() {
+    return Array.from(this.el.querySelectorAll("[data-pc-combo-item]"));
+  },
+
+  visibleItems() {
+    return this.items().filter((i) => !i.hidden && !i.hasAttribute("data-disabled"));
+  },
+
+  // same ladder as the command palette: prefix > word-boundary > substring > fuzzy
+  score(text, query) {
+    if (!query) return 1;
+    if (text.startsWith(query)) return 4;
+    const at = text.indexOf(query);
+    if (at > 0 && /[\s\-_/]/.test(text[at - 1])) return 3;
+    if (at >= 0) return 2;
+    let qi = 0;
+    for (const ch of text) if (ch === query[qi] && ++qi === query.length) return 1;
+    return 0;
+  },
+
+  openPanel({ keepQuery = false } = {}) {
+    if (!this.panel.hidden) return;
+    this.panel.hidden = false;
+    this.input.setAttribute("aria-expanded", "true");
+    if (!keepQuery) this.query = "";
+    this.filter();
+  },
+
+  closePanel() {
+    if (this.panel.hidden) return;
+    this.panel.hidden = true;
+    this.input.setAttribute("aria-expanded", "false");
+    this.highlight(null, false);
+    this.query = "";
+    this.restoreDisplay();
+  },
+
+  chosenItem() {
+    const value = this.select.value;
+    if (!value) return null;
+    return this.items().find((i) => i.dataset.value === value) || null;
+  },
+
+  restoreDisplay() {
+    const chosen = this.chosenItem();
+    this.input.value = chosen ? chosen.dataset.label || "" : "";
+  },
+
+  syncFromSelect() {
+    const value = this.select.value;
+    for (const i of this.items()) {
+      i.setAttribute("aria-selected", value !== "" && i.dataset.value === value ? "true" : "false");
+    }
+    if (this.panel.hidden || document.activeElement !== this.input) this.restoreDisplay();
+  },
+
+  choose(item) {
+    if (this.select.value !== item.dataset.value) {
+      this.select.value = item.dataset.value;
+      this.select.dispatchEvent(new Event("input", { bubbles: true }));
+      this.select.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+    this.syncFromSelect();
+    this.closePanel();
+    this.input.focus();
+  },
+
+  filter() {
+    const query = this.query;
+    let count = 0;
+    let idBase = 0;
+
+    for (const item of this.items()) {
+      if (!item.id) item.id = `${this.el.id}-opt-${idBase}`;
+      idBase++;
+      const text = `${item.dataset.label || item.textContent || ""}`.trim().toLowerCase();
+      const show = this.score(text, query) > 0;
+      item.hidden = !show;
+      if (show) count++;
+    }
+
+    for (const group of this.el.querySelectorAll("[data-pc-combo-group]")) {
+      const any = Array.from(group.querySelectorAll("[data-pc-combo-item]")).some((i) => !i.hidden);
+      group.hidden = !any;
+    }
+
+    const empty = this.el.querySelector("[data-pc-combo-empty]");
+    if (empty) empty.hidden = count > 0;
+
+    // an empty query (just opened) homes the highlight on the chosen value;
+    // a typed query homes it on the best (first) visible match
+    const chosen = this.chosenItem();
+    if (!query && chosen && !chosen.hidden && !chosen.hasAttribute("data-disabled")) {
+      this.highlight(chosen, true);
+    } else {
+      this.highlight(this.visibleItems()[0] || null, false);
+    }
+  },
+
+  highlightedItem() {
+    const id = this.input.getAttribute("aria-activedescendant");
+    return id ? document.getElementById(id) : null;
+  },
+
+  highlight(item, scroll = true) {
+    for (const i of this.items()) i.toggleAttribute("data-highlighted", i === item);
+    if (item) {
+      this.input.setAttribute("aria-activedescendant", item.id);
+      if (scroll) item.scrollIntoView({ block: "nearest" });
+    } else {
+      this.input.removeAttribute("aria-activedescendant");
+    }
+  },
+
+  move(delta) {
+    const items = this.visibleItems();
+    if (!items.length) return;
+    const loop = this.el.dataset.loop === "true";
+    const at = items.indexOf(this.highlightedItem());
+    let next = at + delta;
+    if (at === -1) next = delta > 0 ? 0 : items.length - 1;
+    else if (loop) next = (next + items.length) % items.length;
+    else next = Math.max(0, Math.min(next, items.length - 1));
+    this.highlight(items[next]);
+  },
+
+  keydown(e) {
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        this.panel.hidden ? this.openPanel() : this.move(1);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        this.panel.hidden ? this.openPanel() : this.move(-1);
+        break;
+      case "Home":
+        if (this.panel.hidden) return;
+        e.preventDefault();
+        this.highlight(this.visibleItems()[0] || null);
+        break;
+      case "End":
+        if (this.panel.hidden) return;
+        e.preventDefault();
+        this.highlight(this.visibleItems().slice(-1)[0] || null);
+        break;
+      case "Enter": {
+        if (this.panel.hidden) return; // closed: let the form submit
+        e.preventDefault();
+        const item = this.highlightedItem();
+        if (item && !item.hidden && !item.hasAttribute("data-disabled")) this.choose(item);
+        break;
+      }
+      case "Escape":
+        if (this.panel.hidden) return; // closed: let dialogs/modals handle it
+        e.preventDefault();
+        e.stopPropagation();
+        this.closePanel();
+        break;
+      case "Tab":
+        this.closePanel();
+        break;
+    }
+  },
+};
+
 export default {
   PetalChart,
   PetalColorScheme,
@@ -3365,4 +3604,5 @@ export default {
   PetalAurora,
   PetalNavMenu,
   PetalCommandDialog,
+  PetalComboBox,
 };

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -40,6 +40,7 @@ defmodule PetalComponents do
         Form,
         Icon,
         Input,
+        ComboBox,
         Command,
         InputGroup,
         InputOtp,

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -1,0 +1,248 @@
+defmodule PetalComponents.ComboBox do
+  @moduledoc """
+  A searchable select: type to filter, arrow keys to move, Enter to choose.
+
+  The visible input is display-only chrome; the real form control is a
+  hidden native `<select>` kept in sync by the `PetalComboBox` hook. That
+  makes the component form-native: changesets, `phx-change` and LiveView
+  form recovery all work exactly as they do for a plain select - there is
+  no `phx-update="ignore"` island and no client-owned state to lose.
+
+  Filtering happens client-side in the hook (zero dependencies), reusing
+  the command palette's scoring: value prefix beats word-boundary prefix
+  beats substring beats fuzzy subsequence. Options are hidden, never
+  reordered - the server owns DOM order, which keeps the listbox safe
+  under LiveView patches.
+
+  The markup follows the WAI-ARIA combobox pattern: the input carries
+  `role="combobox"` and `aria-activedescendant`, the panel is a
+  `listbox`, options are `option`s. Keyboard focus never leaves the
+  input; the highlight is virtual (`data-highlighted`), and
+  `aria-selected` means the *chosen* value - the check-marked one - not
+  the highlight.
+
+      <.form :let={f} for={@form} phx-change="validate">
+        <.combo_box field={f[:country]} options={["Australia", "Japan", "Portugal"]} />
+      </.form>
+
+  Options accept the shapes `select` users expect:
+
+    * `"Australia"` - label and value are the string
+    * `{"Australia", "au"}` - label / value
+    * `{"Australia", "au", disabled: true}` - with per-option opts
+    * `{"Oceania", [...]}` - a group: heading plus its options
+  """
+  use Phoenix.Component
+
+  import PetalComponents.Icon
+
+  attr :id, :string,
+    default: nil,
+    doc: "unique id; the PetalComboBox hook mounts here. Derived from field or name when absent"
+
+  attr :field, Phoenix.HTML.FormField,
+    default: nil,
+    doc: "a form field, e.g. f[:country] - supplies name, value and id"
+
+  attr :name, :string, default: nil, doc: "input name, when not using field"
+  attr :value, :any, default: nil, doc: "current value, when not using field (overrides field)"
+
+  attr :options, :list,
+    default: [],
+    doc:
+      "strings, {label, value} tuples, {label, value, opts} (opts: disabled: true), or {group_label, options} groups"
+
+  attr :placeholder, :string, default: "Select an option…"
+  attr :disabled, :boolean, default: false
+
+  attr :loop, :boolean,
+    default: false,
+    doc: "arrow keys wrap from the last option to the first and back"
+
+  attr :no_results_text, :string, default: "No results found"
+  attr :listbox_label, :string, default: "Options", doc: "accessible name for the listbox"
+  attr :class, :any, default: nil, doc: "extra classes for the wrapper"
+  attr :rest, :global
+
+  def combo_box(assigns) do
+    groups = normalize_options(assigns.options)
+    value = current_value(assigns)
+    id = resolve_id(assigns)
+
+    assigns =
+      assigns
+      |> assign(:groups, groups)
+      |> assign(:current_value, value)
+      |> assign(:id, id)
+      |> assign(:input_name, assigns.name || (assigns.field && assigns.field.name))
+      |> assign(:selected_label, selected_label(groups, value))
+
+    ~H"""
+    <div
+      id={@id}
+      class={["pc-combo-box", @class]}
+      phx-hook="PetalComboBox"
+      data-loop={@loop && "true"}
+      {@rest}
+    >
+      <select
+        id={"#{@id}-select"}
+        name={@input_name}
+        class="pc-combo-box__select"
+        tabindex="-1"
+        aria-hidden="true"
+        disabled={@disabled}
+      >
+        <option value=""></option>
+        <%= for group <- @groups do %>
+          <%= if group.label do %>
+            <optgroup label={group.label}>
+              <option
+                :for={opt <- group.options}
+                value={opt.value}
+                selected={selected?(opt, @current_value)}
+                disabled={opt.disabled}
+              >
+                {opt.label}
+              </option>
+            </optgroup>
+          <% else %>
+            <option
+              :for={opt <- group.options}
+              value={opt.value}
+              selected={selected?(opt, @current_value)}
+              disabled={opt.disabled}
+            >
+              {opt.label}
+            </option>
+          <% end %>
+        <% end %>
+      </select>
+
+      <div class="pc-combo-box__control">
+        <input
+          type="text"
+          id={"#{@id}-input"}
+          class="pc-combo-box__input"
+          role="combobox"
+          aria-expanded="false"
+          aria-autocomplete="list"
+          aria-controls={"#{@id}-listbox"}
+          autocomplete="off"
+          autocorrect="off"
+          spellcheck="false"
+          placeholder={@placeholder}
+          value={@selected_label}
+          disabled={@disabled}
+        />
+        <.icon name="hero-chevron-down-mini" class="pc-combo-box__chevron" />
+      </div>
+
+      <div class="pc-combo-box__panel" data-pc-combo-panel hidden>
+        <div
+          role="listbox"
+          id={"#{@id}-listbox"}
+          class="pc-combo-box__list"
+          aria-label={@listbox_label}
+        >
+          <%= for group <- @groups do %>
+            <%= if group.label do %>
+              <div class="pc-combo-box__group" role="group" data-pc-combo-group>
+                <div class="pc-combo-box__group-heading" aria-hidden="true">{group.label}</div>
+                <.option_items options={group.options} current_value={@current_value} />
+              </div>
+            <% else %>
+              <.option_items options={group.options} current_value={@current_value} />
+            <% end %>
+          <% end %>
+          <div class="pc-combo-box__empty" data-pc-combo-empty hidden>{@no_results_text}</div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp option_items(assigns) do
+    ~H"""
+    <div
+      :for={opt <- @options}
+      role="option"
+      class="pc-combo-box__option"
+      data-pc-combo-item
+      data-value={opt.value}
+      data-label={opt.label}
+      data-disabled={opt.disabled && "true"}
+      aria-disabled={opt.disabled && "true"}
+      aria-selected={to_string(selected?(opt, @current_value))}
+    >
+      <span class="pc-combo-box__option-label">{opt.label}</span>
+      <.icon name="hero-check-mini" class="pc-combo-box__check" />
+    </div>
+    """
+  end
+
+  # -- option normalization -------------------------------------------------
+
+  # Everything becomes [%{label: group_or_nil, options: [%{label, value, disabled}]}].
+  # Consecutive flat options gather under a nil group so rendering has one shape,
+  # and groups keep their position between them.
+  defp normalize_options(options) do
+    options
+    |> Enum.chunk_by(&group?/1)
+    |> Enum.flat_map(fn [first | _] = chunk ->
+      if group?(first) do
+        Enum.map(chunk, fn {label, opts} ->
+          %{label: to_string(label), options: Enum.map(opts, &normalize_option/1)}
+        end)
+      else
+        [%{label: nil, options: Enum.map(chunk, &normalize_option/1)}]
+      end
+    end)
+  end
+
+  defp group?({_label, options}) when is_list(options), do: true
+  defp group?(_entry), do: false
+
+  defp normalize_option({label, value, opts}) when is_list(opts) do
+    %{
+      label: to_string(label),
+      value: to_string(value),
+      disabled: Keyword.get(opts, :disabled, false)
+    }
+  end
+
+  defp normalize_option({label, value}) do
+    %{label: to_string(label), value: to_string(value), disabled: false}
+  end
+
+  defp normalize_option(value) when is_binary(value) or is_atom(value) or is_number(value) do
+    %{label: to_string(value), value: to_string(value), disabled: false}
+  end
+
+  # -- value / id resolution ------------------------------------------------
+
+  defp current_value(%{value: value}) when not is_nil(value), do: to_string(value)
+  defp current_value(%{field: %{value: value}}) when not is_nil(value), do: to_string(value)
+  defp current_value(_assigns), do: nil
+
+  defp selected?(_opt, nil), do: false
+  defp selected?(opt, value), do: opt.value == value
+
+  defp selected_label(groups, value) do
+    groups
+    |> Enum.flat_map(& &1.options)
+    |> Enum.find_value(fn opt -> if selected?(opt, value), do: opt.label end)
+  end
+
+  defp resolve_id(%{id: id}) when is_binary(id), do: id
+  defp resolve_id(%{field: %{id: id}}) when is_binary(id), do: "#{id}_combo_box"
+
+  defp resolve_id(%{name: name}) when is_binary(name) do
+    "combo_box_" <> String.replace(name, ~r/[^A-Za-z0-9_]/, "_")
+  end
+
+  defp resolve_id(_assigns) do
+    raise ArgumentError,
+          "combo_box needs an :id, a :field or a :name - the hook requires a stable id"
+  end
+end

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -59,6 +59,14 @@ defmodule PetalComponents.ComboBox do
     default: false,
     doc: "arrow keys wrap from the last option to the first and back"
 
+  attr :required, :boolean,
+    default: false,
+    doc: "renders on the hidden select, so native required validation guards the real control"
+
+  attr :form_id, :string,
+    default: nil,
+    doc: "the form this control belongs to when rendered outside it (the select's form attribute)"
+
   attr :no_results_text, :string, default: "No results found"
   attr :listbox_label, :string, default: "Options", doc: "accessible name for the listbox"
   attr :class, :any, default: nil, doc: "extra classes for the wrapper"
@@ -92,6 +100,8 @@ defmodule PetalComponents.ComboBox do
         tabindex="-1"
         aria-hidden="true"
         disabled={@disabled}
+        required={@required}
+        form={@form_id}
       >
         <option value=""></option>
         <%= for group <- @groups do %>

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -1,0 +1,59 @@
+defmodule PetalComponents.Showcase.ComboBox do
+  @moduledoc false
+  use PetalComponents.Showcase,
+    component: PetalComponents.ComboBox,
+    title: "Combo box"
+
+  example :basic, "The searchable select",
+    description:
+      "Type to filter, arrow keys to move, Enter to choose - the command palette's keyboard machinery on a form control. The visible input is chrome; a hidden native select carries the name and value, so changesets, phx-change and LiveView form recovery behave exactly like a plain select. Zero JS dependencies." do
+    ~H"""
+    <div class="w-full max-w-xs mx-auto">
+      <.combo_box
+        id="sx-combo-basic"
+        name="country"
+        placeholder="Select a country…"
+        options={["Australia", "Japan", "New Zealand", "Portugal", "Sweden"]}
+      />
+    </div>
+    """
+  end
+
+  example :preselected, "A chosen value",
+    description:
+      "value (or the form field's value) marks the chosen option: it renders in the trigger, carries aria-selected and the check mark, and the highlight homes on it when the panel opens. Options are label/value tuples here - the shapes select accepts all work." do
+    ~H"""
+    <div class="w-full max-w-xs mx-auto">
+      <.combo_box
+        id="sx-combo-chosen"
+        name="tz"
+        value="au_syd"
+        options={[
+          {"Sydney", "au_syd"},
+          {"Tokyo", "jp_tyo"},
+          {"Lisbon", "pt_lis"},
+          {"Stockholm", "se_sto"}
+        ]}
+      />
+    </div>
+    """
+  end
+
+  example :groups, "Groups and disabled options",
+    description:
+      "{group_label, options} renders a heading and keeps its position between flat options; a group hides itself when the query filters out every option inside. {label, value, disabled: true} renders the option present but inert - visible in the list, skipped by the keyboard." do
+    ~H"""
+    <div class="w-full max-w-xs mx-auto">
+      <.combo_box
+        id="sx-combo-groups"
+        name="city"
+        placeholder="Pick a city…"
+        options={[
+          {"Oceania", [{"Sydney", "syd"}, {"Auckland", "akl"}]},
+          {"Europe", [{"Lisbon", "lis"}, {"Stockholm", "sto", disabled: true}]}
+        ]}
+      />
+    </div>
+    """
+  end
+end

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -23,6 +23,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.Chart,
     PetalComponents.Showcase.Chat,
     PetalComponents.Showcase.ColorSchemeSwitch,
+    PetalComponents.Showcase.ComboBox,
     PetalComponents.Showcase.Command,
     PetalComponents.Showcase.Confetti,
     PetalComponents.Showcase.Dropdown,

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -1,0 +1,156 @@
+defmodule PetalComponents.ComboBoxTest do
+  use ComponentCase
+  import PetalComponents.ComboBox
+
+  test "renders the hidden select as the real form control" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box id="countries" name="country" options={["Australia", "Japan"]} />
+      """)
+
+    assert html =~ ~s|<select|
+    assert html =~ ~s|name="country"|
+    assert html =~ ~s|class="pc-combo-box__select"|
+    assert html =~ ~s|tabindex="-1"|
+    assert html =~ ~s|aria-hidden="true"|
+    # the empty option so "no selection" posts ""
+    assert html =~ ~s|<option value=""|
+    assert html =~ ~s|<option value="Australia"|
+  end
+
+  test "wires the WAI-ARIA combobox pattern" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box id="countries" name="country" options={["Australia"]} />
+      """)
+
+    assert html =~ ~s|phx-hook="PetalComboBox"|
+    assert html =~ ~s|role="combobox"|
+    assert html =~ ~s|aria-expanded="false"|
+    assert html =~ ~s|aria-autocomplete="list"|
+    assert html =~ ~s|aria-controls="countries-listbox"|
+    assert html =~ ~s|role="listbox"|
+    assert html =~ ~s|role="option"|
+    assert html =~ ~s|autocomplete="off"|
+  end
+
+  test "a chosen value selects the option, fills the display input and check-marks it" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box id="tz" name="tz" value="syd" options={[{"Sydney", "syd"}, {"Tokyo", "tyo"}]} />
+      """)
+
+    assert html =~ ~s|value="syd" selected|
+    assert html =~ ~s|value="Sydney"|
+    assert html =~ ~s|aria-selected="true"|
+  end
+
+  test "no value means empty display and nothing selected" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box id="tz" name="tz" options={[{"Sydney", "syd"}]} />
+      """)
+
+    refute html =~ ~s| selected>|
+    refute html =~ ~s|aria-selected="true"|
+  end
+
+  test "groups render optgroups in the select and headed groups in the listbox" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box
+        id="cities"
+        name="city"
+        options={[{"Oceania", [{"Sydney", "syd"}]}, {"Europe", [{"Lisbon", "lis"}]}]}
+      />
+      """)
+
+    assert html =~ ~s|<optgroup label="Oceania">|
+    assert html =~ ~s|data-pc-combo-group|
+    assert html =~ "Oceania"
+    assert html =~ ~s|data-value="lis"|
+  end
+
+  test "flat options between groups keep their position without a heading" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box
+        id="mixed"
+        name="pick"
+        options={["Loose", {"Grouped", [{"Inside", "in"}]}]}
+      />
+      """)
+
+    assert html =~ ~s|data-value="Loose"|
+    assert html =~ ~s|<optgroup label="Grouped">|
+  end
+
+  test "disabled options are inert in both the select and the listbox" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box id="tz" name="tz" options={[{"Sydney", "syd", disabled: true}]} />
+      """)
+
+    assert html =~ ~s|value="syd" disabled|
+    assert html =~ ~s|data-disabled="true"|
+    assert html =~ ~s|aria-disabled="true"|
+  end
+
+  test "disabling the component disables both the input and the select" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box id="tz" name="tz" disabled options={["Sydney"]} />
+      """)
+
+    # both the select and the input carry disabled
+    assert [_, _, _] = String.split(html, ~s| disabled|)
+  end
+
+  test "a form field supplies name, value and a stable derived id" do
+    assigns = %{
+      field: %Phoenix.HTML.FormField{
+        id: "user_country",
+        name: "user[country]",
+        value: "au",
+        errors: [],
+        field: :country,
+        form: %Phoenix.HTML.Form{}
+      }
+    }
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box field={@field} options={[{"Australia", "au"}]} />
+      """)
+
+    assert html =~ ~s|id="user_country_combo_box"|
+    assert html =~ ~s|name="user[country]"|
+    assert html =~ ~s|value="au" selected|
+  end
+
+  test "raises without any id source" do
+    assigns = %{}
+
+    assert_raise ArgumentError, ~r/stable id/, fn ->
+      rendered_to_string(~H"""
+      <.combo_box options={["Australia"]} />
+      """)
+    end
+  end
+end

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -144,6 +144,21 @@ defmodule PetalComponents.ComboBoxTest do
     assert html =~ ~s|value="au" selected|
   end
 
+  test "required and form_id render on the native select, not the wrapper" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box id="tz" name="tz" required form_id="filters" options={["Sydney"]} />
+      """)
+
+    [select_tag | _] = String.split(html, "</select>")
+    assert select_tag =~ ~s| required|
+    assert select_tag =~ ~s|form="filters"|
+    [wrapper_tag | _] = String.split(html, ">")
+    refute wrapper_tag =~ "required"
+  end
+
   test "raises without any id source" do
     assigns = %{}
 


### PR DESCRIPTION
Milestone 1 of the approved combobox arc (workspace `tasks/data-table-combobox-plan.md` §6.1) - single select on static options. M2 (multiple/chips), M3 (free_text autocomplete + the preserved remote-search contract) and M4 (`<.field type="combobox">`, playground page) follow as separate PRs.

## Architecture
- **The hidden native `<select>` IS the form control.** The visible input is display chrome. Choosing an option sets the select's value and dispatches bubbling input/change events - `phx-change`, changesets and LiveView form recovery behave exactly like a plain select. No `phx-update="ignore"` island, no Tom Select, zero JS deps.
- **`PetalComboBox` forks `PetalCommand`'s proven core**: same scoring ladder, options hidden-never-reordered (server owns DOM order, patch-safe), `updated()` re-syncs from the select so the server always wins.
- **Combobox-correct ARIA** (deliberate delta from the palette): `aria-selected` = the *chosen* option (check mark); the keyboard highlight is virtual (`data-highlighted` + `aria-activedescendant`). Focus never leaves the input.
- **Doctrine surfaces**: control = input_group recipe (ring on wrapper, borderless input); panel = dropdown grammar + 1rem radius clamp; options = command item recipe with derived radius; chevron/check on the doubled-selector icon contract.
- Options accept the `select` shapes: strings, `{label, value}`, `{label, value, disabled: true}`, `{group, options}` (optgroup in select, headed+self-hiding group in listbox).
- The classic trap handled: panel `pointerdown` preventDefaults so option clicks land before focusout closes the panel.

## Verification
- 10 markup tests; full suite 735 green (incl. the registry guard)
- **18 headless-Chrome assertions driving the real hook**: control-click open, filter-to-one, highlight homing (chosen on open, best match on query), Enter selection + change event count, display restore on Escape, empty state, group self-hiding, disabled-option skip - all pass
- Light + dark screenshots against compiled CSS (in session)