### PR TITLE
fix(combo_box): chevron tap closes the panel on iOS - geometric toggle check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@
 
 #### Fixed
 
+- **`combo_box`: a chevron tap on iOS now closes the open panel.** It
+  always did on desktop, but the chevron is `pointer-events-none` by
+  icon doctrine and iOS Safari's tap-target correction snaps taps near
+  a text field onto the field - so a deliberate chevron tap arrived as
+  "caret work on the input" and the panel stayed open. The toggle check
+  is now geometric: a click whose coordinates land in the chevron's box
+  (inflated for thumbs) closes the panel no matter what the browser
+  reassigned the target to. Genuine input clicks away from the chevron
+  are still caret work and never discard the query.
+
+#### Fixed
+
 - **`combo_box` multiple: the highlight stays on the item just picked.**
   Choosing used to reset the filter and re-home the highlight on the
   first option - a disorienting jump when picking from the middle of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,18 @@
 
 #### Fixed
 
-- **`combo_box`: a chevron tap on iOS now closes the open panel.** It
-  always did on desktop, but the chevron is `pointer-events-none` by
-  icon doctrine and iOS Safari's tap-target correction snaps taps near
-  a text field onto the field - so a deliberate chevron tap arrived as
-  "caret work on the input" and the panel stayed open. The toggle check
-  is now geometric: a click whose coordinates land in the chevron's box
-  (inflated for thumbs) closes the panel no matter what the browser
-  reassigned the target to. Genuine input clicks away from the chevron
-  are still caret work and never discard the query.
+- **`combo_box`: chevron press reliably toggles the panel closed on
+  every platform.** Two interacting bugs: on desktop, pressing the
+  (non-focusable) chevron blurred the input, focusout closed the panel
+  mid-press, and the click then saw a closed panel and REOPENED it -
+  the toggle flashed instead of closing. On iOS no blur fires, but tap-
+  target correction rewrites the synthesized click's target and
+  coordinates onto the nearby text field, so the tap read as caret work
+  and nothing closed. Fix: chrome-vs-caret is decided at `pointerdown`
+  (which hit-tests the real touch point and is never rewritten), the
+  click consumes that record, and chrome presses are preventDefaulted
+  so the input never blurs mid-press. Input presses keep caret
+  behavior and never discard the active query.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@
 
 #### Fixed
 
+- **`combo_box`: iOS taps on control chrome and the trigger button
+  reliably toggle the panel.** iOS Safari fires `focusout` with
+  `relatedTarget: null` even when focus moves WITHIN the component, so
+  a chevron or trigger tap closed the panel mid-press and the tap's own
+  click instantly reopened it - an invisible flash that read as a dead
+  chevron zone (input variant) and a picker that never closes (trigger
+  variant). Device-log verified. The focusout close now defers one tick
+  and verifies where focus actually landed instead of trusting
+  `relatedTarget`; genuine Tab-away and click-away close exactly as
+  before.
+
 - **`combo_box`: a touch-scroll no longer dismisses the panel.** The
   outside dismiss closed on `pointerdown`, so starting a scroll gesture
   anywhere outside the panel killed it the instant the finger landed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@
   playground get a working table with zero setup. The `<.data_table>`
   component builds on this next.
 
+#### Added
+
+- **`combo_box` trigger variant supports `clearable`.** A chosen
+  single-select trigger had no road back to the empty state (Nic's
+  find - the input variant had the X, the trigger silently ignored the
+  attr). A button can't nest inside the trigger button, so the clear is
+  a sibling positioned over the trigger's right rail before the chevron
+  (Base UI anatomy), gated by the same `data-has-value` state, with a
+  24px hit target. Clearing empties the select, restores the
+  placeholder label, keeps the panel closed and returns focus to the
+  trigger. Multiple mode stays clear-less by design on both variants -
+  chips and panel toggles are its road back.
+
 #### Fixed
 
 - **`combo_box`: iOS taps on control chrome and the trigger button

--- a/assets/default.css
+++ b/assets/default.css
@@ -2290,6 +2290,17 @@
   .pc-combo-box[data-has-value] .pc-combo-box__clear {
     @apply inline-flex;
   }
+  /* trigger variant: the clear is a SIBLING over the trigger's right rail
+     (no button-in-button); the trigger reserves room for X + chevron */
+  .pc-combo-box__trigger--clearable {
+    @apply pr-14;
+  }
+  .pc-combo-box__trigger-clear {
+    @apply absolute top-1/2 right-8 hidden h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:ring-2 focus-visible:ring-primary-500/50 focus-visible:outline-none dark:text-gray-500 dark:hover:bg-gray-400/17 dark:hover:text-gray-200;
+  }
+  .pc-combo-box[data-has-value] .pc-combo-box__trigger-clear {
+    @apply inline-flex;
+  }
   /* Doubled selector + !important: icon sizing contract (see pagination previous chevron). */
   .pc-combo-box__clear-icon.pc-combo-box__clear-icon {
     @apply w-4! h-4!;

--- a/assets/default.css
+++ b/assets/default.css
@@ -2290,16 +2290,18 @@
   .pc-combo-box[data-has-value] .pc-combo-box__clear {
     @apply inline-flex;
   }
-  /* trigger variant: the clear is a SIBLING over the trigger's right rail
-     (no button-in-button); the trigger reserves room for X + chevron */
-  .pc-combo-box__trigger--clearable {
-    @apply pr-14;
-  }
+  /* trigger variant: the clear is a SIBLING floated over the rail just
+     left of the chevron (no button-in-button). The chevron NEVER moves -
+     the label yields truncation room only while a value is chosen, the
+     exact grammar of the input variant's inline X. */
   .pc-combo-box__trigger-clear {
-    @apply absolute top-1/2 right-8 hidden h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:ring-2 focus-visible:ring-primary-500/50 focus-visible:outline-none dark:text-gray-500 dark:hover:bg-gray-400/17 dark:hover:text-gray-200;
+    @apply absolute top-1/2 right-9 hidden h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:ring-2 focus-visible:ring-primary-500/50 focus-visible:outline-none dark:text-gray-500 dark:hover:bg-gray-400/17 dark:hover:text-gray-200;
   }
   .pc-combo-box[data-has-value] .pc-combo-box__trigger-clear {
     @apply inline-flex;
+  }
+  .pc-combo-box[data-has-value] .pc-combo-box__trigger--clearable .pc-combo-box__trigger-label {
+    @apply pr-6;
   }
   /* Doubled selector + !important: icon sizing contract (see pagination previous chevron). */
   .pc-combo-box__clear-icon.pc-combo-box__clear-icon {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3595,6 +3595,14 @@ export const PetalComboBox = {
     // REOPEN it (the flash). Same pattern onPanelPointerDown proves.
     this.onControlPointerDown = (e) => {
       if (this.input.disabled) return;
+      this.controlPointers.add(e.pointerId);
+      // a second concurrent finger is a gesture (pinch, two-finger
+      // fidget), not a toggle - disarm so one pointer's click can never
+      // consume another pointer's chrome-vs-caret verdict
+      if (this.controlPointers.size > 1) {
+        this.pressOnChrome = null;
+        return;
+      }
       this.pressOnChrome = e.target !== this.input;
       if (this.pressOnChrome) e.preventDefault();
     };
@@ -3603,6 +3611,7 @@ export const PetalComboBox = {
     // consume the record, and a stale "chrome" verdict would make a
     // later synthetic caret click close the panel and discard the query.
     this.onPressSettle = (e) => {
+      this.controlPointers.delete(e.pointerId);
       if (e.type === "pointercancel" || !this.control?.contains(e.target)) {
         this.pressOnChrome = null;
       }
@@ -3707,6 +3716,7 @@ export const PetalComboBox = {
     this.list.addEventListener("click", this.onListClick);
     this.panel.addEventListener("pointerdown", this.onPanelPointerDown);
     this.pressOnChrome = null;
+    this.controlPointers = new Set();
     if (this.control) {
       this.control.addEventListener("pointerdown", this.onControlPointerDown);
       this.control.addEventListener("click", this.onControlClick);

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3652,13 +3652,6 @@ export const PetalComboBox = {
         this.input.focus();
         return;
       }
-      if (e.target.closest("[data-pc-combo-clear]")) {
-        this.select.value = "";
-        this.dispatchChange();
-        this.syncFromSelect();
-        this.input.focus();
-        return;
-      }
       if (this.panel.hidden) {
         // a deliberate chrome close wins its own gesture: trailing
         // clicks from OTHER fingers of the same burst arrive WITHOUT a
@@ -3675,6 +3668,17 @@ export const PetalComboBox = {
         this.input.focus();
         this.suppressOpenAt = now;
       }
+    };
+    // the clear button is bound directly so both anatomies share one
+    // path: inside the input variant's control, and as the trigger
+    // variant's sibling over the right rail. stopPropagation keeps the
+    // clear from reading as a control/trigger toggle.
+    this.onClearClick = (e) => {
+      e.stopPropagation();
+      this.select.value = "";
+      this.dispatchChange();
+      this.syncFromSelect();
+      (this.trigger || this.input).focus();
     };
     this.onFocusOut = (e) => {
       // iOS Safari reports relatedTarget as null even when focus moves
@@ -3754,6 +3758,10 @@ export const PetalComboBox = {
     this.list.addEventListener("pointerover", this.onPointerOver);
     this.list.addEventListener("click", this.onListClick);
     this.panel.addEventListener("pointerdown", this.onPanelPointerDown);
+    this.clearButton = this.el.querySelector("[data-pc-combo-clear]");
+    if (this.clearButton) {
+      this.clearButton.addEventListener("click", this.onClearClick);
+    }
     this.pressVerdicts = new Map();
     this.suppressOpenAt = -Infinity;
     if (this.control) {
@@ -3801,6 +3809,9 @@ export const PetalComboBox = {
       this.trigger.removeEventListener("keydown", this.onTriggerKeydown);
     }
     this.el.removeEventListener("focusout", this.onFocusOut);
+    if (this.clearButton) {
+      this.clearButton.removeEventListener("click", this.onClearClick);
+    }
     if (this.form) this.form.removeEventListener("reset", this.onFormReset);
     document.removeEventListener(
       "pointerdown",

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3649,6 +3649,9 @@ export const PetalComboBox = {
         return;
       }
       if (this.panel.hidden) {
+        // a deliberate chrome close wins its own gesture: trailing
+        // clicks from OTHER fingers of the same burst must not reopen
+        if (this.suppressOpen) return;
         this.openPanel();
         this.input.focus();
       } else if (chrome) {
@@ -3656,6 +3659,8 @@ export const PetalComboBox = {
         // is caret work - closing would discard the active query
         this.closePanel();
         this.input.focus();
+        this.suppressOpen = true;
+        setTimeout(() => (this.suppressOpen = false), 0);
       }
     };
     this.onFocusOut = (e) => {
@@ -3728,6 +3733,7 @@ export const PetalComboBox = {
     this.list.addEventListener("click", this.onListClick);
     this.panel.addEventListener("pointerdown", this.onPanelPointerDown);
     this.pressVerdicts = new Map();
+    this.suppressOpen = false;
     if (this.control) {
       this.control.addEventListener("pointerdown", this.onControlPointerDown);
       this.control.addEventListener("click", this.onControlClick);

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3545,6 +3545,7 @@ export const PetalComboBox = {
     this.select = this.el.querySelector(".pc-combo-box__select");
     this.input = this.el.querySelector(".pc-combo-box__input");
     this.control = this.el.querySelector(".pc-combo-box__control");
+    this.chevron = this.el.querySelector(".pc-combo-box__chevron");
     this.trigger = this.el.querySelector("[data-pc-combo-trigger]");
     this.triggerLabel = this.el.querySelector("[data-pc-combo-trigger-label]");
     this.panel = this.el.querySelector("[data-pc-combo-panel]");
@@ -3604,9 +3605,14 @@ export const PetalComboBox = {
       if (this.panel.hidden) {
         this.openPanel();
         this.input.focus();
-      } else if (e.target !== this.input) {
+      } else if (e.target !== this.input || this.inChevronBox(e)) {
         // chevron / control chrome toggles; a click on the input itself is
-        // caret work - closing here would discard the active query
+        // caret work - closing here would discard the active query. The
+        // chevron check is geometric, not target-based: the icon is
+        // pointer-events-none by doctrine, and iOS Safari's tap-target
+        // correction snaps taps near a text field ONTO the field - so a
+        // deliberate chevron tap can arrive with target === input. Where
+        // the finger landed outranks where Safari says it landed.
         this.closePanel();
         this.input.focus();
       }
@@ -3749,6 +3755,22 @@ export const PetalComboBox = {
     for (const ch of text)
       if (ch === query[qi] && ++qi === query.length) return 1;
     return 0;
+  },
+
+  // True when the click's coordinates fall inside the decorative chevron's
+  // box (inflated for thumbs). Guarded on a real layout - jsdom and
+  // display:none boxes are zero-width and must never match.
+  inChevronBox(e) {
+    if (!this.chevron || e.clientX == null) return false;
+    const r = this.chevron.getBoundingClientRect();
+    if (r.width === 0) return false;
+    const pad = 8;
+    return (
+      e.clientX >= r.left - pad &&
+      e.clientX <= r.right + pad &&
+      e.clientY >= r.top - pad &&
+      e.clientY <= r.bottom + pad
+    );
   },
 
   openPanel({ keepQuery = false } = {}) {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3599,18 +3599,17 @@ export const PetalComboBox = {
     this.onControlPointerDown = (e) => {
       if (this.input.disabled) return;
       const chrome = e.target !== this.input;
-      this.pressVerdicts.set(e.pointerId, chrome);
+      this.pressVerdicts.set(e.pointerId, { chrome, at: performance.now() });
       if (chrome) e.preventDefault();
     };
     // Abandoned records must not linger to poison a later synthetic
-    // caret click: a cancel or an off-control release deletes at once;
-    // an on-control release leaves the record for the click that
-    // follows in the same event burst, then sweeps it.
+    // caret click: a cancel or an off-control release deletes at once.
+    // An on-control release leaves the record for its click - which iOS
+    // Safari may synthesize LATER than any queued task, so there is no
+    // timer sweep; leftovers age out at click time instead (see below).
     this.onPressSettle = (e) => {
       if (e.type === "pointercancel" || !this.control?.contains(e.target)) {
         this.pressVerdicts.delete(e.pointerId);
-      } else {
-        setTimeout(() => this.pressVerdicts.delete(e.pointerId), 0);
       }
     };
     this.onControlClick = (e) => {
@@ -3621,12 +3620,20 @@ export const PetalComboBox = {
       // verdicts (synthetic - tests, assistive tech) falls back to its
       // own target, and genuine multi-pointer ambiguity degrades to
       // caret-safe (never close on a guess)
+      // verdicts older than a second are leftovers from presses whose
+      // click never arrived - drop them before deciding (timer-free, so
+      // no race with Safari's late click synthesis)
+      const now = performance.now();
+      for (const [id, v] of this.pressVerdicts) {
+        if (now - v.at > 1000) this.pressVerdicts.delete(id);
+      }
+
       let chrome;
       if (this.pressVerdicts.has(e.pointerId)) {
-        chrome = this.pressVerdicts.get(e.pointerId);
+        chrome = this.pressVerdicts.get(e.pointerId).chrome;
         this.pressVerdicts.delete(e.pointerId);
       } else if (this.pressVerdicts.size === 1) {
-        chrome = this.pressVerdicts.values().next().value;
+        chrome = this.pressVerdicts.values().next().value.chrome;
         this.pressVerdicts.clear();
       } else if (this.pressVerdicts.size === 0) {
         chrome = e.target !== this.input;
@@ -3650,8 +3657,11 @@ export const PetalComboBox = {
       }
       if (this.panel.hidden) {
         // a deliberate chrome close wins its own gesture: trailing
-        // clicks from OTHER fingers of the same burst must not reopen
-        if (this.suppressOpen) return;
+        // clicks from OTHER fingers of the same burst must not reopen.
+        // Timestamp-gated (not a timer) so Safari's late-synthesized
+        // clicks are covered too; 350ms comfortably outlasts a burst
+        // and is shorter than any deliberate follow-up interaction.
+        if (now - this.suppressOpenAt < 350) return;
         this.openPanel();
         this.input.focus();
       } else if (chrome) {
@@ -3659,8 +3669,7 @@ export const PetalComboBox = {
         // is caret work - closing would discard the active query
         this.closePanel();
         this.input.focus();
-        this.suppressOpen = true;
-        setTimeout(() => (this.suppressOpen = false), 0);
+        this.suppressOpenAt = now;
       }
     };
     this.onFocusOut = (e) => {
@@ -3733,7 +3742,7 @@ export const PetalComboBox = {
     this.list.addEventListener("click", this.onListClick);
     this.panel.addEventListener("pointerdown", this.onPanelPointerDown);
     this.pressVerdicts = new Map();
-    this.suppressOpen = false;
+    this.suppressOpenAt = -Infinity;
     if (this.control) {
       this.control.addEventListener("pointerdown", this.onControlPointerDown);
       this.control.addEventListener("click", this.onControlClick);

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3598,6 +3598,10 @@ export const PetalComboBox = {
     // one another's record - the click claims its pointer's verdict.
     this.onControlPointerDown = (e) => {
       if (this.input.disabled) return;
+      // any fresh press ends close-suppression: a legitimate rapid
+      // follow-up tap has its own pointerdown, a trailing same-gesture
+      // click does not - the exact discriminator, no time window needed
+      this.suppressOpenAt = -Infinity;
       const chrome = e.target !== this.input;
       this.pressVerdicts.set(e.pointerId, { chrome, at: performance.now() });
       if (chrome) e.preventDefault();
@@ -3657,11 +3661,11 @@ export const PetalComboBox = {
       }
       if (this.panel.hidden) {
         // a deliberate chrome close wins its own gesture: trailing
-        // clicks from OTHER fingers of the same burst must not reopen.
-        // Timestamp-gated (not a timer) so Safari's late-synthesized
-        // clicks are covered too; 350ms comfortably outlasts a burst
-        // and is shorter than any deliberate follow-up interaction.
-        if (now - this.suppressOpenAt < 350) return;
+        // clicks from OTHER fingers of the same burst arrive WITHOUT a
+        // fresh pointerdown (which clears the suppression) and must not
+        // reopen. The 1s age cap frees clicks with no pointer sequence
+        // at all (assistive tech) from a long-stale suppression.
+        if (now - this.suppressOpenAt < 1000) return;
         this.openPanel();
         this.input.focus();
       } else if (chrome) {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3677,7 +3677,16 @@ export const PetalComboBox = {
       }
     };
     this.onFocusOut = (e) => {
-      if (!this.el.contains(e.relatedTarget)) this.closePanel();
+      // iOS Safari reports relatedTarget as null even when focus moves
+      // WITHIN the component (tapping the trigger button while the panel
+      // search has focus) - trusting it closed the panel mid-tap and the
+      // button's click then reopened it, an endless flash. Verify where
+      // focus actually landed once it settles; closing a tick later is
+      // imperceptible on the genuine Tab-away/click-away paths.
+      if (this.el.contains(e.relatedTarget)) return;
+      setTimeout(() => {
+        if (!this.el.contains(document.activeElement)) this.closePanel();
+      }, 0);
     };
     // trigger variant: the button opens the panel and focus moves to the
     // search input inside it; ArrowDown/Up on the button open too

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3593,35 +3593,47 @@ export const PetalComboBox = {
     // presses keeps focus in the input - on desktop the blur would fire
     // focusout, close the panel mid-press, and the click would then
     // REOPEN it (the flash). Same pattern onPanelPointerDown proves.
+    // Each pointer carries its OWN chrome-vs-caret verdict, so
+    // interleaved fingers in any press/release order can never consume
+    // one another's record - the click claims its pointer's verdict.
     this.onControlPointerDown = (e) => {
       if (this.input.disabled) return;
-      this.controlPointers.add(e.pointerId);
-      // a second concurrent finger is a gesture (pinch, two-finger
-      // fidget), not a toggle - disarm so one pointer's click can never
-      // consume another pointer's chrome-vs-caret verdict
-      if (this.controlPointers.size > 1) {
-        this.pressOnChrome = null;
-        return;
-      }
-      this.pressOnChrome = e.target !== this.input;
-      if (this.pressOnChrome) e.preventDefault();
+      const chrome = e.target !== this.input;
+      this.pressVerdicts.set(e.pointerId, chrome);
+      if (chrome) e.preventDefault();
     };
-    // An abandoned press must not linger: a chevron press released off
-    // the control (or cancelled) never produces a control click to
-    // consume the record, and a stale "chrome" verdict would make a
-    // later synthetic caret click close the panel and discard the query.
+    // Abandoned records must not linger to poison a later synthetic
+    // caret click: a cancel or an off-control release deletes at once;
+    // an on-control release leaves the record for the click that
+    // follows in the same event burst, then sweeps it.
     this.onPressSettle = (e) => {
-      this.controlPointers.delete(e.pointerId);
       if (e.type === "pointercancel" || !this.control?.contains(e.target)) {
-        this.pressOnChrome = null;
+        this.pressVerdicts.delete(e.pointerId);
+      } else {
+        setTimeout(() => this.pressVerdicts.delete(e.pointerId), 0);
       }
     };
     this.onControlClick = (e) => {
       if (this.input.disabled) return;
-      // fall back to the click's own target when no pointerdown preceded
-      // it (synthetic clicks from tests and assistive tech)
-      const chrome = this.pressOnChrome ?? e.target !== this.input;
-      this.pressOnChrome = null;
+      // the click claims its own pointer's verdict (clicks are
+      // PointerEvents in modern browsers); a click without a usable
+      // pointerId takes the sole surviving verdict, a click with NO
+      // verdicts (synthetic - tests, assistive tech) falls back to its
+      // own target, and genuine multi-pointer ambiguity degrades to
+      // caret-safe (never close on a guess)
+      let chrome;
+      if (this.pressVerdicts.has(e.pointerId)) {
+        chrome = this.pressVerdicts.get(e.pointerId);
+        this.pressVerdicts.delete(e.pointerId);
+      } else if (this.pressVerdicts.size === 1) {
+        chrome = this.pressVerdicts.values().next().value;
+        this.pressVerdicts.clear();
+      } else if (this.pressVerdicts.size === 0) {
+        chrome = e.target !== this.input;
+      } else {
+        chrome = false;
+        this.pressVerdicts.clear();
+      }
       if (e.target.closest("[data-pc-combo-chip-remove]")) {
         const value = e.target.closest("[data-pc-combo-chip-remove]").dataset
           .value;
@@ -3715,8 +3727,7 @@ export const PetalComboBox = {
     this.list.addEventListener("pointerover", this.onPointerOver);
     this.list.addEventListener("click", this.onListClick);
     this.panel.addEventListener("pointerdown", this.onPanelPointerDown);
-    this.pressOnChrome = null;
-    this.controlPointers = new Set();
+    this.pressVerdicts = new Map();
     if (this.control) {
       this.control.addEventListener("pointerdown", this.onControlPointerDown);
       this.control.addEventListener("click", this.onControlClick);

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3545,7 +3545,6 @@ export const PetalComboBox = {
     this.select = this.el.querySelector(".pc-combo-box__select");
     this.input = this.el.querySelector(".pc-combo-box__input");
     this.control = this.el.querySelector(".pc-combo-box__control");
-    this.chevron = this.el.querySelector(".pc-combo-box__chevron");
     this.trigger = this.el.querySelector("[data-pc-combo-trigger]");
     this.triggerLabel = this.el.querySelector("[data-pc-combo-trigger-label]");
     this.panel = this.el.querySelector("[data-pc-combo-panel]");
@@ -3586,8 +3585,25 @@ export const PetalComboBox = {
     this.onPanelPointerDown = (e) => {
       if (e.target !== this.input) e.preventDefault();
     };
+    // Chrome-vs-caret is decided at POINTERDOWN, not click: pointer events
+    // hit-test the real touch point, while iOS tap-target correction
+    // rewrites the synthesized click's target AND coordinates (snapping
+    // both onto the nearby text field), so the click is unreliable
+    // evidence of where the finger landed. preventDefault on chrome
+    // presses keeps focus in the input - on desktop the blur would fire
+    // focusout, close the panel mid-press, and the click would then
+    // REOPEN it (the flash). Same pattern onPanelPointerDown proves.
+    this.onControlPointerDown = (e) => {
+      if (this.input.disabled) return;
+      this.pressOnChrome = e.target !== this.input;
+      if (this.pressOnChrome) e.preventDefault();
+    };
     this.onControlClick = (e) => {
       if (this.input.disabled) return;
+      // fall back to the click's own target when no pointerdown preceded
+      // it (synthetic clicks from tests and assistive tech)
+      const chrome = this.pressOnChrome ?? e.target !== this.input;
+      this.pressOnChrome = null;
       if (e.target.closest("[data-pc-combo-chip-remove]")) {
         const value = e.target.closest("[data-pc-combo-chip-remove]").dataset
           .value;
@@ -3605,14 +3621,9 @@ export const PetalComboBox = {
       if (this.panel.hidden) {
         this.openPanel();
         this.input.focus();
-      } else if (e.target !== this.input || this.inChevronBox(e)) {
-        // chevron / control chrome toggles; a click on the input itself is
-        // caret work - closing here would discard the active query. The
-        // chevron check is geometric, not target-based: the icon is
-        // pointer-events-none by doctrine, and iOS Safari's tap-target
-        // correction snaps taps near a text field ONTO the field - so a
-        // deliberate chevron tap can arrive with target === input. Where
-        // the finger landed outranks where Safari says it landed.
+      } else if (chrome) {
+        // chevron / control chrome toggles; a press on the input itself
+        // is caret work - closing would discard the active query
         this.closePanel();
         this.input.focus();
       }
@@ -3686,8 +3697,11 @@ export const PetalComboBox = {
     this.list.addEventListener("pointerover", this.onPointerOver);
     this.list.addEventListener("click", this.onListClick);
     this.panel.addEventListener("pointerdown", this.onPanelPointerDown);
-    if (this.control)
+    this.pressOnChrome = null;
+    if (this.control) {
+      this.control.addEventListener("pointerdown", this.onControlPointerDown);
       this.control.addEventListener("click", this.onControlClick);
+    }
     if (this.trigger) {
       this.trigger.addEventListener("click", this.onTriggerClick);
       this.trigger.addEventListener("keydown", this.onTriggerKeydown);
@@ -3711,8 +3725,13 @@ export const PetalComboBox = {
     this.list.removeEventListener("pointerover", this.onPointerOver);
     this.list.removeEventListener("click", this.onListClick);
     this.panel.removeEventListener("pointerdown", this.onPanelPointerDown);
-    if (this.control)
+    if (this.control) {
+      this.control.removeEventListener(
+        "pointerdown",
+        this.onControlPointerDown,
+      );
       this.control.removeEventListener("click", this.onControlClick);
+    }
     if (this.trigger) {
       this.trigger.removeEventListener("click", this.onTriggerClick);
       this.trigger.removeEventListener("keydown", this.onTriggerKeydown);
@@ -3755,22 +3774,6 @@ export const PetalComboBox = {
     for (const ch of text)
       if (ch === query[qi] && ++qi === query.length) return 1;
     return 0;
-  },
-
-  // True when the click's coordinates fall inside the decorative chevron's
-  // box (inflated for thumbs). Guarded on a real layout - jsdom and
-  // display:none boxes are zero-width and must never match.
-  inChevronBox(e) {
-    if (!this.chevron || e.clientX == null) return false;
-    const r = this.chevron.getBoundingClientRect();
-    if (r.width === 0) return false;
-    const pad = 8;
-    return (
-      e.clientX >= r.left - pad &&
-      e.clientX <= r.right + pad &&
-      e.clientY >= r.top - pad &&
-      e.clientY <= r.bottom + pad
-    );
   },
 
   openPanel({ keepQuery = false } = {}) {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3598,6 +3598,15 @@ export const PetalComboBox = {
       this.pressOnChrome = e.target !== this.input;
       if (this.pressOnChrome) e.preventDefault();
     };
+    // An abandoned press must not linger: a chevron press released off
+    // the control (or cancelled) never produces a control click to
+    // consume the record, and a stale "chrome" verdict would make a
+    // later synthetic caret click close the panel and discard the query.
+    this.onPressSettle = (e) => {
+      if (e.type === "pointercancel" || !this.control?.contains(e.target)) {
+        this.pressOnChrome = null;
+      }
+    };
     this.onControlClick = (e) => {
       if (this.input.disabled) return;
       // fall back to the click's own target when no pointerdown preceded
@@ -3701,6 +3710,10 @@ export const PetalComboBox = {
     if (this.control) {
       this.control.addEventListener("pointerdown", this.onControlPointerDown);
       this.control.addEventListener("click", this.onControlClick);
+      // click fires between pointerup and any queued task, so consuming
+      // in onControlClick wins the race; these only catch abandonment
+      document.addEventListener("pointerup", this.onPressSettle);
+      document.addEventListener("pointercancel", this.onPressSettle);
     }
     if (this.trigger) {
       this.trigger.addEventListener("click", this.onTriggerClick);
@@ -3731,6 +3744,8 @@ export const PetalComboBox = {
         this.onControlPointerDown,
       );
       this.control.removeEventListener("click", this.onControlClick);
+      document.removeEventListener("pointerup", this.onPressSettle);
+      document.removeEventListener("pointercancel", this.onPressSettle);
     }
     if (this.trigger) {
       this.trigger.removeEventListener("click", this.onTriggerClick);

--- a/dev.exs
+++ b/dev.exs
@@ -7270,6 +7270,7 @@ defmodule Dev.PlaygroundLive do
           <form id="pg-combo-form" phx-change="pg_combo_change" class="w-full max-w-sm">
             <.combo_box
               id="pg-combo"
+              clearable
               name="pg_city"
               placeholder="Search cities…"
               value={@combo.chosen}

--- a/dev/static/tap-debug.html
+++ b/dev/static/tap-debug.html
@@ -1,0 +1,229 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Combobox tap debug</title>
+    <link rel="stylesheet" href="/assets/app.css" />
+    <style>
+      body { margin: 0; font-family: ui-sans-serif, system-ui, sans-serif; }
+      #stage { padding: 16px; }
+      #log-wrap {
+        position: fixed; left: 0; right: 0; bottom: 0; height: 45vh;
+        background: #0b0f19; color: #d1d5db; border-top: 2px solid #374151;
+        display: flex; flex-direction: column; z-index: 9999;
+      }
+      #log-bar { display: flex; gap: 8px; padding: 6px 10px; border-bottom: 1px solid #374151; }
+      #log-bar button {
+        font: 600 12px ui-sans-serif, system-ui; padding: 6px 12px;
+        border-radius: 8px; border: 1px solid #4b5563; background: #1f2937; color: #e5e7eb;
+      }
+      #log {
+        flex: 1; overflow-y: auto; margin: 0; padding: 8px 10px;
+        font: 10px/1.5 ui-monospace, Menlo, monospace; white-space: pre;
+        -webkit-user-select: text; user-select: text;
+      }
+      .chev-box {
+        position: absolute; border: 1.5px dashed #ef4444; border-radius: 4px;
+        pointer-events: none; z-index: 999;
+      }
+      .marker { color: #34d399; font-weight: 700; }
+      h2 { font-size: 14px; font-weight: 700; margin: 14px 0 6px; }
+      .hint { font-size: 11px; color: #6b7280; margin: 2px 0 8px; }
+    </style>
+  </head>
+  <body>
+    <div id="stage">
+      <h2>1. Input variant</h2>
+      <p class="hint">Red dashed box = the chevron's true box. Tap ON it, then just LEFT of it. Panel open/close is logged.</p>
+      <div id="combo" class="pc-combo-box" style="max-width: 20rem">
+        <select id="combo-select" name="city" class="pc-combo-box__select" tabindex="-1" aria-hidden="true" inert>
+          <option value=""></option>
+          <option value="syd">Sydney</option>
+          <option value="tyo">Tokyo</option>
+          <option value="lis">Lisbon</option>
+        </select>
+        <div class="pc-combo-box__control">
+          <div class="pc-combo-box__content">
+            <input type="text" id="combo-input" class="pc-combo-box__input" role="combobox"
+              aria-expanded="false" aria-autocomplete="list" aria-controls="combo-listbox"
+              autocomplete="off" autocorrect="off" spellcheck="false" placeholder="Tap chevron zones…" />
+          </div>
+          <span class="hero-chevron-down-mini pc-combo-box__chevron"></span>
+        </div>
+        <div class="pc-combo-box__panel" data-pc-combo-panel hidden>
+          <div role="listbox" id="combo-listbox" class="pc-combo-box__list" aria-label="Cities">
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="syd" data-label="Sydney" aria-selected="false"><span class="pc-combo-box__option-label">Sydney</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="tyo" data-label="Tokyo" aria-selected="false"><span class="pc-combo-box__option-label">Tokyo</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="lis" data-label="Lisbon" aria-selected="false"><span class="pc-combo-box__option-label">Lisbon</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div class="pc-combo-box__empty" data-pc-combo-empty hidden>No results found</div>
+          </div>
+        </div>
+        <div class="pc-combo-box__live" data-pc-combo-live aria-live="polite"></div>
+      </div>
+
+      <h2>2. Trigger variant</h2>
+      <p class="hint">Open it, then tap the button again — the close that fails on device.</p>
+      <div id="tcombo" class="pc-combo-box" style="max-width: 20rem">
+        <select id="tcombo-select" name="who" class="pc-combo-box__select" tabindex="-1" aria-hidden="true" inert>
+          <option value=""></option>
+          <option value="amelia">Amelia</option>
+          <option value="jonah">Jonah</option>
+          <option value="priya">Priya</option>
+        </select>
+        <button type="button" id="tcombo-trigger" class="pc-combo-box__trigger" role="combobox"
+          aria-haspopup="listbox" aria-expanded="false" aria-controls="tcombo-listbox"
+          data-pc-combo-trigger data-placeholder="true">
+          <span class="pc-combo-box__trigger-label" data-pc-combo-trigger-label
+            data-placeholder-text="Assign to…" data-count-label="selected">Assign to…</span>
+          <span class="hero-chevron-down-mini pc-combo-box__chevron"></span>
+        </button>
+        <div class="pc-combo-box__panel" data-pc-combo-panel hidden>
+          <div class="pc-combo-box__search">
+            <span class="hero-magnifying-glass-mini pc-combo-box__search-icon"></span>
+            <input type="text" id="tcombo-input" class="pc-combo-box__input" role="combobox"
+              aria-expanded="false" aria-autocomplete="list" aria-controls="tcombo-listbox"
+              autocomplete="off" autocorrect="off" spellcheck="false" placeholder="Search…" />
+          </div>
+          <div role="listbox" id="tcombo-listbox" class="pc-combo-box__list" aria-label="People">
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="amelia" data-label="Amelia" aria-selected="false"><span class="pc-combo-box__option-label">Amelia</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="jonah" data-label="Jonah" aria-selected="false"><span class="pc-combo-box__option-label">Jonah</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="priya" data-label="Priya" aria-selected="false"><span class="pc-combo-box__option-label">Priya</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div class="pc-combo-box__empty" data-pc-combo-empty hidden>No results found</div>
+          </div>
+        </div>
+        <div class="pc-combo-box__live" data-pc-combo-live aria-live="polite"></div>
+      </div>
+    </div>
+
+    <div id="log-wrap">
+      <div id="log-bar">
+        <button id="copy-btn" type="button">Copy log</button>
+        <button id="clear-btn" type="button">Clear</button>
+        <span style="font:11px ui-monospace,Menlo,monospace;color:#9ca3af;align-self:center" id="counter"></span>
+      </div>
+      <pre id="log"></pre>
+    </div>
+
+    <script type="module">
+      import hooks from "/assets/js/petal_components.js";
+
+      const logEl = document.getElementById("log");
+      const counter = document.getElementById("counter");
+      const lines = [];
+      let n = 0;
+
+      function desc(el) {
+        if (!el || el === document) return "document";
+        if (el === document.body) return "body";
+        const id = el.id ? `#${el.id}` : "";
+        const cls = el.classList && el.classList.length ? `.${el.classList[0]}` : "";
+        return `${el.tagName ? el.tagName.toLowerCase() : "?"}${id}${cls}`;
+      }
+
+      function render() {
+        logEl.innerHTML = lines
+          .slice()
+          .reverse()
+          .map((l) =>
+            l.startsWith("%%")
+              ? `<span class="marker">${l.slice(2)}</span>`
+              : l,
+          )
+          .join("\n");
+        counter.textContent = `${n} events`;
+      }
+
+      function say(line, marker = false) {
+        n++;
+        lines.push(marker ? `%%${line}` : line);
+        if (lines.length > 400) lines.shift();
+        render();
+      }
+
+      // Capture-phase: what the browser actually delivers, before any handler.
+      // defaultPrevented is sampled after the dispatch completes.
+      const types = [
+        "pointerdown", "pointerup", "pointercancel",
+        "touchstart", "touchend", "touchcancel",
+        "mousedown", "mouseup", "click",
+        "focusin", "focusout",
+      ];
+      for (const t of types) {
+        document.addEventListener(
+          t,
+          (e) => {
+            if (e.target.closest && e.target.closest("#log-wrap")) return;
+            const pt =
+              e.clientX != null && !Number.isNaN(e.clientX)
+                ? ` @${Math.round(e.clientX)},${Math.round(e.clientY)}`
+                : e.touches && e.touches[0]
+                  ? ` @${Math.round(e.touches[0].clientX)},${Math.round(e.touches[0].clientY)}`
+                  : "";
+            const pid = e.pointerId != null ? ` pid=${e.pointerId}` : "";
+            const line = `${t.padEnd(13)} ${desc(e.target)}${pt}${pid}`;
+            const i = lines.length;
+            say(line);
+            Promise.resolve().then(() => {
+              if (e.defaultPrevented && lines[i] === line) {
+                lines[i] = line + "  [PREVENTED]";
+                render();
+              }
+            });
+          },
+          true,
+        );
+      }
+
+      // Panel state transitions
+      for (const [name, panel] of [
+        ["INPUT-VARIANT", document.querySelector("#combo .pc-combo-box__panel")],
+        ["TRIGGER-VARIANT", document.querySelector("#tcombo .pc-combo-box__panel")],
+      ]) {
+        new MutationObserver(() => {
+          say(`==== ${name} PANEL ${panel.hidden ? "CLOSED" : "OPENED"} ====`, true);
+        }).observe(panel, { attributes: true, attributeFilter: ["hidden"] });
+      }
+
+      // Mount the real hooks
+      for (const root of document.querySelectorAll(".pc-combo-box")) {
+        const h = Object.create(hooks.PetalComboBox);
+        h.el = root;
+        h.mounted();
+      }
+
+      // Outline each chevron's true box
+      function outlineChevrons() {
+        document.querySelectorAll(".chev-box").forEach((b) => b.remove());
+        for (const chev of document.querySelectorAll(".pc-combo-box__chevron")) {
+          const r = chev.getBoundingClientRect();
+          if (!r.width) continue;
+          const box = document.createElement("div");
+          box.className = "chev-box";
+          box.style.left = `${r.left + window.scrollX - 2}px`;
+          box.style.top = `${r.top + window.scrollY - 2}px`;
+          box.style.width = `${r.width + 4}px`;
+          box.style.height = `${r.height + 4}px`;
+          document.body.appendChild(box);
+        }
+      }
+      outlineChevrons();
+      window.addEventListener("resize", outlineChevrons);
+      say("ready - tap away (UA: " + navigator.userAgent.slice(0, 80) + ")", true);
+
+      document.getElementById("clear-btn").addEventListener("click", (e) => {
+        e.stopPropagation();
+        lines.length = 0; n = 0; logEl.textContent = ""; counter.textContent = "";
+      });
+      document.getElementById("copy-btn").addEventListener("click", async (e) => {
+        e.stopPropagation();
+        try {
+          await navigator.clipboard.writeText(lines.join("\n"));
+          say("(log copied)", true);
+        } catch {
+          say("(copy failed - long-press the log to select)", true);
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/dev/static/tap-debug.html
+++ b/dev/static/tap-debug.html
@@ -62,6 +62,34 @@
         <div class="pc-combo-box__live" data-pc-combo-live aria-live="polite"></div>
       </div>
 
+      <h2>1b. Input variant - chevron with pointer-events:auto</h2>
+      <p class="hint">Identical to 1, but the chevron accepts events itself. If tapping ITS red box works while 1's is dead, we have the cause.</p>
+      <div id="combo2" class="pc-combo-box" style="max-width: 20rem">
+        <select id="combo2-select" name="city2" class="pc-combo-box__select" tabindex="-1" aria-hidden="true" inert>
+          <option value=""></option>
+          <option value="ber">Berlin</option>
+          <option value="opo">Porto</option>
+          <option value="sel">Seoul</option>
+        </select>
+        <div class="pc-combo-box__control">
+          <div class="pc-combo-box__content">
+            <input type="text" id="combo2-input" class="pc-combo-box__input" role="combobox"
+              aria-expanded="false" aria-autocomplete="list" aria-controls="combo2-listbox"
+              autocomplete="off" autocorrect="off" spellcheck="false" placeholder="p-e:auto chevron…" />
+          </div>
+          <span class="hero-chevron-down-mini pc-combo-box__chevron" style="pointer-events: auto"></span>
+        </div>
+        <div class="pc-combo-box__panel" data-pc-combo-panel hidden>
+          <div role="listbox" id="combo2-listbox" class="pc-combo-box__list" aria-label="Cities 2">
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="ber" data-label="Berlin" aria-selected="false"><span class="pc-combo-box__option-label">Berlin</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="opo" data-label="Porto" aria-selected="false"><span class="pc-combo-box__option-label">Porto</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div role="option" class="pc-combo-box__option" data-pc-combo-item data-value="sel" data-label="Seoul" aria-selected="false"><span class="pc-combo-box__option-label">Seoul</span><span class="hero-check-mini pc-combo-box__check"></span></div>
+            <div class="pc-combo-box__empty" data-pc-combo-empty hidden>No results found</div>
+          </div>
+        </div>
+        <div class="pc-combo-box__live" data-pc-combo-live aria-live="polite"></div>
+      </div>
+
       <h2>2. Trigger variant</h2>
       <p class="hint">Open it, then tap the button again — the close that fails on device.</p>
       <div id="tcombo" class="pc-combo-box" style="max-width: 20rem">
@@ -178,6 +206,7 @@
       // Panel state transitions
       for (const [name, panel] of [
         ["INPUT-VARIANT", document.querySelector("#combo .pc-combo-box__panel")],
+        ["PE-AUTO-VARIANT", document.querySelector("#combo2 .pc-combo-box__panel")],
         ["TRIGGER-VARIANT", document.querySelector("#tcombo .pc-combo-box__panel")],
       ]) {
         new MutationObserver(() => {

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -203,7 +203,10 @@ defmodule PetalComponents.ComboBox do
         :if={@variant == "trigger"}
         type="button"
         id={"#{@id}-trigger"}
-        class="pc-combo-box__trigger"
+        class={[
+          "pc-combo-box__trigger",
+          @clearable && !@multiple && "pc-combo-box__trigger--clearable"
+        ]}
         role="combobox"
         aria-haspopup="listbox"
         aria-expanded="false"
@@ -219,6 +222,21 @@ defmodule PetalComponents.ComboBox do
           data-count-label={@count_label}
         >{@trigger_label}</span>
         <.icon name="hero-chevron-down-mini" class="pc-combo-box__chevron" />
+      </button>
+
+      <%!-- a button cannot nest inside the trigger button, so the clear is a
+      sibling positioned over the trigger's right rail (Base UI anatomy);
+      the same data-has-value gate the input variant uses shows it only
+      when something is chosen --%>
+      <button
+        :if={@variant == "trigger" && @clearable && !@multiple}
+        type="button"
+        class="pc-combo-box__trigger-clear"
+        data-pc-combo-clear
+        aria-label={@clear_label}
+        disabled={@disabled}
+      >
+        <.icon name="hero-x-mark-mini" class="pc-combo-box__clear-icon" />
       </button>
 
       <div :if={@variant == "input"} class="pc-combo-box__control">

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -38,6 +38,7 @@ defmodule PetalComponents.Showcase.ComboBox do
         id="sx-combo-basic"
         name="country"
         placeholder="Select a country…"
+        clearable
         options={[
           {"🇦🇺 Australia", "au"},
           {"🇯🇵 Japan", "jp"},

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -80,6 +80,7 @@ defmodule PetalComponents.Showcase.ComboBox do
       <.combo_box
         id="sx-combo-trigger"
         name="assignee"
+        clearable
         variant="trigger"
         placeholder="Assign to…"
         options={[

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -117,6 +117,7 @@ defmodule PetalComponents.Showcase.ComboBox do
       <.combo_box
         id="sx-combo-rich"
         name="assignee"
+        clearable
         placeholder="Assign to…"
         options={[
           {"Amelia Ward", "amelia", role: "Engineering"},
@@ -144,6 +145,7 @@ defmodule PetalComponents.Showcase.ComboBox do
     <div class="w-full max-w-xs mx-auto">
       <.combo_box
         id="sx-combo-groups"
+        clearable
         name="city"
         placeholder="Pick a city…"
         options={[

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -198,6 +198,29 @@ describe("open and close", () => {
     expect(c.input.value).toBe("syd");
   });
 
+  it("an abandoned chrome press never poisons a later caret click", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    type(c.input, "syd");
+    // press the chevron but release outside the control - no control
+    // click ever fires to consume the record
+    c.control.dispatchEvent(pointerEvent("pointerdown", "touch"));
+    document.body.dispatchEvent(pointerEvent("pointerup", "touch"));
+    // a later synthetic caret click (assistive tech) must stay caret work
+    c.input.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(c.panel.hidden).toBe(false);
+    expect(c.input.value).toBe("syd");
+  });
+
+  it("a cancelled chrome press clears the same way", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    c.control.dispatchEvent(pointerEvent("pointerdown", "touch"));
+    document.body.dispatchEvent(pointerEvent("pointercancel", "touch"));
+    c.input.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(c.panel.hidden).toBe(false);
+  });
+
   it("chrome pointerdowns are preventDefaulted so the input never blurs mid-press (the desktop flash)", () => {
     const c = mountCombo({ options: CITIES });
     c.control.click();

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -241,6 +241,25 @@ describe("open and close", () => {
     expect(c.panel.hidden).toBe(true);
   });
 
+  it("reverse release order: the chevron press still closes after the other finger lifts", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    // finger 1 presses the chevron (chrome), finger 2 brushes the input,
+    // finger 2 lifts off-control FIRST, then finger 1 completes its press
+    c.control.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { pointerId: 1 }),
+    );
+    c.input.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { pointerId: 2 }),
+    );
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "touch", { pointerId: 2 }),
+    );
+    // the click arrives carrying finger 1's pointerId (modern browsers)
+    c.input.dispatchEvent(pointerEvent("click", "touch", { pointerId: 1 }));
+    expect(c.panel.hidden).toBe(true);
+  });
+
   it("a cancelled chrome press clears the same way", () => {
     const c = mountCombo({ options: CITIES });
     c.control.click();

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -260,6 +260,28 @@ describe("open and close", () => {
     expect(c.panel.hidden).toBe(true);
   });
 
+  it("a trailing click from the same gesture never reopens a deliberate chrome close", async () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    expect(c.panel.hidden).toBe(false);
+    // finger 1 presses and clicks the chevron - deliberate close
+    c.control.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { pointerId: 1 }),
+    );
+    c.control.dispatchEvent(pointerEvent("click", "touch", { pointerId: 1 }));
+    expect(c.panel.hidden).toBe(true);
+    // finger 2's trailing click (same burst) must not reopen
+    c.input.dispatchEvent(pointerEvent("click", "touch", { pointerId: 2 }));
+    expect(c.panel.hidden).toBe(true);
+    // after the burst settles, a fresh click opens as normal
+    await new Promise((r) => setTimeout(r, 0));
+    c.control.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { pointerId: 3 }),
+    );
+    c.control.dispatchEvent(pointerEvent("click", "touch", { pointerId: 3 }));
+    expect(c.panel.hidden).toBe(false);
+  });
+
   it("a cancelled chrome press clears the same way", () => {
     const c = mountCombo({ options: CITIES });
     c.control.click();

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -212,6 +212,35 @@ describe("open and close", () => {
     expect(c.input.value).toBe("syd");
   });
 
+  it("interleaved pointers disarm - one finger's click never consumes another's verdict", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    type(c.input, "syd");
+    // finger 1 rests on the input (caret), finger 2 presses the chevron
+    c.input.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { pointerId: 1 }),
+    );
+    c.control.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { pointerId: 2 }),
+    );
+    // finger 1's click must NOT consume finger 2's chrome verdict
+    c.input.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(c.panel.hidden).toBe(false);
+    expect(c.input.value).toBe("syd");
+    // both released; a normal single chevron press still toggles
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "touch", { pointerId: 1 }),
+    );
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "touch", { pointerId: 2 }),
+    );
+    c.control.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { pointerId: 3 }),
+    );
+    c.control.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(c.panel.hidden).toBe(true);
+  });
+
   it("a cancelled chrome press clears the same way", () => {
     const c = mountCombo({ options: CITIES });
     c.control.click();

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -74,7 +74,7 @@ function mountCombo({
         data-pc-combo-trigger data-placeholder="true">
         <span class="pc-combo-box__trigger-label" data-pc-combo-trigger-label
           data-placeholder-text="Pick..." data-count-label="selected">Pick...</span>
-      </button>`
+      </button>${clearable ? '<button type="button" class="pc-combo-box__trigger-clear" data-pc-combo-clear aria-label="Clear selection"><span class="hero-x-mark-mini pc-combo-box__clear-icon"></span></button>' : ""}`
     : `<div class="pc-combo-box__control">
       <div class="pc-combo-box__content">
         ${multiple ? '<div class="pc-combo-box__chips" data-pc-combo-chips data-remove-label="Remove"></div>' : ""}
@@ -466,6 +466,38 @@ describe("open and close", () => {
       }),
     );
     expect(c.panel.hidden).toBe(false);
+  });
+
+  it("the trigger variant's clear empties the value, restores the placeholder label, and never toggles the panel", () => {
+    const c = mountCombo({ options: CITIES, trigger: true, clearable: true });
+    c.trigger.click();
+    c.items()[1].click();
+    expect(c.select.value).toBe("tyo");
+    expect(c.triggerLabel().textContent).toBe("Tokyo");
+    expect(c.panel.hidden).toBe(true);
+    let changes = 0;
+    c.select.addEventListener("change", () => changes++);
+    c.el.querySelector("[data-pc-combo-clear]").click();
+    expect(c.select.value).toBe("");
+    expect(c.triggerLabel().textContent).toBe("Pick...");
+    expect(c.trigger.getAttribute("data-placeholder")).toBe("true");
+    expect(c.el.hasAttribute("data-has-value")).toBe(false);
+    expect(c.panel.hidden).toBe(true);
+    expect(changes).toBe(1);
+  });
+
+  it("the input variant's clear dispatches exactly one change through the direct binding", () => {
+    const c = mountCombo({ options: CITIES, clearable: true });
+    c.control.click();
+    c.items()[0].click();
+    expect(c.select.value).toBe("syd");
+    let changes = 0;
+    c.select.addEventListener("change", () => changes++);
+    c.el.querySelector("[data-pc-combo-clear]").click();
+    expect(c.select.value).toBe("");
+    expect(c.input.value).toBe("");
+    expect(changes).toBe(1);
+    expect(c.panel.hidden).toBe(true);
   });
 
   it("a press that starts inside the combobox and releases outside does not dismiss", () => {

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -8,7 +8,7 @@
 // the boundary cycle, selection through the hidden select, and the
 // keystroke containment that keeps typing out of enclosing phx-change
 // forms.
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import hooks from "../../assets/js/petal_components.js";
 
@@ -260,7 +260,8 @@ describe("open and close", () => {
     expect(c.panel.hidden).toBe(true);
   });
 
-  it("a trailing click from the same gesture never reopens a deliberate chrome close", async () => {
+  it("a trailing click from the same gesture never reopens a deliberate chrome close", () => {
+    const clock = vi.spyOn(performance, "now").mockReturnValue(10_000);
     const c = mountCombo({ options: CITIES });
     c.control.click();
     expect(c.panel.hidden).toBe(false);
@@ -273,13 +274,52 @@ describe("open and close", () => {
     // finger 2's trailing click (same burst) must not reopen
     c.input.dispatchEvent(pointerEvent("click", "touch", { pointerId: 2 }));
     expect(c.panel.hidden).toBe(true);
-    // after the burst settles, a fresh click opens as normal
-    await new Promise((r) => setTimeout(r, 0));
+    // once the burst window passes, a fresh click opens as normal
+    clock.mockReturnValue(10_400);
     c.control.dispatchEvent(
       pointerEvent("pointerdown", "touch", { pointerId: 3 }),
     );
     c.control.dispatchEvent(pointerEvent("click", "touch", { pointerId: 3 }));
     expect(c.panel.hidden).toBe(false);
+    clock.mockRestore();
+  });
+
+  it("Safari's late-synthesized click still finds its verdict - no timer race", () => {
+    const clock = vi.spyOn(performance, "now").mockReturnValue(20_000);
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    // chevron press releases ON the control; the click arrives later
+    // than every queued task (iOS synthesis delay)
+    c.control.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { pointerId: 1 }),
+    );
+    c.control.dispatchEvent(
+      pointerEvent("pointerup", "touch", { pointerId: 1 }),
+    );
+    clock.mockReturnValue(20_400);
+    c.input.dispatchEvent(pointerEvent("click", "touch", { pointerId: 1 }));
+    expect(c.panel.hidden).toBe(true);
+    clock.mockRestore();
+  });
+
+  it("a leftover verdict older than a second cannot poison a synthetic caret click", () => {
+    const clock = vi.spyOn(performance, "now").mockReturnValue(30_000);
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    type(c.input, "syd");
+    // chevron press whose click never arrives (released on-control)
+    c.control.dispatchEvent(
+      pointerEvent("pointerdown", "touch", { pointerId: 1 }),
+    );
+    c.control.dispatchEvent(
+      pointerEvent("pointerup", "touch", { pointerId: 1 }),
+    );
+    // much later, a synthetic caret click (assistive tech)
+    clock.mockReturnValue(31_500);
+    c.input.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(c.panel.hidden).toBe(false);
+    expect(c.input.value).toBe("syd");
+    clock.mockRestore();
   });
 
   it("a cancelled chrome press clears the same way", () => {

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -487,17 +487,47 @@ describe("open and close", () => {
     expect(c.panel.hidden).toBe(false);
   });
 
-  it("focusout to an element outside closes and restores the display", () => {
+  it("focusout to an element outside closes and restores the display", async () => {
     const c = mountCombo({ options: CITIES });
     c.select.value = "tyo";
     c.hook.syncFromSelect();
     c.control.click();
     type(c.input, "sy");
+    // focus genuinely leaves the component, then the event reports it
+    c.input.blur();
     c.el.dispatchEvent(
       new FocusEvent("focusout", { relatedTarget: document.body }),
     );
+    // the close verifies where focus actually landed one tick later
+    await new Promise((r) => setTimeout(r, 0));
     expect(c.panel.hidden).toBe(true);
     expect(c.input.value).toBe("Tokyo");
+  });
+
+  it("a null-relatedTarget focusout does NOT close when focus stayed inside (the iOS trigger flash)", async () => {
+    // iOS reports relatedTarget null even when focus moves WITHIN the
+    // component - trusting it closed the panel mid-tap and the trigger
+    // click then reopened it, an endless flash (device-log verified)
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    c.input.focus();
+    c.el.dispatchEvent(new FocusEvent("focusout", { relatedTarget: null }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(c.panel.hidden).toBe(false);
+  });
+
+  it("the trigger variant closes on a second trigger tap even when focusout reports null", async () => {
+    const c = mountCombo({ options: CITIES, trigger: true });
+    c.trigger.click();
+    expect(c.panel.hidden).toBe(false);
+    // iOS tap on the trigger: input blurs with relatedTarget null while
+    // focus actually lands on the button - the panel must survive the
+    // focusout and let the click toggle it closed
+    c.trigger.focus();
+    c.el.dispatchEvent(new FocusEvent("focusout", { relatedTarget: null }));
+    c.trigger.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(c.panel.hidden).toBe(true);
   });
 
   it("Escape closes when open and is consumed; passes through when closed", () => {

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -176,6 +176,45 @@ describe("open and close", () => {
     expect(c.input.value).toBe("syd");
   });
 
+  it("a tap in the chevron's box closes even when iOS snaps the target onto the input", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    expect(c.panel.hidden).toBe(false);
+    // iOS Safari's tap-target correction reassigns a chevron tap to the
+    // nearby text field - target says input, coordinates say chevron
+    c.hook.chevron.getBoundingClientRect = () => ({
+      left: 300,
+      right: 320,
+      top: 10,
+      bottom: 30,
+      width: 20,
+      height: 20,
+    });
+    c.input.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, clientX: 310, clientY: 20 }),
+    );
+    expect(c.panel.hidden).toBe(true);
+  });
+
+  it("a genuine input click away from the chevron box is still caret work", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    type(c.input, "syd");
+    c.hook.chevron.getBoundingClientRect = () => ({
+      left: 300,
+      right: 320,
+      top: 10,
+      bottom: 30,
+      width: 20,
+      height: 20,
+    });
+    c.input.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, clientX: 80, clientY: 20 }),
+    );
+    expect(c.panel.hidden).toBe(false);
+    expect(c.input.value).toBe("syd");
+  });
+
   it("a click on control chrome (the chevron) toggles closed", () => {
     const c = mountCombo({ options: CITIES });
     c.control.click();

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -274,8 +274,8 @@ describe("open and close", () => {
     // finger 2's trailing click (same burst) must not reopen
     c.input.dispatchEvent(pointerEvent("click", "touch", { pointerId: 2 }));
     expect(c.panel.hidden).toBe(true);
-    // once the burst window passes, a fresh click opens as normal
-    clock.mockReturnValue(10_400);
+    // a RAPID follow-up tap (same instant, fresh pointerdown) reopens -
+    // suppression ends at the next pointerdown, not a time window
     c.control.dispatchEvent(
       pointerEvent("pointerdown", "touch", { pointerId: 3 }),
     );

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -176,43 +176,40 @@ describe("open and close", () => {
     expect(c.input.value).toBe("syd");
   });
 
-  it("a tap in the chevron's box closes even when iOS snaps the target onto the input", () => {
+  it("a chevron tap closes even when iOS snaps the click onto the input", () => {
     const c = mountCombo({ options: CITIES });
     c.control.click();
     expect(c.panel.hidden).toBe(false);
-    // iOS Safari's tap-target correction reassigns a chevron tap to the
-    // nearby text field - target says input, coordinates say chevron
-    c.hook.chevron.getBoundingClientRect = () => ({
-      left: 300,
-      right: 320,
-      top: 10,
-      bottom: 30,
-      width: 20,
-      height: 20,
-    });
-    c.input.dispatchEvent(
-      new MouseEvent("click", { bubbles: true, clientX: 310, clientY: 20 }),
-    );
+    // the pointerdown hit-tests the REAL touch point (control chrome);
+    // iOS tap-target correction then rewrites the synthesized click's
+    // target AND coordinates onto the nearby text field
+    c.control.dispatchEvent(pointerEvent("pointerdown", "touch"));
+    c.input.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(c.panel.hidden).toBe(true);
   });
 
-  it("a genuine input click away from the chevron box is still caret work", () => {
+  it("an input press is caret work even if the click reports the control", () => {
     const c = mountCombo({ options: CITIES });
     c.control.click();
     type(c.input, "syd");
-    c.hook.chevron.getBoundingClientRect = () => ({
-      left: 300,
-      right: 320,
-      top: 10,
-      bottom: 30,
-      width: 20,
-      height: 20,
-    });
-    c.input.dispatchEvent(
-      new MouseEvent("click", { bubbles: true, clientX: 80, clientY: 20 }),
-    );
+    c.input.dispatchEvent(pointerEvent("pointerdown", "touch"));
+    c.control.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(c.panel.hidden).toBe(false);
     expect(c.input.value).toBe("syd");
+  });
+
+  it("chrome pointerdowns are preventDefaulted so the input never blurs mid-press (the desktop flash)", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    const onChrome = pointerEvent("pointerdown", "mouse", { cancelable: true });
+    c.control.dispatchEvent(onChrome);
+    expect(onChrome.defaultPrevented).toBe(true);
+    c.control.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(c.panel.hidden).toBe(true);
+    // ...but a press on the input itself keeps its default (caret, focus)
+    const onInput = pointerEvent("pointerdown", "mouse", { cancelable: true });
+    c.input.dispatchEvent(onInput);
+    expect(onInput.defaultPrevented).toBe(false);
   });
 
   it("a click on control chrome (the chevron) toggles closed", () => {

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -337,6 +337,31 @@ defmodule PetalComponents.ComboBoxTest do
     end
   end
 
+  test "trigger variant with clearable renders the sibling clear over the rail" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box id="t" name="who" variant="trigger" clearable value="a" options={[{"A", "a"}]} />
+      """)
+
+    assert html =~ "pc-combo-box__trigger-clear"
+    assert html =~ "pc-combo-box__trigger--clearable"
+    # the clear is a SIBLING, never nested inside the trigger button
+    [before_panel, _] = String.split(html, "pc-combo-box__panel", parts: 2)
+
+    assert before_panel =~
+             ~r/<\/button>\s*(<!--.*?-->\s*)?<button[^>]*pc-combo-box__trigger-clear/s
+
+    # multiple never renders a trigger clear (the panel toggles are the road back)
+    multi =
+      rendered_to_string(~H"""
+      <.combo_box id="tm" name="who" variant="trigger" clearable multiple options={[{"A", "a"}]} />
+      """)
+
+    refute multi =~ "pc-combo-box__trigger-clear"
+  end
+
   test "raises without any id source" do
     assigns = %{}
 


### PR DESCRIPTION
Nic's iOS find (the last of the device pass): once open, tapping the chevron didn't close the panel on iOS - only tapping away did. Desktop has always toggled closed on chevron click (committed spec), so this was mobile-only.

## Root cause

The chevron is `pointer-events-none` by the icon-anatomy doctrine, so the tap should land on the control and hit the toggle branch. But iOS Safari's tap-target correction snaps taps near a text field **onto the field** - a deliberate chevron tap arrives with `target === input`, and an input click is deliberately treated as caret work (closing would discard the active query).

## Fix

Geometry outranks the browser's target reassignment: `inChevronBox(e)` tests the click coordinates against the chevron's rect, inflated 8px for thumbs. A click in that box closes the panel regardless of target; genuine input clicks away from the box stay caret work. Guarded on a real layout - zero-width rects (jsdom, hidden elements) never match. No anatomy change: the icon stays decorative, the control still owns the interaction.

## Tests

2 new specs (snapped-target tap closes; away-from-box input click keeps panel + query). Suites: 755 Elixir / 57 JS green (branch is off main, pre-#554).

Note: GitHub Actions is still recovering from today's outage - CI may need a manual rerun.