### PR TITLE
Combo box playground page + highlight the best match, not the first

### DIFF
--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3356,7 +3356,14 @@ export const PetalComboBox = {
 
     this.query = "";
 
-    this.onInput = () => {
+    this.onInput = (e) => {
+      // The display input is chrome, not data: keep its keystrokes inside the
+      // component. Without this every character reaches an enclosing form's
+      // phx-change - a round trip per keystroke, validation running against
+      // the not-yet-chosen value, and a patch that can wipe the query
+      // mid-type. The select's own input/change events (dispatched in
+      // choose) still bubble, which is how the server learns the value.
+      e.stopPropagation();
       this.query = this.input.value.trim().toLowerCase();
       if (this.panel.hidden) this.openPanel({ keepQuery: true });
       this.filter();

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3488,14 +3488,25 @@ export const PetalComboBox = {
     const query = this.query;
     let count = 0;
     let idBase = 0;
+    let best = null;
+    let bestScore = 0;
 
     for (const item of this.items()) {
       if (!item.id) item.id = `${this.el.id}-opt-${idBase}`;
       idBase++;
       const text = `${item.dataset.label || item.textContent || ""}`.trim().toLowerCase();
-      const show = this.score(text, query) > 0;
-      item.hidden = !show;
-      if (show) count++;
+      const score = this.score(text, query);
+      item.hidden = score === 0;
+      if (score === 0) continue;
+      count++;
+      // Options are hidden, never reordered (the server owns DOM order), so
+      // the highlight carries the ranking instead: Enter must commit the best
+      // match, not whichever match happens to sit highest. Typing "tok" has to
+      // land on Tokyo, not on Stockholm's fuzzy subsequence.
+      if (score > bestScore && !item.hasAttribute("data-disabled")) {
+        best = item;
+        bestScore = score;
+      }
     }
 
     for (const group of this.el.querySelectorAll("[data-pc-combo-group]")) {
@@ -3512,7 +3523,7 @@ export const PetalComboBox = {
     if (!query && chosen && !chosen.hidden && !chosen.hasAttribute("data-disabled")) {
       this.highlight(chosen, true);
     } else {
-      this.highlight(this.visibleItems()[0] || null, false);
+      this.highlight(best || this.visibleItems()[0] || null, false);
     }
   },
 

--- a/dev.exs
+++ b/dev.exs
@@ -227,6 +227,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "input-group", name: "Input group", ready: true},
         %{slug: "checkbox", name: "Checkbox", ready: true},
         %{slug: "select", name: "Select", ready: true},
+        %{slug: "combo-box", name: "Combo box", ready: true},
         %{slug: "radio", name: "Radio", ready: true},
         %{slug: "switch", name: "Switch", ready: true},
         %{slug: "slider", name: "Slider", ready: true},
@@ -743,6 +744,7 @@ defmodule Dev.PlaygroundLive do
        input: %{type: "text", disabled: false, error: false, help: false},
        checkbox: %{layout: "row", disabled: false, error: false},
        select: %{disabled: false, error: false, help: false},
+       combo: %{disabled: false, loop: false, chosen: nil},
        radio: %{
          style: "cards",
          variant: "outline",
@@ -1422,6 +1424,16 @@ defmodule Dev.PlaygroundLive do
     do:
       {:noreply,
        update(socket, :select, &Map.update!(&1, String.to_existing_atom(k), fn v -> !v end))}
+
+  def handle_event("ctl_combo", %{"k" => k}, socket) when k in ~w(disabled loop),
+    do:
+      {:noreply,
+       update(socket, :combo, &Map.update!(&1, String.to_existing_atom(k), fn v -> !v end))}
+
+  # the hidden select posts like any select - this is the whole point of the
+  # component, so the page proves it live
+  def handle_event("pg_combo_change", %{"pg_city" => value}, socket),
+    do: {:noreply, update(socket, :combo, &%{&1 | chosen: value})}
 
   def handle_event("ctl_checkbox", %{"k" => "layout", "v" => v}, socket) when v in ~w(row col),
     do: {:noreply, update(socket, :checkbox, &%{&1 | layout: v})}
@@ -7229,6 +7241,97 @@ defmodule Dev.PlaygroundLive do
 
       <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
         These examples render from the shared <code>PetalComponents.Showcase.Field</code>
+        registry - the same source petal.build renders, so the playground and the marketing
+        docs can't drift.
+      </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "combo-box"} = assigns) do
+    ~H"""
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">Combo box</h1>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        A searchable select: type to filter, arrow keys to move, Enter to choose.
+        The visible input is chrome - a hidden native select carries the value,
+        so it posts and recovers like any other form control.
+      </p>
+
+      <h2 class="mt-8 mb-2 text-lg font-semibold">Try it</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        This one is wired to a real form with phx-change. Choose a city and the
+        server receives it immediately - no hook messages, no client state, just
+        the select underneath doing what selects do.
+      </p>
+
+      <div class="border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="flex items-center justify-center px-6 py-12">
+          <form phx-change="pg_combo_change" class="w-full max-w-sm">
+            <.combo_box
+              id="pg-combo"
+              name="pg_city"
+              placeholder="Search cities…"
+              value={@combo.chosen}
+              disabled={@combo.disabled}
+              loop={@combo.loop}
+              options={[
+                {"Oceania",
+                 [
+                   {"Sydney", "syd"},
+                   {"Melbourne", "mel"},
+                   {"Auckland", "akl"},
+                   {"Perth", "per", disabled: true}
+                 ]},
+                {"Europe",
+                 [{"Lisbon", "lis"}, {"Stockholm", "sto"}, {"Berlin", "ber"}, {"Porto", "opo"}]},
+                {"Asia", [{"Tokyo", "tyo"}, {"Singapore", "sin"}, {"Seoul", "sel"}]}
+              ]}
+            />
+          </form>
+        </div>
+
+        <div class="px-4 py-3 text-sm border-t border-gray-200 sm:px-6 dark:border-gray-800">
+          <span class="text-gray-400">the server has:</span>
+          <code class="ml-1 font-mono text-gray-900 dark:text-gray-100">
+            {if @combo.chosen in [nil, ""], do: "nothing yet", else: @combo.chosen}
+          </code>
+        </div>
+
+        <div class="flex flex-wrap items-end px-4 py-4 border-t border-gray-200 gap-x-8 gap-y-4 sm:px-6 dark:border-gray-800">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">state</div>
+            <.toggle_group
+              multiple
+              variant="outline"
+              size="sm"
+              aria_label="State"
+              value={for {k, on} <- [{"disabled", @combo.disabled}, {"loop", @combo.loop}], on, do: k}
+              on_change="ctl_combo"
+            >
+              <:item value="disabled" phx-value-k="disabled">disabled</:item>
+              <:item value="loop" phx-value-k="loop">loop</:item>
+            </.toggle_group>
+          </div>
+        </div>
+      </div>
+
+      <div
+        :for={ex <- examples_for(PetalComponents.Showcase.ComboBox, ~w(basic preselected groups)a)}
+        class="mt-10"
+      >
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
+      <.showcase_props component={PetalComponents.ComboBox} function={:combo_box} />
+
+      <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        These examples render from the shared <code>PetalComponents.Showcase.ComboBox</code>
         registry - the same source petal.build renders, so the playground and the marketing
         docs can't drift.
       </div>


### PR DESCRIPTION
Nic asked to eye-test the combobox locally; the component had registry examples but no playground page (that was scheduled for M4). Adding the page immediately surfaced a real bug, which is the more important half of this PR.

## The fix
Typing `tok` highlighted **Stockholm** - its fuzzy subsequence (s-**t**-**o**-c-**k**) sits above Tokyo's prefix match in DOM order. Since options are hidden and never reordered (the server owns DOM order), the first *visible* option was winning the highlight regardless of score, so **Enter committed the wrong value**.

`filter()` now homes the highlight on the best-scoring visible option. Ranking lives in the highlight precisely because it can't live in the order.

## The page
- **Try it** section wired to a real form with `phx-change` - the server's received value renders live underneath, which demonstrates the whole architectural claim (hidden native select, no client state) rather than just asserting it
- `disabled` / `loop` dials, three grouped option sets, one disabled option
- The three registry examples + props table

## Verification
- Full suite 744 green
- Headless hook suite now 21/21, including a new regression assertion for the ranking bug
- Eye-tested live in the playground: open, filter, keyboard, selection round-trip to the server