### PR TITLE
combo_box: trailing icons leave the wrapping row (chip-wrap layout break)

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -2208,13 +2208,22 @@
   .pc-combo-box__empty {
     @apply px-2 py-6 text-center text-sm text-gray-500 dark:text-gray-400;
   }
-  /* multiple: the control becomes a wrapping chip row; the input shares the
-     line and keeps a typing floor */
+  /* The content area owns the wrapping (chips + input); the control row
+     never wraps, so the trailing rail - clear button, chevron - stays
+     pinned as chrome no matter how many lines the chips take. This is the
+     icon-anatomy doctrine applied: containers own layout, icons only own
+     their box. */
+  .pc-combo-box__content {
+    @apply flex min-w-0 flex-1 flex-wrap items-center;
+  }
   .pc-combo-box__control:has([data-pc-combo-chips]) {
-    @apply flex-wrap gap-y-1 py-1;
+    @apply py-1;
+  }
+  .pc-combo-box__control:has([data-pc-combo-chips]) .pc-combo-box__content {
+    @apply gap-y-1;
   }
   .pc-combo-box__control:has([data-pc-combo-chips]) .pc-combo-box__input {
-    @apply flex-1 min-w-24 py-1;
+    @apply w-auto flex-1 min-w-24 py-1;
   }
   .pc-combo-box__chips {
     @apply flex flex-wrap items-center gap-1 pl-1.5 max-w-full;

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -176,41 +176,43 @@ defmodule PetalComponents.ComboBox do
       </select>
 
       <div class="pc-combo-box__control">
-        <div
-          :if={@multiple}
-          class="pc-combo-box__chips"
-          data-pc-combo-chips
-          data-remove-label={@remove_label}
-        >
-          <span :for={opt <- @selected_options} class="pc-combo-box__chip" data-pc-combo-chip>
-            <span class="pc-combo-box__chip-label">{opt.label}</span>
-            <button
-              type="button"
-              class="pc-combo-box__chip-remove"
-              data-pc-combo-chip-remove
-              data-value={opt.value}
-              aria-label={"#{@remove_label} #{opt.label}"}
-              tabindex="-1"
-            >
-              <.icon name="hero-x-mark-mini" class="pc-combo-box__chip-remove-icon" />
-            </button>
-          </span>
+        <div class="pc-combo-box__content">
+          <div
+            :if={@multiple}
+            class="pc-combo-box__chips"
+            data-pc-combo-chips
+            data-remove-label={@remove_label}
+          >
+            <span :for={opt <- @selected_options} class="pc-combo-box__chip" data-pc-combo-chip>
+              <span class="pc-combo-box__chip-label">{opt.label}</span>
+              <button
+                type="button"
+                class="pc-combo-box__chip-remove"
+                data-pc-combo-chip-remove
+                data-value={opt.value}
+                aria-label={"#{@remove_label} #{opt.label}"}
+                tabindex="-1"
+              >
+                <.icon name="hero-x-mark-mini" class="pc-combo-box__chip-remove-icon" />
+              </button>
+            </span>
+          </div>
+          <input
+            type="text"
+            id={"#{@id}-input"}
+            class="pc-combo-box__input"
+            role="combobox"
+            aria-expanded="false"
+            aria-autocomplete="list"
+            aria-controls={"#{@id}-listbox"}
+            autocomplete="off"
+            autocorrect="off"
+            spellcheck="false"
+            placeholder={if @multiple && @current_values != [], do: nil, else: @placeholder}
+            value={@selected_label}
+            disabled={@disabled}
+          />
         </div>
-        <input
-          type="text"
-          id={"#{@id}-input"}
-          class="pc-combo-box__input"
-          role="combobox"
-          aria-expanded="false"
-          aria-autocomplete="list"
-          aria-controls={"#{@id}-listbox"}
-          autocomplete="off"
-          autocorrect="off"
-          spellcheck="false"
-          placeholder={if @multiple && @current_values != [], do: nil, else: @placeholder}
-          value={@selected_label}
-          disabled={@disabled}
-        />
         <button
           :if={@clearable && !@multiple}
           type="button"

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -59,10 +59,12 @@ function mountCombo({ id = "combo", options = [], groups = [], multiple = false,
       ${selectOptions}
     </select>
     <div class="pc-combo-box__control">
-      ${multiple ? '<div class="pc-combo-box__chips" data-pc-combo-chips data-remove-label="Remove"></div>' : ""}
-      <input type="text" id="${id}-input" class="pc-combo-box__input" role="combobox"
-        aria-expanded="false" aria-autocomplete="list" aria-controls="${id}-listbox"
-        autocomplete="off" placeholder="Pick..." />
+      <div class="pc-combo-box__content">
+        ${multiple ? '<div class="pc-combo-box__chips" data-pc-combo-chips data-remove-label="Remove"></div>' : ""}
+        <input type="text" id="${id}-input" class="pc-combo-box__input" role="combobox"
+          aria-expanded="false" aria-autocomplete="list" aria-controls="${id}-listbox"
+          autocomplete="off" placeholder="Pick..." />
+      </div>
       ${clearable ? '<button type="button" class="pc-combo-box__clear" data-pc-combo-clear aria-label="Clear selection"><span class="hero-x-mark-mini pc-combo-box__clear-icon"></span></button>' : ""}
       <span class="hero-chevron-down-mini pc-combo-box__chevron"></span>
     </div>


### PR DESCRIPTION
Nic's on-device find: with enough chips to wrap to a second line, the chevron dropped to its own line at the control's left - it lived inside the same flex-wrap row as the chips and input, so it wrapped like content instead of staying pinned as chrome.

**Fix** - the anatomy the icon doctrine prescribes: the control row never wraps; a new `.pc-combo-box__content` area (chips + input) owns the wrapping as `flex-1`, and the trailing rail (clear button, chevron) sits beside it, `shrink-0`, vertically centered regardless of chip lines.

**Verified**: 38 JS + 17 Elixir combobox tests green (JS mount mirrors the new anatomy); measured live at 2 chip lines - chevron 11px from the right edge, centered. Screenshot in session.

The M2 icon-anatomy sweep applies this container-owns-layout rule everywhere; this lands the combobox's share early because it was user-visible breakage.