### PR TITLE
Playground: sweep loop remnants off the combo page

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -744,7 +744,7 @@ defmodule Dev.PlaygroundLive do
        input: %{type: "text", disabled: false, error: false, help: false},
        checkbox: %{layout: "row", disabled: false, error: false},
        select: %{disabled: false, error: false, help: false},
-       combo: %{disabled: false, loop: false, chosen: nil},
+       combo: %{disabled: false, chosen: nil},
        radio: %{
          style: "cards",
          variant: "outline",
@@ -1425,7 +1425,7 @@ defmodule Dev.PlaygroundLive do
       {:noreply,
        update(socket, :select, &Map.update!(&1, String.to_existing_atom(k), fn v -> !v end))}
 
-  def handle_event("ctl_combo", %{"k" => k}, socket) when k in ~w(disabled loop),
+  def handle_event("ctl_combo", %{"k" => k}, socket) when k in ~w(disabled),
     do:
       {:noreply,
        update(socket, :combo, &Map.update!(&1, String.to_existing_atom(k), fn v -> !v end))}
@@ -7274,7 +7274,6 @@ defmodule Dev.PlaygroundLive do
               placeholder="Search cities…"
               value={@combo.chosen}
               disabled={@combo.disabled}
-              loop={@combo.loop}
               options={[
                 {"Oceania",
                  [


### PR DESCRIPTION
The `loop` attr was removed with the empty-stop keyboard ruling (#543), but three remnants survived on the combo playground page: the `loop: false` state key, the `ctl_combo` handler still accepting `"loop"`, and `loop={@combo.loop}` passed to a component that no longer declares the attr - a compile warning on every playground boot. The dial markup itself was already clean; this removes the dead plumbing. dev.exs parses; no behavior change.