### PR TITLE
feat(combo_box): :option slot for rich option content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 #### Added
 
+- **`combo_box` `:option` slot - rich options.** Render anything inside
+  each panel option (avatars, flags, secondary text); `:let` receives
+  the normalized option - `label`, `value`, `disabled`, and `meta`
+  carrying whatever extra data the option tuple's keyword list held
+  (`{"Amelia", "am", role: "Engineering"}`). Filtering, chips and the
+  trigger label keep using the plain label, so rich content never
+  affects search or the closed state.
 - **`combo_box` `variant="trigger"` - the picker anatomy.** A select-like
   button shows the chosen value (or "N selected" with `multiple` -
   `count_label` localizes the word) and the search input lives inside

--- a/assets/default.css
+++ b/assets/default.css
@@ -2229,6 +2229,9 @@
   .pc-combo-box__option-label {
     @apply flex-1 truncate;
   }
+  .pc-combo-box__option-content {
+    @apply flex min-w-0 flex-1 items-center gap-2;
+  }
   .pc-combo-box__check {
     @apply invisible shrink-0 pointer-events-none text-gray-900 dark:text-white;
   }

--- a/dev.exs
+++ b/dev.exs
@@ -7319,7 +7319,7 @@ defmodule Dev.PlaygroundLive do
           ex <-
             examples_for(
               PetalComponents.Showcase.ComboBox,
-              ~w(multiple trigger basic preselected groups)a
+              ~w(multiple trigger rich_options basic preselected groups)a
             )
         }
         class="mt-10"

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -125,6 +125,15 @@ defmodule PetalComponents.ComboBox do
   attr :class, :any, default: nil, doc: "extra classes for the wrapper"
   attr :rest, :global
 
+  slot :option,
+    doc: """
+    custom option content, rendered inside each panel option in place of the
+    plain label - `:let` receives the normalized option map (`label`,
+    `value`, `disabled`, and `meta`: everything else from the option's
+    keyword opts). Filtering, chips and the trigger label keep using the
+    plain label, so rich content never affects search or the closed state.
+    """
+
   def combo_box(assigns) do
     groups = normalize_options(assigns.options)
     values = current_values(assigns)
@@ -294,10 +303,18 @@ defmodule PetalComponents.ComboBox do
             <%= if group.label do %>
               <div class="pc-combo-box__group" role="group" data-pc-combo-group>
                 <div class="pc-combo-box__group-heading" aria-hidden="true">{group.label}</div>
-                <.option_items options={group.options} current_values={@current_values} />
+                <.option_items
+                  options={group.options}
+                  current_values={@current_values}
+                  option_slot={@option}
+                />
               </div>
             <% else %>
-              <.option_items options={group.options} current_values={@current_values} />
+              <.option_items
+                options={group.options}
+                current_values={@current_values}
+                option_slot={@option}
+              />
             <% end %>
           <% end %>
           <div class="pc-combo-box__empty" data-pc-combo-empty hidden>{@no_results_text}</div>
@@ -329,7 +346,11 @@ defmodule PetalComponents.ComboBox do
       aria-disabled={opt.disabled && "true"}
       aria-selected={to_string(selected?(opt, @current_values))}
     >
-      <span class="pc-combo-box__option-label">{opt.label}</span>
+      <%= if @option_slot != [] do %>
+        <span class="pc-combo-box__option-content">{render_slot(@option_slot, opt)}</span>
+      <% else %>
+        <span class="pc-combo-box__option-label">{opt.label}</span>
+      <% end %>
       <.icon name="hero-check-mini" class="pc-combo-box__check" />
     </div>
     """
@@ -361,16 +382,17 @@ defmodule PetalComponents.ComboBox do
     %{
       label: to_string(label),
       value: to_string(value),
-      disabled: Keyword.get(opts, :disabled, false)
+      disabled: Keyword.get(opts, :disabled, false),
+      meta: opts |> Keyword.delete(:disabled) |> Map.new()
     }
   end
 
   defp normalize_option({label, value}) do
-    %{label: to_string(label), value: to_string(value), disabled: false}
+    %{label: to_string(label), value: to_string(value), disabled: false, meta: %{}}
   end
 
   defp normalize_option(value) when is_binary(value) or is_atom(value) or is_number(value) do
-    %{label: to_string(value), value: to_string(value), disabled: false}
+    %{label: to_string(value), value: to_string(value), disabled: false, meta: %{}}
   end
 
   # -- value / name / id resolution -----------------------------------------

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -44,15 +44,16 @@ defmodule PetalComponents.Showcase.ComboBox do
     """
   end
 
-  example :preselected, "A chosen value",
+  example :preselected, "A chosen value, clearable",
     description:
-      "value (or the form field's value) marks the chosen option: it renders in the trigger, carries aria-selected and the check mark, and the highlight homes on it when the panel opens. Options are label/value tuples here - the shapes select accepts all work." do
+      "value (or the form field's value) marks the chosen option: it renders in the trigger, carries aria-selected and the check mark, and the highlight homes on it when the panel opens. clearable adds an X button whenever a value is chosen - one press empties the selection. Options are label/value tuples here - the shapes select accepts all work." do
     ~H"""
     <div class="w-full max-w-xs mx-auto">
       <.combo_box
         id="sx-combo-chosen"
         name="tz"
         value="au_syd"
+        clearable
         options={[
           {"Sydney", "au_syd"},
           {"Tokyo", "jp_tyo"},

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -100,6 +100,34 @@ defmodule PetalComponents.Showcase.ComboBox do
     """
   end
 
+  example :rich_options, "Rich options - the :option slot",
+    description:
+      "The :option slot renders anything inside each panel option - avatars, flags, secondary text - with :let receiving the normalized option (label, value, disabled, and meta: whatever extra data the option tuple carried). Filtering, chips and the trigger label keep using the plain label, so rich content never affects search or the closed state." do
+    ~H"""
+    <div class="w-full max-w-sm mx-auto">
+      <.combo_box
+        id="sx-combo-rich"
+        name="assignee"
+        placeholder="Assign to…"
+        options={[
+          {"Amelia Ward", "amelia", role: "Engineering"},
+          {"Jonah Reyes", "jonah", role: "Design"},
+          {"Priya Anand", "priya", role: "Support"},
+          {"Tom Hale", "tom", role: "Engineering"}
+        ]}
+      >
+        <:option :let={opt}>
+          <.avatar size="xs" name={opt.label} random_color />
+          <span class="flex min-w-0 flex-col leading-tight">
+            <span class="truncate">{opt.label}</span>
+            <span class="truncate text-xs text-gray-500 dark:text-gray-400">{opt.meta[:role]}</span>
+          </span>
+        </:option>
+      </.combo_box>
+    </div>
+    """
+  end
+
   example :groups, "Groups and disabled options",
     description:
       "{group_label, options} renders a heading and keeps its position between flat options; a group hides itself when the query filters out every option inside. {label, value, disabled: true} renders the option present but inert - visible in the list, skipped by the keyboard." do

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -302,6 +302,41 @@ defmodule PetalComponents.ComboBoxTest do
     end
   end
 
+  describe "the :option slot" do
+    test "renders custom content per option with meta passthrough; filter attrs intact" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="who" name="who" options={[{"Amelia Ward", "am", role: "Engineering"}]}>
+          <:option :let={opt}>
+            <strong>{opt.label}</strong>
+            <em>{opt.meta[:role]}</em>
+          </:option>
+        </.combo_box>
+        """)
+
+      assert html =~ "<strong>Amelia Ward</strong>"
+      assert html =~ "<em>Engineering</em>"
+      assert html =~ "pc-combo-box__option-content"
+      # the filter text still rides data-label, custom content or not
+      assert html =~ ~s|data-label="Amelia Ward"|
+      refute html =~ "pc-combo-box__option-label"
+    end
+
+    test "without the slot the plain label renders as before" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="who" name="who" options={["Amelia"]} />
+        """)
+
+      assert html =~ "pc-combo-box__option-label"
+      refute html =~ "pc-combo-box__option-content"
+    end
+  end
+
   test "raises without any id source" do
     assigns = %{}
 


### PR DESCRIPTION
Closes out combobox M2. Adds a `slot :option` so each panel option can render arbitrary content - avatars, flags, secondary text - while every text-driven behavior keeps working untouched.

## How it works

- `:let={opt}` receives the normalized option map: `label`, `value`, `disabled`, and `meta` - a map of whatever extra data the 3-tuple's keyword list carried, e.g. `{"Amelia Ward", "amelia", role: "Engineering"}` → `opt.meta[:role]`.
- Slot content renders inside a new `.pc-combo-box__option-content` span (flex, min-w-0, gap-2) in place of the default label span. The check icon stays appended after it.
- `data-label` still carries the plain label, so **filtering, chips, and the trigger-variant label are unaffected** - rich content is panel-only by design. The closed input always shows plain text.
- No hook changes - the JS already reads only `data-label`/`data-value`.

## Tests

- 2 new Elixir specs: slot renders with meta passthrough (and `data-label` stays plain, default label span absent), and the no-slot fallback renders exactly as before.
- Suites: 755 Elixir / 52 JS, all green.
- Live-verified on the playground: filter `pri` → matches on plain label, choose → hidden select gets `priya`, panel closes, input shows "Priya Anand".

## Showcase

New `rich_options` assignee-picker example (avatar + name + role from `opt.meta`), wired into the playground page.