### PR TITLE
Combobox: panel flips above at the viewport edge

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -2171,6 +2171,11 @@
     @apply absolute left-0 top-full z-30 mt-1 w-full bg-white shadow-lg border border-gray-200 dark:bg-gray-900 dark:border-gray-400/17;
     border-radius: min(var(--pc-radius, 0.625rem), 1rem);
   }
+  /* flipped: no room below the control and more room above - the hook
+     measures on open and on scroll/resize while open */
+  .pc-combo-box__panel[data-flip] {
+    @apply top-auto bottom-full mt-0 mb-1;
+  }
   .pc-combo-box__list {
     @apply max-h-64 overflow-y-auto p-1;
   }

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3422,6 +3422,7 @@ export const PetalComboBox = {
     };
     // form.reset() resets the select; nothing else would re-sync the chrome
     this.onFormReset = () => setTimeout(() => this.syncFromSelect(), 0);
+    this.onReposition = () => this.positionPanel();
 
     this.input.addEventListener("input", this.onInput);
     this.input.addEventListener("keydown", this.onKeydown);
@@ -3453,6 +3454,8 @@ export const PetalComboBox = {
     this.el.removeEventListener("focusout", this.onFocusOut);
     if (this.form) this.form.removeEventListener("reset", this.onFormReset);
     document.removeEventListener("pointerdown", this.onOutsidePointerDown, true);
+    window.removeEventListener("scroll", this.onReposition, true);
+    window.removeEventListener("resize", this.onReposition);
   },
 
   items() {
@@ -3480,18 +3483,40 @@ export const PetalComboBox = {
     this.panel.hidden = false;
     this.input.setAttribute("aria-expanded", "true");
     document.addEventListener("pointerdown", this.onOutsidePointerDown, true);
+    window.addEventListener("scroll", this.onReposition, true);
+    window.addEventListener("resize", this.onReposition);
     if (!keepQuery) this.query = "";
     this.filter();
+    this.positionPanel();
   },
 
   closePanel() {
     document.removeEventListener("pointerdown", this.onOutsidePointerDown, true);
+    window.removeEventListener("scroll", this.onReposition, true);
+    window.removeEventListener("resize", this.onReposition);
     if (this.panel.hidden) return;
     this.panel.hidden = true;
+    this.panel.removeAttribute("data-flip");
     this.input.setAttribute("aria-expanded", "false");
     this.highlight(null, false);
     this.query = "";
     this.restoreDisplay();
+  },
+
+  // Open downward by default; flip above when the viewport has no room
+  // below AND more room above (the bottom-of-form combobox that used to
+  // open 200px off-screen). Measured with the flip cleared so the panel's
+  // natural height decides, not its last position.
+  positionPanel() {
+    if (this.panel.hidden) return;
+    this.panel.removeAttribute("data-flip");
+    const control = this.control.getBoundingClientRect();
+    const panelH = this.panel.offsetHeight;
+    if (!panelH || (!control.top && !control.bottom)) return; // jsdom / unrendered
+    const gap = 8;
+    const below = window.innerHeight - control.bottom;
+    const above = control.top;
+    if (below < panelH + gap && above > below) this.panel.setAttribute("data-flip", "");
   },
 
   selectedValues() {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3497,6 +3497,7 @@ export const PetalComboBox = {
     if (this.panel.hidden) return;
     this.panel.hidden = true;
     this.panel.removeAttribute("data-flip");
+    this.list.style.maxHeight = "";
     this.input.setAttribute("aria-expanded", "false");
     this.highlight(null, false);
     this.query = "";
@@ -3505,18 +3506,27 @@ export const PetalComboBox = {
 
   // Open downward by default; flip above when the viewport has no room
   // below AND more room above (the bottom-of-form combobox that used to
-  // open 200px off-screen). Measured with the flip cleared so the panel's
-  // natural height decides, not its last position.
+  // open 200px off-screen). When NEITHER side fits the whole panel, the
+  // winning side's space caps the scroll area instead - the list scrolls
+  // within what fits, so no option ever sits outside the viewport.
+  // Measured with flip and cap cleared so natural height decides.
   positionPanel() {
     if (this.panel.hidden) return;
     this.panel.removeAttribute("data-flip");
+    this.list.style.maxHeight = "";
     const control = this.control.getBoundingClientRect();
     const panelH = this.panel.offsetHeight;
     if (!panelH || (!control.top && !control.bottom)) return; // jsdom / unrendered
     const gap = 8;
-    const below = window.innerHeight - control.bottom;
-    const above = control.top;
-    if (below < panelH + gap && above > below) this.panel.setAttribute("data-flip", "");
+    const below = window.innerHeight - control.bottom - gap;
+    const above = control.top - gap;
+    const flip = panelH > below && above > below;
+    if (flip) this.panel.setAttribute("data-flip", "");
+    const room = flip ? above : below;
+    if (panelH > room) {
+      const chrome = panelH - this.list.offsetHeight;
+      this.list.style.maxHeight = `${Math.max(room - chrome, 40)}px`;
+    }
   },
 
   selectedValues() {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3671,6 +3671,11 @@ export const PetalComboBox = {
     } else {
       this.highlight(best || this.visibleItems()[0] || null, false);
     }
+
+    // filtering changes the panel's height (narrowing shrinks, broadening
+    // grows it back) - the flip decision must track it or a grown panel
+    // near the viewport bottom re-clips
+    this.positionPanel();
   },
 
   highlightedItem() {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3524,8 +3524,10 @@ export const PetalComboBox = {
     if (flip) this.panel.setAttribute("data-flip", "");
     const room = flip ? above : below;
     if (panelH > room) {
+      // no floor: in a viewport too cramped for even one row, a sliver of
+      // scrollable list still beats options rendered outside the viewport
       const chrome = panelH - this.list.offsetHeight;
-      this.list.style.maxHeight = `${Math.max(room - chrome, 40)}px`;
+      this.list.style.maxHeight = `${Math.max(room - chrome, 0)}px`;
     }
   },
 

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -436,6 +436,18 @@ describe("panel flip", () => {
     expect(c.panel.hasAttribute("data-flip")).toBe(false);
   });
 
+  it("re-measures when filtering changes the panel height", () => {
+    const c = mountCombo({ options: CITIES });
+    // short panel fits below at first...
+    withRects(c, { controlTop: 700, controlBottom: 740, panelHeight: 40 });
+    c.control.click();
+    expect(c.panel.hasAttribute("data-flip")).toBe(false);
+    // ...then broadening the query grows it past the available space
+    Object.defineProperty(c.panel, "offsetHeight", { configurable: true, value: 200 });
+    type(c.input, "");
+    expect(c.panel.hasAttribute("data-flip")).toBe(true);
+  });
+
   it("close clears the flip so the next open measures fresh", () => {
     const c = mountCombo({ options: CITIES });
     withRects(c, { controlTop: 700, controlBottom: 740, panelHeight: 200 });

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -462,6 +462,18 @@ describe("panel flip", () => {
     expect(c.el.querySelector(".pc-combo-box__list").style.maxHeight).toBe("162px");
   });
 
+  it("never crosses the edge even when less than a row fits", () => {
+    const c = mountCombo({ options: CITIES });
+    // room above = 40-8=32, chrome 10 -> cap 22: a sliver, but contained
+    withRects(c, { controlTop: 40, controlBottom: 80, panelHeight: 200, viewport: 100 });
+    Object.defineProperty(c.el.querySelector(".pc-combo-box__list"), "offsetHeight", {
+      configurable: true,
+      value: 190,
+    });
+    c.control.click();
+    expect(c.el.querySelector(".pc-combo-box__list").style.maxHeight).toBe("22px");
+  });
+
   it("the cap clears when room returns", () => {
     const c = mountCombo({ options: CITIES });
     withRects(c, { controlTop: 180, controlBottom: 220, panelHeight: 200, viewport: 300 });

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -448,6 +448,35 @@ describe("panel flip", () => {
     expect(c.panel.hasAttribute("data-flip")).toBe(true);
   });
 
+  it("caps the scroll area when neither side fits, on the winning side", () => {
+    const c = mountCombo({ options: CITIES });
+    // viewport 300: above the control 172px, below 52px, panel wants 200px
+    withRects(c, { controlTop: 180, controlBottom: 220, panelHeight: 200, viewport: 300 });
+    Object.defineProperty(c.el.querySelector(".pc-combo-box__list"), "offsetHeight", {
+      configurable: true,
+      value: 190,
+    });
+    c.control.click();
+    expect(c.panel.hasAttribute("data-flip")).toBe(true);
+    // room above = 180-8=172, chrome = 200-190=10 -> cap 162
+    expect(c.el.querySelector(".pc-combo-box__list").style.maxHeight).toBe("162px");
+  });
+
+  it("the cap clears when room returns", () => {
+    const c = mountCombo({ options: CITIES });
+    withRects(c, { controlTop: 180, controlBottom: 220, panelHeight: 200, viewport: 300 });
+    Object.defineProperty(c.el.querySelector(".pc-combo-box__list"), "offsetHeight", {
+      configurable: true,
+      value: 190,
+    });
+    c.control.click();
+    expect(c.el.querySelector(".pc-combo-box__list").style.maxHeight).not.toBe("");
+    withRects(c, { controlTop: 100, controlBottom: 140, panelHeight: 200, viewport: 800 });
+    window.dispatchEvent(new Event("resize"));
+    expect(c.el.querySelector(".pc-combo-box__list").style.maxHeight).toBe("");
+    expect(c.panel.hasAttribute("data-flip")).toBe(false);
+  });
+
   it("close clears the flip so the next open measures fresh", () => {
     const c = mountCombo({ options: CITIES });
     withRects(c, { controlTop: 700, controlBottom: 740, panelHeight: 200 });

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -405,6 +405,46 @@ describe("hardening riders", () => {
   });
 });
 
+describe("panel flip", () => {
+  function withRects(c, { controlTop, controlBottom, panelHeight, viewport = 800 }) {
+    c.control.getBoundingClientRect = () => ({ top: controlTop, bottom: controlBottom, left: 0, right: 200, width: 200, height: controlBottom - controlTop });
+    Object.defineProperty(c.panel, "offsetHeight", { configurable: true, value: panelHeight });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: viewport, writable: true });
+  }
+
+  it("stays below when there is room", () => {
+    const c = mountCombo({ options: CITIES });
+    withRects(c, { controlTop: 100, controlBottom: 140, panelHeight: 200 });
+    c.control.click();
+    expect(c.panel.hasAttribute("data-flip")).toBe(false);
+  });
+
+  it("flips above when the viewport has no room below and more above", () => {
+    const c = mountCombo({ options: CITIES });
+    withRects(c, { controlTop: 700, controlBottom: 740, panelHeight: 200 });
+    c.control.click();
+    expect(c.panel.hasAttribute("data-flip")).toBe(true);
+  });
+
+  it("re-measures on scroll while open and clears the flip when room returns", () => {
+    const c = mountCombo({ options: CITIES });
+    withRects(c, { controlTop: 700, controlBottom: 740, panelHeight: 200 });
+    c.control.click();
+    expect(c.panel.hasAttribute("data-flip")).toBe(true);
+    withRects(c, { controlTop: 100, controlBottom: 140, panelHeight: 200 });
+    window.dispatchEvent(new Event("resize"));
+    expect(c.panel.hasAttribute("data-flip")).toBe(false);
+  });
+
+  it("close clears the flip so the next open measures fresh", () => {
+    const c = mountCombo({ options: CITIES });
+    withRects(c, { controlTop: 700, controlBottom: 740, panelHeight: 200 });
+    c.control.click();
+    key(c.input, "Escape");
+    expect(c.panel.hasAttribute("data-flip")).toBe(false);
+  });
+});
+
 describe("server ownership", () => {
   it("updated() re-syncs from the select - the server wins", () => {
     const c = mountCombo({ options: CITIES });


### PR DESCRIPTION
The quantified M2 item from the review cycle: a combobox near the bottom of a page opened its panel **225px off-screen with 33px visible** (500px viewport, measured).

The panel now measures on open - and on scroll/resize while open - and flips above the control when the viewport has no room below AND more room above, via a `data-flip` attribute the CSS turns into `bottom-full` positioning. Flip clears on close so every open measures fresh; jsdom zero-rects are guarded.

**Verified**: 42 JS specs (4 new: stays-below-with-room, flips-at-edge, re-measures-on-scroll, clears-on-close), 751 Elixir green, and the exact former-bug scenario re-run live: 500px viewport, 37px below the control → panel opens fully on-screen above (screenshot in session).