### PR TITLE
combo_box: outside-press closes the panel (iOS Safari tap-away)

### DIFF
--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3395,6 +3395,14 @@ export const PetalComboBox = {
     this.onFocusOut = (e) => {
       if (!this.el.contains(e.relatedTarget)) this.closePanel();
     };
+    // focusout covers Tab-away and desktop clicks (desktop blurs the input
+    // when you click static content), but iOS Safari deliberately keeps
+    // focus when tapping non-interactive content - no blur, no focusout, a
+    // panel that would not close. Outside-press detection is the standard
+    // answer; bound only while the panel is open.
+    this.onOutsidePointerDown = (e) => {
+      if (!this.el.contains(e.target)) this.closePanel();
+    };
 
     this.input.addEventListener("input", this.onInput);
     this.input.addEventListener("keydown", this.onKeydown);
@@ -3422,6 +3430,7 @@ export const PetalComboBox = {
     this.panel.removeEventListener("pointerdown", this.onPanelPointerDown);
     this.control.removeEventListener("click", this.onControlClick);
     this.el.removeEventListener("focusout", this.onFocusOut);
+    document.removeEventListener("pointerdown", this.onOutsidePointerDown, true);
   },
 
   items() {
@@ -3448,11 +3457,13 @@ export const PetalComboBox = {
     if (!this.panel.hidden) return;
     this.panel.hidden = false;
     this.input.setAttribute("aria-expanded", "true");
+    document.addEventListener("pointerdown", this.onOutsidePointerDown, true);
     if (!keepQuery) this.query = "";
     this.filter();
   },
 
   closePanel() {
+    document.removeEventListener("pointerdown", this.onOutsidePointerDown, true);
     if (this.panel.hidden) return;
     this.panel.hidden = true;
     this.input.setAttribute("aria-expanded", "false");


### PR DESCRIPTION
Nic's on-device find: on iOS Safari, tapping anything that isn't another input left the combobox panel open - the only exits were choosing an option or focusing another field.

**Cause**: the close path relied on `focusout`. Desktop browsers blur a focused input when you click static content; **iOS Safari deliberately doesn't** - non-interactive taps keep focus and the keyboard, so no blur, no focusout, no close. iOS Chrome's touch layer blurs, which is why it behaved there.

**Fix**: explicit outside-press detection, the same approach Base UI/shadcn use - a capture-phase `document` pointerdown listener bound only while the panel is open (removed on close and destroy). `focusout` remains for Tab-away.

**Verification**: full suite 744 green; headless hook suite 29/29 with two new assertions (outside-press closes; inside-press does not close before the click lands).