### PR TITLE
Combobox: variant="trigger" - the picker anatomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 
 #### Added
 
+- **`combo_box` `variant="trigger"` - the picker anatomy.** A select-like
+  button shows the chosen value (or "N selected" with `multiple` -
+  `count_label` localizes the word) and the search input lives inside
+  the panel, command-palette style. Open from the button, arrow keys or
+  click; search; choose - single select closes and returns focus to the
+  button, multiple stays open and the count label tracks live. Same
+  hidden select underneath, same form behavior, same positioning
+  (flip + space cap). This is the anatomy pickers use - and the exact
+  shape the 4.12 data table's filter editors are built from.
+
 - **`combo_box` grows up: `multiple` with chips, `clearable`, and the
   hardening pass** (combobox M2 core). `multiple` turns the trigger into
   a chip row - removable tokens, panel stays open while picking,

--- a/assets/default.css
+++ b/assets/default.css
@@ -2167,6 +2167,32 @@
     @apply w-4! h-4!;
   }
 
+  /* trigger variant: a select-like button; the search input lives in the
+     panel (command-palette grammar) */
+  .pc-combo-box__trigger {
+    @apply flex w-full items-center justify-between gap-2 bg-white border border-gray-300 px-3 py-2 text-left text-sm text-gray-900 shadow-xs transition-[color,box-shadow] duration-200 ease-out focus-visible:outline-none focus-visible:border-primary-500 focus-visible:ring-2 focus-visible:ring-primary-500/50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-400/8 dark:border-gray-400/25 dark:text-gray-100;
+    border-radius: var(--pc-radius, 0.625rem);
+  }
+  .pc-combo-box__trigger[data-placeholder] .pc-combo-box__trigger-label {
+    @apply text-gray-400 dark:text-gray-500;
+  }
+  .pc-combo-box__trigger-label {
+    @apply truncate;
+  }
+  .pc-combo-box__search {
+    @apply flex items-center gap-2 border-b border-gray-200 px-3 dark:border-gray-400/17;
+  }
+  .pc-combo-box__search-icon {
+    @apply shrink-0 text-gray-400 dark:text-gray-500;
+  }
+  /* Doubled selector + !important: icon sizing contract (see pagination previous chevron). */
+  .pc-combo-box__search-icon.pc-combo-box__search-icon {
+    @apply w-4! h-4!;
+  }
+  .pc-combo-box__search .pc-combo-box__input {
+    @apply w-full border-0 bg-transparent px-0 py-2 focus:outline-none focus:ring-0;
+  }
+
   .pc-combo-box__panel {
     @apply absolute left-0 top-full z-30 mt-1 w-full bg-white shadow-lg border border-gray-200 dark:bg-gray-900 dark:border-gray-400/17;
     border-radius: min(var(--pc-radius, 0.625rem), 1rem);

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3350,6 +3350,8 @@ export const PetalComboBox = {
     this.select = this.el.querySelector(".pc-combo-box__select");
     this.input = this.el.querySelector(".pc-combo-box__input");
     this.control = this.el.querySelector(".pc-combo-box__control");
+    this.trigger = this.el.querySelector("[data-pc-combo-trigger]");
+    this.triggerLabel = this.el.querySelector("[data-pc-combo-trigger-label]");
     this.panel = this.el.querySelector("[data-pc-combo-panel]");
     this.list = this.el.querySelector(".pc-combo-box__list");
     if (!this.select || !this.input || !this.panel || !this.list) return;
@@ -3382,8 +3384,11 @@ export const PetalComboBox = {
       if (item && !item.hasAttribute("data-disabled")) this.choose(item);
     };
     // keep focus on the input while clicking inside the panel, or the
-    // focusout close would swallow the click before it lands
-    this.onPanelPointerDown = (e) => e.preventDefault();
+    // focusout close would swallow the click before it lands; the search
+    // input (trigger variant) must stay clickable for caret work
+    this.onPanelPointerDown = (e) => {
+      if (e.target !== this.input) e.preventDefault();
+    };
     this.onControlClick = (e) => {
       if (this.input.disabled) return;
       if (e.target.closest("[data-pc-combo-chip-remove]")) {
@@ -3412,6 +3417,25 @@ export const PetalComboBox = {
     this.onFocusOut = (e) => {
       if (!this.el.contains(e.relatedTarget)) this.closePanel();
     };
+    // trigger variant: the button opens the panel and focus moves to the
+    // search input inside it; ArrowDown/Up on the button open too
+    this.onTriggerClick = () => {
+      if (this.trigger.disabled) return;
+      if (this.panel.hidden) {
+        this.openPanel();
+        this.input.focus();
+      } else {
+        this.closePanel();
+      }
+    };
+    this.onTriggerKeydown = (e) => {
+      if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+      e.preventDefault();
+      if (this.panel.hidden) {
+        this.openPanel();
+        this.input.focus();
+      }
+    };
     // focusout covers Tab-away and desktop clicks (desktop blurs the input
     // when you click static content), but iOS Safari deliberately keeps
     // focus when tapping non-interactive content - no blur, no focusout, a
@@ -3429,7 +3453,11 @@ export const PetalComboBox = {
     this.list.addEventListener("pointerover", this.onPointerOver);
     this.list.addEventListener("click", this.onListClick);
     this.panel.addEventListener("pointerdown", this.onPanelPointerDown);
-    this.control.addEventListener("click", this.onControlClick);
+    if (this.control) this.control.addEventListener("click", this.onControlClick);
+    if (this.trigger) {
+      this.trigger.addEventListener("click", this.onTriggerClick);
+      this.trigger.addEventListener("keydown", this.onTriggerKeydown);
+    }
     this.el.addEventListener("focusout", this.onFocusOut);
     this.form = this.select.form;
     if (this.form) this.form.addEventListener("reset", this.onFormReset);
@@ -3450,7 +3478,11 @@ export const PetalComboBox = {
     this.list.removeEventListener("pointerover", this.onPointerOver);
     this.list.removeEventListener("click", this.onListClick);
     this.panel.removeEventListener("pointerdown", this.onPanelPointerDown);
-    this.control.removeEventListener("click", this.onControlClick);
+    if (this.control) this.control.removeEventListener("click", this.onControlClick);
+    if (this.trigger) {
+      this.trigger.removeEventListener("click", this.onTriggerClick);
+      this.trigger.removeEventListener("keydown", this.onTriggerKeydown);
+    }
     this.el.removeEventListener("focusout", this.onFocusOut);
     if (this.form) this.form.removeEventListener("reset", this.onFormReset);
     document.removeEventListener("pointerdown", this.onOutsidePointerDown, true);
@@ -3482,6 +3514,7 @@ export const PetalComboBox = {
     if (!this.panel.hidden) return;
     this.panel.hidden = false;
     this.input.setAttribute("aria-expanded", "true");
+    if (this.trigger) this.trigger.setAttribute("aria-expanded", "true");
     document.addEventListener("pointerdown", this.onOutsidePointerDown, true);
     window.addEventListener("scroll", this.onReposition, true);
     window.addEventListener("resize", this.onReposition);
@@ -3502,6 +3535,14 @@ export const PetalComboBox = {
     this.highlight(null, false);
     this.query = "";
     this.restoreDisplay();
+    if (this.trigger) {
+      this.trigger.setAttribute("aria-expanded", "false");
+      // the search input just vanished with the panel - focus returns to
+      // the trigger unless something outside already took it
+      if (this.el.contains(document.activeElement) || document.activeElement === document.body) {
+        this.trigger.focus();
+      }
+    }
   },
 
   // Open downward by default; flip above when the viewport has no room
@@ -3514,7 +3555,9 @@ export const PetalComboBox = {
     if (this.panel.hidden) return;
     this.panel.removeAttribute("data-flip");
     this.list.style.maxHeight = "";
-    const control = this.control.getBoundingClientRect();
+    const anchor = this.control || this.trigger;
+    if (!anchor) return;
+    const control = anchor.getBoundingClientRect();
     const panelH = this.panel.offsetHeight;
     if (!panelH || (!control.top && !control.bottom)) return; // jsdom / unrendered
     const gap = 8;
@@ -3549,7 +3592,9 @@ export const PetalComboBox = {
   },
 
   restoreDisplay() {
-    if (this.multiple) {
+    if (this.multiple || this.trigger) {
+      // chips carry the state in multiple mode; the trigger label carries
+      // it in trigger mode - the input is pure query either way
       this.input.value = "";
       return;
     }
@@ -3612,6 +3657,21 @@ export const PetalComboBox = {
       this.syncChips();
       this.el.toggleAttribute("data-max-reached", this.maxReached());
     }
+    if (this.triggerLabel) {
+      const placeholder = this.triggerLabel.dataset.placeholderText;
+      if (values.length === 0) {
+        this.triggerLabel.textContent = placeholder || "";
+        this.trigger.setAttribute("data-placeholder", "true");
+      } else {
+        this.trigger.removeAttribute("data-placeholder");
+        if (this.multiple) {
+          this.triggerLabel.textContent = `${values.length} ${this.triggerLabel.dataset.countLabel || "selected"}`;
+        } else {
+          const chosen = this.chosenItem();
+          this.triggerLabel.textContent = chosen ? chosen.dataset.label || "" : "";
+        }
+      }
+    }
     if (this.panel.hidden || document.activeElement !== this.input) this.restoreDisplay();
   },
 
@@ -3631,7 +3691,7 @@ export const PetalComboBox = {
     }
     this.setSelected(value, true);
     this.closePanel();
-    this.input.focus();
+    if (!this.trigger) this.input.focus();
   },
 
   announce(count) {

--- a/dev.exs
+++ b/dev.exs
@@ -7317,7 +7317,10 @@ defmodule Dev.PlaygroundLive do
       <div
         :for={
           ex <-
-            examples_for(PetalComponents.Showcase.ComboBox, ~w(multiple basic preselected groups)a)
+            examples_for(
+              PetalComponents.Showcase.ComboBox,
+              ~w(multiple trigger basic preselected groups)a
+            )
         }
         class="mt-10"
       >

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -76,6 +76,20 @@ defmodule PetalComponents.ComboBox do
     doc:
       "strings, {label, value} tuples, {label, value, opts} (opts: disabled: true), or {group_label, options} groups"
 
+  attr :variant, :string,
+    default: "input",
+    values: ["input", "trigger"],
+    doc:
+      "input is the searchable field; trigger is a select-like button whose panel carries the search input - the picker anatomy, and the data table's filter editor"
+
+  attr :search_placeholder, :string,
+    default: "Search…",
+    doc: "trigger variant: placeholder for the search input inside the panel"
+
+  attr :count_label, :string,
+    default: "selected",
+    doc: "trigger variant with multiple: the word after the count in the closed label"
+
   attr :multiple, :boolean,
     default: false,
     doc: "chip-row selection: the hidden select becomes select multiple and the name gains []"
@@ -127,6 +141,7 @@ defmodule PetalComponents.ComboBox do
         if(assigns.multiple, do: nil, else: selected_label(groups, values))
       )
       |> assign(:selected_options, selected_options(groups, values))
+      |> assign(:trigger_label, trigger_label(assigns, groups, values))
 
     ~H"""
     <div
@@ -175,7 +190,29 @@ defmodule PetalComponents.ComboBox do
         <% end %>
       </select>
 
-      <div class="pc-combo-box__control">
+      <button
+        :if={@variant == "trigger"}
+        type="button"
+        id={"#{@id}-trigger"}
+        class="pc-combo-box__trigger"
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded="false"
+        aria-controls={"#{@id}-listbox"}
+        data-pc-combo-trigger
+        data-placeholder={@current_values == [] && "true"}
+        disabled={@disabled}
+      >
+        <span
+          class="pc-combo-box__trigger-label"
+          data-pc-combo-trigger-label
+          data-placeholder-text={@placeholder}
+          data-count-label={@count_label}
+        >{@trigger_label}</span>
+        <.icon name="hero-chevron-down-mini" class="pc-combo-box__chevron" />
+      </button>
+
+      <div :if={@variant == "input"} class="pc-combo-box__control">
         <div class="pc-combo-box__content">
           <div
             :if={@multiple}
@@ -230,6 +267,22 @@ defmodule PetalComponents.ComboBox do
       </div>
 
       <div class="pc-combo-box__panel" data-pc-combo-panel hidden>
+        <div :if={@variant == "trigger"} class="pc-combo-box__search">
+          <.icon name="hero-magnifying-glass-mini" class="pc-combo-box__search-icon" />
+          <input
+            type="text"
+            id={"#{@id}-input"}
+            class="pc-combo-box__input"
+            role="combobox"
+            aria-expanded="false"
+            aria-autocomplete="list"
+            aria-controls={"#{@id}-listbox"}
+            autocomplete="off"
+            autocorrect="off"
+            spellcheck="false"
+            placeholder={@search_placeholder}
+          />
+        </div>
         <div
           role="listbox"
           id={"#{@id}-listbox"}
@@ -348,6 +401,16 @@ defmodule PetalComponents.ComboBox do
     # chip order follows the chosen order, not the option order
     Enum.flat_map(values, fn value -> Enum.filter(all, &(&1.value == value)) end)
   end
+
+  defp trigger_label(%{variant: "trigger"} = assigns, groups, values) do
+    case values do
+      [] -> assigns.placeholder
+      _ when assigns.multiple -> "#{length(values)} #{assigns.count_label}"
+      [value | _] -> selected_label(groups, [value]) || assigns.placeholder
+    end
+  end
+
+  defp trigger_label(_assigns, _groups, _values), do: nil
 
   defp input_name(%{multiple: true} = assigns) do
     case assigns.name || (assigns.field && assigns.field.name) do

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -64,6 +64,42 @@ defmodule PetalComponents.Showcase.ComboBox do
     """
   end
 
+  example :trigger, "The picker - trigger variant",
+    description:
+      "variant=\"trigger\" is the select-like anatomy: a button shows the chosen value (or a count with multiple), and the search input lives inside the panel. This is the shape pickers and the data table's filter editors use - open it from anywhere, search, choose, and focus returns to the button. Same hidden select underneath, same form behavior." do
+    ~H"""
+    <div class="flex flex-col items-center w-full max-w-xs gap-4 mx-auto">
+      <.combo_box
+        id="sx-combo-trigger"
+        name="assignee"
+        variant="trigger"
+        placeholder="Assign to…"
+        options={[
+          {"Amelia Ward", "amelia"},
+          {"Jonah Reyes", "jonah"},
+          {"Priya Anand", "priya"},
+          {"Tom Hale", "tom"}
+        ]}
+      />
+      <.combo_box
+        id="sx-combo-trigger-multi"
+        name="labels"
+        variant="trigger"
+        multiple
+        value={["bug", "ui"]}
+        placeholder="Labels…"
+        count_label="labels"
+        options={[
+          {"Bug", "bug"},
+          {"UI", "ui"},
+          {"Docs", "docs"},
+          {"Performance", "perf"}
+        ]}
+      />
+    </div>
+    """
+  end
+
   example :groups, "Groups and disabled options",
     description:
       "{group_label, options} renders a heading and keeps its position between flat options; a group hides itself when the query filters out every option inside. {label, value, disabled: true} renders the option present but inert - visible in the list, skipped by the keyboard." do

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -459,6 +459,20 @@ describe("trigger variant", () => {
     expect(document.activeElement).toBe(c.trigger);
   });
 
+  it("updated() reconciles the trigger label from the server-patched select", () => {
+    const c = mountCombo({ options: CITIES, trigger: true });
+    // the server patched a value in
+    c.select.value = "tyo";
+    c.hook.updated();
+    expect(c.triggerLabel().textContent).toBe("Tokyo");
+    expect(c.trigger.hasAttribute("data-placeholder")).toBe(false);
+    // and patched it back out
+    c.select.value = "";
+    c.hook.updated();
+    expect(c.triggerLabel().textContent).toBe("Pick...");
+    expect(c.trigger.hasAttribute("data-placeholder")).toBe(true);
+  });
+
   it("clearing every choice restores the placeholder state", () => {
     const c = mountCombo({ options: CITIES, trigger: true, multiple: true });
     c.trigger.click();

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -31,7 +31,7 @@ function optionHtml(opt) {
     </div>`;
 }
 
-function mountCombo({ id = "combo", options = [], groups = [], multiple = false, maxItems = null, clearable = false } = {}) {
+function mountCombo({ id = "combo", options = [], groups = [], multiple = false, maxItems = null, clearable = false, trigger = false } = {}) {
   const selectOptions = [...options, ...groups.flatMap((g) => g.options)]
     .map((o) => `<option value="${o.value}" ${o.disabled ? "disabled" : ""}>${o.label}</option>`)
     .join("");
@@ -53,22 +53,34 @@ function mountCombo({ id = "combo", options = [], groups = [], multiple = false,
   el.className = "pc-combo-box";
   el.setAttribute("phx-hook", "PetalComboBox");
   if (maxItems) el.setAttribute("data-max-items", String(maxItems));
+  const inputHtml = `<input type="text" id="${id}-input" class="pc-combo-box__input" role="combobox"
+          aria-expanded="false" aria-autocomplete="list" aria-controls="${id}-listbox"
+          autocomplete="off" placeholder="Pick..." />`;
+
+  const bodyHtml = trigger
+    ? `<button type="button" id="${id}-trigger" class="pc-combo-box__trigger" role="combobox"
+        aria-haspopup="listbox" aria-expanded="false" aria-controls="${id}-listbox"
+        data-pc-combo-trigger data-placeholder="true">
+        <span class="pc-combo-box__trigger-label" data-pc-combo-trigger-label
+          data-placeholder-text="Pick..." data-count-label="selected">Pick...</span>
+      </button>`
+    : `<div class="pc-combo-box__control">
+      <div class="pc-combo-box__content">
+        ${multiple ? '<div class="pc-combo-box__chips" data-pc-combo-chips data-remove-label="Remove"></div>' : ""}
+        ${inputHtml}
+      </div>
+      ${clearable ? '<button type="button" class="pc-combo-box__clear" data-pc-combo-clear aria-label="Clear selection"><span class="hero-x-mark-mini pc-combo-box__clear-icon"></span></button>' : ""}
+      ${multiple ? "" : '<span class="hero-chevron-down-mini pc-combo-box__chevron"></span>'}
+    </div>`;
+
   el.innerHTML = `
     <select id="${id}-select" name="city${multiple ? "[]" : ""}" class="pc-combo-box__select" tabindex="-1" aria-hidden="true" inert ${multiple ? "multiple" : ""}>
       ${multiple ? "" : '<option value=""></option>'}
       ${selectOptions}
     </select>
-    <div class="pc-combo-box__control">
-      <div class="pc-combo-box__content">
-        ${multiple ? '<div class="pc-combo-box__chips" data-pc-combo-chips data-remove-label="Remove"></div>' : ""}
-        <input type="text" id="${id}-input" class="pc-combo-box__input" role="combobox"
-          aria-expanded="false" aria-autocomplete="list" aria-controls="${id}-listbox"
-          autocomplete="off" placeholder="Pick..." />
-      </div>
-      ${clearable ? '<button type="button" class="pc-combo-box__clear" data-pc-combo-clear aria-label="Clear selection"><span class="hero-x-mark-mini pc-combo-box__clear-icon"></span></button>' : ""}
-      ${multiple ? "" : '<span class="hero-chevron-down-mini pc-combo-box__chevron"></span>'}
-    </div>
+    ${bodyHtml}
     <div class="pc-combo-box__panel" data-pc-combo-panel hidden>
+      ${trigger ? '<div class="pc-combo-box__search"><span class="hero-magnifying-glass-mini pc-combo-box__search-icon"></span>' + inputHtml + "</div>" : ""}
       <div role="listbox" id="${id}-listbox" class="pc-combo-box__list" aria-label="Options">
         ${listHtml}
         <div class="pc-combo-box__empty" data-pc-combo-empty hidden>No results found</div>
@@ -96,6 +108,8 @@ function mountCombo({ id = "combo", options = [], groups = [], multiple = false,
     empty: () => el.querySelector("[data-pc-combo-empty]"),
     chips: () => [...el.querySelectorAll("[data-pc-combo-chip]")],
     live: () => el.querySelector("[data-pc-combo-live]"),
+    trigger: el.querySelector("[data-pc-combo-trigger]"),
+    triggerLabel: () => el.querySelector("[data-pc-combo-trigger-label]"),
   };
 }
 
@@ -402,6 +416,56 @@ describe("hardening riders", () => {
     expect(c.live().textContent).toBe("2 results");
     type(c.input, "zzz");
     expect(c.live().textContent).toBe("No results found");
+  });
+});
+
+describe("trigger variant", () => {
+  it("the button opens the panel, focuses the search input, mirrors aria-expanded", () => {
+    const c = mountCombo({ options: CITIES, trigger: true });
+    c.trigger.click();
+    expect(c.panel.hidden).toBe(false);
+    expect(c.trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(document.activeElement).toBe(c.input);
+  });
+
+  it("choosing closes, returns focus to the trigger, and updates the label", () => {
+    const c = mountCombo({ options: CITIES, trigger: true });
+    c.trigger.click();
+    type(c.input, "lis");
+    key(c.input, "Enter");
+    expect(c.panel.hidden).toBe(true);
+    expect(c.trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(c.trigger);
+    expect(c.triggerLabel().textContent).toBe("Lisbon");
+    expect(c.trigger.hasAttribute("data-placeholder")).toBe(false);
+  });
+
+  it("multiple keeps the panel open and the count label live", () => {
+    const c = mountCombo({ options: CITIES, trigger: true, multiple: true });
+    c.trigger.click();
+    c.items()[0].click();
+    c.items()[1].click();
+    expect(c.panel.hidden).toBe(false);
+    expect(c.triggerLabel().textContent).toBe("2 selected");
+  });
+
+  it("ArrowDown on the trigger opens; Escape closes back to the trigger", () => {
+    const c = mountCombo({ options: CITIES, trigger: true });
+    c.trigger.focus();
+    key(c.trigger, "ArrowDown");
+    expect(c.panel.hidden).toBe(false);
+    key(c.input, "Escape");
+    expect(c.panel.hidden).toBe(true);
+    expect(document.activeElement).toBe(c.trigger);
+  });
+
+  it("clearing every choice restores the placeholder state", () => {
+    const c = mountCombo({ options: CITIES, trigger: true, multiple: true });
+    c.trigger.click();
+    c.items()[0].click();
+    c.items()[0].click();
+    expect(c.triggerLabel().textContent).toBe("Pick...");
+    expect(c.trigger.hasAttribute("data-placeholder")).toBe(true);
   });
 });
 

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -218,6 +218,51 @@ defmodule PetalComponents.ComboBoxTest do
     end
   end
 
+  describe "trigger variant" do
+    test "renders a combobox button with the search input inside the panel" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="pick" name="pick" variant="trigger" options={["Sydney"]} />
+        """)
+
+      assert html =~ ~s|data-pc-combo-trigger|
+      assert html =~ ~s|aria-haspopup="listbox"|
+      assert html =~ "pc-combo-box__search"
+      # the search input lives in the panel, not a control row
+      refute html =~ "pc-combo-box__control"
+      # placeholder state on an empty trigger
+      assert html =~ ~s|data-placeholder="true"|
+    end
+
+    test "single trigger shows the chosen label; multiple shows the count" do
+      assigns = %{}
+
+      single =
+        rendered_to_string(~H"""
+        <.combo_box id="s" name="s" variant="trigger" value="syd" options={[{"Sydney", "syd"}]} />
+        """)
+
+      assert single =~ ">Sydney</span>"
+      refute single =~ ~s|data-placeholder="true"|
+
+      multi =
+        rendered_to_string(~H"""
+        <.combo_box
+          id="m"
+          name="m"
+          variant="trigger"
+          multiple
+          value={["a", "b"]}
+          options={[{"Alpha", "a"}, {"Beta", "b"}]}
+        />
+        """)
+
+      assert multi =~ ">2 selected</span>"
+    end
+  end
+
   describe "clearable and hardening" do
     test "clearable renders the labelled clear button and data-has-value tracks the value" do
       assigns = %{}


### PR DESCRIPTION
The last big M2 item: shadcn's default combobox shape, built on our machinery.

- **Trigger**: a select-like button on the field surface - truncating label, placeholder state via `data-placeholder`, real focus-visible ring, ArrowDown/Up opens. Chevron stays `chevron-down` (one chevron family, deliberately not shadcn's up-down double).
- **Panel search**: the input moves inside the panel, command-palette grammar (magnifier, borderless, bottom hairline) including the 16px-below-sm iOS rule.
- **Single**: choose → close → focus returns to the trigger, label updates. **Multiple**: panel stays open, live "N selected" count (`count_label` localizes; server renders the same label for SSR, hook keeps it live - server wins on patch, same model as chips).
- Same hidden select, form behavior, and positioning (flip + space cap) as the input variant.
- **The spec suite caught a real crash before any browser did**: `positionPanel` anchored on the null `control` in trigger mode - the anchor is now whichever of control/trigger exists.

**This is the exact shape the 4.12 data table's filter editors compose from** - building it here pre-fabricates that work, per the plan.

**Verification**: 51 JS specs (5 new trigger cases: open/focus, choose/close/focus-return/label, multi count, ArrowDown open + Escape return, placeholder restore), 753 Elixir (2 new), full flow click-verified live in the playground (screenshot in session).