### PR TITLE
feat(data_table): State contract + in-memory list engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 ### Unreleased
 
+#### Added
+
+- **`DataTable.State` + the in-memory engine - the 4.12 data table
+  foundation.** `PetalComponents.DataTable.State` is the whole backend
+  contract in one struct (multi-sort `order_by`, typed `filters`, page,
+  page_size, total) with `from_params/2` / `to_params/2` for URL-as-state
+  round-trips (whitelisted fields, no atom creation from user input,
+  clamped sizes) plus the interaction helpers (`toggle_sort/2` cycling
+  asc→desc→off, `put_filter/4`, `clear_filters/1`, `total_pages/1`).
+  `Engine.List.run/2` sorts, filters and paginates a plain list against
+  that state - case-insensitive strings, nils always last, numeric and
+  date coercion from string params - so registry examples and the
+  playground get a working table with zero setup. The `<.data_table>`
+  component builds on this next.
+
 #### Fixed
 
 - **`combo_box` multiple: the highlight stays on the item just picked.**

--- a/lib/petal_components/data_table/engine/list.ex
+++ b/lib/petal_components/data_table/engine/list.ex
@@ -108,13 +108,13 @@ defmodule PetalComponents.DataTable.Engine.List do
   defp matches?(nil, _op, _value), do: false
 
   defp matches?(field_value, :contains, value),
-    do: String.contains?(downcase(field_value), downcase(value))
+    do: with_text(value, &String.contains?(downcase(field_value), &1))
 
   defp matches?(field_value, :starts_with, value),
-    do: String.starts_with?(downcase(field_value), downcase(value))
+    do: with_text(value, &String.starts_with?(downcase(field_value), &1))
 
   defp matches?(field_value, :eq, value) when is_binary(field_value),
-    do: downcase(field_value) == downcase(value)
+    do: with_text(value, &(downcase(field_value) == &1))
 
   defp matches?(field_value, :eq, value) when is_number(field_value),
     do: with_number(value, &(field_value == &1))
@@ -157,9 +157,14 @@ defmodule PetalComponents.DataTable.Engine.List do
 
   defp matches?(_field_value, _op, _value), do: false
 
-  defp values_equal?(a, b) when is_binary(a), do: downcase(a) == downcase(b)
-  defp values_equal?(a, b) when is_atom(a), do: Atom.to_string(a) == to_string(b)
-  defp values_equal?(a, b), do: to_string(a) == to_string(b)
+  defp values_equal?(a, b) when is_binary(a),
+    do: with_text(b, &(downcase(a) == &1))
+
+  defp values_equal?(a, b) when is_atom(a),
+    do: with_text(b, &(String.downcase(Atom.to_string(a)) == &1))
+
+  defp values_equal?(a, b),
+    do: with_text(b, &(String.downcase(to_string(a)) == &1))
 
   # -- coercion --------------------------------------------------------------
 
@@ -167,6 +172,16 @@ defmodule PetalComponents.DataTable.Engine.List do
 
   defp downcase(value) when is_binary(value), do: String.downcase(value)
   defp downcase(value), do: value |> to_string() |> String.downcase()
+
+  # Filter values come straight from params and can be ANY shape (a list,
+  # a map, whatever the query string carried) - a text op against a
+  # non-scalar is a no-match, never a to_string crash.
+  defp with_text(value, fun) when is_binary(value), do: fun.(String.downcase(value))
+
+  defp with_text(value, fun) when is_number(value) or is_atom(value),
+    do: fun.(value |> to_string() |> String.downcase())
+
+  defp with_text(_other, _fun), do: false
 
   defp number(value) when is_number(value), do: {:ok, value}
 
@@ -189,6 +204,38 @@ defmodule PetalComponents.DataTable.Engine.List do
   defp to_date(%Date{} = date), do: {:ok, date}
   defp to_date(%DateTime{} = dt), do: {:ok, DateTime.to_date(dt)}
   defp to_date(%NaiveDateTime{} = ndt), do: {:ok, NaiveDateTime.to_date(ndt)}
-  defp to_date(value) when is_binary(value), do: Date.from_iso8601(value)
+
+  # Accept both date and datetime ISO 8601 strings - "2026-01-05",
+  # "2026-01-05T10:30:00Z" (datetime inputs) and the offset-less
+  # "2026-01-05T10:30" that <input type="datetime-local"> submits.
+  defp to_date(value) when is_binary(value) do
+    with {:error, _} <- Date.from_iso8601(value),
+         {:error, _} <- iso_datetime_to_date(value) do
+      :error
+    end
+  end
+
   defp to_date(_other), do: :error
+
+  defp iso_datetime_to_date(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} ->
+        {:ok, DateTime.to_date(dt)}
+
+      {:error, _} ->
+        # datetime-local submits without seconds ("2026-01-05T10:30");
+        # NaiveDateTime requires them, so retry with ":00" appended -
+        # garbage just fails again.
+        case NaiveDateTime.from_iso8601(value) do
+          {:ok, ndt} ->
+            {:ok, NaiveDateTime.to_date(ndt)}
+
+          {:error, _} ->
+            case NaiveDateTime.from_iso8601(value <> ":00") do
+              {:ok, ndt} -> {:ok, NaiveDateTime.to_date(ndt)}
+              {:error, _} = error -> error
+            end
+        end
+    end
+  end
 end

--- a/lib/petal_components/data_table/engine/list.ex
+++ b/lib/petal_components/data_table/engine/list.ex
@@ -26,17 +26,29 @@ defmodule PetalComponents.DataTable.Engine.List do
 
   alias PetalComponents.DataTable.State
 
+  # The only shapes text matching can safely coerce - anything else
+  # (a map, a list, a tuple living in a row cell) is a no-match, never
+  # a to_string crash. Guards both sides: row field values AND filter
+  # values, which arrive raw from params.
+  defguardp is_scalar(v) when is_binary(v) or is_number(v) or is_atom(v)
+
   @doc "Runs the full pipeline: filter -> sort -> count -> paginate."
   def run(rows, %State{} = state) when is_list(rows) do
+    # from_params clamps, but hand-built structs can carry page 0 or a
+    # non-positive size - a negative slice offset would silently take
+    # rows from the END of the list, so clamp here too
+    page = max(state.page, 1)
+    page_size = max(state.page_size, 1)
+
     filtered = Enum.reduce(state.filters, rows, &apply_filter(&2, &1))
     total = length(filtered)
 
     page_rows =
       filtered
       |> sort(state.order_by)
-      |> Enum.slice((state.page - 1) * state.page_size, state.page_size)
+      |> Enum.slice((page - 1) * page_size, page_size)
 
-    {page_rows, %{state | total: total}}
+    {page_rows, %{state | page: page, page_size: page_size, total: total}}
   end
 
   # -- sorting ---------------------------------------------------------------
@@ -107,10 +119,10 @@ defmodule PetalComponents.DataTable.Engine.List do
 
   defp matches?(nil, _op, _value), do: false
 
-  defp matches?(field_value, :contains, value),
+  defp matches?(field_value, :contains, value) when is_scalar(field_value),
     do: with_text(value, &String.contains?(downcase(field_value), &1))
 
-  defp matches?(field_value, :starts_with, value),
+  defp matches?(field_value, :starts_with, value) when is_scalar(field_value),
     do: with_text(value, &String.starts_with?(downcase(field_value), &1))
 
   defp matches?(field_value, :eq, value) when is_binary(field_value),
@@ -157,14 +169,10 @@ defmodule PetalComponents.DataTable.Engine.List do
 
   defp matches?(_field_value, _op, _value), do: false
 
-  defp values_equal?(a, b) when is_binary(a),
+  defp values_equal?(a, b) when is_scalar(a),
     do: with_text(b, &(downcase(a) == &1))
 
-  defp values_equal?(a, b) when is_atom(a),
-    do: with_text(b, &(String.downcase(Atom.to_string(a)) == &1))
-
-  defp values_equal?(a, b),
-    do: with_text(b, &(String.downcase(to_string(a)) == &1))
+  defp values_equal?(_a, _b), do: false
 
   # -- coercion --------------------------------------------------------------
 

--- a/lib/petal_components/data_table/engine/list.ex
+++ b/lib/petal_components/data_table/engine/list.ex
@@ -1,0 +1,194 @@
+defmodule PetalComponents.DataTable.Engine.List do
+  @moduledoc """
+  The in-memory engine: sort, filter and paginate a plain list of maps or
+  structs against a `PetalComponents.DataTable.State`.
+
+  This is the zero-setup path - the registry examples, the playground and
+  any app with an already-loaded list get a working table with no database
+  and no extra dependency. It is deliberately a toy for data that fits in
+  memory; real query backends (Ecto/Flop adapters, cursor pagination) are
+  the production wiring layer, not this module.
+
+      {rows, state} = Engine.List.run(all_rows, state)
+
+  returns the visible page plus the state with `total` filled in (the
+  post-filter count), which is what the footer and pagination render from.
+
+  Filter semantics by operator - all string comparisons are
+  case-insensitive, `nil` field values never match:
+
+    * `:contains`, `:starts_with`, `:eq` on strings
+    * `:eq`, `:neq`, `:gt`, `:lt` numeric (value coerced from string)
+    * `:between` with a `[min, max]` (or `%{"min" => _, "max" => _}`) value
+    * `:in` with a list value (select/enum filters)
+    * `:before`, `:on`, `:after` on `Date`/`DateTime`/ISO8601 strings
+  """
+
+  alias PetalComponents.DataTable.State
+
+  @doc "Runs the full pipeline: filter -> sort -> count -> paginate."
+  def run(rows, %State{} = state) when is_list(rows) do
+    filtered = Enum.reduce(state.filters, rows, &apply_filter(&2, &1))
+    total = length(filtered)
+
+    page_rows =
+      filtered
+      |> sort(state.order_by)
+      |> Enum.slice((state.page - 1) * state.page_size, state.page_size)
+
+    {page_rows, %{state | total: total}}
+  end
+
+  # -- sorting ---------------------------------------------------------------
+
+  defp sort(rows, []), do: rows
+
+  defp sort(rows, order_by) do
+    Enum.sort(rows, fn a, b -> compare_by(a, b, order_by) end)
+  end
+
+  defp compare_by(_a, _b, []), do: true
+
+  defp compare_by(a, b, [{field, dir} | rest]) do
+    av = fetch(a, field)
+    bv = fetch(b, field)
+
+    # nils sort last REGARDLESS of direction - a blank cell at the top of
+    # a sorted column reads as a bug to users, not as collation - so the
+    # nil rule sits outside the asc/desc flip.
+    case {av, bv} do
+      {nil, nil} ->
+        compare_by(a, b, rest)
+
+      {nil, _} ->
+        false
+
+      {_, nil} ->
+        true
+
+      _ ->
+        case {dir, cmp(av, bv)} do
+          {_, :eq} -> compare_by(a, b, rest)
+          {:asc, :lt} -> true
+          {:asc, :gt} -> false
+          {:desc, :lt} -> false
+          {:desc, :gt} -> true
+        end
+    end
+  end
+
+  defp cmp(%m{} = a, %m{} = b) when m in [Date, DateTime, NaiveDateTime, Time],
+    do: m.compare(a, b)
+
+  defp cmp(a, b) when is_binary(a) and is_binary(b) do
+    da = String.downcase(a)
+    db = String.downcase(b)
+
+    cond do
+      da == db -> :eq
+      da < db -> :lt
+      true -> :gt
+    end
+  end
+
+  defp cmp(a, b) do
+    cond do
+      a == b -> :eq
+      a < b -> :lt
+      true -> :gt
+    end
+  end
+
+  # -- filtering -------------------------------------------------------------
+
+  defp apply_filter(rows, %{field: field, op: op, value: value}) do
+    Enum.filter(rows, fn row -> matches?(fetch(row, field), op, value) end)
+  end
+
+  defp matches?(nil, _op, _value), do: false
+
+  defp matches?(field_value, :contains, value),
+    do: String.contains?(downcase(field_value), downcase(value))
+
+  defp matches?(field_value, :starts_with, value),
+    do: String.starts_with?(downcase(field_value), downcase(value))
+
+  defp matches?(field_value, :eq, value) when is_binary(field_value),
+    do: downcase(field_value) == downcase(value)
+
+  defp matches?(field_value, :eq, value) when is_number(field_value),
+    do: with_number(value, &(field_value == &1))
+
+  defp matches?(field_value, :neq, value) when is_number(field_value),
+    do: with_number(value, &(field_value != &1))
+
+  defp matches?(field_value, :gt, value) when is_number(field_value),
+    do: with_number(value, &(field_value > &1))
+
+  defp matches?(field_value, :lt, value) when is_number(field_value),
+    do: with_number(value, &(field_value < &1))
+
+  defp matches?(field_value, :between, [min, max]) when is_number(field_value) do
+    with_number(min, fn lo ->
+      with_number(max, fn hi -> field_value >= lo and field_value <= hi end)
+    end)
+  end
+
+  defp matches?(field_value, :between, %{"min" => min, "max" => max}),
+    do: matches?(field_value, :between, [min, max])
+
+  defp matches?(field_value, :in, values) when is_list(values) do
+    Enum.any?(values, &values_equal?(field_value, &1))
+  end
+
+  defp matches?(field_value, op, value) when op in [:before, :on, :after] do
+    with {:ok, field_date} <- to_date(field_value),
+         {:ok, value_date} <- to_date(value) do
+      case {op, Date.compare(field_date, value_date)} do
+        {:before, :lt} -> true
+        {:on, :eq} -> true
+        {:after, :gt} -> true
+        _ -> false
+      end
+    else
+      _ -> false
+    end
+  end
+
+  defp matches?(_field_value, _op, _value), do: false
+
+  defp values_equal?(a, b) when is_binary(a), do: downcase(a) == downcase(b)
+  defp values_equal?(a, b) when is_atom(a), do: Atom.to_string(a) == to_string(b)
+  defp values_equal?(a, b), do: to_string(a) == to_string(b)
+
+  # -- coercion --------------------------------------------------------------
+
+  defp fetch(row, field) when is_map(row), do: Map.get(row, field)
+
+  defp downcase(value) when is_binary(value), do: String.downcase(value)
+  defp downcase(value), do: value |> to_string() |> String.downcase()
+
+  defp number(value) when is_number(value), do: {:ok, value}
+
+  defp number(value) when is_binary(value) do
+    case Float.parse(value) do
+      {n, ""} -> {:ok, n}
+      _ -> :error
+    end
+  end
+
+  defp number(_other), do: :error
+
+  defp with_number(value, fun) do
+    case number(value) do
+      {:ok, n} -> fun.(n)
+      :error -> false
+    end
+  end
+
+  defp to_date(%Date{} = date), do: {:ok, date}
+  defp to_date(%DateTime{} = dt), do: {:ok, DateTime.to_date(dt)}
+  defp to_date(%NaiveDateTime{} = ndt), do: {:ok, NaiveDateTime.to_date(ndt)}
+  defp to_date(value) when is_binary(value), do: Date.from_iso8601(value)
+  defp to_date(_other), do: :error
+end

--- a/lib/petal_components/data_table/state.ex
+++ b/lib/petal_components/data_table/state.ex
@@ -138,7 +138,7 @@ defmodule PetalComponents.DataTable.State do
   def total_pages(%__MODULE__{total: nil}), do: nil
 
   def total_pages(%__MODULE__{total: total, page_size: size}),
-    do: max(ceil(total / size), 1)
+    do: max(ceil(total / max(size, 1)), 1)
 
   # -- parsing ---------------------------------------------------------------
 

--- a/lib/petal_components/data_table/state.ex
+++ b/lib/petal_components/data_table/state.ex
@@ -72,8 +72,10 @@ defmodule PetalComponents.DataTable.State do
   def from_params(params, opts) when is_map(params) and is_list(opts) do
     fields = Keyword.fetch!(opts, :fields)
     field_strings = Map.new(fields, &{Atom.to_string(&1), &1})
-    default_size = Keyword.get(opts, :page_size, 10)
-    max_size = Keyword.get(opts, :max_page_size, 100)
+    # misconfigured options must not violate the struct contract either -
+    # a non-positive default or ceiling clamps to 1
+    default_size = opts |> Keyword.get(:page_size, 10) |> max(1)
+    max_size = opts |> Keyword.get(:max_page_size, 100) |> max(1)
 
     %__MODULE__{
       order_by: parse_order_by(params["order_by"], field_strings),

--- a/lib/petal_components/data_table/state.ex
+++ b/lib/petal_components/data_table/state.ex
@@ -1,0 +1,232 @@
+defmodule PetalComponents.DataTable.State do
+  @moduledoc """
+  The data table's entire backend contract in one struct.
+
+  Flop-shaped on purpose, Flop-free on purpose: anything that can produce
+  this struct can drive `<.data_table>`, and anything that can consume it
+  can execute the query - the in-memory `Engine.List` for plain lists,
+  or (Petal Pro) a Flop adapter for Ecto.
+
+      %State{
+        order_by: [{:email, :asc}],
+        filters: [%{field: :email, op: :contains, value: "d"}],
+        page: 1,
+        page_size: 10,
+        total: 74            # nil = cursor/unknown mode
+      }
+
+  `from_params/2` and `to_params/1` round-trip the struct through URL
+  params, so URL-as-state (shareable sorts/filters, working back button)
+  is a one-liner in `handle_params` rather than a hand-rolled encoding.
+
+  ## Filter operators
+
+  Text: `:contains`, `:eq`, `:starts_with` - number: `:eq`, `:neq`,
+  `:gt`, `:lt`, `:between` - select: `:in` - date: `:before`, `:on`,
+  `:after`. Engines may support a subset; unknown ops are an engine
+  concern, not a state concern.
+
+  ## Security
+
+  `from_params/2` never creates atoms from user input: `:fields` is a
+  required whitelist and anything outside it is dropped, ops outside the
+  known set are dropped, and page/page_size are clamped (`:max_page_size`,
+  default 100).
+  """
+
+  @enforce_keys []
+  defstruct order_by: [], filters: [], page: 1, page_size: 10, total: nil
+
+  @type order :: {atom(), :asc | :desc}
+  @type filter :: %{field: atom(), op: atom(), value: term()}
+  @type t :: %__MODULE__{
+          order_by: [order()],
+          filters: [filter()],
+          page: pos_integer(),
+          page_size: pos_integer(),
+          total: non_neg_integer() | nil
+        }
+
+  @ops ~w(contains eq starts_with neq gt lt between in before on after)a
+  @op_strings Map.new(@ops, &{Atom.to_string(&1), &1})
+  @dir_strings %{"asc" => :asc, "desc" => :desc}
+
+  @doc """
+  Builds a `State` from URL/event params.
+
+  Options:
+
+    * `:fields` (required) - the whitelist of sortable/filterable fields,
+      as atoms. Params referencing any other field are silently dropped.
+    * `:page_size` - default page size when the params carry none (10).
+    * `:max_page_size` - clamp ceiling for user-supplied sizes (100).
+
+  Accepted param shapes (all optional, all strings - what `to_params/1`
+  emits and what hand-written URLs naturally produce):
+
+    * `"order_by"` - `"email"` or `"email:desc"` or `"email:desc,name"`
+    * `"filters"` - a list (or Phoenix-style indexed map) of
+      `%{"field" => f, "op" => op, "value" => v}`
+    * `"page"`, `"page_size"` - integers as strings
+  """
+  def from_params(params, opts) when is_map(params) and is_list(opts) do
+    fields = Keyword.fetch!(opts, :fields)
+    field_strings = Map.new(fields, &{Atom.to_string(&1), &1})
+    default_size = Keyword.get(opts, :page_size, 10)
+    max_size = Keyword.get(opts, :max_page_size, 100)
+
+    %__MODULE__{
+      order_by: parse_order_by(params["order_by"], field_strings),
+      filters: parse_filters(params["filters"], field_strings),
+      page: parse_pos_int(params["page"], 1),
+      page_size: params["page_size"] |> parse_pos_int(default_size) |> min(max_size)
+    }
+  end
+
+  @doc """
+  Encodes the state as a flat params map suitable for `push_patch`
+  query strings. Defaults (page 1, empty sorts/filters, the default
+  page size) are omitted so URLs stay clean; `total` never round-trips -
+  it is a result, not a request.
+
+  Pass the same `:page_size` default given to `from_params/2` so the
+  two stay symmetric (an omitted size decodes back to that default).
+  """
+  def to_params(%__MODULE__{} = state, opts \\ []) do
+    default_size = Keyword.get(opts, :page_size, 10)
+
+    %{}
+    |> put_order_by(state.order_by)
+    |> put_filters(state.filters)
+    |> put_unless("page", state.page, 1)
+    |> put_unless("page_size", state.page_size, default_size)
+  end
+
+  @doc """
+  Returns the state with `field` as the primary sort: cycles
+  asc -> desc -> removed on repeated calls (the header-click grammar),
+  and always resets to page 1 - a reordered page 7 is meaningless.
+  """
+  def toggle_sort(%__MODULE__{} = state, field) when is_atom(field) do
+    order_by =
+      case List.keyfind(state.order_by, field, 0) do
+        nil -> [{field, :asc}]
+        {^field, :asc} -> [{field, :desc}]
+        {^field, :desc} -> []
+      end
+
+    %{state | order_by: order_by, page: 1}
+  end
+
+  @doc "Replaces the filter for `field` (or removes it when `value` is nil/empty), resetting to page 1."
+  def put_filter(%__MODULE__{} = state, field, _op, value)
+      when value in [nil, "", []] do
+    %{state | filters: Enum.reject(state.filters, &(&1.field == field)), page: 1}
+  end
+
+  def put_filter(%__MODULE__{} = state, field, op, value)
+      when is_atom(field) and op in @ops do
+    filter = %{field: field, op: op, value: value}
+    rest = Enum.reject(state.filters, &(&1.field == field))
+    %{state | filters: rest ++ [filter], page: 1}
+  end
+
+  @doc "Removes every filter, resetting to page 1."
+  def clear_filters(%__MODULE__{} = state), do: %{state | filters: [], page: 1}
+
+  @doc "Total pages when `total` is known, else nil (cursor/unknown mode)."
+  def total_pages(%__MODULE__{total: nil}), do: nil
+
+  def total_pages(%__MODULE__{total: total, page_size: size}),
+    do: max(ceil(total / size), 1)
+
+  # -- parsing ---------------------------------------------------------------
+
+  defp parse_order_by(nil, _fields), do: []
+
+  defp parse_order_by(value, fields) when is_binary(value) do
+    value
+    |> String.split(",", trim: true)
+    |> Enum.flat_map(fn part ->
+      {field_part, dir} =
+        case String.split(part, ":", parts: 2) do
+          [f, d] -> {f, Map.get(@dir_strings, d, :asc)}
+          [f] -> {f, :asc}
+        end
+
+      case Map.fetch(fields, field_part) do
+        {:ok, field} -> [{field, dir}]
+        :error -> []
+      end
+    end)
+  end
+
+  defp parse_order_by(_other, _fields), do: []
+
+  defp parse_filters(nil, _fields), do: []
+
+  # Phoenix decodes indexed params ("filters[0][field]=...") into a map of
+  # index-string keys; a JSON payload arrives as a real list. Accept both.
+  defp parse_filters(%{} = indexed, fields) do
+    indexed
+    |> Enum.sort_by(fn {k, _v} -> parse_pos_int(k, 0) end)
+    |> Enum.map(fn {_k, v} -> v end)
+    |> parse_filters(fields)
+  end
+
+  defp parse_filters(list, fields) when is_list(list) do
+    Enum.flat_map(list, fn
+      %{"field" => f, "op" => op, "value" => value} ->
+        with {:ok, field} <- Map.fetch(fields, f),
+             {:ok, op} <- Map.fetch(@op_strings, op) do
+          [%{field: field, op: op, value: value}]
+        else
+          :error -> []
+        end
+
+      _other ->
+        []
+    end)
+  end
+
+  defp parse_filters(_other, _fields), do: []
+
+  defp parse_pos_int(value, default) when is_binary(value) do
+    case Integer.parse(value) do
+      {n, ""} when n > 0 -> n
+      _ -> default
+    end
+  end
+
+  defp parse_pos_int(value, _default) when is_integer(value) and value > 0, do: value
+  defp parse_pos_int(_other, default), do: default
+
+  # -- encoding --------------------------------------------------------------
+
+  defp put_order_by(params, []), do: params
+
+  defp put_order_by(params, order_by) do
+    encoded =
+      Enum.map_join(order_by, ",", fn
+        {field, :asc} -> Atom.to_string(field)
+        {field, :desc} -> "#{field}:desc"
+      end)
+
+    Map.put(params, "order_by", encoded)
+  end
+
+  defp put_filters(params, []), do: params
+
+  defp put_filters(params, filters) do
+    encoded =
+      Enum.map(filters, fn %{field: field, op: op, value: value} ->
+        %{"field" => Atom.to_string(field), "op" => Atom.to_string(op), "value" => value}
+      end)
+
+    Map.put(params, "filters", encoded)
+  end
+
+  defp put_unless(params, _key, value, value), do: params
+  defp put_unless(params, _key, nil, _default), do: params
+  defp put_unless(params, key, value, _default), do: Map.put(params, key, value)
+end

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -1,0 +1,132 @@
+defmodule PetalComponents.DataTable.Engine.ListTest do
+  use ExUnit.Case, async: true
+
+  alias PetalComponents.DataTable.Engine.List, as: Engine
+  alias PetalComponents.DataTable.State
+
+  @rows [
+    %{id: 1, email: "dan@a.com", name: "Dan", amount: 120, joined: ~D[2026-01-05]},
+    %{id: 2, email: "bea@b.com", name: "bea", amount: 40, joined: ~D[2026-03-10]},
+    %{id: 3, email: "amy@c.com", name: "Amy", amount: 300, joined: ~D[2026-02-01]},
+    %{id: 4, email: "cal@d.com", name: nil, amount: 40, joined: ~D[2026-01-05]},
+    %{id: 5, email: "dee@e.com", name: "Dee", amount: 88.5, joined: ~D[2026-04-20]}
+  ]
+
+  defp run(state_attrs) do
+    Engine.run(@rows, struct!(State, state_attrs))
+  end
+
+  defp ids({rows, _state}), do: Enum.map(rows, & &1.id)
+
+  describe "pagination and total" do
+    test "returns the requested page and fills total in" do
+      {rows, state} = run(page: 2, page_size: 2)
+      assert length(rows) == 2
+      assert state.total == 5
+    end
+
+    test "a page past the end is empty, not an error" do
+      {rows, _} = run(page: 9, page_size: 10)
+      assert rows == []
+    end
+
+    test "total counts the FILTERED set, not the source list" do
+      {_, state} =
+        run(filters: [%{field: :amount, op: :eq, value: "40"}], page_size: 1)
+
+      assert state.total == 2
+    end
+  end
+
+  describe "sorting" do
+    test "sorts strings case-insensitively" do
+      assert ids(run(order_by: [name: :asc], page_size: 10)) == [3, 2, 1, 5, 4]
+    end
+
+    test "nils sort last in both directions" do
+      asc = ids(run(order_by: [name: :asc], page_size: 10))
+      desc = ids(run(order_by: [name: :desc], page_size: 10))
+      assert List.last(asc) == 4
+      assert List.last(desc) == 4
+    end
+
+    test "multi-sort: ties on the first key break on the second" do
+      assert ids(run(order_by: [amount: :asc, email: :desc], page_size: 10)) ==
+               [4, 2, 5, 1, 3]
+    end
+
+    test "sorts dates" do
+      assert ids(run(order_by: [joined: :desc], page_size: 10)) |> hd() == 5
+    end
+  end
+
+  describe "filtering" do
+    test "contains is case-insensitive" do
+      assert ids(run(filters: [%{field: :name, op: :contains, value: "DE"}])) == [5]
+    end
+
+    test "starts_with" do
+      assert ids(run(filters: [%{field: :email, op: :starts_with, value: "d"}])) == [1, 5]
+    end
+
+    test "string eq is case-insensitive" do
+      assert ids(run(filters: [%{field: :name, op: :eq, value: "BEA"}])) == [2]
+    end
+
+    test "numeric ops coerce string values from params" do
+      assert ids(run(filters: [%{field: :amount, op: :gt, value: "100"}])) == [1, 3]
+      assert ids(run(filters: [%{field: :amount, op: :lt, value: "50"}])) == [2, 4]
+      assert ids(run(filters: [%{field: :amount, op: :neq, value: "40"}])) == [1, 3, 5]
+
+      assert ids(run(filters: [%{field: :amount, op: :between, value: ["40", "120"]}])) ==
+               [1, 2, 4, 5]
+    end
+
+    test "between accepts the min/max map shape phoenix forms produce" do
+      filter = %{field: :amount, op: :between, value: %{"min" => "80", "max" => "200"}}
+      assert ids(run(filters: [filter])) == [1, 5]
+    end
+
+    test "a non-numeric value never matches numeric ops instead of raising" do
+      assert ids(run(filters: [%{field: :amount, op: :gt, value: "abc"}])) == []
+    end
+
+    test "in matches any of the listed values" do
+      assert ids(run(filters: [%{field: :name, op: :in, value: ["amy", "Dee"]}])) == [3, 5]
+    end
+
+    test "date ops compare against ISO8601 strings from params" do
+      assert ids(run(filters: [%{field: :joined, op: :before, value: "2026-02-01"}])) == [1, 4]
+      assert ids(run(filters: [%{field: :joined, op: :on, value: "2026-01-05"}])) == [1, 4]
+      assert ids(run(filters: [%{field: :joined, op: :after, value: "2026-03-01"}])) == [2, 5]
+    end
+
+    test "nil field values never match" do
+      assert ids(run(filters: [%{field: :name, op: :contains, value: ""}])) ==
+               [1, 2, 3, 5]
+    end
+
+    test "filters stack with AND semantics" do
+      filters = [
+        %{field: :amount, op: :lt, value: "150"},
+        %{field: :email, op: :contains, value: "a"}
+      ]
+
+      assert ids(run(filters: filters)) == [1, 2, 4]
+    end
+  end
+
+  test "the full pipeline composes: filter, then sort, then paginate" do
+    {rows, state} =
+      run(
+        filters: [%{field: :amount, op: :lt, value: "150"}],
+        order_by: [amount: :desc],
+        page: 1,
+        page_size: 2
+      )
+
+    assert Enum.map(rows, & &1.id) == [1, 5]
+    assert state.total == 4
+    assert State.total_pages(state) == 2
+  end
+end

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -101,6 +101,25 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
       assert ids(run(filters: [%{field: :joined, op: :after, value: "2026-03-01"}])) == [2, 5]
     end
 
+    test "non-scalar filter values (raw param shapes) never match and never raise" do
+      for junk <- [%{"a" => 1}, [%{"b" => 2}], [["nested"]], {:tuple, 1}] do
+        assert ids(run(filters: [%{field: :name, op: :contains, value: junk}])) == []
+        assert ids(run(filters: [%{field: :name, op: :starts_with, value: junk}])) == []
+        assert ids(run(filters: [%{field: :name, op: :eq, value: junk}])) == []
+        assert ids(run(filters: [%{field: :name, op: :in, value: [junk]}])) == []
+      end
+    end
+
+    test "date ops accept ISO 8601 datetime strings, including datetime-local's offset-less shape" do
+      assert ids(run(filters: [%{field: :joined, op: :on, value: "2026-01-05T10:30:00Z"}])) ==
+               [1, 4]
+
+      assert ids(run(filters: [%{field: :joined, op: :on, value: "2026-01-05T10:30"}])) ==
+               [1, 4]
+
+      assert ids(run(filters: [%{field: :joined, op: :before, value: "not-a-date"}])) == []
+    end
+
     test "nil field values never match" do
       assert ids(run(filters: [%{field: :name, op: :contains, value: ""}])) ==
                [1, 2, 3, 5]

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -25,6 +25,17 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
       assert state.total == 5
     end
 
+    test "hand-built states with page 0 or size 0 clamp instead of slicing from the end" do
+      {rows, state} = run(page: 0, page_size: 10)
+      assert Enum.map(rows, & &1.id) == [1, 2, 3, 4, 5]
+      assert state.page == 1
+
+      {rows, state} = run(page: 1, page_size: 0)
+      assert length(rows) == 1
+      assert state.page_size == 1
+      assert State.total_pages(%State{total: 74, page_size: 0}) == 74
+    end
+
     test "a page past the end is empty, not an error" do
       {rows, _} = run(page: 9, page_size: 10)
       assert rows == []
@@ -118,6 +129,23 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
                [1, 4]
 
       assert ids(run(filters: [%{field: :joined, op: :before, value: "not-a-date"}])) == []
+    end
+
+    test "composite ROW field values (maps, lists, tuples in cells) never match and never raise" do
+      rows = [
+        %{id: 1, tags: %{a: 1}},
+        %{id: 2, tags: [1, 2]},
+        %{id: 3, tags: {:t, 1}},
+        %{id: 4, tags: "real"}
+      ]
+
+      state = struct!(State, filters: [%{field: :tags, op: :contains, value: "real"}])
+      {out, _} = Engine.run(rows, state)
+      assert Enum.map(out, & &1.id) == [4]
+
+      state = struct!(State, filters: [%{field: :tags, op: :in, value: ["real"]}])
+      {out, _} = Engine.run(rows, state)
+      assert Enum.map(out, & &1.id) == [4]
     end
 
     test "nil field values never match" do

--- a/test/petal/data_table/state_test.exs
+++ b/test/petal/data_table/state_test.exs
@@ -71,6 +71,16 @@ defmodule PetalComponents.DataTable.StateTest do
       assert state.page_size == 100
     end
 
+    test "misconfigured non-positive size options clamp to the contract" do
+      state = State.from_params(%{}, fields: @fields, page_size: 0)
+      assert state.page_size == 1
+
+      state =
+        State.from_params(%{"page_size" => "50"}, fields: @fields, max_page_size: -5)
+
+      assert state.page_size == 1
+    end
+
     test "garbage page values fall back to defaults" do
       state =
         State.from_params(%{"page" => "-2", "page_size" => "abc"},

--- a/test/petal/data_table/state_test.exs
+++ b/test/petal/data_table/state_test.exs
@@ -1,0 +1,186 @@
+defmodule PetalComponents.DataTable.StateTest do
+  use ExUnit.Case, async: true
+
+  alias PetalComponents.DataTable.State
+
+  @fields ~w(email name amount inserted_at)a
+
+  describe "from_params/2" do
+    test "empty params produce the defaults" do
+      state = State.from_params(%{}, fields: @fields)
+      assert state == %State{order_by: [], filters: [], page: 1, page_size: 10, total: nil}
+    end
+
+    test "parses order_by with directions, defaulting asc" do
+      state = State.from_params(%{"order_by" => "email:desc,name"}, fields: @fields)
+      assert state.order_by == [email: :desc, name: :asc]
+    end
+
+    test "drops order_by fields outside the whitelist - no atom creation from input" do
+      state =
+        State.from_params(%{"order_by" => "email,__struct__:desc,secret"}, fields: @fields)
+
+      assert state.order_by == [email: :asc]
+    end
+
+    test "an unknown direction falls back to asc" do
+      state = State.from_params(%{"order_by" => "email:sideways"}, fields: @fields)
+      assert state.order_by == [email: :asc]
+    end
+
+    test "parses filters from a list" do
+      params = %{"filters" => [%{"field" => "email", "op" => "contains", "value" => "d"}]}
+      state = State.from_params(params, fields: @fields)
+      assert state.filters == [%{field: :email, op: :contains, value: "d"}]
+    end
+
+    test "parses filters from Phoenix-style indexed maps, in index order" do
+      params = %{
+        "filters" => %{
+          "1" => %{"field" => "name", "op" => "eq", "value" => "b"},
+          "0" => %{"field" => "email", "op" => "contains", "value" => "a"}
+        }
+      }
+
+      state = State.from_params(params, fields: @fields)
+      assert Enum.map(state.filters, & &1.field) == [:email, :name]
+    end
+
+    test "drops filters with unknown fields or ops, and malformed entries" do
+      params = %{
+        "filters" => [
+          %{"field" => "secret", "op" => "contains", "value" => "x"},
+          %{"field" => "email", "op" => "drop_table", "value" => "x"},
+          %{"nope" => true},
+          %{"field" => "email", "op" => "eq", "value" => "keep"}
+        ]
+      }
+
+      state = State.from_params(params, fields: @fields)
+      assert state.filters == [%{field: :email, op: :eq, value: "keep"}]
+    end
+
+    test "parses and clamps page and page_size" do
+      state =
+        State.from_params(%{"page" => "3", "page_size" => "500"},
+          fields: @fields,
+          max_page_size: 100
+        )
+
+      assert state.page == 3
+      assert state.page_size == 100
+    end
+
+    test "garbage page values fall back to defaults" do
+      state =
+        State.from_params(%{"page" => "-2", "page_size" => "abc"},
+          fields: @fields,
+          page_size: 25
+        )
+
+      assert state.page == 1
+      assert state.page_size == 25
+    end
+  end
+
+  describe "to_params/1 round-trip" do
+    test "defaults encode to an empty map - clean URLs" do
+      assert State.to_params(%State{}) == %{}
+    end
+
+    test "a full state round-trips through from_params" do
+      state = %State{
+        order_by: [email: :desc, name: :asc],
+        filters: [%{field: :amount, op: :gt, value: "100"}],
+        page: 3,
+        page_size: 25,
+        total: 74
+      }
+
+      params =
+        state
+        |> State.to_params()
+        |> Map.new(fn {k, v} -> {k, v} end)
+
+      rebuilt = State.from_params(stringify(params), fields: @fields)
+
+      assert rebuilt.order_by == state.order_by
+      assert rebuilt.filters == state.filters
+      assert rebuilt.page == state.page
+      assert rebuilt.page_size == state.page_size
+      # total is a result, not a request - it never round-trips
+      assert rebuilt.total == nil
+    end
+  end
+
+  describe "toggle_sort/2" do
+    test "cycles asc -> desc -> removed and resets the page" do
+      state = %State{page: 7}
+
+      s1 = State.toggle_sort(state, :email)
+      assert s1.order_by == [email: :asc]
+      assert s1.page == 1
+
+      s2 = State.toggle_sort(s1, :email)
+      assert s2.order_by == [email: :desc]
+
+      s3 = State.toggle_sort(s2, :email)
+      assert s3.order_by == []
+    end
+
+    test "sorting a new field replaces the previous sort" do
+      state = %State{order_by: [email: :desc]}
+      assert State.toggle_sort(state, :name).order_by == [name: :asc]
+    end
+  end
+
+  describe "put_filter/4 and clear_filters/1" do
+    test "adds, replaces per field, and resets the page" do
+      state =
+        %State{page: 4}
+        |> State.put_filter(:email, :contains, "a")
+        |> State.put_filter(:name, :eq, "bo")
+        |> State.put_filter(:email, :contains, "b")
+
+      assert state.filters == [
+               %{field: :name, op: :eq, value: "bo"},
+               %{field: :email, op: :contains, value: "b"}
+             ]
+
+      assert state.page == 1
+    end
+
+    test "a nil/empty value removes the field's filter" do
+      state =
+        %State{}
+        |> State.put_filter(:email, :contains, "a")
+        |> State.put_filter(:email, :contains, "")
+
+      assert state.filters == []
+    end
+
+    test "clear_filters/1 empties everything" do
+      state = %State{filters: [%{field: :email, op: :eq, value: "x"}], page: 3}
+      assert State.clear_filters(state) == %State{filters: [], page: 1}
+    end
+  end
+
+  describe "total_pages/1" do
+    test "nil total means unknown" do
+      assert State.total_pages(%State{total: nil}) == nil
+    end
+
+    test "rounds up and floors at 1" do
+      assert State.total_pages(%State{total: 74, page_size: 10}) == 8
+      assert State.total_pages(%State{total: 0, page_size: 10}) == 1
+    end
+  end
+
+  defp stringify(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {to_string(k), stringify(v)} end)
+  end
+
+  defp stringify(list) when is_list(list), do: Enum.map(list, &stringify/1)
+  defp stringify(value) when is_integer(value), do: Integer.to_string(value)
+  defp stringify(value), do: value
+end


### PR DESCRIPTION
First PR of the 4.12 data table arc ([plan §4](https://github.com/petalframework) - the State contract and the free in-memory engine). Deliberately UI-free: this is the foundation the `<.data_table>` component composes on next.

## `PetalComponents.DataTable.State`

The whole backend contract in one struct - Flop-shaped on purpose, Flop-free on purpose:

- `order_by` (multi-sort), `filters` (typed: `contains/eq/starts_with`, `eq/neq/gt/lt/between`, `in`, `before/on/after`), `page`, `page_size`, `total` (nil = cursor/unknown mode).
- `from_params/2` / `to_params/2`: URL-as-state round-trip. Safe by construction - `:fields` is a required whitelist so **no atom is ever created from user input**, unknown ops are dropped, page sizes are clamped. Defaults are omitted from the encoding so URLs stay clean; `total` never round-trips (it's a result, not a request).
- Interaction helpers that encode the component's grammar: `toggle_sort/2` (asc → desc → off, always resets to page 1), `put_filter/4` (per-field replace; empty value removes), `clear_filters/1`, `total_pages/1`.

## `Engine.List`

`run(rows, state)` → `{page_rows, state_with_total}` for plain lists of maps/structs: filter → sort → count → paginate. Case-insensitive string matching, **nils sort last in both directions** (the nil rule sits outside the asc/desc flip), numeric/date coercion straight from string params, malformed values never match instead of raising. Zero-setup working tables for registry examples and the playground; DB-grade engines stay Pro per the plan's fence.

## Tests

36 new tests (whitelist safety, indexed-map filter params, round-trip symmetry, sort cycling, every filter op, nil semantics, pipeline composition). Full suite 791 green.

Note: GitHub Actions is mid-outage (webhooks throttled ~15%) so CI checks may be delayed - both suites are green locally.