### PR TITLE
The in-field icon anatomy sweep + chips polish

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -1967,9 +1967,6 @@
   .pc-dropdown {
     @apply relative inline-block text-left;
   }
-  .pc-dropdown__chevron {
-    @apply w-5 h-5 ml-2 -mr-1 dark:text-gray-100;
-  }
   .pc-dropdown__menu-items-wrapper {
     /* Content-driven width: menus hug their items (min-w floor keeps tiny
        menus from looking cramped, max-w caps runaway labels). Consumers can
@@ -1986,8 +1983,13 @@
   }
   /* The one trigger chevron for the dropdown family - user menu,
      language select and friends share this so the colour can't drift. */
+  /* THE decorative-chevron rule for the dropdown family (dropdown,
+     user-menu, combobox trigger sibling classes mirror it). Icon anatomy
+     doctrine: a fixed box at the glyph's comfortable size, shrink-0,
+     pointer-events-none, muted - the CONTAINER owns all spacing. Never
+     put margins on this class or inline utilities beside it. */
   .pc-dropdown__chevron {
-    @apply w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500;
+    @apply w-5 h-5 shrink-0 pointer-events-none text-gray-400 dark:text-gray-500;
   }
   .pc-dropdown__menu-item {
     @apply flex items-center self-start justify-start w-full gap-2 px-3 py-2 text-sm text-left text-gray-700 transition-colors duration-150 ease-out hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-400/17;
@@ -1998,6 +2000,7 @@
     border-radius: var(--pc-radius, 0.625rem);
   }
   .pc-dropdown__trigger-button--with-label {
+    @apply inline-flex items-center gap-2;
     @apply inline-flex items-center justify-center w-full px-4 py-2 text-sm font-medium bg-transparent border border-gray-300 text-gray-700 shadow-xs transition-colors duration-200 ease-out hover:bg-gray-100 hover:text-gray-900 active:bg-gray-200 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:border-gray-400/25 dark:bg-gray-400/8 dark:text-gray-200 dark:hover:bg-gray-400/17 dark:hover:text-gray-50;
     border-radius: var(--pc-radius, 0.625rem);
   }
@@ -2144,7 +2147,7 @@
     @apply sr-only;
   }
   .pc-combo-box__control {
-    @apply flex items-center w-full bg-white border border-gray-300 shadow-xs touch-manipulation transition-[color,box-shadow] duration-200 ease-out focus-within:border-primary-500 focus-within:ring-2 focus-within:ring-primary-500/50 dark:bg-gray-400/8 dark:border-gray-400/25;
+    @apply flex items-center gap-1.5 w-full pr-3 bg-white border border-gray-300 shadow-xs touch-manipulation transition-[color,box-shadow] duration-200 ease-out focus-within:border-primary-500 focus-within:ring-2 focus-within:ring-primary-500/50 dark:bg-gray-400/8 dark:border-gray-400/25;
     border-radius: var(--pc-radius, 0.625rem);
   }
   .pc-combo-box__control:has(.pc-combo-box__input:disabled) {
@@ -2160,11 +2163,11 @@
     border-radius: inherit;
   }
   .pc-combo-box__chevron {
-    @apply mr-2.5 shrink-0 text-gray-400 dark:text-gray-500;
+    @apply shrink-0 pointer-events-none text-gray-400 dark:text-gray-500;
   }
   /* Doubled selector + !important: icon sizing contract (see pagination previous chevron). */
   .pc-combo-box__chevron.pc-combo-box__chevron {
-    @apply w-4! h-4!;
+    @apply w-5! h-5!;
   }
 
   /* trigger variant: a select-like button; the search input lives in the
@@ -2183,7 +2186,7 @@
     @apply flex items-center gap-2 border-b border-gray-200 px-3 dark:border-gray-400/17;
   }
   .pc-combo-box__search-icon {
-    @apply shrink-0 text-gray-400 dark:text-gray-500;
+    @apply shrink-0 pointer-events-none text-gray-400 dark:text-gray-500;
   }
   /* Doubled selector + !important: icon sizing contract (see pagination previous chevron). */
   .pc-combo-box__search-icon.pc-combo-box__search-icon {
@@ -2227,7 +2230,7 @@
     @apply flex-1 truncate;
   }
   .pc-combo-box__check {
-    @apply invisible ml-auto shrink-0 text-gray-900 dark:text-white;
+    @apply invisible shrink-0 pointer-events-none text-gray-900 dark:text-white;
   }
   .pc-combo-box__option[aria-selected="true"] .pc-combo-box__check {
     @apply visible;
@@ -2264,20 +2267,22 @@
   }
   .pc-combo-box__chip {
     @apply inline-flex max-w-full items-center gap-0.5 bg-gray-100 py-0.5 pl-1.5 pr-0.5 text-xs font-medium text-gray-700 dark:bg-gray-400/17 dark:text-gray-200;
-    border-radius: max(calc(min(var(--pc-radius, 0.625rem), 1rem) - 0.25rem), 0px);
+    /* derived from the CONTROL's radius (not the panel clamp) so chips pill
+       inside a pilled control at radius=full - the segmented-family curve */
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.375rem), 0px);
   }
   .pc-combo-box__chip-label {
     @apply truncate;
   }
   /* interactive in-field icon = a real button: hit target, focus ring */
   .pc-combo-box__chip-remove {
-    @apply inline-flex h-4.5 w-4.5 shrink-0 items-center justify-center rounded-sm text-gray-500 transition-colors hover:bg-gray-200 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:text-gray-400 dark:hover:bg-gray-400/25 dark:hover:text-white;
+    @apply inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-gray-500 transition-colors hover:bg-gray-200 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:text-gray-400 dark:hover:bg-gray-400/25 dark:hover:text-white;
   }
   .pc-combo-box__chip-remove-icon.pc-combo-box__chip-remove-icon {
-    @apply w-3.5! h-3.5!;
+    @apply w-4! h-4!;
   }
   .pc-combo-box__clear {
-    @apply mr-0.5 hidden h-6 w-6 shrink-0 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:text-gray-500 dark:hover:bg-gray-400/17 dark:hover:text-gray-200;
+    @apply hidden h-6 w-6 shrink-0 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:text-gray-500 dark:hover:bg-gray-400/17 dark:hover:text-gray-200;
   }
   .pc-combo-box[data-has-value] .pc-combo-box__clear {
     @apply inline-flex;
@@ -5411,7 +5416,7 @@
   }
 
   .pc-language-select__chevron {
-    @apply w-4 h-4 text-gray-400 dark:text-gray-500;
+    @apply w-5 h-5 shrink-0 pointer-events-none text-gray-400 dark:text-gray-500;
   }
 
   .pc-language-select__code {

--- a/lib/petal_components/dropdown.ex
+++ b/lib/petal_components/dropdown.ex
@@ -75,7 +75,7 @@ defmodule PetalComponents.Dropdown do
 
           <%= if @label do %>
             {@label}
-            <.icon name="hero-chevron-down-solid" class="w-5 h-5 pc-dropdown__chevron" />
+            <.icon name="hero-chevron-down-mini" class="pc-dropdown__chevron" />
           <% end %>
 
           <%= if @trigger_element do %>

--- a/lib/petal_components/user_dropdown_menu.ex
+++ b/lib/petal_components/user_dropdown_menu.ex
@@ -18,7 +18,7 @@ defmodule PetalComponents.UserDropdownMenu do
     ~H"""
     <.dropdown :if={@user_menu_items != []}>
       <:trigger_element>
-        <div class="inline-flex items-center justify-center w-full align-middle focus:outline-hidden">
+        <div class="inline-flex items-center justify-center w-full gap-1 align-middle focus:outline-hidden">
           <%= if assigns[:current_user_name] || assigns[:avatar_src] do %>
             <.avatar name={@current_user_name} src={@avatar_src} size="sm" random_color />
           <% else %>
@@ -28,7 +28,7 @@ defmodule PetalComponents.UserDropdownMenu do
           <.icon
             :if={@show_chevron}
             name="hero-chevron-down-mini"
-            class="pc-dropdown__chevron ml-1 -mr-1"
+            class="pc-dropdown__chevron"
           />
         </div>
       </:trigger_element>


### PR DESCRIPTION
Nic's trigger-vs-input chevron misalignment (22px vs 10px from the edge) was the icon-owned-spacing defect composing wrong in its second context - the sweep the plan prescribed, executed family-wide.

**The rules**: decorative icons = fixed box at native size, `shrink-0`, `pointer-events-none`, muted, **container owns all spacing**. Interactive icons = real buttons with hit targets and focus rings.

| Site | Before | After |
|---|---|---|
| `.pc-dropdown__chevron` (CSS) | TWO conflicting rules - stale `ml-2 -mr-1` + bright `dark:text-gray-100` half-overridden since 4.10 | one rule: 20px, muted, no margins, no events |
| Dropdown label trigger | glyph `chevron-down-solid` + inline `w-5 h-5` utilities | `chevron-down-mini`, class-only; button owns spacing via `gap-2` |
| User menu | markup margins `ml-1 -mr-1` on the icon | container `gap-1` |
| Language select chevron | 16px | 20px + `pointer-events-none` |
| Combobox chevron | `mr-2.5` on icon; 16px; **10px vs 22px edge offset across variants** | control owns rail (`gap-1.5 pr-3`); 20px; **13px offset, identical across input/trigger/trigger-multi (measured)** |
| Combobox check | `ml-auto` layout-on-icon | label's `flex-1` owns it; `pointer-events-none` |
| Chips radius | panel-clamp derivation - squares inside a pilled control at `full` | control-token derivation - **pills inside the pill (measured 9993px/9999px)** |
| Chip remove | 18px target | 20px target, 16px glyph |

Deliberately out of scope: nav-menu and accordion chevrons are rotating *disclosure* indicators with their own animation contracts - different role, not field chrome.

**Verification**: 753 Elixir + 52 JS green; every offset/size/radius measured live in the playground.