### PR TITLE
Combobox: chips mode drops the chevron; naming standardized

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -227,7 +227,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "input-group", name: "Input group", ready: true},
         %{slug: "checkbox", name: "Checkbox", ready: true},
         %{slug: "select", name: "Select", ready: true},
-        %{slug: "combo-box", name: "Combo box", ready: true},
+        %{slug: "combo-box", name: "Combobox", ready: true},
         %{slug: "radio", name: "Radio", ready: true},
         %{slug: "switch", name: "Switch", ready: true},
         %{slug: "slider", name: "Slider", ready: true},
@@ -7251,7 +7251,7 @@ defmodule Dev.PlaygroundLive do
   defp render_page(%{active: "combo-box"} = assigns) do
     ~H"""
     <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
-      <h1 class="text-3xl font-bold tracking-tight">Combo box</h1>
+      <h1 class="text-3xl font-bold tracking-tight">Combobox</h1>
       <p class="mt-2 text-gray-500 dark:text-gray-400">
         A searchable select: type to filter, arrow keys to move, Enter to choose.
         The visible input is chrome - a hidden native select carries the value,

--- a/dev/static/combo-harness.html
+++ b/dev/static/combo-harness.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Combo box keyboard harness</title>
+    <title>Combobox keyboard harness</title>
     <link rel="stylesheet" href="/assets/app.css" />
     <style>
       body { margin: 0; font-family: ui-sans-serif, system-ui, sans-serif; padding: 40px; }

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -222,7 +222,11 @@ defmodule PetalComponents.ComboBox do
         >
           <.icon name="hero-x-mark-mini" class="pc-combo-box__clear-icon" />
         </button>
-        <.icon name="hero-chevron-down-mini" class="pc-combo-box__chevron" />
+        <%!-- chips mode is a token field, not a dropdown: the chips and input
+        are the affordance, so the single-select chevron would mislead
+        (shadcn chips, Tom Select multi and the token-field family all drop
+        it) --%>
+        <.icon :if={!@multiple} name="hero-chevron-down-mini" class="pc-combo-box__chevron" />
       </div>
 
       <div class="pc-combo-box__panel" data-pc-combo-panel hidden>

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -2,7 +2,7 @@ defmodule PetalComponents.Showcase.ComboBox do
   @moduledoc false
   use PetalComponents.Showcase,
     component: PetalComponents.ComboBox,
-    title: "Combo box"
+    title: "Combobox"
 
   example :multiple, "Chips - multiple selection",
     description:

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -66,7 +66,7 @@ function mountCombo({ id = "combo", options = [], groups = [], multiple = false,
           autocomplete="off" placeholder="Pick..." />
       </div>
       ${clearable ? '<button type="button" class="pc-combo-box__clear" data-pc-combo-clear aria-label="Clear selection"><span class="hero-x-mark-mini pc-combo-box__clear-icon"></span></button>' : ""}
-      <span class="hero-chevron-down-mini pc-combo-box__chevron"></span>
+      ${multiple ? "" : '<span class="hero-chevron-down-mini pc-combo-box__chevron"></span>'}
     </div>
     <div class="pc-combo-box__panel" data-pc-combo-panel hidden>
       <div role="listbox" id="${id}-listbox" class="pc-combo-box__list" aria-label="Options">

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -195,6 +195,17 @@ defmodule PetalComponents.ComboBoxTest do
       assert html =~ ~s|data-pc-combo-chip-remove|
     end
 
+    test "chips mode is a token field - no chevron" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="tags" name="tags" multiple options={["a"]} />
+        """)
+
+      refute html =~ "pc-combo-box__chevron"
+    end
+
     test "max_items lands as a data attribute for the hook" do
       assigns = %{}
 


### PR DESCRIPTION
Two rulings from Nic's review, surveyed before deciding:

**Chips mode has no chevron.** The field splits into two families: classic selects (MUI, Ant, React-Select) center a chevron as the control grows; the token-field family (shadcn/Base UI ComboboxChips, Tom Select multi - our own heritage - Select2, GitHub's label picker) drops it in chips mode entirely, because a chevron communicates single-pick dropdown semantics while a chip row communicates 'type or tap to add'. The centered-chevron-in-a-tall-control oddity was that semantic mismatch, not an alignment bug. Single select keeps the chevron; `multiple` renders none. Pinned by tests on both sides.

**Display name: Combobox, one word** - the WAI-ARIA role name and every modern library's usage; 'combo box' is legacy Windows terminology. `combo_box/1` stays per Elixir atom convention; showcase title, playground nav and page heading updated.

751 Elixir + 38 JS green.