### PR TITLE
test(js): PetalComboBox hook spec - M2 task one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 
 #### Added
 
+- **`combo_box` grows up: `multiple` with chips, `clearable`, and the
+  hardening pass** (combobox M2 core). `multiple` turns the trigger into
+  a chip row - removable tokens, panel stays open while picking,
+  Backspace in an empty input removes the last chip - backed by a real
+  `<select multiple>` whose name gains `[]`, so every choice survives
+  the form post like a native multiple select. `max_items` caps the
+  count (at the cap, unchosen options rest until something is removed).
+  `clearable` adds a real clear *button* - hit target, focus ring,
+  aria-label - to single selects. Riders: the hidden select is `inert`
+  (dialog autofocus can never land on it), `form.reset()` re-syncs the
+  chrome, and a polite live region announces result counts as you
+  filter. The native WebKit search-cancel X is suppressed on pc search
+  inputs package-wide - the clear affordance is the house clearable
+  pattern, never browser chrome. The hook's behavioral contract is now
+  pinned by a committed vitest spec (the session harness, ported).
+
 - **`combo_box` - the searchable select, milestone 1 of the combobox arc**
   (tasks/data-table-combobox-plan.md §6, Matt-approved). Type to filter,
   arrow keys to move, Enter to choose: the command palette's proven

--- a/assets/default.css
+++ b/assets/default.css
@@ -2208,6 +2208,61 @@
   .pc-combo-box__empty {
     @apply px-2 py-6 text-center text-sm text-gray-500 dark:text-gray-400;
   }
+  /* multiple: the control becomes a wrapping chip row; the input shares the
+     line and keeps a typing floor */
+  .pc-combo-box__control:has([data-pc-combo-chips]) {
+    @apply flex-wrap gap-y-1 py-1;
+  }
+  .pc-combo-box__control:has([data-pc-combo-chips]) .pc-combo-box__input {
+    @apply flex-1 min-w-24 py-1;
+  }
+  .pc-combo-box__chips {
+    @apply flex flex-wrap items-center gap-1 pl-1.5 max-w-full;
+  }
+  .pc-combo-box__chips:empty {
+    @apply hidden;
+  }
+  .pc-combo-box__chip {
+    @apply inline-flex max-w-full items-center gap-0.5 bg-gray-100 py-0.5 pl-1.5 pr-0.5 text-xs font-medium text-gray-700 dark:bg-gray-400/17 dark:text-gray-200;
+    border-radius: max(calc(min(var(--pc-radius, 0.625rem), 1rem) - 0.25rem), 0px);
+  }
+  .pc-combo-box__chip-label {
+    @apply truncate;
+  }
+  /* interactive in-field icon = a real button: hit target, focus ring */
+  .pc-combo-box__chip-remove {
+    @apply inline-flex h-4.5 w-4.5 shrink-0 items-center justify-center rounded-sm text-gray-500 transition-colors hover:bg-gray-200 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:text-gray-400 dark:hover:bg-gray-400/25 dark:hover:text-white;
+  }
+  .pc-combo-box__chip-remove-icon.pc-combo-box__chip-remove-icon {
+    @apply w-3.5! h-3.5!;
+  }
+  .pc-combo-box__clear {
+    @apply mr-0.5 hidden h-6 w-6 shrink-0 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:text-gray-500 dark:hover:bg-gray-400/17 dark:hover:text-gray-200;
+  }
+  .pc-combo-box[data-has-value] .pc-combo-box__clear {
+    @apply inline-flex;
+  }
+  /* Doubled selector + !important: icon sizing contract (see pagination previous chevron). */
+  .pc-combo-box__clear-icon.pc-combo-box__clear-icon {
+    @apply w-4! h-4!;
+  }
+  /* at max_items, unchosen options rest until something is removed */
+  .pc-combo-box[data-max-reached] .pc-combo-box__option:not([aria-selected="true"]) {
+    @apply pointer-events-none opacity-50;
+  }
+  .pc-combo-box__live {
+    @apply sr-only;
+  }
+
+  /* Search inputs: the native WebKit cancel button is unstyleable browser
+     chrome - the clear affordance is the house clearable pattern instead
+     (field clearable / combo_box clearable). */
+  .pc-text-input[type="search"]::-webkit-search-cancel-button,
+  .pc-combo-box__input::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    appearance: none;
+    display: none;
+  }
 
   /* Tooltip */
 

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3354,6 +3354,10 @@ export const PetalComboBox = {
     this.list = this.el.querySelector(".pc-combo-box__list");
     if (!this.select || !this.input || !this.panel || !this.list) return;
 
+    this.multiple = this.select.multiple;
+    this.chips = this.el.querySelector("[data-pc-combo-chips]");
+    this.live = this.el.querySelector("[data-pc-combo-live]");
+    this.clearBtn = this.el.querySelector("[data-pc-combo-clear]");
     this.query = "";
 
     this.onInput = (e) => {
@@ -3382,6 +3386,19 @@ export const PetalComboBox = {
     this.onPanelPointerDown = (e) => e.preventDefault();
     this.onControlClick = (e) => {
       if (this.input.disabled) return;
+      if (e.target.closest("[data-pc-combo-chip-remove]")) {
+        const value = e.target.closest("[data-pc-combo-chip-remove]").dataset.value;
+        this.setSelected(value, false);
+        this.input.focus();
+        return;
+      }
+      if (e.target.closest("[data-pc-combo-clear]")) {
+        this.select.value = "";
+        this.dispatchChange();
+        this.syncFromSelect();
+        this.input.focus();
+        return;
+      }
       if (this.panel.hidden) {
         this.openPanel();
         this.input.focus();
@@ -3403,6 +3420,8 @@ export const PetalComboBox = {
     this.onOutsidePointerDown = (e) => {
       if (!this.el.contains(e.target)) this.closePanel();
     };
+    // form.reset() resets the select; nothing else would re-sync the chrome
+    this.onFormReset = () => setTimeout(() => this.syncFromSelect(), 0);
 
     this.input.addEventListener("input", this.onInput);
     this.input.addEventListener("keydown", this.onKeydown);
@@ -3411,6 +3430,8 @@ export const PetalComboBox = {
     this.panel.addEventListener("pointerdown", this.onPanelPointerDown);
     this.control.addEventListener("click", this.onControlClick);
     this.el.addEventListener("focusout", this.onFocusOut);
+    this.form = this.select.form;
+    if (this.form) this.form.addEventListener("reset", this.onFormReset);
 
     this.syncFromSelect();
   },
@@ -3430,6 +3451,7 @@ export const PetalComboBox = {
     this.panel.removeEventListener("pointerdown", this.onPanelPointerDown);
     this.control.removeEventListener("click", this.onControlClick);
     this.el.removeEventListener("focusout", this.onFocusOut);
+    if (this.form) this.form.removeEventListener("reset", this.onFormReset);
     document.removeEventListener("pointerdown", this.onOutsidePointerDown, true);
   },
 
@@ -3472,6 +3494,17 @@ export const PetalComboBox = {
     this.restoreDisplay();
   },
 
+  selectedValues() {
+    return Array.from(this.select.selectedOptions)
+      .map((o) => o.value)
+      .filter((v) => v !== "");
+  },
+
+  maxReached() {
+    const max = parseInt(this.el.dataset.maxItems || "", 10);
+    return this.multiple && !isNaN(max) && this.selectedValues().length >= max;
+  },
+
   chosenItem() {
     const value = this.select.value;
     if (!value) return null;
@@ -3479,27 +3512,96 @@ export const PetalComboBox = {
   },
 
   restoreDisplay() {
+    if (this.multiple) {
+      this.input.value = "";
+      return;
+    }
     const chosen = this.chosenItem();
     this.input.value = chosen ? chosen.dataset.label || "" : "";
   },
 
+  dispatchChange() {
+    this.select.dispatchEvent(new Event("input", { bubbles: true }));
+    this.select.dispatchEvent(new Event("change", { bubbles: true }));
+  },
+
+  setSelected(value, selected) {
+    const option = Array.from(this.select.options).find((o) => o.value === value);
+    if (!option || option.selected === selected) return;
+    if (this.multiple) {
+      option.selected = selected;
+    } else {
+      this.select.value = selected ? value : "";
+    }
+    this.dispatchChange();
+    this.syncFromSelect();
+    if (!this.panel.hidden) this.filter();
+  },
+
+  syncChips() {
+    if (!this.chips) return;
+    const removeLabel = (this.chips.dataset.removeLabel || "Remove") + " ";
+    this.chips.textContent = "";
+    for (const option of this.select.selectedOptions) {
+      if (option.value === "") continue;
+      const chip = document.createElement("span");
+      chip.className = "pc-combo-box__chip";
+      chip.setAttribute("data-pc-combo-chip", "");
+      const label = document.createElement("span");
+      label.className = "pc-combo-box__chip-label";
+      label.textContent = option.textContent.trim();
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "pc-combo-box__chip-remove";
+      btn.setAttribute("data-pc-combo-chip-remove", "");
+      btn.dataset.value = option.value;
+      btn.setAttribute("aria-label", removeLabel + option.textContent.trim());
+      btn.tabIndex = -1;
+      const icon = document.createElement("span");
+      icon.className = "hero-x-mark-mini pc-combo-box__chip-remove-icon";
+      btn.appendChild(icon);
+      chip.append(label, btn);
+      this.chips.appendChild(chip);
+    }
+  },
+
   syncFromSelect() {
-    const value = this.select.value;
+    const values = this.selectedValues();
     for (const i of this.items()) {
-      i.setAttribute("aria-selected", value !== "" && i.dataset.value === value ? "true" : "false");
+      i.setAttribute("aria-selected", values.includes(i.dataset.value) ? "true" : "false");
+    }
+    this.el.toggleAttribute("data-has-value", values.length > 0);
+    if (this.multiple) {
+      this.syncChips();
+      this.el.toggleAttribute("data-max-reached", this.maxReached());
     }
     if (this.panel.hidden || document.activeElement !== this.input) this.restoreDisplay();
   },
 
   choose(item) {
-    if (this.select.value !== item.dataset.value) {
-      this.select.value = item.dataset.value;
-      this.select.dispatchEvent(new Event("input", { bubbles: true }));
-      this.select.dispatchEvent(new Event("change", { bubbles: true }));
+    const value = item.dataset.value;
+    if (this.multiple) {
+      const selected = this.selectedValues().includes(value);
+      if (!selected && this.maxReached()) return;
+      this.setSelected(value, !selected);
+      // the panel stays open for more picks; the query resets so the next
+      // keystrokes start a fresh search
+      this.query = "";
+      this.input.value = "";
+      this.filter();
+      this.input.focus();
+      return;
     }
-    this.syncFromSelect();
+    this.setSelected(value, true);
     this.closePanel();
     this.input.focus();
+  },
+
+  announce(count) {
+    if (!this.live) return;
+    const label = this.live.dataset.resultsLabel || "results";
+    const empty = this.live.dataset.noResultsText || "No results found";
+    this.live.textContent = count === 0 ? empty : `${count} ${label}`;
   },
 
   filter() {
@@ -3534,10 +3636,11 @@ export const PetalComboBox = {
 
     const empty = this.el.querySelector("[data-pc-combo-empty]");
     if (empty) empty.hidden = count > 0;
+    this.announce(count);
 
     // an empty query (just opened) homes the highlight on the chosen value;
     // a typed query homes it on the best (first) visible match
-    const chosen = this.chosenItem();
+    const chosen = this.multiple ? null : this.chosenItem();
     if (!query && chosen && !chosen.hidden && !chosen.hasAttribute("data-disabled")) {
       this.highlight(chosen, true);
     } else {
@@ -3597,6 +3700,12 @@ export const PetalComboBox = {
         e.preventDefault();
         this.highlight(this.visibleItems().slice(-1)[0] || null);
         break;
+      case "Backspace": {
+        if (!this.multiple || this.input.value !== "") return;
+        const values = this.selectedValues();
+        if (values.length) this.setSelected(values[values.length - 1], false);
+        break;
+      }
       case "Enter": {
         if (this.panel.hidden) return; // closed: let the form submit
         e.preventDefault();

--- a/dev.exs
+++ b/dev.exs
@@ -7315,7 +7315,10 @@ defmodule Dev.PlaygroundLive do
       </div>
 
       <div
-        :for={ex <- examples_for(PetalComponents.Showcase.ComboBox, ~w(basic preselected groups)a)}
+        :for={
+          ex <-
+            examples_for(PetalComponents.Showcase.ComboBox, ~w(multiple basic preselected groups)a)
+        }
         class="mt-10"
       >
         <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -7,6 +7,8 @@ defmodule PetalComponents.ComboBox do
   makes the component form-native: changesets, `phx-change` and LiveView
   form recovery all work exactly as they do for a plain select - there is
   no `phx-update="ignore"` island and no client-owned state to lose.
+  (Recovery follows the standard LiveView rules: the enclosing form needs
+  an id and a phx-change.)
 
   Filtering happens client-side in the hook (zero dependencies), reusing
   the command palette's scoring: value prefix beats word-boundary prefix
@@ -19,11 +21,30 @@ defmodule PetalComponents.ComboBox do
   `listbox`, options are `option`s. Keyboard focus never leaves the
   input; the highlight is virtual (`data-highlighted`), and
   `aria-selected` means the *chosen* value - the check-marked one - not
-  the highlight.
+  the highlight. Arrow keys wrap through an empty stop: Down past the
+  last option clears the highlight, Down again starts from the top.
 
       <.form :let={f} for={@form} phx-change="validate">
         <.combo_box field={f[:country]} options={["Australia", "Japan", "Portugal"]} />
       </.form>
+
+  ## Multiple
+
+  `multiple` turns the trigger into a chip row: each chosen option renders
+  as a removable token, the panel stays open while picking, Backspace in
+  an empty input removes the last chip, and the hidden select becomes a
+  real `<select multiple>` (the name gains `[]` so every choice survives
+  the form post). `max_items` caps how many can be chosen - at the cap,
+  unchosen options render inert until something is removed.
+
+      <.combo_box
+        field={f[:tags]}
+        multiple
+        max_items={5}
+        options={["elixir", "phoenix", "liveview"]}
+      />
+
+  ## Options
 
   Options accept the shapes `select` users expect:
 
@@ -45,12 +66,27 @@ defmodule PetalComponents.ComboBox do
     doc: "a form field, e.g. f[:country] - supplies name, value and id"
 
   attr :name, :string, default: nil, doc: "input name, when not using field"
-  attr :value, :any, default: nil, doc: "current value, when not using field (overrides field)"
+
+  attr :value, :any,
+    default: nil,
+    doc: "current value - or list of values when multiple (overrides field)"
 
   attr :options, :list,
     default: [],
     doc:
       "strings, {label, value} tuples, {label, value, opts} (opts: disabled: true), or {group_label, options} groups"
+
+  attr :multiple, :boolean,
+    default: false,
+    doc: "chip-row selection: the hidden select becomes select multiple and the name gains []"
+
+  attr :max_items, :integer,
+    default: nil,
+    doc: "multiple only: cap on chosen options; at the cap, unchosen options render inert"
+
+  attr :clearable, :boolean,
+    default: false,
+    doc: "single select only: show a clear button in the control when a value is chosen"
 
   attr :placeholder, :string, default: "Select an option…"
   attr :disabled, :boolean, default: false
@@ -64,28 +100,41 @@ defmodule PetalComponents.ComboBox do
     doc: "the form this control belongs to when rendered outside it (the select's form attribute)"
 
   attr :no_results_text, :string, default: "No results found"
+  attr :results_label, :string, default: "results", doc: "the live-region word after the count"
+  attr :clear_label, :string, default: "Clear selection", doc: "aria-label for the clear button"
+
+  attr :remove_label, :string,
+    default: "Remove",
+    doc: "aria-label prefix for chip remove buttons; the option label is appended"
+
   attr :listbox_label, :string, default: "Options", doc: "accessible name for the listbox"
   attr :class, :any, default: nil, doc: "extra classes for the wrapper"
   attr :rest, :global
 
   def combo_box(assigns) do
     groups = normalize_options(assigns.options)
-    value = current_value(assigns)
+    values = current_values(assigns)
     id = resolve_id(assigns)
 
     assigns =
       assigns
       |> assign(:groups, groups)
-      |> assign(:current_value, value)
+      |> assign(:current_values, values)
       |> assign(:id, id)
-      |> assign(:input_name, assigns.name || (assigns.field && assigns.field.name))
-      |> assign(:selected_label, selected_label(groups, value))
+      |> assign(:input_name, input_name(assigns))
+      |> assign(
+        :selected_label,
+        if(assigns.multiple, do: nil, else: selected_label(groups, values))
+      )
+      |> assign(:selected_options, selected_options(groups, values))
 
     ~H"""
     <div
       id={@id}
       class={["pc-combo-box", @class]}
       phx-hook="PetalComboBox"
+      data-max-items={@max_items}
+      data-has-value={@current_values != [] && "true"}
       {@rest}
     >
       <select
@@ -94,18 +143,20 @@ defmodule PetalComponents.ComboBox do
         class="pc-combo-box__select"
         tabindex="-1"
         aria-hidden="true"
+        inert
+        multiple={@multiple}
         disabled={@disabled}
         required={@required}
         form={@form_id}
       >
-        <option value=""></option>
+        <option :if={!@multiple} value=""></option>
         <%= for group <- @groups do %>
           <%= if group.label do %>
             <optgroup label={group.label}>
               <option
                 :for={opt <- group.options}
                 value={opt.value}
-                selected={selected?(opt, @current_value)}
+                selected={selected?(opt, @current_values)}
                 disabled={opt.disabled}
               >
                 {opt.label}
@@ -115,7 +166,7 @@ defmodule PetalComponents.ComboBox do
             <option
               :for={opt <- group.options}
               value={opt.value}
-              selected={selected?(opt, @current_value)}
+              selected={selected?(opt, @current_values)}
               disabled={opt.disabled}
             >
               {opt.label}
@@ -125,6 +176,26 @@ defmodule PetalComponents.ComboBox do
       </select>
 
       <div class="pc-combo-box__control">
+        <div
+          :if={@multiple}
+          class="pc-combo-box__chips"
+          data-pc-combo-chips
+          data-remove-label={@remove_label}
+        >
+          <span :for={opt <- @selected_options} class="pc-combo-box__chip" data-pc-combo-chip>
+            <span class="pc-combo-box__chip-label">{opt.label}</span>
+            <button
+              type="button"
+              class="pc-combo-box__chip-remove"
+              data-pc-combo-chip-remove
+              data-value={opt.value}
+              aria-label={"#{@remove_label} #{opt.label}"}
+              tabindex="-1"
+            >
+              <.icon name="hero-x-mark-mini" class="pc-combo-box__chip-remove-icon" />
+            </button>
+          </span>
+        </div>
         <input
           type="text"
           id={"#{@id}-input"}
@@ -136,10 +207,19 @@ defmodule PetalComponents.ComboBox do
           autocomplete="off"
           autocorrect="off"
           spellcheck="false"
-          placeholder={@placeholder}
+          placeholder={if @multiple && @current_values != [], do: nil, else: @placeholder}
           value={@selected_label}
           disabled={@disabled}
         />
+        <button
+          :if={@clearable && !@multiple}
+          type="button"
+          class="pc-combo-box__clear"
+          data-pc-combo-clear
+          aria-label={@clear_label}
+        >
+          <.icon name="hero-x-mark-mini" class="pc-combo-box__clear-icon" />
+        </button>
         <.icon name="hero-chevron-down-mini" class="pc-combo-box__chevron" />
       </div>
 
@@ -149,19 +229,29 @@ defmodule PetalComponents.ComboBox do
           id={"#{@id}-listbox"}
           class="pc-combo-box__list"
           aria-label={@listbox_label}
+          aria-multiselectable={@multiple && "true"}
         >
           <%= for group <- @groups do %>
             <%= if group.label do %>
               <div class="pc-combo-box__group" role="group" data-pc-combo-group>
                 <div class="pc-combo-box__group-heading" aria-hidden="true">{group.label}</div>
-                <.option_items options={group.options} current_value={@current_value} />
+                <.option_items options={group.options} current_values={@current_values} />
               </div>
             <% else %>
-              <.option_items options={group.options} current_value={@current_value} />
+              <.option_items options={group.options} current_values={@current_values} />
             <% end %>
           <% end %>
           <div class="pc-combo-box__empty" data-pc-combo-empty hidden>{@no_results_text}</div>
         </div>
+      </div>
+
+      <div
+        class="pc-combo-box__live"
+        data-pc-combo-live
+        data-results-label={@results_label}
+        data-no-results-text={@no_results_text}
+        aria-live="polite"
+      >
       </div>
     </div>
     """
@@ -178,7 +268,7 @@ defmodule PetalComponents.ComboBox do
       data-label={opt.label}
       data-disabled={opt.disabled && "true"}
       aria-disabled={opt.disabled && "true"}
-      aria-selected={to_string(selected?(opt, @current_value))}
+      aria-selected={to_string(selected?(opt, @current_values))}
     >
       <span class="pc-combo-box__option-label">{opt.label}</span>
       <.icon name="hero-check-mini" class="pc-combo-box__check" />
@@ -224,20 +314,43 @@ defmodule PetalComponents.ComboBox do
     %{label: to_string(value), value: to_string(value), disabled: false}
   end
 
-  # -- value / id resolution ------------------------------------------------
+  # -- value / name / id resolution -----------------------------------------
 
-  defp current_value(%{value: value}) when not is_nil(value), do: to_string(value)
-  defp current_value(%{field: %{value: value}}) when not is_nil(value), do: to_string(value)
-  defp current_value(_assigns), do: nil
+  defp current_values(%{value: value}) when not is_nil(value) and value != [],
+    do: value |> List.wrap() |> Enum.map(&to_string/1)
 
-  defp selected?(_opt, nil), do: false
-  defp selected?(opt, value), do: opt.value == value
+  defp current_values(%{field: %{value: value}}) when not is_nil(value) and value != [],
+    do: value |> List.wrap() |> Enum.map(&to_string/1)
 
-  defp selected_label(groups, value) do
+  defp current_values(_assigns), do: []
+
+  defp selected?(_opt, []), do: false
+  defp selected?(opt, values), do: opt.value in values
+
+  defp selected_label(_groups, []), do: nil
+
+  defp selected_label(groups, [value | _]) do
     groups
     |> Enum.flat_map(& &1.options)
-    |> Enum.find_value(fn opt -> if selected?(opt, value), do: opt.label end)
+    |> Enum.find_value(fn opt -> if opt.value == value, do: opt.label end)
   end
+
+  defp selected_options(_groups, []), do: []
+
+  defp selected_options(groups, values) do
+    all = Enum.flat_map(groups, & &1.options)
+    # chip order follows the chosen order, not the option order
+    Enum.flat_map(values, fn value -> Enum.filter(all, &(&1.value == value)) end)
+  end
+
+  defp input_name(%{multiple: true} = assigns) do
+    case assigns.name || (assigns.field && assigns.field.name) do
+      nil -> nil
+      name -> if String.ends_with?(name, "[]"), do: name, else: name <> "[]"
+    end
+  end
+
+  defp input_name(assigns), do: assigns.name || (assigns.field && assigns.field.name)
 
   defp resolve_id(%{id: id}) when is_binary(id), do: id
   defp resolve_id(%{field: %{id: id}}) when is_binary(id), do: "#{id}_combo_box"

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -4,6 +4,31 @@ defmodule PetalComponents.Showcase.ComboBox do
     component: PetalComponents.ComboBox,
     title: "Combo box"
 
+  example :multiple, "Chips - multiple selection",
+    description:
+      "multiple turns the trigger into a chip row: every choice renders as a removable token, the panel stays open while picking, and Backspace in an empty input removes the last chip. The hidden select becomes a real select multiple - its name gains [] - so every choice survives the form post exactly like a native multiple select. max_items caps the count; at the cap, unchosen options rest until something is removed." do
+    ~H"""
+    <div class="w-full max-w-sm mx-auto">
+      <.combo_box
+        id="sx-combo-multi"
+        name="stack"
+        multiple
+        max_items={4}
+        value={["phx", "lv"]}
+        placeholder="Build your stack…"
+        options={[
+          {"Phoenix", "phx"},
+          {"LiveView", "lv"},
+          {"Ecto", "ecto"},
+          {"Oban", "oban"},
+          {"Tailwind", "tw"},
+          {"Postgres", "pg"}
+        ]}
+      />
+    </div>
+    """
+  end
+
   example :basic, "The searchable select",
     description:
       "Type to filter, arrow keys to move, Enter to choose - the command palette's keyboard machinery on a form control. The visible input is chrome; a hidden native select carries the name and value, so changesets, phx-change and LiveView form recovery behave exactly like a plain select. Zero JS dependencies." do

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -1,0 +1,304 @@
+// PetalComboBox hook behavior.
+//
+// The markup built here mirrors what PetalComponents.ComboBox renders -
+// test/petal/combo_box_test.exs pins that structure on the Elixir side;
+// update both together if the anatomy changes. These specs pin the hook's
+// contracts: open/close paths (including the iOS ones that only exist
+// because Safari never blurs on static-content taps), filter ranking,
+// the boundary cycle, selection through the hidden select, and the
+// keystroke containment that keeps typing out of enclosing phx-change
+// forms.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import hooks from "../../assets/js/petal_components.js";
+
+import { pointerEvent } from "./helpers.js";
+
+const mounted = [];
+
+function option(value, label, disabled = false) {
+  return { value, label, disabled };
+}
+
+function optionHtml(opt) {
+  return `
+    <div role="option" class="pc-combo-box__option" data-pc-combo-item
+      data-value="${opt.value}" data-label="${opt.label}"
+      ${opt.disabled ? 'data-disabled="true" aria-disabled="true"' : ""}
+      aria-selected="false">
+      <span class="pc-combo-box__option-label">${opt.label}</span>
+      <span class="hero-check-mini pc-combo-box__check"></span>
+    </div>`;
+}
+
+function mountCombo({ id = "combo", options = [], groups = [] } = {}) {
+  const selectOptions = [...options, ...groups.flatMap((g) => g.options)]
+    .map((o) => `<option value="${o.value}" ${o.disabled ? "disabled" : ""}>${o.label}</option>`)
+    .join("");
+
+  const listHtml =
+    options.map(optionHtml).join("") +
+    groups
+      .map(
+        (g) => `
+        <div class="pc-combo-box__group" role="group" data-pc-combo-group>
+          <div class="pc-combo-box__group-heading" aria-hidden="true">${g.label}</div>
+          ${g.options.map(optionHtml).join("")}
+        </div>`
+      )
+      .join("");
+
+  const el = document.createElement("div");
+  el.id = id;
+  el.className = "pc-combo-box";
+  el.setAttribute("phx-hook", "PetalComboBox");
+  el.innerHTML = `
+    <select id="${id}-select" name="city" class="pc-combo-box__select" tabindex="-1" aria-hidden="true">
+      <option value=""></option>
+      ${selectOptions}
+    </select>
+    <div class="pc-combo-box__control">
+      <input type="text" id="${id}-input" class="pc-combo-box__input" role="combobox"
+        aria-expanded="false" aria-autocomplete="list" aria-controls="${id}-listbox"
+        autocomplete="off" placeholder="Pick..." />
+      <span class="hero-chevron-down-mini pc-combo-box__chevron"></span>
+    </div>
+    <div class="pc-combo-box__panel" data-pc-combo-panel hidden>
+      <div role="listbox" id="${id}-listbox" class="pc-combo-box__list" aria-label="Options">
+        ${listHtml}
+        <div class="pc-combo-box__empty" data-pc-combo-empty hidden>No results found</div>
+      </div>
+    </div>`;
+  document.body.appendChild(el);
+
+  const hook = Object.create(hooks.PetalComboBox);
+  hook.el = el;
+  hook.mounted();
+  mounted.push(hook);
+
+  return {
+    hook,
+    el,
+    input: el.querySelector(".pc-combo-box__input"),
+    select: el.querySelector(".pc-combo-box__select"),
+    control: el.querySelector(".pc-combo-box__control"),
+    panel: el.querySelector("[data-pc-combo-panel]"),
+    chevron: el.querySelector(".pc-combo-box__chevron"),
+    items: () => [...el.querySelectorAll("[data-pc-combo-item]")],
+    visible: () => [...el.querySelectorAll("[data-pc-combo-item]:not([hidden])")],
+    highlighted: () => el.querySelector("[data-highlighted]"),
+    empty: () => el.querySelector("[data-pc-combo-empty]"),
+  };
+}
+
+const CITIES = [option("syd", "Sydney"), option("tyo", "Tokyo"), option("lis", "Lisbon"), option("sto", "Stockholm")];
+
+function type(input, text) {
+  input.value = text;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function key(target, k) {
+  const ev = new KeyboardEvent("keydown", { key: k, bubbles: true, cancelable: true });
+  target.dispatchEvent(ev);
+  return ev;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  // jsdom has no scrollIntoView
+  Element.prototype.scrollIntoView = () => {};
+});
+
+afterEach(() => {
+  mounted.splice(0).forEach((hook) => hook.destroyed());
+});
+
+describe("open and close", () => {
+  it("opens on control click with aria-expanded, all options visible", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    expect(c.panel.hidden).toBe(false);
+    expect(c.input.getAttribute("aria-expanded")).toBe("true");
+    expect(c.visible()).toHaveLength(4);
+  });
+
+  it("a click on the open input is caret work - panel and query survive", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    type(c.input, "syd");
+    c.input.click();
+    expect(c.panel.hidden).toBe(false);
+    expect(c.input.value).toBe("syd");
+  });
+
+  it("a click on control chrome (the chevron) toggles closed", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    c.chevron.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(c.panel.hidden).toBe(true);
+  });
+
+  it("outside pointerdown closes - the iOS Safari path where focusout never fires", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    document.body.dispatchEvent(pointerEvent("pointerdown", "touch"));
+    expect(c.panel.hidden).toBe(true);
+  });
+
+  it("inside pointerdown does not close before the option click lands", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    c.items()[0].dispatchEvent(pointerEvent("pointerdown", "touch"));
+    expect(c.panel.hidden).toBe(false);
+  });
+
+  it("focusout to an element outside closes and restores the display", () => {
+    const c = mountCombo({ options: CITIES });
+    c.select.value = "tyo";
+    c.hook.syncFromSelect();
+    c.control.click();
+    type(c.input, "sy");
+    c.el.dispatchEvent(new FocusEvent("focusout", { relatedTarget: document.body }));
+    expect(c.panel.hidden).toBe(true);
+    expect(c.input.value).toBe("Tokyo");
+  });
+
+  it("Escape closes when open and is consumed; passes through when closed", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    const first = key(c.input, "Escape");
+    expect(first.defaultPrevented).toBe(true);
+    expect(c.panel.hidden).toBe(true);
+    const second = key(c.input, "Escape");
+    expect(second.defaultPrevented).toBe(false);
+  });
+});
+
+describe("filtering", () => {
+  it("the best-scoring match wins the highlight, not the first in DOM order", () => {
+    // The original playground bug: Stockholm's fuzzy s-t-o-k subsequence
+    // sat ABOVE Tokyo's prefix match in DOM order and stole the highlight,
+    // so Enter committed the wrong value. The fixture pins that ordering.
+    const c = mountCombo({
+      options: [option("sto", "Stockholm"), option("lis", "Lisbon"), option("tyo", "Tokyo")],
+    });
+    c.control.click();
+    type(c.input, "tok");
+    expect(c.visible().map((i) => i.dataset.value)).toEqual(["sto", "tyo"]);
+    expect(c.highlighted()?.dataset.value).toBe("tyo");
+  });
+
+  it("no match shows the empty state; clearing hides it and restores options", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    type(c.input, "zzz");
+    expect(c.visible()).toHaveLength(0);
+    expect(c.empty().hidden).toBe(false);
+    type(c.input, "");
+    expect(c.visible()).toHaveLength(4);
+    expect(c.empty().hidden).toBe(true);
+  });
+
+  it("a group hides itself when the query filters out every option inside", () => {
+    const c = mountCombo({
+      groups: [
+        { label: "Oceania", options: [option("syd", "Sydney")] },
+        { label: "Europe", options: [option("lis", "Lisbon")] },
+      ],
+    });
+    c.control.click();
+    type(c.input, "lis");
+    const [oceania] = c.el.querySelectorAll("[data-pc-combo-group]");
+    expect(oceania.hidden).toBe(true);
+  });
+});
+
+describe("selection through the hidden select", () => {
+  it("click chooses: select value, bubbled input+change, display, close, check", () => {
+    const c = mountCombo({ options: CITIES });
+    let inputs = 0;
+    let changes = 0;
+    c.select.addEventListener("input", () => inputs++);
+    c.select.addEventListener("change", () => changes++);
+    c.control.click();
+    c.items()[1].click();
+    expect(c.select.value).toBe("tyo");
+    expect(inputs).toBe(1);
+    expect(changes).toBe(1);
+    expect(c.input.value).toBe("Tokyo");
+    expect(c.panel.hidden).toBe(true);
+    expect(c.items()[1].getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("Enter chooses the highlighted option and is consumed; closed Enter is not", () => {
+    const c = mountCombo({ options: CITIES });
+    const closedEnter = key(c.input, "Enter");
+    expect(closedEnter.defaultPrevented).toBe(false);
+    c.control.click();
+    type(c.input, "lis");
+    const openEnter = key(c.input, "Enter");
+    expect(openEnter.defaultPrevented).toBe(true);
+    expect(c.select.value).toBe("lis");
+  });
+
+  it("disabled options are skipped by highlight and inert to clicks", () => {
+    const c = mountCombo({ options: [option("syd", "Sydney"), option("sto", "Stockholm", true)] });
+    c.control.click();
+    type(c.input, "sto");
+    expect(c.highlighted()).toBe(null);
+    c.items()[1].click();
+    expect(c.select.value).toBe("");
+  });
+
+  it("opening with a chosen value homes the highlight on it", () => {
+    const c = mountCombo({ options: CITIES });
+    c.select.value = "lis";
+    c.hook.syncFromSelect();
+    c.control.click();
+    expect(c.highlighted()?.dataset.value).toBe("lis");
+  });
+});
+
+describe("the boundary cycle", () => {
+  it("wraps through an empty stop in both directions", () => {
+    const c = mountCombo({ options: CITIES });
+    key(c.input, "ArrowDown"); // opens, homes on first
+    key(c.input, "End");
+    expect(c.highlighted()?.dataset.value).toBe("sto");
+    key(c.input, "ArrowDown");
+    expect(c.highlighted()).toBe(null);
+    expect(c.input.hasAttribute("aria-activedescendant")).toBe(false);
+    key(c.input, "ArrowDown");
+    expect(c.highlighted()?.dataset.value).toBe("syd");
+    key(c.input, "ArrowUp");
+    expect(c.highlighted()).toBe(null);
+    key(c.input, "ArrowUp");
+    expect(c.highlighted()?.dataset.value).toBe("sto");
+  });
+});
+
+describe("server ownership", () => {
+  it("updated() re-syncs from the select - the server wins", () => {
+    const c = mountCombo({ options: CITIES });
+    c.select.value = "syd";
+    c.hook.updated();
+    expect(c.input.value).toBe("Sydney");
+    expect(c.items()[0].getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("typing keystrokes never reach an enclosing form; selection does", () => {
+    const c = mountCombo({ options: CITIES });
+    const form = document.createElement("form");
+    document.body.appendChild(form);
+    form.appendChild(c.el);
+    let formInputs = 0;
+    form.addEventListener("input", () => formInputs++);
+    c.control.click();
+    type(c.input, "to");
+    type(c.input, "tok");
+    expect(formInputs).toBe(0);
+    key(c.input, "Enter");
+    expect(formInputs).toBe(1);
+  });
+});

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -31,7 +31,7 @@ function optionHtml(opt) {
     </div>`;
 }
 
-function mountCombo({ id = "combo", options = [], groups = [] } = {}) {
+function mountCombo({ id = "combo", options = [], groups = [], multiple = false, maxItems = null, clearable = false } = {}) {
   const selectOptions = [...options, ...groups.flatMap((g) => g.options)]
     .map((o) => `<option value="${o.value}" ${o.disabled ? "disabled" : ""}>${o.label}</option>`)
     .join("");
@@ -52,15 +52,18 @@ function mountCombo({ id = "combo", options = [], groups = [] } = {}) {
   el.id = id;
   el.className = "pc-combo-box";
   el.setAttribute("phx-hook", "PetalComboBox");
+  if (maxItems) el.setAttribute("data-max-items", String(maxItems));
   el.innerHTML = `
-    <select id="${id}-select" name="city" class="pc-combo-box__select" tabindex="-1" aria-hidden="true">
-      <option value=""></option>
+    <select id="${id}-select" name="city${multiple ? "[]" : ""}" class="pc-combo-box__select" tabindex="-1" aria-hidden="true" inert ${multiple ? "multiple" : ""}>
+      ${multiple ? "" : '<option value=""></option>'}
       ${selectOptions}
     </select>
     <div class="pc-combo-box__control">
+      ${multiple ? '<div class="pc-combo-box__chips" data-pc-combo-chips data-remove-label="Remove"></div>' : ""}
       <input type="text" id="${id}-input" class="pc-combo-box__input" role="combobox"
         aria-expanded="false" aria-autocomplete="list" aria-controls="${id}-listbox"
         autocomplete="off" placeholder="Pick..." />
+      ${clearable ? '<button type="button" class="pc-combo-box__clear" data-pc-combo-clear aria-label="Clear selection"><span class="hero-x-mark-mini pc-combo-box__clear-icon"></span></button>' : ""}
       <span class="hero-chevron-down-mini pc-combo-box__chevron"></span>
     </div>
     <div class="pc-combo-box__panel" data-pc-combo-panel hidden>
@@ -68,7 +71,8 @@ function mountCombo({ id = "combo", options = [], groups = [] } = {}) {
         ${listHtml}
         <div class="pc-combo-box__empty" data-pc-combo-empty hidden>No results found</div>
       </div>
-    </div>`;
+    </div>
+    <div class="pc-combo-box__live" data-pc-combo-live data-results-label="results" data-no-results-text="No results found" aria-live="polite"></div>`;
   document.body.appendChild(el);
 
   const hook = Object.create(hooks.PetalComboBox);
@@ -88,6 +92,8 @@ function mountCombo({ id = "combo", options = [], groups = [] } = {}) {
     visible: () => [...el.querySelectorAll("[data-pc-combo-item]:not([hidden])")],
     highlighted: () => el.querySelector("[data-highlighted]"),
     empty: () => el.querySelector("[data-pc-combo-empty]"),
+    chips: () => [...el.querySelectorAll("[data-pc-combo-chip]")],
+    live: () => el.querySelector("[data-pc-combo-live]"),
   };
 }
 
@@ -275,6 +281,125 @@ describe("the boundary cycle", () => {
     expect(c.highlighted()).toBe(null);
     key(c.input, "ArrowUp");
     expect(c.highlighted()?.dataset.value).toBe("sto");
+  });
+});
+
+describe("multiple with chips", () => {
+  it("choosing toggles, keeps the panel open, clears the query, builds a chip", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    c.control.click();
+    type(c.input, "syd");
+    key(c.input, "Enter");
+    expect(c.select.querySelector('option[value="syd"]').selected).toBe(true);
+    expect(c.panel.hidden).toBe(false);
+    expect(c.input.value).toBe("");
+    expect(c.chips()).toHaveLength(1);
+    expect(c.chips()[0].textContent).toContain("Sydney");
+  });
+
+  it("choosing a chosen option un-chooses it", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    c.control.click();
+    c.items()[0].click();
+    c.items()[0].click();
+    expect(c.select.querySelector('option[value="syd"]').selected).toBe(false);
+    expect(c.chips()).toHaveLength(0);
+  });
+
+  it("the chip remove button unselects and dispatches through the select", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    let changes = 0;
+    c.select.addEventListener("change", () => changes++);
+    c.control.click();
+    c.items()[0].click();
+    c.items()[1].click();
+    expect(c.chips()).toHaveLength(2);
+    c.chips()[0].querySelector("[data-pc-combo-chip-remove]").click();
+    expect(c.chips()).toHaveLength(1);
+    expect(c.select.querySelector('option[value="syd"]').selected).toBe(false);
+    expect(changes).toBe(3);
+  });
+
+  it("Backspace in an empty input removes the last chip", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    c.control.click();
+    c.items()[0].click();
+    c.items()[1].click();
+    key(c.input, "Backspace");
+    expect(c.chips()).toHaveLength(1);
+    expect(c.chips()[0].textContent).toContain("Sydney");
+  });
+
+  it("Backspace with a query is just editing - chips survive", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    c.control.click();
+    c.items()[0].click();
+    type(c.input, "to");
+    key(c.input, "Backspace");
+    expect(c.chips()).toHaveLength(1);
+  });
+
+  it("max_items blocks new choices and marks the root; removal unblocks", () => {
+    const c = mountCombo({ options: CITIES, multiple: true, maxItems: 2 });
+    c.control.click();
+    c.items()[0].click();
+    c.items()[1].click();
+    expect(c.el.hasAttribute("data-max-reached")).toBe(true);
+    c.items()[2].click();
+    expect(c.select.querySelector('option[value="lis"]').selected).toBe(false);
+    c.chips()[0].querySelector("[data-pc-combo-chip-remove]").click();
+    expect(c.el.hasAttribute("data-max-reached")).toBe(false);
+    c.items()[2].click();
+    expect(c.select.querySelector('option[value="lis"]').selected).toBe(true);
+  });
+});
+
+describe("clearable", () => {
+  it("the clear button empties the select, dispatches, and clears the display", () => {
+    const c = mountCombo({ options: CITIES, clearable: true });
+    let changes = 0;
+    c.select.addEventListener("change", () => changes++);
+    c.control.click();
+    c.items()[1].click();
+    expect(c.input.value).toBe("Tokyo");
+    expect(c.el.hasAttribute("data-has-value")).toBe(true);
+    c.el.querySelector("[data-pc-combo-clear]").click();
+    expect(c.select.value).toBe("");
+    expect(c.input.value).toBe("");
+    expect(c.el.hasAttribute("data-has-value")).toBe(false);
+    expect(changes).toBe(2);
+  });
+});
+
+describe("hardening riders", () => {
+  it("form.reset() re-syncs chips and display from the select", () => {
+    const form = document.createElement("form");
+    document.body.appendChild(form);
+    const c = mountCombo({ options: CITIES });
+    form.appendChild(c.el);
+    // re-mount so the hook binds to the form it now lives in
+    c.hook.destroyed();
+    c.hook.mounted();
+    c.control.click();
+    c.items()[1].click();
+    expect(c.input.value).toBe("Tokyo");
+    form.reset();
+    return new Promise((resolve) =>
+      setTimeout(() => {
+        expect(c.input.value).toBe("");
+        resolve();
+      }, 5)
+    );
+  });
+
+  it("the live region announces counts and the empty state", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    expect(c.live().textContent).toBe("4 results");
+    type(c.input, "tok");
+    expect(c.live().textContent).toBe("2 results");
+    type(c.input, "zzz");
+    expect(c.live().textContent).toBe("No results found");
   });
 });
 

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -159,6 +159,93 @@ defmodule PetalComponents.ComboBoxTest do
     refute wrapper_tag =~ "required"
   end
 
+  describe "multiple" do
+    test "the select is multiple, the name gains [], no empty option" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="tags" name="tags" multiple options={["a", "b"]} />
+        """)
+
+      assert html =~ ~s|multiple|
+      assert html =~ ~s|name="tags[]"|
+      refute html =~ ~s|<option value=""|
+      assert html =~ ~s|aria-multiselectable="true"|
+    end
+
+    test "chosen values render as chips with labelled remove buttons" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box
+          id="tags"
+          name="tags"
+          multiple
+          value={["b", "a"]}
+          options={[{"Alpha", "a"}, {"Beta", "b"}]}
+        />
+        """)
+
+      assert html =~ "pc-combo-box__chip"
+      # chip order follows chosen order
+      assert html =~ ~r/Beta.*Alpha/s
+      assert html =~ ~s|aria-label="Remove Beta"|
+      assert html =~ ~s|data-pc-combo-chip-remove|
+    end
+
+    test "max_items lands as a data attribute for the hook" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="tags" name="tags" multiple max_items={3} options={["a"]} />
+        """)
+
+      assert html =~ ~s|data-max-items="3"|
+    end
+  end
+
+  describe "clearable and hardening" do
+    test "clearable renders the labelled clear button and data-has-value tracks the value" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="tz" name="tz" clearable value="syd" options={[{"Sydney", "syd"}]} />
+        """)
+
+      assert html =~ ~s|data-pc-combo-clear|
+      assert html =~ ~s|aria-label="Clear selection"|
+      assert html =~ ~s|data-has-value|
+    end
+
+    test "the hidden select is inert so dialog autofocus can never land on it" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="tz" name="tz" options={["Sydney"]} />
+        """)
+
+      [select_tag | _] = String.split(html, "</select>")
+      assert select_tag =~ ~s| inert|
+    end
+
+    test "the polite live region renders with its labels" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="tz" name="tz" options={["Sydney"]} />
+        """)
+
+      assert html =~ ~s|aria-live="polite"|
+      assert html =~ ~s|data-results-label="results"|
+    end
+  end
+
   test "raises without any id source" do
     assigns = %{}
 


### PR DESCRIPTION
Greptile's P2 on #544 adopted: the combobox hook's behavioral guarantees lived only in a session-local headless-Chrome harness. This ports them into the repo's existing vitest+jsdom setup (the `js` CI job already runs it) as 17 specs:

- **Open/close**: control-click open, caret-click survival, chrome toggle, **outside-press** (the iOS Safari path where focusout never fires), inside-press survival, focusout close+restore, Escape consumed-when-open / pass-through-when-closed
- **Filter ranking**: the fixture places the fuzzy match *above* the prefix match in DOM order - the exact playground bug - so a ranking regression fails loudly
- **Selection**: through the hidden select with bubbled input+change counted, disabled-option inertness, chosen homing on open
- **Boundary cycle**: wrap through the empty stop, both directions
- **Server ownership**: `updated()` re-sync; **keystroke containment** (typing never reaches an enclosing form, selection does exactly once)

29 total JS tests green (17 new + 12 existing toast). This is M2's task one - chips, clearable and the trigger variant will extend this file rather than re-invent verification.