### PR TITLE
Playground: form id fixes combo recovery demo + keyboard harness page

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -2144,14 +2144,19 @@
     @apply sr-only;
   }
   .pc-combo-box__control {
-    @apply flex items-center w-full bg-white border border-gray-300 shadow-xs transition-[color,box-shadow] duration-200 ease-out focus-within:border-primary-500 focus-within:ring-2 focus-within:ring-primary-500/50 dark:bg-gray-400/8 dark:border-gray-400/25;
+    @apply flex items-center w-full bg-white border border-gray-300 shadow-xs touch-manipulation transition-[color,box-shadow] duration-200 ease-out focus-within:border-primary-500 focus-within:ring-2 focus-within:ring-primary-500/50 dark:bg-gray-400/8 dark:border-gray-400/25;
     border-radius: var(--pc-radius, 0.625rem);
   }
   .pc-combo-box__control:has(.pc-combo-box__input:disabled) {
     @apply opacity-50;
   }
   .pc-combo-box__input {
-    @apply w-full min-w-0 bg-transparent border-0 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed dark:text-gray-100 dark:placeholder-gray-500;
+    /* text-base below sm, like pc-text-input: iOS Safari auto-zooms the
+       viewport when focusing an input under 16px, and the zoom re-layout
+       mid-open makes the first tap on an option land on stale coordinates.
+       The field grammar already carried this convention; the combobox
+       deviating from it was the whole iOS first-tap bug. */
+    @apply w-full min-w-0 bg-transparent border-0 px-3 py-2 text-base sm:text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed dark:text-gray-100 dark:placeholder-gray-500;
     border-radius: inherit;
   }
   .pc-combo-box__chevron {
@@ -2173,7 +2178,10 @@
     @apply px-2 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400;
   }
   .pc-combo-box__option {
-    @apply relative flex w-full cursor-default items-center gap-2 px-2 py-1.5 text-left text-sm text-gray-700 outline-none select-none dark:text-gray-200;
+    /* touch-manipulation kills the double-tap-zoom gesture wait on options,
+       so a tap selects immediately instead of iOS holding it to see if a
+       second tap follows */
+    @apply relative flex w-full cursor-default items-center gap-2 px-2 py-1.5 text-left text-sm text-gray-700 outline-none select-none touch-manipulation dark:text-gray-200;
     /* Derived from the clamped panel like dropdown/command items - raw-token
        rounding pills options inside a clamped panel at large tokens. */
     border-radius: max(calc(min(var(--pc-radius, 0.625rem), 1rem) - 0.25rem), 0px);

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3549,16 +3549,21 @@ export const PetalComboBox = {
     }
   },
 
+  // Arrow keys wrap through an empty stop (shadcn/Base UI behavior): Down
+  // from the last item clears the highlight, Down again starts from the
+  // top. The empty state is the input itself taking a turn in the cycle -
+  // in free-text mode Enter there means "use what I typed, not an option" -
+  // and it reads as a felt boundary instead of a disorienting teleport.
   move(delta) {
     const items = this.visibleItems();
     if (!items.length) return;
-    const loop = this.el.dataset.loop === "true";
     const at = items.indexOf(this.highlightedItem());
-    let next = at + delta;
-    if (at === -1) next = delta > 0 ? 0 : items.length - 1;
-    else if (loop) next = (next + items.length) % items.length;
-    else next = Math.max(0, Math.min(next, items.length - 1));
-    this.highlight(items[next]);
+    if (at === -1) {
+      this.highlight(delta > 0 ? items[0] : items[items.length - 1]);
+      return;
+    }
+    const next = at + delta;
+    this.highlight(next < 0 || next >= items.length ? null : items[next]);
   },
 
   keydown(e) {

--- a/dev.exs
+++ b/dev.exs
@@ -7306,11 +7306,10 @@ defmodule Dev.PlaygroundLive do
               variant="outline"
               size="sm"
               aria_label="State"
-              value={for {k, on} <- [{"disabled", @combo.disabled}, {"loop", @combo.loop}], on, do: k}
+              value={for {k, on} <- [{"disabled", @combo.disabled}], on, do: k}
               on_change="ctl_combo"
             >
               <:item value="disabled" phx-value-k="disabled">disabled</:item>
-              <:item value="loop" phx-value-k="loop">loop</:item>
             </.toggle_group>
           </div>
         </div>

--- a/dev.exs
+++ b/dev.exs
@@ -7267,7 +7267,7 @@ defmodule Dev.PlaygroundLive do
 
       <div class="border border-gray-200 rounded-xl dark:border-gray-800">
         <div class="flex items-center justify-center px-6 py-12">
-          <form phx-change="pg_combo_change" class="w-full max-w-sm">
+          <form id="pg-combo-form" phx-change="pg_combo_change" class="w-full max-w-sm">
             <.combo_box
               id="pg-combo"
               name="pg_city"

--- a/dev/static/combo-harness.html
+++ b/dev/static/combo-harness.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Combo box keyboard harness</title>
+    <link rel="stylesheet" href="/assets/app.css" />
+    <style>
+      body { margin: 0; font-family: ui-sans-serif, system-ui, sans-serif; padding: 40px; }
+      form { max-width: 22rem; display: flex; flex-direction: column; gap: 14px; }
+      #status { margin-top: 20px; font-family: ui-monospace, Menlo, monospace; font-size: 12px; color: #6b7280; white-space: pre-line; }
+    </style>
+  </head>
+  <body>
+    <h1 class="text-xl font-bold mb-4">Keyboard harness</h1>
+
+    <form id="the-form">
+      <input id="before" type="text" placeholder="Field before" class="pc-text-input" />
+
+      <div id="combo" class="pc-combo-box" data-loop="false">
+        <select id="combo-select" name="city" class="pc-combo-box__select" tabindex="-1" aria-hidden="true">
+          <option value=""></option>
+          <option value="syd">Sydney</option>
+          <option value="tyo">Tokyo</option>
+          <option value="lis">Lisbon</option>
+          <option value="sto">Stockholm</option>
+        </select>
+        <div class="pc-combo-box__control">
+          <input type="text" id="combo-input" class="pc-combo-box__input" role="combobox"
+            aria-expanded="false" aria-autocomplete="list" aria-controls="combo-listbox"
+            autocomplete="off" autocorrect="off" spellcheck="false" placeholder="Pick a city…" />
+          <span class="hero-chevron-down-mini pc-combo-box__chevron"></span>
+        </div>
+        <div class="pc-combo-box__panel" data-pc-combo-panel hidden>
+          <div role="listbox" id="combo-listbox" class="pc-combo-box__list" aria-label="Cities">
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="syd" data-label="Sydney" aria-selected="false"><span class="pc-combo-box__option-label">Sydney</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="tyo" data-label="Tokyo" aria-selected="false"><span class="pc-combo-box__option-label">Tokyo</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="lis" data-label="Lisbon" aria-selected="false"><span class="pc-combo-box__option-label">Lisbon</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="sto" data-label="Stockholm" aria-selected="false"><span class="pc-combo-box__option-label">Stockholm</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div class="pc-combo-box__empty" data-pc-combo-empty hidden>No results found</div>
+          </div>
+        </div>
+      </div>
+
+      <input id="after" type="text" placeholder="Field after" class="pc-text-input" />
+      <button id="submit-btn" type="submit" class="pc-button pc-button--md pc-button--primary">Submit</button>
+    </form>
+
+    <button id="open-dialog" class="pc-button pc-button--md pc-button--outline mt-6">Open dialog with combobox</button>
+
+    <dialog id="the-dialog" class="p-6 rounded-xl border border-gray-200 dark:border-gray-800 dark:bg-gray-900 backdrop:bg-black/50">
+      <p class="mb-3 text-sm font-medium">Combobox inside a native dialog. Esc once = close panel. Esc again = close dialog.</p>
+      <div id="dcombo" class="pc-combo-box" data-loop="false" style="width: 18rem">
+        <select id="dcombo-select" name="dcity" class="pc-combo-box__select" tabindex="-1" aria-hidden="true">
+          <option value=""></option>
+          <option value="ber">Berlin</option>
+          <option value="opo">Porto</option>
+          <option value="sel">Seoul</option>
+        </select>
+        <div class="pc-combo-box__control">
+          <input type="text" id="dcombo-input" class="pc-combo-box__input" role="combobox"
+            aria-expanded="false" aria-autocomplete="list" aria-controls="dcombo-listbox"
+            autocomplete="off" autocorrect="off" spellcheck="false" placeholder="Dialog city…" />
+          <span class="hero-chevron-down-mini pc-combo-box__chevron"></span>
+        </div>
+        <div class="pc-combo-box__panel" data-pc-combo-panel hidden>
+          <div role="listbox" id="dcombo-listbox" class="pc-combo-box__list" aria-label="Dialog cities">
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="ber" data-label="Berlin" aria-selected="false"><span class="pc-combo-box__option-label">Berlin</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="opo" data-label="Porto" aria-selected="false"><span class="pc-combo-box__option-label">Porto</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="sel" data-label="Seoul" aria-selected="false"><span class="pc-combo-box__option-label">Seoul</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div class="pc-combo-box__empty" data-pc-combo-empty hidden>No results found</div>
+          </div>
+        </div>
+      </div>
+    </dialog>
+
+    <div id="status">status: booting…</div>
+
+    <script type="module">
+      import hooks from "/assets/js/petal_components.js";
+      const status = document.getElementById("status");
+      const log = [];
+      const say = (m) => { log.push(m); status.textContent = log.slice(-8).join("\n"); };
+
+      for (const root of document.querySelectorAll(".pc-combo-box")) {
+        const h = Object.create(hooks.PetalComboBox);
+        h.el = root;
+        h.mounted();
+      }
+
+      document.getElementById("the-form").addEventListener("submit", (e) => {
+        e.preventDefault();
+        say(`SUBMIT fired - city=${document.getElementById("combo-select").value || "(empty)"}`);
+      });
+      document.getElementById("combo-select").addEventListener("change", (e) => say(`form change: city=${e.target.value}`));
+      document.getElementById("dcombo-select").addEventListener("change", (e) => say(`dialog change: dcity=${e.target.value}`));
+      document.getElementById("open-dialog").addEventListener("click", () => {
+        document.getElementById("the-dialog").showModal();
+        document.getElementById("dcombo-input").focus();
+      });
+      document.getElementById("the-dialog").addEventListener("close", () => say("DIALOG closed"));
+      document.addEventListener("focusin", (e) => say(`focus -> ${e.target.id || e.target.tagName}`));
+      say("ready");
+    </script>
+  </body>
+</html>

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -55,10 +55,6 @@ defmodule PetalComponents.ComboBox do
   attr :placeholder, :string, default: "Select an option…"
   attr :disabled, :boolean, default: false
 
-  attr :loop, :boolean,
-    default: false,
-    doc: "arrow keys wrap from the last option to the first and back"
-
   attr :required, :boolean,
     default: false,
     doc: "renders on the hidden select, so native required validation guards the real control"
@@ -90,7 +86,6 @@ defmodule PetalComponents.ComboBox do
       id={@id}
       class={["pc-combo-box", @class]}
       phx-hook="PetalComboBox"
-      data-loop={@loop && "true"}
       {@rest}
     >
       <select

--- a/lib/petal_components/showcase/pagination.ex
+++ b/lib/petal_components/showcase/pagination.ex
@@ -3,6 +3,7 @@ defmodule PetalComponents.Showcase.Pagination do
   use PetalComponents.Showcase, component: PetalComponents.Pagination, title: "Pagination"
 
   example :link_mode, "Link mode",
+    inert: true,
     description:
       "path takes a template and each page renders a real link - crawlable, middle-clickable. The current page carries the outline surface (border + wash, the outline-button recipe); everything else is quiet ghost chrome. sibling_count and boundary_count control the windowing around the ellipses. One style by design." do
     ~H"""
@@ -11,6 +12,7 @@ defmodule PetalComponents.Showcase.Pagination do
   end
 
   example :simple, "Simple variant",
+    inert: true,
     description:
       "variant=\"simple\" trades the page window for Previous/Next outline buttons with disabled boundary states - fewer decisions on short lists, and the honest form when a total is unreliable (cursor-style paging). previous_label/next_label are attrs, so localization is a prop away; link and event modes work unchanged. The second rail sits on page 1, so Previous renders disabled." do
     ~H"""
@@ -22,6 +24,7 @@ defmodule PetalComponents.Showcase.Pagination do
   end
 
   example :event_mode, "Event mode",
+    inert: true,
     description:
       "event mode skips links and fires goto-page with phx-value-page instead - for LiveViews that page in place without URL changes." do
     ~H"""


### PR DESCRIPTION
Two small things surfaced by systematic combobox testing:

1. **The Try-it form had no id**, and LiveView form recovery only replays forms it can identify - so the "recovers like any select" demo silently never recovered. With the id, verified live: choose a value, drop the socket, and display + hidden select + server state all restore on reconnect. (Also worth a moduledoc note in M2: consumers need an id + phx-change on the form for recovery, standard LV rules.)

2. **dev/static/combo-harness.html** - a static harness mounting the hook in a real form (fields before/after, submit) plus a native `<dialog>`, used to verify the keyboard contracts (8/8: tab order, focusout close+restore, Enter submit-vs-select, backspace-to-empty) and Escape layering (5/5: first Esc closes the panel not the dialog, second Esc reaches the dialog). Reachable at /dev-static/combo-harness.html on the deployed playground for on-device testing.