### PR TITLE
feat(combo_box): M3a - the slot family (:header, :footer, :selected, :chip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 
 #### Added
 
+- **`combo_box` M3a - the slot family completes: `:header`, `:footer`,
+  `:selected`, `:chip`.** All four speak the `:option` slot's grammar
+  (`:let` receives normalized options with `meta`), all render-only, no
+  new hook state machines. `:header`/`:footer` are panel chrome OUTSIDE
+  the listbox - captions, counts, manage links - keyboard navigation
+  and filtering never touch them. `:selected` renders rich closed-state
+  content in the trigger (colored label dots with a "+N" overflow is
+  pure composition, not an attr); `:chip` renders rich chips with the
+  remove button intact. Both closed-state slots reconcile by
+  server-wins-on-patch: client picks show plain optimistic text, the
+  LiveView patch swaps the rich content back in, and fresh
+  server-rendered DOM is left untouched whenever it already matches
+  the selection (value-stamped diffing on the label and per-chip
+  `data-value`).
+
 - **`DataTable.State` + the in-memory engine - the 4.12 data table
   foundation.** `PetalComponents.DataTable.State` is the whole backend
   contract in one struct (multi-sort `order_by`, typed `filters`, page,

--- a/assets/default.css
+++ b/assets/default.css
@@ -2242,6 +2242,17 @@
   .pc-combo-box__check.pc-combo-box__check {
     @apply w-4! h-4!;
   }
+  /* panel chrome: header above the list, footer below - OUTSIDE the
+     listbox, so keyboard navigation and filtering never touch them */
+  .pc-combo-box__header {
+    @apply border-b border-gray-200 px-3 py-2 text-xs text-gray-500 dark:border-gray-400/25 dark:text-gray-400;
+  }
+  .pc-combo-box__footer {
+    @apply border-t border-gray-200 px-3 py-2 text-xs text-gray-500 dark:border-gray-400/25 dark:text-gray-400;
+  }
+  .pc-combo-box__selected-content {
+    @apply flex min-w-0 items-center gap-2 truncate;
+  }
   .pc-combo-box__empty {
     @apply px-2 py-6 text-center text-sm text-gray-500 dark:text-gray-400;
   }

--- a/assets/default.css
+++ b/assets/default.css
@@ -2286,7 +2286,7 @@
     border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.375rem), 0px);
   }
   .pc-combo-box__chip-label {
-    @apply truncate;
+    @apply flex min-w-0 items-center gap-1.5 truncate;
   }
   /* interactive in-field icon = a real button: hit target, focus ring */
   .pc-combo-box__chip-remove {
@@ -2553,6 +2553,10 @@
 
   /* Avatars - sizes */
 
+  /* dense contexts: chips, table cells - the reui/shadcn size-4/5 band */
+  .pc-avatar--2xs {
+    @apply h-5 w-5 text-[10px];
+  }
   .pc-avatar--xs {
     @apply text-xs w-7 h-7;
   }

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4039,6 +4039,44 @@ export const PetalComboBox = {
       need.set(v, left - 1);
       this.chips.appendChild(this.buildChip(v));
     }
+    this.applyChipOrder();
+  },
+
+  // The server's chosen order arrives via data-order (data attrs still
+  // update on phx-update=ignore containers). Enforce it after membership
+  // reconciliation; chips the server does not know yet (client picks
+  // awaiting their patch) keep their spot at the end.
+  applyChipOrder() {
+    let order = null;
+    try {
+      order = JSON.parse(this.chips.dataset.order || "null");
+    } catch {
+      order = null;
+    }
+    if (!Array.isArray(order)) return;
+    const byValue = new Map();
+    const current = [];
+    for (const chip of Array.from(
+      this.chips.querySelectorAll("[data-pc-combo-chip]"),
+    )) {
+      current.push(chip);
+      const v = chip.dataset.value;
+      if (!byValue.has(v)) byValue.set(v, []);
+      byValue.get(v).push(chip);
+    }
+    const seq = [];
+    for (const v of order) {
+      const arr = byValue.get(v);
+      if (arr && arr.length) seq.push(arr.shift());
+    }
+    for (const arr of byValue.values()) seq.push(...arr);
+    if (
+      seq.length === current.length &&
+      seq.every((c, i) => c === current[i])
+    ) {
+      return;
+    }
+    for (const chip of seq) this.chips.appendChild(chip);
   },
 
   buildChip(value) {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3540,6 +3540,15 @@ export const PetalToast = {
 // hidden, never reordered - the server owns DOM order. aria-selected tracks
 // the CHOSEN option (the check mark); the keyboard highlight is virtual:
 // data-highlighted + aria-activedescendant.
+// Same selection, any order: server-rendered rich content follows chosen
+// order while the hook reads DOM option order - freshness checks compare
+// membership, never sequence.
+function sameValueSet(a, b) {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return set.size === a.length ? b.every((v) => set.has(v)) : false;
+}
+
 export const PetalComboBox = {
   mounted() {
     this.select = this.el.querySelector(".pc-combo-box__select");
@@ -3996,7 +4005,9 @@ export const PetalComboBox = {
     const have = Array.from(
       this.chips.querySelectorAll("[data-pc-combo-chip]"),
     ).map((c) => c.dataset.value);
-    if (want.length === have.length && want.every((v, i) => v === have[i])) {
+    // set comparison: server chips follow chosen order, the select follows
+    // option order - both describe the same selection
+    if (sameValueSet(want, have)) {
       return;
     }
     const removeLabel = (this.chips.dataset.removeLabel || "Remove") + " ";
@@ -4047,10 +4058,13 @@ export const PetalComboBox = {
     // patch that just landed), leave the rich DOM alone - overwrite with
     // optimistic text only for client-side changes, and drop the marker
     // so later syncs stay optimistic until the next patch.
+    // Order differences are legitimate: the server renders chosen order
+    // (chips follow pick order by design) while the hook reads DOM option
+    // order - so freshness is a SET comparison, never a sequence one.
     let labelIsFresh = false;
     if (this.triggerLabel && this.triggerLabel.dataset.customLabel != null) {
       const rendered = this.triggerLabel.dataset.values;
-      if (rendered != null && rendered === values.join("\u001f")) {
+      if (rendered != null && sameValueSet(rendered.split("\u001f"), values)) {
         labelIsFresh = true;
       } else {
         delete this.triggerLabel.dataset.values;

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3986,6 +3986,19 @@ export const PetalComboBox = {
 
   syncChips() {
     if (!this.chips) return;
+    // server-rendered chips may carry rich :chip slot content - leave the
+    // DOM alone whenever it already matches the selection, and rebuild
+    // plain-text chips only for client-side changes (the LiveView patch
+    // then swaps the rich ones back in: server wins on patch)
+    const want = Array.from(this.select.selectedOptions)
+      .map((o) => o.value)
+      .filter((v) => v !== "");
+    const have = Array.from(
+      this.chips.querySelectorAll("[data-pc-combo-chip]"),
+    ).map((c) => c.dataset.value);
+    if (want.length === have.length && want.every((v, i) => v === have[i])) {
+      return;
+    }
     const removeLabel = (this.chips.dataset.removeLabel || "Remove") + " ";
     this.chips.textContent = "";
     for (const option of this.select.selectedOptions) {
@@ -3993,6 +4006,7 @@ export const PetalComboBox = {
       const chip = document.createElement("span");
       chip.className = "pc-combo-box__chip";
       chip.setAttribute("data-pc-combo-chip", "");
+      chip.dataset.value = option.value;
       const label = document.createElement("span");
       label.className = "pc-combo-box__chip-label";
       label.textContent = option.textContent.trim();
@@ -4028,7 +4042,21 @@ export const PetalComboBox = {
       // the hook never touches the attribute, so a server-rendered
       // placeholder (including live changes to it) is always the truth
     }
-    if (this.triggerLabel) {
+    // :selected slot content is server-rendered; the label carries the
+    // values it was rendered for. When they match the selection (the
+    // patch that just landed), leave the rich DOM alone - overwrite with
+    // optimistic text only for client-side changes, and drop the marker
+    // so later syncs stay optimistic until the next patch.
+    let labelIsFresh = false;
+    if (this.triggerLabel && this.triggerLabel.dataset.customLabel != null) {
+      const rendered = this.triggerLabel.dataset.values;
+      if (rendered != null && rendered === values.join("\u001f")) {
+        labelIsFresh = true;
+      } else {
+        delete this.triggerLabel.dataset.values;
+      }
+    }
+    if (this.triggerLabel && !labelIsFresh) {
       const placeholder = this.triggerLabel.dataset.placeholderText;
       if (values.length === 0) {
         this.triggerLabel.textContent = placeholder || "";

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3810,8 +3810,20 @@ export const PetalComboBox = {
       if (this.trigger) this.trigger.setAttribute("aria-expanded", "true");
       this.positionPanel();
     }
+    // the highlight is client state too: the patch re-renders options
+    // without data-highlighted, and filter() would re-home on the first
+    // item (visible on iOS, masked by hover re-highlighting on desktop)
+    const keepHighlight = this.highlightedValue;
     this.syncFromSelect();
-    if (!this.panel.hidden) this.filter();
+    if (!this.panel.hidden) {
+      this.filter();
+      if (keepHighlight) {
+        const item = this.visibleItems().find(
+          (i) => i.dataset.value === keepHighlight,
+        );
+        if (item) this.highlight(item, false);
+      }
+    }
   },
 
   destroyed() {
@@ -4153,29 +4165,30 @@ export const PetalComboBox = {
         labelIsFresh = true;
         clearTimeout(this.labelPatchTimer);
         this.labelPatchTimer = null;
+        this.labelStaleSince = null;
       } else {
         delete this.triggerLabel.dataset.values;
         // a phx-change form means the patch that re-renders the rich
         // content is already on its way - keeping the briefly-stale rich
         // DOM reads better than flashing plain text for one round trip.
         // Unwired comboboxes get the honest optimistic text instead, and
-        // a grace timer self-heals wired ones whose handler never
-        // re-renders the value: past it, stale rich degrades to text.
+        // the grace window self-heals wired ones whose handler never
+        // re-renders the value. The window anchors to the FIRST
+        // divergence - continuing picks or unrelated patches never
+        // extend it, so a silent handler always degrades within 2s.
         const form = this.select.form;
-        if (
-          form &&
-          form.hasAttribute("phx-change") &&
-          values.length > 0 &&
-          !this.labelPatchOverdue
-        ) {
-          labelIsFresh = true;
-          clearTimeout(this.labelPatchTimer);
-          this.labelPatchTimer = setTimeout(() => {
-            this.labelPatchTimer = null;
-            this.labelPatchOverdue = true;
-            this.syncFromSelect();
-            this.labelPatchOverdue = false;
-          }, 2000);
+        if (form && form.hasAttribute("phx-change") && values.length > 0) {
+          if (this.labelStaleSince == null) {
+            this.labelStaleSince = performance.now();
+            clearTimeout(this.labelPatchTimer);
+            this.labelPatchTimer = setTimeout(() => {
+              this.labelPatchTimer = null;
+              this.syncFromSelect();
+            }, 2000);
+          }
+          if (performance.now() - this.labelStaleSince < 2000) {
+            labelIsFresh = true;
+          }
         }
       }
     }
@@ -4294,6 +4307,7 @@ export const PetalComboBox = {
   },
 
   highlight(item, scroll = true) {
+    this.highlightedValue = item ? item.dataset.value : null;
     for (const i of this.items())
       i.toggleAttribute("data-highlighted", i === item);
     if (item) {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3799,7 +3799,17 @@ export const PetalComboBox = {
   },
 
   updated() {
-    // LiveView patched the component - the select (server state) wins.
+    // LiveView patched the component - the select (server state) wins
+    // for SELECTION, but open-state belongs to the client: the server
+    // always renders the panel hidden, so a phx-change round-trip would
+    // otherwise slam the panel shut mid-multi-pick (Nic's find - reui
+    // and every peer keep it open). Re-assert and re-measure.
+    if (this.isOpen && this.panel.hidden) {
+      this.panel.hidden = false;
+      this.input.setAttribute("aria-expanded", "true");
+      if (this.trigger) this.trigger.setAttribute("aria-expanded", "true");
+      this.positionPanel();
+    }
     this.syncFromSelect();
     if (!this.panel.hidden) this.filter();
   },
@@ -3870,6 +3880,7 @@ export const PetalComboBox = {
 
   openPanel({ keepQuery = false } = {}) {
     if (!this.panel.hidden) return;
+    this.isOpen = true;
     this.panel.hidden = false;
     this.input.setAttribute("aria-expanded", "true");
     if (this.trigger) this.trigger.setAttribute("aria-expanded", "true");
@@ -3903,6 +3914,7 @@ export const PetalComboBox = {
     );
     window.removeEventListener("scroll", this.onReposition, true);
     window.removeEventListener("resize", this.onReposition);
+    this.isOpen = false;
     if (this.panel.hidden) return;
     this.panel.hidden = true;
     this.panel.removeAttribute("data-flip");
@@ -4041,7 +4053,16 @@ export const PetalComboBox = {
     chip.dataset.value = value;
     const label = document.createElement("span");
     label.className = "pc-combo-box__chip-label";
-    label.textContent = text;
+    // server-rendered :chip templates let client-built chips be RICH
+    // immediately - no round-trip pop-in, rich even without wiring
+    const tpl = Array.from(
+      this.el.querySelectorAll("template[data-pc-combo-chip-template]"),
+    ).find((t) => t.dataset.value === value);
+    if (tpl) {
+      label.appendChild(tpl.content.cloneNode(true));
+    } else {
+      label.textContent = text;
+    }
     const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "pc-combo-box__chip-remove";

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4002,45 +4002,57 @@ export const PetalComboBox = {
 
   syncChips() {
     if (!this.chips) return;
-    // server-rendered chips may carry rich :chip slot content - leave the
-    // DOM alone whenever it already matches the selection, and rebuild
-    // plain-text chips only for client-side changes (the LiveView patch
-    // then swaps the rich ones back in: server wins on patch)
+    // Incremental sync: chips whose value still belongs to the selection
+    // are NEVER touched - server-rendered rich :chip content survives
+    // both patches and client-side picks with zero flash. Surplus chips
+    // are removed, missing ones appended as plain optimistic chips (the
+    // LiveView patch swaps rich content in: server wins). Multiset
+    // counting keeps duplicate-value options honest.
     const want = Array.from(this.select.selectedOptions)
       .map((o) => o.value)
       .filter((v) => v !== "");
-    const have = Array.from(
+    const need = new Map();
+    for (const v of want) need.set(v, (need.get(v) || 0) + 1);
+    for (const chip of Array.from(
       this.chips.querySelectorAll("[data-pc-combo-chip]"),
-    ).map((c) => c.dataset.value);
-    // set comparison: server chips follow chosen order, the select follows
-    // option order - both describe the same selection
-    if (sameValueMultiset(want, have)) {
-      return;
+    )) {
+      const n = need.get(chip.dataset.value) || 0;
+      if (n > 0) need.set(chip.dataset.value, n - 1);
+      else chip.remove();
     }
+    for (const v of want) {
+      const left = need.get(v) || 0;
+      if (left === 0) continue;
+      need.set(v, left - 1);
+      this.chips.appendChild(this.buildChip(v));
+    }
+  },
+
+  buildChip(value) {
+    const option = Array.from(this.select.options).find(
+      (o) => o.value === value,
+    );
+    const text = option ? option.textContent.trim() : value;
     const removeLabel = (this.chips.dataset.removeLabel || "Remove") + " ";
-    this.chips.textContent = "";
-    for (const option of this.select.selectedOptions) {
-      if (option.value === "") continue;
-      const chip = document.createElement("span");
-      chip.className = "pc-combo-box__chip";
-      chip.setAttribute("data-pc-combo-chip", "");
-      chip.dataset.value = option.value;
-      const label = document.createElement("span");
-      label.className = "pc-combo-box__chip-label";
-      label.textContent = option.textContent.trim();
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = "pc-combo-box__chip-remove";
-      btn.setAttribute("data-pc-combo-chip-remove", "");
-      btn.dataset.value = option.value;
-      btn.setAttribute("aria-label", removeLabel + option.textContent.trim());
-      btn.tabIndex = -1;
-      const icon = document.createElement("span");
-      icon.className = "hero-x-mark-mini pc-combo-box__chip-remove-icon";
-      btn.appendChild(icon);
-      chip.append(label, btn);
-      this.chips.appendChild(chip);
-    }
+    const chip = document.createElement("span");
+    chip.className = "pc-combo-box__chip";
+    chip.setAttribute("data-pc-combo-chip", "");
+    chip.dataset.value = value;
+    const label = document.createElement("span");
+    label.className = "pc-combo-box__chip-label";
+    label.textContent = text;
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "pc-combo-box__chip-remove";
+    btn.setAttribute("data-pc-combo-chip-remove", "");
+    btn.dataset.value = value;
+    btn.setAttribute("aria-label", removeLabel + text);
+    btn.tabIndex = -1;
+    const icon = document.createElement("span");
+    icon.className = "hero-x-mark-mini pc-combo-box__chip-remove-icon";
+    btn.appendChild(icon);
+    chip.append(label, btn);
+    return chip;
   },
 
   syncFromSelect() {
@@ -4081,6 +4093,14 @@ export const PetalComboBox = {
         labelIsFresh = true;
       } else {
         delete this.triggerLabel.dataset.values;
+        // a phx-change form means the patch that re-renders the rich
+        // content is already on its way - keeping the briefly-stale rich
+        // DOM reads better than flashing plain text for one round trip.
+        // Unwired comboboxes get the honest optimistic text instead.
+        const form = this.select.form;
+        if (form && form.hasAttribute("phx-change") && values.length > 0) {
+          labelIsFresh = true;
+        }
       }
     }
     if (this.triggerLabel && !labelIsFresh) {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3541,12 +3541,19 @@ export const PetalToast = {
 // the CHOSEN option (the check mark); the keyboard highlight is virtual:
 // data-highlighted + aria-activedescendant.
 // Same selection, any order: server-rendered rich content follows chosen
-// order while the hook reads DOM option order - freshness checks compare
-// membership, never sequence.
-function sameValueSet(a, b) {
+// order while the hook reads DOM option order - freshness compares
+// MULTISETS (duplicate values are counted, never flattened), never
+// sequences.
+function sameValueMultiset(a, b) {
   if (a.length !== b.length) return false;
-  const set = new Set(a);
-  return set.size === a.length ? b.every((v) => set.has(v)) : false;
+  const counts = new Map();
+  for (const v of a) counts.set(v, (counts.get(v) || 0) + 1);
+  for (const v of b) {
+    const n = counts.get(v);
+    if (!n) return false;
+    counts.set(v, n - 1);
+  }
+  return true;
 }
 
 export const PetalComboBox = {
@@ -4007,7 +4014,7 @@ export const PetalComboBox = {
     ).map((c) => c.dataset.value);
     // set comparison: server chips follow chosen order, the select follows
     // option order - both describe the same selection
-    if (sameValueSet(want, have)) {
+    if (sameValueMultiset(want, have)) {
       return;
     }
     const removeLabel = (this.chips.dataset.removeLabel || "Remove") + " ";
@@ -4063,8 +4070,14 @@ export const PetalComboBox = {
     // order - so freshness is a SET comparison, never a sequence one.
     let labelIsFresh = false;
     if (this.triggerLabel && this.triggerLabel.dataset.customLabel != null) {
-      const rendered = this.triggerLabel.dataset.values;
-      if (rendered != null && sameValueSet(rendered.split("\u001f"), values)) {
+      // JSON-encoded stamp: no delimiter to collide with value contents
+      let rendered = null;
+      try {
+        rendered = JSON.parse(this.triggerLabel.dataset.values);
+      } catch {
+        rendered = null;
+      }
+      if (Array.isArray(rendered) && sameValueMultiset(rendered, values)) {
         labelIsFresh = true;
       } else {
         delete this.triggerLabel.dataset.values;

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3825,6 +3825,7 @@ export const PetalComboBox = {
       this.trigger.removeEventListener("keydown", this.onTriggerKeydown);
     }
     this.el.removeEventListener("focusout", this.onFocusOut);
+    clearTimeout(this.labelPatchTimer);
     if (this.clearButton) {
       this.clearButton.removeEventListener("click", this.onClearClick);
     }
@@ -4091,15 +4092,31 @@ export const PetalComboBox = {
       }
       if (Array.isArray(rendered) && sameValueMultiset(rendered, values)) {
         labelIsFresh = true;
+        clearTimeout(this.labelPatchTimer);
+        this.labelPatchTimer = null;
       } else {
         delete this.triggerLabel.dataset.values;
         // a phx-change form means the patch that re-renders the rich
         // content is already on its way - keeping the briefly-stale rich
         // DOM reads better than flashing plain text for one round trip.
-        // Unwired comboboxes get the honest optimistic text instead.
+        // Unwired comboboxes get the honest optimistic text instead, and
+        // a grace timer self-heals wired ones whose handler never
+        // re-renders the value: past it, stale rich degrades to text.
         const form = this.select.form;
-        if (form && form.hasAttribute("phx-change") && values.length > 0) {
+        if (
+          form &&
+          form.hasAttribute("phx-change") &&
+          values.length > 0 &&
+          !this.labelPatchOverdue
+        ) {
           labelIsFresh = true;
+          clearTimeout(this.labelPatchTimer);
+          this.labelPatchTimer = setTimeout(() => {
+            this.labelPatchTimer = null;
+            this.labelPatchOverdue = true;
+            this.syncFromSelect();
+            this.labelPatchOverdue = false;
+          }, 2000);
         }
       }
     }

--- a/dev.exs
+++ b/dev.exs
@@ -7393,7 +7393,7 @@ defmodule Dev.PlaygroundLive do
               <span class="truncate">{opt.label}</span>
             </:chip>
             <:option :let={opt}>
-              <.avatar size="2xs" name={opt.label} random_gradient />
+              <.avatar size="xs" name={opt.label} random_gradient />
               <span class="flex min-w-0 flex-col leading-tight">
                 <span class="truncate">{opt.label}</span>
                 <span class="truncate text-xs text-gray-500 dark:text-gray-400">

--- a/dev.exs
+++ b/dev.exs
@@ -7358,6 +7358,7 @@ defmodule Dev.PlaygroundLive do
                 class="h-3 w-3 shrink-0 rounded-full"
                 style={"background-color: #{opt.meta[:color]}"}
               ></span>
+              <span :if={length(chosen) == 1} class="truncate">{hd(chosen).label}</span>
               <span
                 :if={length(chosen) > 3}
                 class="text-xs tabular-nums text-gray-500 dark:text-gray-400"
@@ -7388,11 +7389,11 @@ defmodule Dev.PlaygroundLive do
             ]}
           >
             <:chip :let={opt}>
-              <.avatar size="xs" name={opt.label} random_gradient />
+              <.avatar size="2xs" name={opt.label} random_gradient />
               <span class="truncate">{opt.label}</span>
             </:chip>
             <:option :let={opt}>
-              <.avatar size="xs" name={opt.label} random_gradient />
+              <.avatar size="2xs" name={opt.label} random_gradient />
               <span class="flex min-w-0 flex-col leading-tight">
                 <span class="truncate">{opt.label}</span>
                 <span class="truncate text-xs text-gray-500 dark:text-gray-400">

--- a/dev.exs
+++ b/dev.exs
@@ -745,6 +745,7 @@ defmodule Dev.PlaygroundLive do
        checkbox: %{layout: "row", disabled: false, error: false},
        select: %{disabled: false, error: false, help: false},
        combo: %{disabled: false, chosen: nil},
+       rich: %{labels: ~w(feat bug imp des), team: ~w(amelia jonah)},
        radio: %{
          style: "cards",
          variant: "outline",
@@ -1434,6 +1435,14 @@ defmodule Dev.PlaygroundLive do
   # component, so the page proves it live
   def handle_event("pg_combo_change", %{"pg_city" => value}, socket),
     do: {:noreply, update(socket, :combo, &%{&1 | chosen: value})}
+
+  def handle_event("pg_rich_change", params, socket) do
+    {:noreply,
+     assign(socket, :rich, %{
+       labels: Map.get(params, "pg_labels", []),
+       team: Map.get(params, "pg_team", [])
+     })}
+  end
 
   def handle_event("ctl_checkbox", %{"k" => "layout", "v" => v}, socket) when v in ~w(row col),
     do: {:noreply, update(socket, :checkbox, &%{&1 | layout: v})}
@@ -7315,12 +7324,92 @@ defmodule Dev.PlaygroundLive do
         </div>
       </div>
 
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Rich closed states - live</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        The same :selected and :chip slots, wired to a real form with phx-change. Every pick
+        round-trips, so the server re-renders the rich content immediately - dots, +N, avatar
+        chips all track your choices live.
+      </p>
+      <div class="border border-gray-200 dark:border-gray-400/20 rounded-xl px-6 py-10">
+        <form
+          id="pg-rich-form"
+          phx-change="pg_rich_change"
+          class="mx-auto flex w-full max-w-sm flex-col gap-4"
+        >
+          <.combo_box
+            id="pg-combo-labels"
+            name="pg_labels"
+            variant="trigger"
+            multiple
+            placeholder="Labels…"
+            count_label="labels"
+            value={@rich.labels}
+            options={[
+              {"Feature", "feat", color: "#0ea5e9"},
+              {"Bug", "bug", color: "#f43f5e"},
+              {"Improvement", "imp", color: "#10b981"},
+              {"Design", "des", color: "#a855f7"},
+              {"Docs", "docs", color: "#f59e0b"}
+            ]}
+          >
+            <:selected :let={chosen}>
+              <span
+                :for={opt <- Enum.take(chosen, 3)}
+                class="h-3 w-3 shrink-0 rounded-full"
+                style={"background-color: #{opt.meta[:color]}"}
+              ></span>
+              <span
+                :if={length(chosen) > 3}
+                class="text-xs tabular-nums text-gray-500 dark:text-gray-400"
+              >
+                +{length(chosen) - 3}
+              </span>
+            </:selected>
+            <:option :let={opt}>
+              <span
+                class="h-2.5 w-2.5 shrink-0 rounded-full"
+                style={"background-color: #{opt.meta[:color]}"}
+              ></span>
+              <span class="truncate">{opt.label}</span>
+            </:option>
+          </.combo_box>
+
+          <.combo_box
+            id="pg-combo-team"
+            name="pg_team"
+            multiple
+            placeholder="Add members…"
+            value={@rich.team}
+            options={[
+              {"Amelia Ward", "amelia", role: "Engineering"},
+              {"Jonah Reyes", "jonah", role: "Design"},
+              {"Priya Anand", "priya", role: "Support"},
+              {"Tom Hale", "tom", role: "Engineering"}
+            ]}
+          >
+            <:chip :let={opt}>
+              <.avatar size="xs" name={opt.label} random_gradient />
+              <span class="truncate">{opt.label}</span>
+            </:chip>
+            <:option :let={opt}>
+              <.avatar size="xs" name={opt.label} random_gradient />
+              <span class="flex min-w-0 flex-col leading-tight">
+                <span class="truncate">{opt.label}</span>
+                <span class="truncate text-xs text-gray-500 dark:text-gray-400">
+                  {opt.meta[:role]}
+                </span>
+              </span>
+            </:option>
+          </.combo_box>
+        </form>
+      </div>
+
       <div
         :for={
           ex <-
             examples_for(
               PetalComponents.Showcase.ComboBox,
-              ~w(multiple trigger rich_options basic preselected groups)a
+              ~w(labels team panel_chrome multiple trigger rich_options basic preselected groups)a
             )
         }
         class="mt-10"

--- a/lib/petal_components/avatar.ex
+++ b/lib/petal_components/avatar.ex
@@ -5,7 +5,7 @@ defmodule PetalComponents.Avatar do
 
   attr(:src, :string, default: nil, doc: "hosted avatar URL")
   attr(:alt, :string, default: nil, doc: "alt text for avatar image")
-  attr(:size, :string, default: "md", values: ["xs", "sm", "md", "lg", "xl"])
+  attr(:size, :string, default: "md", values: ["2xs", "xs", "sm", "md", "lg", "xl"])
   attr(:class, :any, default: nil, doc: "CSS class")
   attr(:name, :string, default: nil, doc: "name for placeholder initials")
 
@@ -145,7 +145,7 @@ defmodule PetalComponents.Avatar do
     """
   end
 
-  attr(:size, :string, default: "md", values: ["xs", "sm", "md", "lg", "xl"])
+  attr(:size, :string, default: "md", values: ["2xs", "xs", "sm", "md", "lg", "xl"])
   attr(:class, :any, default: nil, doc: "CSS class")
   attr(:avatars, :list, default: [], doc: "list of your hosted avatar URLs")
 

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -397,6 +397,15 @@ defmodule PetalComponents.ComboBox do
         </div>
       </div>
 
+      <%!-- one inert template per option when :chip is present: the hook
+      clones these to build rich chips client-side instantly - no
+      round-trip pop-in, and unwired comboboxes get rich chips too --%>
+      <template
+        :for={opt <- (@chip != [] && @multiple && Enum.flat_map(@groups, & &1.options)) || []}
+        data-pc-combo-chip-template
+        data-value={opt.value}
+      >{render_slot(@chip, opt)}</template>
+
       <div
         class="pc-combo-box__live"
         data-pc-combo-live

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -289,6 +289,8 @@ defmodule PetalComponents.ComboBox do
           diff misalign - its skip markers landed on moved nodes and
           blanked chip icons. The hook reconciles from the select (server
           truth) plus the :chip templates, which stay server-owned. --%>
+          <%!-- data-* attrs still update on ignored elements - data-order
+          carries the server's chosen order so reorders reach the hook --%>
           <div
             :if={@multiple}
             id={"#{@id}-chips"}
@@ -296,6 +298,7 @@ defmodule PetalComponents.ComboBox do
             class="pc-combo-box__chips"
             data-pc-combo-chips
             data-remove-label={@remove_label}
+            data-order={Jason.encode!(@current_values)}
           >
             <span
               :for={opt <- @selected_options}

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -171,7 +171,9 @@ defmodule PetalComponents.ComboBox do
 
   def combo_box(assigns) do
     groups = normalize_options(assigns.options)
-    values = current_values(assigns)
+    # a native select can only select each option once - duplicated caller
+    # values are meaningless and would desync the freshness stamps
+    values = assigns |> current_values() |> Enum.uniq()
     id = resolve_id(assigns)
 
     assigns =
@@ -256,7 +258,7 @@ defmodule PetalComponents.ComboBox do
           data-placeholder-text={@placeholder}
           data-count-label={@count_label}
           data-custom-label={@selected != [] && "true"}
-          data-values={@selected != [] && Jason.encode!(@current_values)}
+          data-values={@selected != [] && Jason.encode!(Enum.map(@selected_options, & &1.value))}
         ><%= if @selected != [] && @current_values != [] do %>
           <span class="pc-combo-box__selected-content">{render_slot(@selected, @selected_options)}</span>
         <% else %>

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -256,7 +256,7 @@ defmodule PetalComponents.ComboBox do
           data-placeholder-text={@placeholder}
           data-count-label={@count_label}
           data-custom-label={@selected != [] && "true"}
-          data-values={@selected != [] && Enum.join(@current_values, "\x1f")}
+          data-values={@selected != [] && Jason.encode!(@current_values)}
         ><%= if @selected != [] && @current_values != [] do %>
           <span class="pc-combo-box__selected-content">{render_slot(@selected, @selected_options)}</span>
         <% else %>

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -134,6 +134,41 @@ defmodule PetalComponents.ComboBox do
     plain label, so rich content never affects search or the closed state.
     """
 
+  slot :header,
+    doc: """
+    panel chrome rendered above the option list (below the trigger
+    variant's search) - column captions, hints. Lives OUTSIDE the
+    listbox, so keyboard navigation and filtering never touch it.
+    """
+
+  slot :footer,
+    doc: """
+    panel chrome rendered below the option list - counts, "manage"
+    links. Lives OUTSIDE the listbox; pointer-interactive content works,
+    keyboard focus stays with the options.
+    """
+
+  slot :selected,
+    doc: """
+    trigger variant only: custom closed-state content rendered inside
+    the trigger in place of the plain label/count - avatars, colored
+    dots, "+N" summaries. `:let` receives the LIST of chosen normalized
+    option maps (`label`, `value`, `meta`). Client-side picks show the
+    plain optimistic text until the LiveView patch re-renders the slot -
+    the server-wins reconciliation the trigger label already uses. The
+    empty state always shows the placeholder.
+    """
+
+  slot :chip,
+    doc: """
+    multiple mode: custom chip content rendered in place of the plain
+    label - avatars, dots. `:let` receives the chosen normalized option
+    map. The remove button stays appended. Client-side picks build
+    plain-text chips optimistically until the LiveView patch re-renders
+    the rich ones (server wins); server-rendered chips are left intact
+    whenever they already match the selection.
+    """
+
   def combo_box(assigns) do
     groups = normalize_options(assigns.options)
     values = current_values(assigns)
@@ -220,7 +255,13 @@ defmodule PetalComponents.ComboBox do
           data-pc-combo-trigger-label
           data-placeholder-text={@placeholder}
           data-count-label={@count_label}
-        >{@trigger_label}</span>
+          data-custom-label={@selected != [] && "true"}
+          data-values={@selected != [] && Enum.join(@current_values, "\x1f")}
+        ><%= if @selected != [] && @current_values != [] do %>
+          <span class="pc-combo-box__selected-content">{render_slot(@selected, @selected_options)}</span>
+        <% else %>
+          {@trigger_label}
+        <% end %></span>
         <.icon name="hero-chevron-down-mini" class="pc-combo-box__chevron" />
       </button>
 
@@ -247,8 +288,17 @@ defmodule PetalComponents.ComboBox do
             data-pc-combo-chips
             data-remove-label={@remove_label}
           >
-            <span :for={opt <- @selected_options} class="pc-combo-box__chip" data-pc-combo-chip>
-              <span class="pc-combo-box__chip-label">{opt.label}</span>
+            <span
+              :for={opt <- @selected_options}
+              class="pc-combo-box__chip"
+              data-pc-combo-chip
+              data-value={opt.value}
+            >
+              <span class="pc-combo-box__chip-label"><%= if @chip != [] do %>
+                {render_slot(@chip, opt)}
+              <% else %>
+                {opt.label}
+              <% end %></span>
               <button
                 type="button"
                 class="pc-combo-box__chip-remove"
@@ -310,6 +360,9 @@ defmodule PetalComponents.ComboBox do
             placeholder={@search_placeholder}
           />
         </div>
+        <div :if={@header != []} class="pc-combo-box__header">
+          {render_slot(@header)}
+        </div>
         <div
           role="listbox"
           id={"#{@id}-listbox"}
@@ -336,6 +389,9 @@ defmodule PetalComponents.ComboBox do
             <% end %>
           <% end %>
           <div class="pc-combo-box__empty" data-pc-combo-empty hidden>{@no_results_text}</div>
+        </div>
+        <div :if={@footer != []} class="pc-combo-box__footer">
+          {render_slot(@footer)}
         </div>
       </div>
 

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -284,8 +284,15 @@ defmodule PetalComponents.ComboBox do
 
       <div :if={@variant == "input"} class="pc-combo-box__control">
         <div class="pc-combo-box__content">
+          <%!-- phx-update="ignore": after the initial render the HOOK is the
+          sole writer in here. Two writers on one region made LiveView's
+          diff misalign - its skip markers landed on moved nodes and
+          blanked chip icons. The hook reconciles from the select (server
+          truth) plus the :chip templates, which stay server-owned. --%>
           <div
             :if={@multiple}
+            id={"#{@id}-chips"}
+            phx-update="ignore"
             class="pc-combo-box__chips"
             data-pc-combo-chips
             data-remove-label={@remove_label}

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -136,6 +136,7 @@ defmodule PetalComponents.Showcase.ComboBox do
             class="h-3 w-3 shrink-0 rounded-full"
             style={"background-color: #{opt.meta[:color]}"}
           ></span>
+          <span :if={length(chosen) == 1} class="truncate">{hd(chosen).label}</span>
           <span :if={length(chosen) > 3} class="text-xs tabular-nums text-gray-500 dark:text-gray-400">
             +{length(chosen) - 3}
           </span>
@@ -171,11 +172,11 @@ defmodule PetalComponents.Showcase.ComboBox do
         ]}
       >
         <:chip :let={opt}>
-          <.avatar size="xs" name={opt.label} random_gradient />
+          <.avatar size="2xs" name={opt.label} random_gradient />
           <span class="truncate">{opt.label}</span>
         </:chip>
         <:option :let={opt}>
-          <.avatar size="xs" name={opt.label} random_gradient />
+          <.avatar size="2xs" name={opt.label} random_gradient />
           <span class="flex min-w-0 flex-col leading-tight">
             <span class="truncate">{opt.label}</span>
             <span class="truncate text-xs text-gray-500 dark:text-gray-400">{opt.meta[:role]}</span>
@@ -233,7 +234,7 @@ defmodule PetalComponents.Showcase.ComboBox do
         ]}
       >
         <:option :let={opt}>
-          <.avatar size="xs" name={opt.label} random_gradient />
+          <.avatar size="2xs" name={opt.label} random_gradient />
           <span class="flex min-w-0 flex-col leading-tight">
             <span class="truncate">{opt.label}</span>
             <span class="truncate text-xs text-gray-500 dark:text-gray-400">{opt.meta[:role]}</span>

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -109,6 +109,112 @@ defmodule PetalComponents.Showcase.ComboBox do
     """
   end
 
+  example :labels, "Label picker - the :selected slot",
+    description:
+      "The :selected slot renders rich CLOSED-state content in the trigger - here colored dots with a +N overflow, pure composition, no overflow attr. :let receives the list of chosen normalized options (label, value, meta). Client-side picks show the plain count until the LiveView patch re-renders the slot (server wins); a preset value shows the rich state immediately." do
+    ~H"""
+    <div class="w-full max-w-xs mx-auto">
+      <.combo_box
+        id="sx-combo-labels"
+        name="labels"
+        variant="trigger"
+        multiple
+        placeholder="Labels…"
+        count_label="labels"
+        value={["feat", "bug", "imp", "des"]}
+        options={[
+          {"Feature", "feat", color: "#0ea5e9"},
+          {"Bug", "bug", color: "#f43f5e"},
+          {"Improvement", "imp", color: "#10b981"},
+          {"Design", "des", color: "#a855f7"},
+          {"Docs", "docs", color: "#f59e0b"}
+        ]}
+      >
+        <:selected :let={chosen}>
+          <span
+            :for={opt <- Enum.take(chosen, 3)}
+            class="h-3 w-3 shrink-0 rounded-full"
+            style={"background-color: #{opt.meta[:color]}"}
+          ></span>
+          <span :if={length(chosen) > 3} class="text-xs tabular-nums text-gray-500 dark:text-gray-400">
+            +{length(chosen) - 3}
+          </span>
+        </:selected>
+        <:option :let={opt}>
+          <span
+            class="h-2.5 w-2.5 shrink-0 rounded-full"
+            style={"background-color: #{opt.meta[:color]}"}
+          ></span>
+          <span class="truncate">{opt.label}</span>
+        </:option>
+      </.combo_box>
+    </div>
+    """
+  end
+
+  example :team, "Avatar chips - the :chip slot",
+    description:
+      "The :chip slot renders rich chip content - the remove button stays appended. Client-side picks build plain optimistic chips until the LiveView patch swaps the rich ones back in (server wins on patch); server-rendered chips are left intact whenever they already match the selection." do
+    ~H"""
+    <div class="w-full max-w-sm mx-auto">
+      <.combo_box
+        id="sx-combo-team"
+        name="team"
+        multiple
+        placeholder="Add members…"
+        value={["amelia", "jonah"]}
+        options={[
+          {"Amelia Ward", "amelia", role: "Engineering"},
+          {"Jonah Reyes", "jonah", role: "Design"},
+          {"Priya Anand", "priya", role: "Support"},
+          {"Tom Hale", "tom", role: "Engineering"}
+        ]}
+      >
+        <:chip :let={opt}>
+          <.avatar size="xs" name={opt.label} random_gradient />
+          <span class="truncate">{opt.label}</span>
+        </:chip>
+        <:option :let={opt}>
+          <.avatar size="xs" name={opt.label} random_gradient />
+          <span class="flex min-w-0 flex-col leading-tight">
+            <span class="truncate">{opt.label}</span>
+            <span class="truncate text-xs text-gray-500 dark:text-gray-400">{opt.meta[:role]}</span>
+          </span>
+        </:option>
+      </.combo_box>
+    </div>
+    """
+  end
+
+  example :panel_chrome, "Panel chrome - :header and :footer",
+    description:
+      "Panel chrome lives OUTSIDE the listbox: a caption above the options, a summary or manage link below. Keyboard navigation and filtering never touch either - options stay the only stops." do
+    ~H"""
+    <div class="w-full max-w-xs mx-auto">
+      <.combo_box
+        id="sx-combo-chrome"
+        name="dest"
+        placeholder="Where to?"
+        options={[
+          {"🇯🇵 Tokyo", "tyo"},
+          {"🇵🇹 Lisbon", "lis"},
+          {"🇸🇪 Stockholm", "sto"},
+          {"🇦🇺 Sydney", "syd"},
+          {"🇰🇷 Seoul", "sel"}
+        ]}
+      >
+        <:header>Popular destinations</:header>
+        <:footer>
+          <span class="flex items-center justify-between">
+            <span>5 cities</span>
+            <span class="font-medium text-primary-600 dark:text-primary-400">Manage list</span>
+          </span>
+        </:footer>
+      </.combo_box>
+    </div>
+    """
+  end
+
   example :rich_options, "Rich options - the :option slot",
     description:
       "The :option slot renders anything inside each panel option - avatars, flags, secondary text - with :let receiving the normalized option (label, value, disabled, and meta: whatever extra data the option tuple carried). Filtering, chips and the trigger label keep using the plain label, so rich content never affects search or the closed state." do

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -176,7 +176,7 @@ defmodule PetalComponents.Showcase.ComboBox do
           <span class="truncate">{opt.label}</span>
         </:chip>
         <:option :let={opt}>
-          <.avatar size="2xs" name={opt.label} random_gradient />
+          <.avatar size="xs" name={opt.label} random_gradient />
           <span class="flex min-w-0 flex-col leading-tight">
             <span class="truncate">{opt.label}</span>
             <span class="truncate text-xs text-gray-500 dark:text-gray-400">{opt.meta[:role]}</span>
@@ -234,7 +234,7 @@ defmodule PetalComponents.Showcase.ComboBox do
         ]}
       >
         <:option :let={opt}>
-          <.avatar size="2xs" name={opt.label} random_gradient />
+          <.avatar size="xs" name={opt.label} random_gradient />
           <span class="flex min-w-0 flex-col leading-tight">
             <span class="truncate">{opt.label}</span>
             <span class="truncate text-xs text-gray-500 dark:text-gray-400">{opt.meta[:role]}</span>

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -748,12 +748,18 @@ describe("multiple with chips", () => {
       '<button type="button" class="pc-combo-box__chip-remove" data-pc-combo-chip-remove data-value="syd" tabindex="-1"></button></span>';
     c.hook.updated();
     expect(c.chips_el.querySelector("em")).not.toBeNull();
-    // a client-side change rebuilds plain optimistic chips (server wins later)
+    // incremental sync: a client-side pick APPENDS a plain chip and never
+    // touches the existing rich one - zero flash, server upgrades later
     c.control.click();
     c.items()[1].click();
     expect(c.chips()).toHaveLength(2);
-    expect(c.el.querySelector("[data-pc-combo-chip] em")).toBeNull();
+    expect(c.chips()[0].querySelector("em")).not.toBeNull();
+    expect(c.chips()[1].querySelector("em")).toBeNull();
     expect(c.chips().map((x) => x.dataset.value)).toEqual(["syd", "tyo"]);
+    // unpicking removes exactly the right chip, leaving the rich one alone
+    c.items()[1].click();
+    expect(c.chips()).toHaveLength(1);
+    expect(c.chips()[0].querySelector("em")).not.toBeNull();
   });
 
   it("server-rendered :selected content survives sync when it matches; client picks go optimistic", () => {
@@ -823,6 +829,27 @@ describe("multiple with chips", () => {
       '<span class="pc-combo-box__chip" data-pc-combo-chip data-value="syd"><span class="pc-combo-box__chip-label"><em>R2</em></span></span>';
     c.hook.updated();
     expect(c.chips_el.querySelectorAll("em")).toHaveLength(2);
+  });
+
+  it("inside a phx-change form, a stale rich label is kept until the patch (no text flash)", () => {
+    const c = mountCombo({ options: CITIES, trigger: true, multiple: true });
+    const form = document.createElement("form");
+    form.setAttribute("phx-change", "changed");
+    c.el.parentNode.insertBefore(form, c.el);
+    form.appendChild(c.el);
+    c.select.querySelector('option[value="syd"]').selected = true;
+    const label = c.triggerLabel();
+    label.dataset.customLabel = "true";
+    label.dataset.values = JSON.stringify(["syd"]);
+    label.innerHTML =
+      '<span class="pc-combo-box__selected-content"><em>RICH</em></span>';
+    c.hook.updated();
+    // pick another: wired form -> patch is coming -> rich content stays
+    c.trigger.click();
+    c.items()
+      .find((i) => i.dataset.value === "tyo")
+      .click();
+    expect(label.querySelector("em")).not.toBeNull();
   });
 
   it("choosing a chosen option un-chooses it", () => {

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -879,6 +879,46 @@ describe("multiple with chips", () => {
     vi.useRealTimers();
   });
 
+  it("the panel stays open across LiveView patches mid-multi-pick", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    c.control.click();
+    c.items()[0].click();
+    expect(c.panel.hidden).toBe(false);
+    // the phx-change patch: server always renders the panel hidden and
+    // aria-expanded false - open-state belongs to the client
+    c.panel.hidden = true;
+    c.input.setAttribute("aria-expanded", "false");
+    c.hook.updated();
+    expect(c.panel.hidden).toBe(false);
+    expect(c.input.getAttribute("aria-expanded")).toBe("true");
+    // a panel the user closed stays closed through patches
+    key(c.input, "Escape");
+    c.hook.updated();
+    expect(c.panel.hidden).toBe(true);
+  });
+
+  it("client-built chips clone the server-rendered :chip template - rich immediately", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    const tpl = document.createElement("template");
+    tpl.setAttribute("data-pc-combo-chip-template", "");
+    tpl.dataset.value = "tyo";
+    tpl.innerHTML = '<em class="rich-bit">T</em><span>Tokyo</span>';
+    c.el.appendChild(tpl);
+    c.control.click();
+    c.items()
+      .find((i) => i.dataset.value === "tyo")
+      .click();
+    const chip = c.chips().find((x) => x.dataset.value === "tyo");
+    expect(chip.querySelector("em.rich-bit")).not.toBeNull();
+    // options without a template still build plain text chips
+    c.items()
+      .find((i) => i.dataset.value === "syd")
+      .click();
+    const plain = c.chips().find((x) => x.dataset.value === "syd");
+    expect(plain.querySelector("em")).toBeNull();
+    expect(plain.textContent).toContain("Sydney");
+  });
+
   it("choosing a chosen option un-chooses it", () => {
     const c = mountCombo({ options: CITIES, multiple: true });
     c.control.click();

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -919,6 +919,26 @@ describe("multiple with chips", () => {
     expect(plain.textContent).toContain("Sydney");
   });
 
+  it("a server reorder reaches hook-owned chips via data-order; unstamped client picks stay last", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    c.chips_el = c.el.querySelector("[data-pc-combo-chips]");
+    c.control.click();
+    c.items()[0].click(); // syd
+    c.items()[1].click(); // tyo
+    expect(c.chips().map((x) => x.dataset.value)).toEqual(["syd", "tyo"]);
+    // the patch updates data-order (attrs update even on ignored nodes)
+    c.chips_el.dataset.order = JSON.stringify(["tyo", "syd"]);
+    c.hook.updated();
+    expect(c.chips().map((x) => x.dataset.value)).toEqual(["tyo", "syd"]);
+    // a fresh client pick the server has not stamped yet appends last
+    c.items()[2].click(); // lis
+    expect(c.chips().map((x) => x.dataset.value)).toEqual([
+      "tyo",
+      "syd",
+      "lis",
+    ]);
+  });
+
   it("choosing a chosen option un-chooses it", () => {
     const c = mountCombo({ options: CITIES, multiple: true });
     c.control.click();

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -778,6 +778,20 @@ describe("multiple with chips", () => {
     expect(label.dataset.values).toBeUndefined();
   });
 
+  it("freshness is a set check - chosen-order stamps and chips survive against option-order reads", () => {
+    const c = mountCombo({ options: CITIES, trigger: true, multiple: true });
+    c.select.querySelector('option[value="syd"]').selected = true;
+    c.select.querySelector('option[value="tyo"]').selected = true;
+    const label = c.triggerLabel();
+    label.dataset.customLabel = "true";
+    // server stamped CHOSEN order (tyo picked first); hook reads option order
+    label.dataset.values = "tyo\u001fsyd";
+    label.innerHTML =
+      '<span class="pc-combo-box__selected-content"><em>RICH</em></span>';
+    c.hook.updated();
+    expect(label.querySelector("em")).not.toBeNull();
+  });
+
   it("choosing a chosen option un-chooses it", () => {
     const c = mountCombo({ options: CITIES, multiple: true });
     c.control.click();

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -852,6 +852,33 @@ describe("multiple with chips", () => {
     expect(label.querySelector("em")).not.toBeNull();
   });
 
+  it("a wired form whose handler never re-renders self-heals to optimistic text after the grace window", () => {
+    vi.useFakeTimers();
+    const c = mountCombo({ options: CITIES, trigger: true, multiple: true });
+    const form = document.createElement("form");
+    form.setAttribute("phx-change", "changed");
+    c.el.parentNode.insertBefore(form, c.el);
+    form.appendChild(c.el);
+    c.select.querySelector('option[value="syd"]').selected = true;
+    const label = c.triggerLabel();
+    label.dataset.customLabel = "true";
+    label.dataset.values = JSON.stringify(["syd"]);
+    label.innerHTML =
+      '<span class="pc-combo-box__selected-content"><em>RICH</em></span>';
+    c.hook.updated();
+    c.trigger.click();
+    c.items()
+      .find((i) => i.dataset.value === "tyo")
+      .click();
+    // grace window: stale rich kept while the patch is presumed en route
+    expect(label.querySelector("em")).not.toBeNull();
+    // no patch ever arrives - the timer degrades to honest optimistic text
+    vi.advanceTimersByTime(2100);
+    expect(label.querySelector("em")).toBeNull();
+    expect(label.textContent).toBe("2 selected");
+    vi.useRealTimers();
+  });
+
   it("choosing a chosen option un-chooses it", () => {
     const c = mountCombo({ options: CITIES, multiple: true });
     c.control.click();

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -736,6 +736,48 @@ describe("multiple with chips", () => {
     expect(c.input.getAttribute("placeholder")).toBe("Añadir…");
   });
 
+  it("server-rendered rich chips survive updated() when the selection matches", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    // simulate the LiveView patch: server marked options selected and
+    // rendered rich :chip content with matching data-values
+    c.select.querySelector('option[value="syd"]').selected = true;
+    c.chips_el = c.el.querySelector("[data-pc-combo-chips]");
+    c.chips_el.innerHTML =
+      '<span class="pc-combo-box__chip" data-pc-combo-chip data-value="syd">' +
+      '<span class="pc-combo-box__chip-label"><em>RICH</em> Sydney</span>' +
+      '<button type="button" class="pc-combo-box__chip-remove" data-pc-combo-chip-remove data-value="syd" tabindex="-1"></button></span>';
+    c.hook.updated();
+    expect(c.chips_el.querySelector("em")).not.toBeNull();
+    // a client-side change rebuilds plain optimistic chips (server wins later)
+    c.control.click();
+    c.items()[1].click();
+    expect(c.chips()).toHaveLength(2);
+    expect(c.el.querySelector("[data-pc-combo-chip] em")).toBeNull();
+    expect(c.chips().map((x) => x.dataset.value)).toEqual(["syd", "tyo"]);
+  });
+
+  it("server-rendered :selected content survives sync when it matches; client picks go optimistic", () => {
+    const c = mountCombo({ options: CITIES, trigger: true, multiple: true });
+    // simulate the patch: server chose syd+tyo and rendered rich label content
+    c.select.querySelector('option[value="syd"]').selected = true;
+    c.select.querySelector('option[value="tyo"]').selected = true;
+    const label = c.triggerLabel();
+    label.dataset.customLabel = "true";
+    label.dataset.values = "syd\u001ftyo";
+    label.innerHTML =
+      '<span class="pc-combo-box__selected-content"><em>RICH</em></span>';
+    c.hook.updated();
+    expect(label.querySelector("em")).not.toBeNull();
+    // a client-side pick diverges from the rendered values -> optimistic text
+    c.trigger.click();
+    c.items()
+      .find((i) => i.dataset.value === "lis")
+      .click();
+    expect(label.querySelector("em")).toBeNull();
+    expect(label.textContent).toBe("3 selected");
+    expect(label.dataset.values).toBeUndefined();
+  });
+
   it("choosing a chosen option un-chooses it", () => {
     const c = mountCombo({ options: CITIES, multiple: true });
     c.control.click();

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -854,6 +854,8 @@ describe("multiple with chips", () => {
 
   it("a wired form whose handler never re-renders self-heals to optimistic text after the grace window", () => {
     vi.useFakeTimers();
+    const now = vi.spyOn(performance, "now");
+    now.mockReturnValue(0);
     const c = mountCombo({ options: CITIES, trigger: true, multiple: true });
     const form = document.createElement("form");
     form.setAttribute("phx-change", "changed");
@@ -873,9 +875,48 @@ describe("multiple with chips", () => {
     // grace window: stale rich kept while the patch is presumed en route
     expect(label.querySelector("em")).not.toBeNull();
     // no patch ever arrives - the timer degrades to honest optimistic text
+    now.mockReturnValue(2100);
     vi.advanceTimersByTime(2100);
     expect(label.querySelector("em")).toBeNull();
     expect(label.textContent).toBe("2 selected");
+    now.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("continuing picks never extend the grace window - it anchors to the first divergence", () => {
+    vi.useFakeTimers();
+    const now = vi.spyOn(performance, "now");
+    now.mockReturnValue(0);
+    const c = mountCombo({ options: CITIES, trigger: true, multiple: true });
+    const form = document.createElement("form");
+    form.setAttribute("phx-change", "changed");
+    c.el.parentNode.insertBefore(form, c.el);
+    form.appendChild(c.el);
+    c.select.querySelector('option[value="syd"]').selected = true;
+    const label = c.triggerLabel();
+    label.dataset.customLabel = "true";
+    label.dataset.values = JSON.stringify(["syd"]);
+    label.innerHTML =
+      '<span class="pc-combo-box__selected-content"><em>RICH</em></span>';
+    c.hook.updated();
+    // divergence begins
+    c.trigger.click();
+    c.items()
+      .find((i) => i.dataset.value === "tyo")
+      .click();
+    expect(label.querySelector("em")).not.toBeNull();
+    // keep interacting inside the window - must NOT re-arm it
+    now.mockReturnValue(1500);
+    vi.advanceTimersByTime(1500);
+    c.items()
+      .find((i) => i.dataset.value === "lis")
+      .click();
+    expect(label.querySelector("em")).not.toBeNull();
+    // past 2s from the FIRST divergence: degrade despite recent activity
+    now.mockReturnValue(2100);
+    vi.advanceTimersByTime(600);
+    expect(label.querySelector("em")).toBeNull();
+    now.mockRestore();
     vi.useRealTimers();
   });
 
@@ -937,6 +978,19 @@ describe("multiple with chips", () => {
       "syd",
       "lis",
     ]);
+  });
+
+  it("the highlight survives LiveView patches - no re-homing on the first item", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    c.control.click();
+    const third = c.items()[2];
+    third.click();
+    expect(third.hasAttribute("data-highlighted")).toBe(true);
+    // the patch: server renders options without client highlight state
+    for (const i of c.items()) i.removeAttribute("data-highlighted");
+    c.hook.updated();
+    expect(third.hasAttribute("data-highlighted")).toBe(true);
+    expect(c.items()[0].hasAttribute("data-highlighted")).toBe(false);
   });
 
   it("choosing a chosen option un-chooses it", () => {

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -763,7 +763,7 @@ describe("multiple with chips", () => {
     c.select.querySelector('option[value="tyo"]').selected = true;
     const label = c.triggerLabel();
     label.dataset.customLabel = "true";
-    label.dataset.values = "syd\u001ftyo";
+    label.dataset.values = JSON.stringify(["syd", "tyo"]);
     label.innerHTML =
       '<span class="pc-combo-box__selected-content"><em>RICH</em></span>';
     c.hook.updated();
@@ -785,11 +785,44 @@ describe("multiple with chips", () => {
     const label = c.triggerLabel();
     label.dataset.customLabel = "true";
     // server stamped CHOSEN order (tyo picked first); hook reads option order
-    label.dataset.values = "tyo\u001fsyd";
+    label.dataset.values = JSON.stringify(["tyo", "syd"]);
     label.innerHTML =
       '<span class="pc-combo-box__selected-content"><em>RICH</em></span>';
     c.hook.updated();
     expect(label.querySelector("em")).not.toBeNull();
+  });
+
+  it("values containing old-delimiter bytes can never falsely match a different selection", () => {
+    const c = mountCombo({ options: CITIES, trigger: true, multiple: true });
+    c.select.querySelector('option[value="syd"]').selected = true;
+    c.select.querySelector('option[value="tyo"]').selected = true;
+    const label = c.triggerLabel();
+    label.dataset.customLabel = "true";
+    // a single weird value whose contents embed both real values - JSON
+    // keeps it one value, so it must NOT match the two-value selection
+    label.dataset.values = JSON.stringify(["syd\u001ftyo"]);
+    label.innerHTML =
+      '<span class="pc-combo-box__selected-content"><em>WRONG</em></span>';
+    c.hook.updated();
+    expect(label.querySelector("em")).toBeNull();
+  });
+
+  it("duplicate values stay fresh - multiset counting, never set flattening", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    // two selected options sharing a value (degenerate but legal HTML)
+    const dup = document.createElement("option");
+    dup.value = "syd";
+    dup.textContent = "Sydney 2";
+    c.select.appendChild(dup);
+    c.select
+      .querySelectorAll('option[value="syd"]')
+      .forEach((o) => (o.selected = true));
+    c.chips_el = c.el.querySelector("[data-pc-combo-chips]");
+    c.chips_el.innerHTML =
+      '<span class="pc-combo-box__chip" data-pc-combo-chip data-value="syd"><span class="pc-combo-box__chip-label"><em>R1</em></span></span>' +
+      '<span class="pc-combo-box__chip" data-pc-combo-chip data-value="syd"><span class="pc-combo-box__chip-label"><em>R2</em></span></span>';
+    c.hook.updated();
+    expect(c.chips_el.querySelectorAll("em")).toHaveLength(2);
   });
 
   it("choosing a chosen option un-chooses it", () => {

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -482,6 +482,18 @@ defmodule PetalComponents.ComboBoxTest do
       refute plain =~ "data-pc-combo-chip-template"
     end
 
+    test "the chips container is hook-owned: phx-update ignore with a stable id" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="own" name="own" multiple options={[{"Alpha", "a"}]} />
+        """)
+
+      assert html =~ ~s|id="own-chips"|
+      assert html =~ ~s|phx-update="ignore"|
+    end
+
     test ":chip renders rich chip content with the remove button intact; chips carry data-value" do
       assigns = %{}
 

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -397,6 +397,26 @@ defmodule PetalComponents.ComboBoxTest do
       refute html =~ "2 selected"
     end
 
+    test ":selected stamps data-values with the chosen values (chosen order - the hook compares as a set)" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box
+          id="ord"
+          name="ord"
+          variant="trigger"
+          multiple
+          value={["b", "a"]}
+          options={[{"Alpha", "a"}, {"Beta", "b"}]}
+        >
+          <:selected :let={chosen}>{length(chosen)}</:selected>
+        </.combo_box>
+        """)
+
+      assert html =~ ~s|data-values="b\x1fa"|
+    end
+
     test ":selected falls back to the placeholder when nothing is chosen" do
       assigns = %{}
 

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -459,6 +459,29 @@ defmodule PetalComponents.ComboBoxTest do
       assert html =~ "Pick…"
     end
 
+    test ":chip renders one inert template per option for instant client-side rich chips" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="tpl" name="tpl" multiple options={[{"Alpha", "a"}, {"Beta", "b"}]}>
+          <:chip :let={opt}><em>{opt.label}</em></:chip>
+        </.combo_box>
+        """)
+
+      assert length(String.split(html, "data-pc-combo-chip-template")) - 1 == 2
+      assert html =~ "<em>Alpha</em>"
+      assert html =~ "<em>Beta</em>"
+
+      # no templates without the slot, and none for single select
+      plain =
+        rendered_to_string(~H"""
+        <.combo_box id="np" name="np" multiple options={[{"Alpha", "a"}]} />
+        """)
+
+      refute plain =~ "data-pc-combo-chip-template"
+    end
+
     test ":chip renders rich chip content with the remove button intact; chips carry data-value" do
       assigns = %{}
 

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -244,7 +244,7 @@ defmodule PetalComponents.ComboBoxTest do
         <.combo_box id="s" name="s" variant="trigger" value="syd" options={[{"Sydney", "syd"}]} />
         """)
 
-      assert single =~ ">Sydney</span>"
+      assert single =~ ~r/data-count-label="selected">\s*Sydney\s*</
       refute single =~ ~s|data-placeholder="true"|
 
       multi =
@@ -259,7 +259,7 @@ defmodule PetalComponents.ComboBoxTest do
         />
         """)
 
-      assert multi =~ ">2 selected</span>"
+      assert multi =~ ~r/data-count-label="selected">\s*2 selected\s*</
     end
   end
 
@@ -334,6 +334,104 @@ defmodule PetalComponents.ComboBoxTest do
 
       assert html =~ "pc-combo-box__option-label"
       refute html =~ "pc-combo-box__option-content"
+    end
+  end
+
+  describe "M3a slots" do
+    test ":header and :footer render as panel chrome OUTSIDE the listbox" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="hf" name="hf" options={["A"]}>
+          <:header>Frameworks</:header>
+          <:footer>12 teammates</:footer>
+        </.combo_box>
+        """)
+
+      assert html =~ "pc-combo-box__header"
+      assert html =~ "pc-combo-box__footer"
+      # chrome, not options: both live outside the listbox element
+      [_, after_list_open] = String.split(html, ~s|role="listbox"|, parts: 2)
+      [inside_list, after_list] = String.split(after_list_open, "pc-combo-box__footer", parts: 2)
+      refute inside_list =~ "pc-combo-box__header"
+      assert after_list =~ "12 teammates"
+    end
+
+    test "no header/footer chrome renders without the slots" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="nf" name="nf" options={["A"]} />
+        """)
+
+      refute html =~ "pc-combo-box__header"
+      refute html =~ "pc-combo-box__footer"
+    end
+
+    test ":selected renders rich closed-state content in the trigger, list of chosen options" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box
+          id="sel"
+          name="sel"
+          variant="trigger"
+          multiple
+          value={["a", "b"]}
+          options={[{"Alpha", "a", color: "sky"}, {"Beta", "b", color: "rose"}]}
+        >
+          <:selected :let={chosen}>
+            <span :for={opt <- chosen} class={"dot-#{opt.meta[:color]}"}></span>
+            <span>{length(chosen)} labels</span>
+          </:selected>
+        </.combo_box>
+        """)
+
+      assert html =~ "pc-combo-box__selected-content"
+      assert html =~ "dot-sky"
+      assert html =~ "dot-rose"
+      assert html =~ "2 labels"
+      refute html =~ "2 selected"
+    end
+
+    test ":selected falls back to the placeholder when nothing is chosen" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="sel2" name="sel2" variant="trigger" placeholder="Pick…" options={["A"]}>
+          <:selected :let={_chosen}>never</:selected>
+        </.combo_box>
+        """)
+
+      refute html =~ "pc-combo-box__selected-content"
+      assert html =~ "Pick…"
+    end
+
+    test ":chip renders rich chip content with the remove button intact; chips carry data-value" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box
+          id="ch"
+          name="ch"
+          multiple
+          value={["a"]}
+          options={[{"Alpha", "a", color: "sky"}]}
+        >
+          <:chip :let={opt}>
+            <em>{opt.meta[:color]}</em> {opt.label}
+          </:chip>
+        </.combo_box>
+        """)
+
+      assert html =~ "<em>sky</em>"
+      assert html =~ ~s|data-value="a"|
+      assert html =~ "pc-combo-box__chip-remove"
     end
   end
 

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -417,6 +417,34 @@ defmodule PetalComponents.ComboBoxTest do
       assert html =~ ~s|data-values="[&quot;b&quot;,&quot;a&quot;]"|
     end
 
+    test "duplicated caller values dedupe - one chip, stamp matches what the select yields" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box
+          id="dup"
+          name="dup"
+          variant="trigger"
+          multiple
+          value={["a", "a"]}
+          options={[{"Alpha", "a"}]}
+        >
+          <:selected :let={chosen}>{length(chosen)}</:selected>
+        </.combo_box>
+        """)
+
+      assert html =~ ~s|data-values="[&quot;a&quot;]"|
+
+      chips =
+        rendered_to_string(~H"""
+        <.combo_box id="dupc" name="dupc" multiple value={["a", "a"]} options={[{"Alpha", "a"}]} />
+        """)
+
+      assert length(String.split(chips, "data-pc-combo-chip\"")) - 1 <= 2
+      assert length(String.split(chips, ~s|class="pc-combo-box__chip"|)) - 1 == 1
+    end
+
     test ":selected falls back to the placeholder when nothing is chosen" do
       assigns = %{}
 

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -397,7 +397,7 @@ defmodule PetalComponents.ComboBoxTest do
       refute html =~ "2 selected"
     end
 
-    test ":selected stamps data-values with the chosen values (chosen order - the hook compares as a set)" do
+    test ":selected stamps data-values as JSON (no delimiter to collide; hook compares as a multiset)" do
       assigns = %{}
 
       html =
@@ -414,7 +414,7 @@ defmodule PetalComponents.ComboBoxTest do
         </.combo_box>
         """)
 
-      assert html =~ ~s|data-values="b\x1fa"|
+      assert html =~ ~s|data-values="[&quot;b&quot;,&quot;a&quot;]"|
     end
 
     test ":selected falls back to the placeholder when nothing is chosen" do


### PR DESCRIPTION
Stacked on #556 (base = its branch, so this diff is M3a alone). The line from the bloat discussion, implemented: slots yes, knobs no.

## The four slots

One grammar across the family - `:let` receives normalized options (`label`, `value`, `meta`) exactly like `:option`:

- **`:header` / `:footer`** - panel chrome OUTSIDE the `role=listbox`. Captions above, counts/manage links below. Keyboard navigation and filtering never touch them (spec: End lands on the last option, chrome is never a stop).
- **`:selected`** (trigger variant) - rich closed-state content. The reui labels pattern (colored dots + "+N" overflow) is pure composition in the showcase, zero component API for overflow.
- **`:chip`** - rich chip content with the remove button appended.

## The reconciliation contract (the one real design point)

Both closed-state slots are server-rendered; the hook writes plain optimistic text on client-side picks. The fix that makes this correct: **value-stamped diffing**. The trigger label carries `data-values` (the values its slot content was rendered for) and chips carry per-chip `data-value` - `syncFromSelect`/`syncChips` leave fresh matching DOM alone and rebuild only on divergence, so server-rendered rich content survives every patch and client picks still update instantly.

## Demos

Three new showcase examples (labels marquee, avatar-chip team picker, panel chrome) plus a **phx-change-wired live section** on the playground page - every pick round-trips so the rich states track live.

Verified in-browser: dots 3/+1 → pick → 3/+2 → unpick → 3/none; avatar chips stay rich through patches; header/footer geometry and keyboard contract measured.

## Tests

5 Elixir slot tests, 2 JS reconciliation specs. 802 Elixir / 76 JS green.

No new hook state machines - render + diffing only.