### PR TITLE
fix(combo_box): outside dismiss is a completed press, not a touch-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 
 #### Fixed
 
+- **`combo_box`: a touch-scroll no longer dismisses the panel.** The
+  outside dismiss closed on `pointerdown`, so starting a scroll gesture
+  anywhere outside the panel killed it the instant the finger landed
+  (Nic's iOS find). The dismiss is now a completed press - `pointerdown`
+  arms it, `pointerup` in (roughly) the same spot closes; a scroll ends
+  in `pointercancel` or a far-away release and leaves the panel open,
+  matching shadcn/Base UI and the old Tom Select behavior. A clean tap
+  outside still closes, and the desktop focusout path is unchanged.
+
+#### Fixed
+
 - **`combo_box` multiple: the highlight stays on the item just picked.**
   Choosing used to reset the filter and re-home the highlight on the
   first option - a disorienting jump when picking from the middle of the

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3637,9 +3637,26 @@ export const PetalComboBox = {
     // when you click static content), but iOS Safari deliberately keeps
     // focus when tapping non-interactive content - no blur, no focusout, a
     // panel that would not close. Outside-press detection is the standard
-    // answer; bound only while the panel is open.
+    // answer; bound only while the panel is open. The dismiss is a
+    // completed PRESS, not a touch-start: closing on pointerdown would
+    // kill the panel the instant a scroll gesture lands outside it, so
+    // the decision waits for pointerup - a scroll ends in pointercancel
+    // (or a far-away pointerup on pages that cannot scroll), a tap ends
+    // in a pointerup where it started.
     this.onOutsidePointerDown = (e) => {
+      this.outsidePress = this.el.contains(e.target)
+        ? null
+        : { x: e.clientX, y: e.clientY };
+    };
+    this.onOutsidePointerUp = (e) => {
+      const press = this.outsidePress;
+      this.outsidePress = null;
+      if (!press) return;
+      if (Math.hypot(e.clientX - press.x, e.clientY - press.y) > 10) return;
       if (!this.el.contains(e.target)) this.closePanel();
+    };
+    this.onOutsidePointerCancel = () => {
+      this.outsidePress = null;
     };
     // form.reset() resets the select; nothing else would re-sync the chrome
     this.onFormReset = () => setTimeout(() => this.syncFromSelect(), 0);
@@ -3688,6 +3705,12 @@ export const PetalComboBox = {
       this.onOutsidePointerDown,
       true,
     );
+    document.removeEventListener("pointerup", this.onOutsidePointerUp, true);
+    document.removeEventListener(
+      "pointercancel",
+      this.onOutsidePointerCancel,
+      true,
+    );
     window.removeEventListener("scroll", this.onReposition, true);
     window.removeEventListener("resize", this.onReposition);
   },
@@ -3720,7 +3743,14 @@ export const PetalComboBox = {
     this.panel.hidden = false;
     this.input.setAttribute("aria-expanded", "true");
     if (this.trigger) this.trigger.setAttribute("aria-expanded", "true");
+    this.outsidePress = null;
     document.addEventListener("pointerdown", this.onOutsidePointerDown, true);
+    document.addEventListener("pointerup", this.onOutsidePointerUp, true);
+    document.addEventListener(
+      "pointercancel",
+      this.onOutsidePointerCancel,
+      true,
+    );
     window.addEventListener("scroll", this.onReposition, true);
     window.addEventListener("resize", this.onReposition);
     if (!keepQuery) this.query = "";
@@ -3732,6 +3762,12 @@ export const PetalComboBox = {
     document.removeEventListener(
       "pointerdown",
       this.onOutsidePointerDown,
+      true,
+    );
+    document.removeEventListener("pointerup", this.onOutsidePointerUp, true);
+    document.removeEventListener(
+      "pointercancel",
+      this.onOutsidePointerCancel,
       true,
     );
     window.removeEventListener("scroll", this.onReposition, true);

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3643,20 +3643,33 @@ export const PetalComboBox = {
     // the decision waits for pointerup - a scroll ends in pointercancel
     // (or a far-away pointerup on pages that cannot scroll), a tap ends
     // in a pointerup where it started.
+    // The press record is scoped to its pointerId: only the arming
+    // finger's release can complete the dismiss, and a second finger
+    // landing mid-press disarms it - multi-touch is a gesture (pinch,
+    // two-finger scroll), never a deliberate dismiss tap.
     this.onOutsidePointerDown = (e) => {
+      this.activePointers.add(e.pointerId);
+      if (this.activePointers.size > 1) {
+        this.outsidePress = null;
+        return;
+      }
       this.outsidePress = this.el.contains(e.target)
         ? null
-        : { x: e.clientX, y: e.clientY };
+        : { id: e.pointerId, x: e.clientX, y: e.clientY };
     };
     this.onOutsidePointerUp = (e) => {
+      this.activePointers.delete(e.pointerId);
       const press = this.outsidePress;
+      if (!press || e.pointerId !== press.id) return;
       this.outsidePress = null;
-      if (!press) return;
       if (Math.hypot(e.clientX - press.x, e.clientY - press.y) > 10) return;
       if (!this.el.contains(e.target)) this.closePanel();
     };
-    this.onOutsidePointerCancel = () => {
-      this.outsidePress = null;
+    this.onOutsidePointerCancel = (e) => {
+      this.activePointers.delete(e.pointerId);
+      if (this.outsidePress && e.pointerId === this.outsidePress.id) {
+        this.outsidePress = null;
+      }
     };
     // form.reset() resets the select; nothing else would re-sync the chrome
     this.onFormReset = () => setTimeout(() => this.syncFromSelect(), 0);
@@ -3744,6 +3757,7 @@ export const PetalComboBox = {
     this.input.setAttribute("aria-expanded", "true");
     if (this.trigger) this.trigger.setAttribute("aria-expanded", "true");
     this.outsidePress = null;
+    this.activePointers = new Set();
     document.addEventListener("pointerdown", this.onOutsidePointerDown, true);
     document.addEventListener("pointerup", this.onOutsidePointerUp, true);
     document.addEventListener(

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -229,6 +229,76 @@ describe("open and close", () => {
     expect(c.panel.hidden).toBe(false);
   });
 
+  it("a second finger disarms - multi-touch is a gesture, not a press", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    document.body.dispatchEvent(
+      pointerEvent("pointerdown", "touch", {
+        clientX: 10,
+        clientY: 10,
+        pointerId: 1,
+      }),
+    );
+    document.body.dispatchEvent(
+      pointerEvent("pointerdown", "touch", {
+        clientX: 60,
+        clientY: 10,
+        pointerId: 2,
+      }),
+    );
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "touch", {
+        clientX: 10,
+        clientY: 10,
+        pointerId: 1,
+      }),
+    );
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "touch", {
+        clientX: 60,
+        clientY: 10,
+        pointerId: 2,
+      }),
+    );
+    expect(c.panel.hidden).toBe(false);
+    // a clean single-finger tap afterwards still closes
+    document.body.dispatchEvent(
+      pointerEvent("pointerdown", "touch", {
+        clientX: 10,
+        clientY: 10,
+        pointerId: 3,
+      }),
+    );
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "touch", {
+        clientX: 10,
+        clientY: 10,
+        pointerId: 3,
+      }),
+    );
+    expect(c.panel.hidden).toBe(true);
+  });
+
+  it("a pointerup from a different pointer never completes another pointer's press", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    document.body.dispatchEvent(
+      pointerEvent("pointerdown", "touch", {
+        clientX: 10,
+        clientY: 10,
+        pointerId: 1,
+      }),
+    );
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "touch", {
+        clientX: 10,
+        clientY: 10,
+        pointerId: 9,
+      }),
+    );
+    expect(c.panel.hidden).toBe(false);
+  });
+
   it("a press that starts inside the combobox and releases outside does not dismiss", () => {
     const c = mountCombo({ options: CITIES });
     c.control.click();

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -183,11 +183,62 @@ describe("open and close", () => {
     expect(c.panel.hidden).toBe(true);
   });
 
-  it("outside pointerdown closes - the iOS Safari path where focusout never fires", () => {
+  it("an outside tap (press completed in place) closes - the iOS Safari path where focusout never fires", () => {
     const c = mountCombo({ options: CITIES });
     c.control.click();
-    document.body.dispatchEvent(pointerEvent("pointerdown", "touch"));
+    document.body.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { clientX: 10, clientY: 10 }),
+    );
+    expect(c.panel.hidden).toBe(false);
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "touch", { clientX: 10, clientY: 10 }),
+    );
     expect(c.panel.hidden).toBe(true);
+  });
+
+  it("a touch-scroll that starts outside does not dismiss - pointercancel path", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    document.body.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { clientX: 10, clientY: 200 }),
+    );
+    document.body.dispatchEvent(pointerEvent("pointercancel", "touch"));
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "touch", { clientX: 10, clientY: 40 }),
+    );
+    expect(c.panel.hidden).toBe(false);
+    // a clean tap afterwards still closes
+    document.body.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { clientX: 10, clientY: 10 }),
+    );
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "touch", { clientX: 10, clientY: 10 }),
+    );
+    expect(c.panel.hidden).toBe(true);
+  });
+
+  it("a drag that never cancels (unscrollable page) still reads as a scroll, not a press", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    document.body.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { clientX: 10, clientY: 200 }),
+    );
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "touch", { clientX: 10, clientY: 80 }),
+    );
+    expect(c.panel.hidden).toBe(false);
+  });
+
+  it("a press that starts inside the combobox and releases outside does not dismiss", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    c.input.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { clientX: 50, clientY: 10 }),
+    );
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "touch", { clientX: 50, clientY: 10 }),
+    );
+    expect(c.panel.hidden).toBe(false);
   });
 
   it("inside pointerdown does not close before the option click lands", () => {


### PR DESCRIPTION
Nic's iOS find: with the panel open, tap-and-hold-then-drag to scroll the page closed the panel the instant the finger landed. The outside dismiss fired on `pointerdown` - before the browser even knows the gesture is a scroll. shadcn (Base UI) and the old Tom Select both survive the scroll; ours should too.

## Mechanics

- `pointerdown` outside now only **arms** the dismiss, recording the press origin.
- `pointerup` outside within ~10px of the origin closes - a clean tap.
- A scroll disarms: iOS fires `pointercancel` once the scroll takes over; on pages that can't scroll (no cancel), the far-away release fails the 10px check.
- A press that starts **inside** the combobox never dismisses, wherever it ends.
- Desktop unchanged: the focusout path still closes instantly on click-away (blur fires on mousedown), and `scroll` still repositions rather than dismissing.

## Tests

4 specs replace the old single pointerdown spec: outside tap closes; cancel-scroll survives and a following tap still closes; dragged release survives; inside-press-outside-release survives. Suites: 755 Elixir / 58 JS green. Live-verified all four paths with touch-emulated PointerEvents on the playground.