### PR TITLE
feat(combo_box): M3b - free_text, create, and remote search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 
 #### Added
 
+- **`combo_box` M3b - the modes: `free_text`, `create`, remote search.**
+  The last of the Tom Select parity surface, on the new architecture:
+  - `free_text`: Enter at the empty stop commits the typed text as a
+    dynamic option in the hidden select, so forms post it like any
+    choice. Existing labels are chosen instead of duplicated
+    (case-insensitive). The server owns persistence.
+  - `create`: free_text plus an explicit, keyboard-reachable
+    "Create …" row (the last arrow stop) that appears for novel
+    queries. `create_label` localizes the verb.
+  - `remote_options_event_name` + `remote_options_target`: the
+    contract preserved verbatim - typing pushes the raw term
+    (debounced 300ms), the handler replies
+    `{:reply, %{results: [%{text: …, value: …}]}, socket}`, and the
+    hook renders the results (the listbox is hook-owned in remote
+    mode - one writer per region). Designed loading row
+    (`loading_label`), stale replies dropped by sequence, chosen
+    results inserted into the select.
+
+#### Added
+
 - **`combo_box` M3a - the slot family completes: `:header`, `:footer`,
   `:selected`, `:chip`.** All four speak the `:option` slot's grammar
   (`:let` receives normalized options with `meta`), all render-only, no

--- a/assets/default.css
+++ b/assets/default.css
@@ -2253,6 +2253,16 @@
   .pc-combo-box__selected-content {
     @apply flex min-w-0 items-center gap-2 truncate;
   }
+  /* the create row: an option-shaped, keyboard-reachable panel action */
+  .pc-combo-box__create {
+    @apply relative flex w-full cursor-default items-center gap-2 border-t border-gray-200 px-2 py-1.5 text-left text-sm text-primary-600 outline-none select-none touch-manipulation dark:border-gray-400/25 dark:text-primary-400;
+  }
+  .pc-combo-box__create[data-highlighted] {
+    @apply bg-gray-100 dark:bg-gray-400/15;
+  }
+  .pc-combo-box__create-icon.pc-combo-box__create-icon {
+    @apply w-4! h-4! shrink-0;
+  }
   .pc-combo-box__empty {
     @apply px-2 py-6 text-center text-sm text-gray-500 dark:text-gray-400;
   }

--- a/assets/default.css
+++ b/assets/default.css
@@ -2263,6 +2263,12 @@
   .pc-combo-box__create-icon.pc-combo-box__create-icon {
     @apply w-4! h-4! shrink-0;
   }
+  .pc-combo-box__loading {
+    @apply flex items-center gap-2 border-b border-gray-200 px-3 py-2 text-sm text-gray-500 dark:border-gray-400/25 dark:text-gray-400;
+  }
+  .pc-combo-box__loading-icon.pc-combo-box__loading-icon {
+    @apply w-4! h-4! shrink-0 animate-spin;
+  }
   .pc-combo-box__empty {
     @apply px-2 py-6 text-center text-sm text-gray-500 dark:text-gray-400;
   }

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3828,10 +3828,19 @@ export const PetalComboBox = {
 
   updated() {
     // mode configuration and conditionally-rendered rows are server
-    // truth and can change on any patch - re-read them
+    // truth and can change on any patch - re-read them, and a CHANGED
+    // remote event/target invalidates the previous configuration's
+    // in-flight work so obsolete results can never land
+    const prevEvent = this.remoteEvent;
+    const prevTarget = this.remoteTarget;
     this.freeText = this.el.hasAttribute("data-free-text");
     this.remoteEvent = this.el.dataset.remoteEvent || null;
     this.remoteTarget = this.el.dataset.remoteTarget || null;
+    if (this.remoteEvent !== prevEvent || this.remoteTarget !== prevTarget) {
+      this.remoteSeq++;
+      clearTimeout(this.remoteTimer);
+      if (this.loadingRow) this.loadingRow.hidden = true;
+    }
     this.loadingRow = this.el.querySelector("[data-pc-combo-loading]");
     this.createRow = this.el.querySelector("[data-pc-combo-create]");
     if (this.createRow) {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3569,6 +3569,14 @@ export const PetalComboBox = {
 
     this.multiple = this.select.multiple;
     this.chips = this.el.querySelector("[data-pc-combo-chips]");
+    this.freeText = this.el.hasAttribute("data-free-text");
+    this.createRow = this.el.querySelector("[data-pc-combo-create]");
+    if (this.createRow) {
+      this.createRow.id = `${this.el.id}-create`;
+      this.createQueryEl = this.createRow.querySelector(
+        "[data-pc-combo-create-query]",
+      );
+    }
     this.live = this.el.querySelector("[data-pc-combo-live]");
     this.clearBtn = this.el.querySelector("[data-pc-combo-clear]");
     this.query = "";
@@ -3587,11 +3595,19 @@ export const PetalComboBox = {
     };
     this.onKeydown = (e) => this.keydown(e);
     this.onPointerOver = (e) => {
+      if (this.createRow && e.target.closest("[data-pc-combo-create]")) {
+        if (!this.createRow.hidden) this.highlight(this.createRow, false);
+        return;
+      }
       const item = e.target.closest("[data-pc-combo-item]");
       if (item && !item.hasAttribute("data-disabled") && !item.hidden)
         this.highlight(item, false);
     };
     this.onListClick = (e) => {
+      if (this.createRow && e.target.closest("[data-pc-combo-create]")) {
+        if (!this.createRow.hidden) this.commitFreeText();
+        return;
+      }
       const item = e.target.closest("[data-pc-combo-item]");
       if (item && !item.hasAttribute("data-disabled")) this.choose(item);
     };
@@ -4002,7 +4018,20 @@ export const PetalComboBox = {
       return;
     }
     const chosen = this.chosenItem();
-    this.input.value = chosen ? chosen.dataset.label || "" : "";
+    if (chosen) {
+      this.input.value = chosen.dataset.label || "";
+      return;
+    }
+    // free-text values have no list item - the select option carries
+    // their display text. select.value is the single source of truth
+    // (selectedOptions can carry stale flags after form.reset()).
+    const v = this.select.value;
+    if (v === "") {
+      this.input.value = "";
+      return;
+    }
+    const opt = Array.from(this.select.options).find((o) => o.value === v);
+    this.input.value = opt ? opt.textContent.trim() : v;
   },
 
   dispatchChange() {
@@ -4236,6 +4265,47 @@ export const PetalComboBox = {
     if (!this.trigger) this.input.focus();
   },
 
+  // free-text commit: the typed query becomes a real value in the hidden
+  // select (a dynamic option marked data-pc-combo-custom), so the form
+  // posts it like any other choice. The SERVER owns persistence: unless
+  // the app re-renders the value into options, the next patch drops it.
+  commitFreeText() {
+    const raw = this.input.value.trim();
+    if (!raw) return;
+    // an existing option with the same label wins - never dupe by case
+    const existing = this.items().find(
+      (i) => (i.dataset.label || "").trim().toLowerCase() === raw.toLowerCase(),
+    );
+    if (existing && !existing.hasAttribute("data-disabled")) {
+      this.choose(existing);
+      return;
+    }
+    if (this.multiple && this.maxReached()) return;
+    let option = Array.from(this.select.options).find((o) => o.value === raw);
+    if (!option) {
+      option = document.createElement("option");
+      option.value = raw;
+      option.textContent = raw;
+      option.setAttribute("data-pc-combo-custom", "");
+      this.select.appendChild(option);
+    }
+    if (this.multiple) {
+      option.selected = true;
+      this.dispatchChange();
+      this.syncFromSelect();
+      this.query = "";
+      this.input.value = "";
+      this.filter();
+      this.input.focus();
+      return;
+    }
+    this.select.value = raw;
+    this.dispatchChange();
+    this.syncFromSelect();
+    this.closePanel();
+    (this.trigger || this.input).focus();
+  },
+
   announce(count) {
     if (!this.live) return;
     const label = this.live.dataset.resultsLabel || "results";
@@ -4277,8 +4347,26 @@ export const PetalComboBox = {
       group.hidden = !any;
     }
 
+    // the create row shows for a non-empty query with no EXACT label
+    // match (a case-insensitive duplicate would be a confusing offer)
+    let createVisible = false;
+    if (this.createRow) {
+      const q = query.trim();
+      const exact =
+        q &&
+        this.items().some(
+          (i) =>
+            (i.dataset.label || "").trim().toLowerCase() === q.toLowerCase(),
+        );
+      createVisible = Boolean(q) && !exact;
+      this.createRow.hidden = !createVisible;
+      // display the raw typed text - the scoring query is lowercased
+      if (this.createQueryEl)
+        this.createQueryEl.textContent = this.input.value.trim();
+    }
+
     const empty = this.el.querySelector("[data-pc-combo-empty]");
-    if (empty) empty.hidden = count > 0;
+    if (empty) empty.hidden = count > 0 || createVisible;
     this.announce(count);
 
     // an empty query (just opened) homes the highlight on the chosen value;
@@ -4310,6 +4398,11 @@ export const PetalComboBox = {
     this.highlightedValue = item ? item.dataset.value : null;
     for (const i of this.items())
       i.toggleAttribute("data-highlighted", i === item);
+    if (this.createRow)
+      this.createRow.toggleAttribute(
+        "data-highlighted",
+        this.createRow === item,
+      );
     if (item) {
       this.input.setAttribute("aria-activedescendant", item.id);
       if (scroll) item.scrollIntoView({ block: "nearest" });
@@ -4323,8 +4416,16 @@ export const PetalComboBox = {
   // top. The empty state is the input itself taking a turn in the cycle -
   // in free-text mode Enter there means "use what I typed, not an option" -
   // and it reads as a felt boundary instead of a disorienting teleport.
-  move(delta) {
+  // the visible create row participates as the last keyboard stop - the
+  // footer-region consumer the panel-slot ruling promised
+  navItems() {
     const items = this.visibleItems();
+    if (this.createRow && !this.createRow.hidden) items.push(this.createRow);
+    return items;
+  },
+
+  move(delta) {
+    const items = this.navItems();
     if (!items.length) return;
     const at = items.indexOf(this.highlightedItem());
     if (at === -1) {
@@ -4353,7 +4454,7 @@ export const PetalComboBox = {
       case "End":
         if (this.panel.hidden) return;
         e.preventDefault();
-        this.highlight(this.visibleItems().slice(-1)[0] || null);
+        this.highlight(this.navItems().slice(-1)[0] || null);
         break;
       case "Backspace": {
         if (!this.multiple || this.input.value !== "") return;
@@ -4365,8 +4466,17 @@ export const PetalComboBox = {
         if (this.panel.hidden) return; // closed: let the form submit
         e.preventDefault();
         const item = this.highlightedItem();
-        if (item && !item.hidden && !item.hasAttribute("data-disabled"))
+        if (item === this.createRow && this.createRow) {
+          this.commitFreeText();
+          break;
+        }
+        if (item && !item.hidden && !item.hasAttribute("data-disabled")) {
           this.choose(item);
+          break;
+        }
+        // the empty stop: in free-text mode Enter here means "use what I
+        // typed, not an option" - the grammar this state was built for
+        if (this.freeText && this.input.value.trim()) this.commitFreeText();
         break;
       }
       case "Escape":

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3570,6 +3570,10 @@ export const PetalComboBox = {
     this.multiple = this.select.multiple;
     this.chips = this.el.querySelector("[data-pc-combo-chips]");
     this.freeText = this.el.hasAttribute("data-free-text");
+    this.remoteEvent = this.el.dataset.remoteEvent || null;
+    this.remoteTarget = this.el.dataset.remoteTarget || null;
+    this.loadingRow = this.el.querySelector("[data-pc-combo-loading]");
+    this.remoteSeq = 0;
     this.createRow = this.el.querySelector("[data-pc-combo-create]");
     if (this.createRow) {
       this.createRow.id = `${this.el.id}-create`;
@@ -3591,6 +3595,10 @@ export const PetalComboBox = {
       e.stopPropagation();
       this.query = this.input.value.trim().toLowerCase();
       if (this.panel.hidden) this.openPanel({ keepQuery: true });
+      if (this.remoteEvent) {
+        clearTimeout(this.remoteTimer);
+        this.remoteTimer = setTimeout(() => this.remoteSearch(), 300);
+      }
       this.filter();
     };
     this.onKeydown = (e) => this.keydown(e);
@@ -3864,6 +3872,7 @@ export const PetalComboBox = {
     }
     this.el.removeEventListener("focusout", this.onFocusOut);
     clearTimeout(this.labelPatchTimer);
+    clearTimeout(this.remoteTimer);
     if (this.clearButton) {
       this.clearButton.removeEventListener("click", this.onClearClick);
     }
@@ -4242,8 +4251,24 @@ export const PetalComboBox = {
       this.restoreDisplay();
   },
 
+  // remote rows (and free-text commits) have no server-rendered option in
+  // the hidden select - create one so the form posts the value. Marked
+  // data-pc-combo-custom: the server owns persistence on the next patch.
+  ensureOption(value, label) {
+    let option = Array.from(this.select.options).find((o) => o.value === value);
+    if (!option) {
+      option = document.createElement("option");
+      option.value = value;
+      option.textContent = label;
+      option.setAttribute("data-pc-combo-custom", "");
+      this.select.appendChild(option);
+    }
+    return option;
+  },
+
   choose(item) {
     const value = item.dataset.value;
+    this.ensureOption(value, item.dataset.label || value);
     if (this.multiple) {
       const selected = this.selectedValues().includes(value);
       if (!selected && this.maxReached()) return;
@@ -4265,6 +4290,63 @@ export const PetalComboBox = {
     if (!this.trigger) this.input.focus();
   },
 
+  // Remote search, contract-verbatim from the Tom Select era: push the
+  // raw search term, receive {:reply, %{results: [%{text, value}]}}, and
+  // render the results as the option list. The listbox is hook-owned in
+  // remote mode (phx-update=ignore), so there is exactly one writer. A
+  // sequence counter drops stale replies from out-of-order round trips.
+  remoteSearch() {
+    if (
+      typeof this.pushEventTo !== "function" &&
+      typeof this.pushEvent !== "function"
+    ) {
+      return; // remote needs a LiveView socket
+    }
+    const seq = ++this.remoteSeq;
+    if (this.loadingRow) this.loadingRow.hidden = false;
+    const term = this.input.value.trim();
+    const handle = (reply) => {
+      if (seq !== this.remoteSeq) return; // a newer search superseded this one
+      if (this.loadingRow) this.loadingRow.hidden = true;
+      this.renderRemoteResults((reply && reply.results) || []);
+    };
+    if (this.remoteTarget && typeof this.pushEventTo === "function") {
+      this.pushEventTo(this.remoteTarget, this.remoteEvent, term, handle);
+    } else {
+      this.pushEvent(this.remoteEvent, term, handle);
+    }
+  },
+
+  renderRemoteResults(results) {
+    for (const stale of this.el.querySelectorAll(
+      "[data-pc-combo-item], [data-pc-combo-group]",
+    )) {
+      stale.remove();
+    }
+    const anchor =
+      (this.createRow && this.createRow.parentElement === this.list
+        ? this.createRow
+        : null) || this.el.querySelector("[data-pc-combo-empty]");
+    for (const result of results) {
+      const row = document.createElement("div");
+      row.className = "pc-combo-box__option";
+      row.setAttribute("role", "option");
+      row.setAttribute("data-pc-combo-item", "");
+      row.setAttribute("aria-selected", "false");
+      row.dataset.value = String(result.value);
+      row.dataset.label = String(result.text);
+      const label = document.createElement("span");
+      label.className = "pc-combo-box__option-label";
+      label.textContent = String(result.text);
+      const check = document.createElement("span");
+      check.className = "hero-check-mini pc-combo-box__check";
+      row.append(label, check);
+      this.list.insertBefore(row, anchor);
+    }
+    this.syncFromSelect();
+    this.filter();
+  },
+
   // free-text commit: the typed query becomes a real value in the hidden
   // select (a dynamic option marked data-pc-combo-custom), so the form
   // posts it like any other choice. The SERVER owns persistence: unless
@@ -4281,14 +4363,7 @@ export const PetalComboBox = {
       return;
     }
     if (this.multiple && this.maxReached()) return;
-    let option = Array.from(this.select.options).find((o) => o.value === raw);
-    if (!option) {
-      option = document.createElement("option");
-      option.value = raw;
-      option.textContent = raw;
-      option.setAttribute("data-pc-combo-custom", "");
-      this.select.appendChild(option);
-    }
+    const option = this.ensureOption(raw, raw);
     if (this.multiple) {
       option.selected = true;
       this.dispatchChange();
@@ -4326,7 +4401,8 @@ export const PetalComboBox = {
       const text = `${item.dataset.label || item.textContent || ""}`
         .trim()
         .toLowerCase();
-      const score = this.score(text, query);
+      // remote mode: the server already filtered - every row is a match
+      const score = this.remoteEvent ? 1 : this.score(text, query);
       item.hidden = score === 0;
       if (score === 0) continue;
       count++;

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3596,6 +3596,10 @@ export const PetalComboBox = {
       this.query = this.input.value.trim().toLowerCase();
       if (this.panel.hidden) this.openPanel({ keepQuery: true });
       if (this.remoteEvent) {
+        // every keystroke invalidates in-flight replies immediately - a
+        // reply landing inside the NEXT search's debounce window must
+        // never render against the newer query
+        this.remoteSeq++;
         clearTimeout(this.remoteTimer);
         this.remoteTimer = setTimeout(() => this.remoteSearch(), 300);
       }
@@ -3823,6 +3827,21 @@ export const PetalComboBox = {
   },
 
   updated() {
+    // mode configuration and conditionally-rendered rows are server
+    // truth and can change on any patch - re-read them
+    this.freeText = this.el.hasAttribute("data-free-text");
+    this.remoteEvent = this.el.dataset.remoteEvent || null;
+    this.remoteTarget = this.el.dataset.remoteTarget || null;
+    this.loadingRow = this.el.querySelector("[data-pc-combo-loading]");
+    this.createRow = this.el.querySelector("[data-pc-combo-create]");
+    if (this.createRow) {
+      this.createRow.id = `${this.el.id}-create`;
+      this.createQueryEl = this.createRow.querySelector(
+        "[data-pc-combo-create-query]",
+      );
+    } else {
+      this.createQueryEl = null;
+    }
     // LiveView patched the component - the select (server state) wins
     // for SELECTION, but open-state belongs to the client: the server
     // always renders the panel hidden, so a phx-change round-trip would
@@ -3952,6 +3971,11 @@ export const PetalComboBox = {
     window.removeEventListener("scroll", this.onReposition, true);
     window.removeEventListener("resize", this.onReposition);
     this.isOpen = false;
+    if (this.remoteEvent) {
+      this.remoteSeq++;
+      clearTimeout(this.remoteTimer);
+      if (this.loadingRow) this.loadingRow.hidden = true;
+    }
     if (this.panel.hidden) return;
     this.panel.hidden = true;
     this.panel.removeAttribute("data-flip");
@@ -4302,7 +4326,7 @@ export const PetalComboBox = {
     ) {
       return; // remote needs a LiveView socket
     }
-    const seq = ++this.remoteSeq;
+    const seq = this.remoteSeq;
     if (this.loadingRow) this.loadingRow.hidden = false;
     const term = this.input.value.trim();
     const handle = (reply) => {

--- a/dev.exs
+++ b/dev.exs
@@ -1436,6 +1436,26 @@ defmodule Dev.PlaygroundLive do
   def handle_event("pg_combo_change", %{"pg_city" => value}, socket),
     do: {:noreply, update(socket, :combo, &%{&1 | chosen: value})}
 
+  def handle_event("pg_remote_search", term, socket) do
+    term = String.downcase(to_string(term))
+
+    results =
+      ~w(Amsterdam Athens Auckland Bangkok Barcelona Beijing Berlin Bogota Boston Brisbane
+         Brussels Budapest BuenosAires Cairo CapeTown Chicago Copenhagen Dallas Delhi Dubai
+         Dublin Edinburgh Geneva Hanoi Helsinki HongKong Houston Istanbul Jakarta Johannesburg
+         KualaLumpur Lagos Lima Lisbon London LosAngeles Madrid Melbourne MexicoCity Miami
+         Milan Montreal Moscow Mumbai Munich Nairobi NewYork Osaka Oslo Paris Prague Rome
+         SanFrancisco Santiago Seoul Shanghai Singapore Stockholm Sydney Tokyo Toronto
+         Vancouver Vienna Warsaw Wellington Zurich)
+      |> Enum.filter(&String.contains?(String.downcase(&1), term))
+      |> Enum.take(8)
+      |> Enum.map(&%{text: &1, value: &1})
+
+    {:reply, %{results: results}, socket}
+  end
+
+  def handle_event("pg_remote_change", _params, socket), do: {:noreply, socket}
+
   def handle_event("pg_rich_change", params, socket) do
     {:noreply,
      assign(socket, :rich, %{
@@ -7324,6 +7344,24 @@ defmodule Dev.PlaygroundLive do
         </div>
       </div>
 
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Remote search - live</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        The LiveView is the data source: typing pushes a debounced event with the raw term, the
+        handler replies with results, and the hook renders them - loading row, stale-reply
+        protection and all. This one searches ~60 world cities server-side.
+      </p>
+      <div class="border border-gray-200 dark:border-gray-400/20 rounded-xl px-6 py-10">
+        <form id="pg-remote-form" phx-change="pg_remote_change" class="mx-auto w-full max-w-sm">
+          <.combo_box
+            id="pg-combo-remote"
+            name="pg_city_remote"
+            placeholder="Search cities (server-side)…"
+            remote_options_event_name="pg_remote_search"
+            options={[]}
+          />
+        </form>
+      </div>
+
       <h2 class="mt-10 mb-1 text-lg font-semibold">Rich closed states - live</h2>
       <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
         The same :selected and :chip slots, wired to a real form with phx-change. Every pick
@@ -7410,7 +7448,7 @@ defmodule Dev.PlaygroundLive do
           ex <-
             examples_for(
               PetalComponents.Showcase.ComboBox,
-              ~w(labels team panel_chrome multiple trigger rich_options basic preselected groups)a
+              ~w(creatable labels team panel_chrome multiple trigger rich_options basic preselected groups)a
             )
         }
         class="mt-10"

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -124,6 +124,31 @@ defmodule PetalComponents.ComboBox do
     default: "Create",
     doc: "the create row's verb, localizable"
 
+  attr :remote_options_event_name, :string,
+    default: nil,
+    doc: """
+    use your LiveView as a remote data source: typing pushes this event
+    (debounced) with the search term as the payload, exactly like the
+    Tom Select-era contract. Handle it and reply with results:
+
+        def handle_event("search", term, socket) do
+          results = MyApp.search(term) |> Enum.map(&%{text: &1.name, value: &1.id})
+          {:reply, %{results: results}, socket}
+        end
+
+    The hook renders the results as the option list (the listbox becomes
+    hook-owned in remote mode); a chosen result is inserted into the
+    hidden select so the form posts it. Requires a LiveView socket.
+    """
+
+  attr :remote_options_target, :any,
+    default: nil,
+    doc: "the event's target - pass @myself when the handler lives on a LiveComponent"
+
+  attr :loading_label, :string,
+    default: "Searching…",
+    doc: "the remote loading row's text, localizable"
+
   attr :placeholder, :string, default: "Select an option…"
   attr :disabled, :boolean, default: false
 
@@ -218,6 +243,8 @@ defmodule PetalComponents.ComboBox do
       phx-hook="PetalComboBox"
       data-max-items={@max_items}
       data-free-text={(@free_text || @create) && "true"}
+      data-remote-event={@remote_options_event_name}
+      data-remote-target={@remote_options_target}
       data-has-value={@current_values != [] && "true"}
       {@rest}
     >
@@ -399,8 +426,20 @@ defmodule PetalComponents.ComboBox do
           {render_slot(@header)}
         </div>
         <div
+          :if={@remote_options_event_name}
+          class="pc-combo-box__loading"
+          data-pc-combo-loading
+          hidden
+        >
+          <.icon name="hero-arrow-path-mini" class="pc-combo-box__loading-icon" />
+          <span>{@loading_label}</span>
+        </div>
+        <%!-- remote mode: the hook renders result rows, so the listbox is
+        hook-owned (the chips container taught us: one writer per region) --%>
+        <div
           role="listbox"
           id={"#{@id}-listbox"}
+          phx-update={@remote_options_event_name && "ignore"}
           class="pc-combo-box__list"
           aria-label={@listbox_label}
           aria-multiselectable={@multiple && "true"}

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -102,6 +102,28 @@ defmodule PetalComponents.ComboBox do
     default: false,
     doc: "single select only: show a clear button in the control when a value is chosen"
 
+  attr :free_text, :boolean,
+    default: false,
+    doc: """
+    typed text is a committable value: Enter with no highlighted option
+    commits the query itself (the empty-stop keyboard grammar's payoff).
+    The committed value is inserted into the hidden select as a dynamic
+    option, so forms post it like any other choice - the server owns
+    whether it persists (re-render it in options to keep it).
+    """
+
+  attr :create, :boolean,
+    default: false,
+    doc: """
+    free_text plus an explicit "create" row in the panel: when the query
+    matches no option label exactly, a keyboard-reachable row offers to
+    create it. Implies free_text's commit behavior.
+    """
+
+  attr :create_label, :string,
+    default: "Create",
+    doc: "the create row's verb, localizable"
+
   attr :placeholder, :string, default: "Select an option…"
   attr :disabled, :boolean, default: false
 
@@ -195,6 +217,7 @@ defmodule PetalComponents.ComboBox do
       class={["pc-combo-box", @class]}
       phx-hook="PetalComboBox"
       data-max-items={@max_items}
+      data-free-text={(@free_text || @create) && "true"}
       data-has-value={@current_values != [] && "true"}
       {@rest}
     >
@@ -400,6 +423,17 @@ defmodule PetalComponents.ComboBox do
               />
             <% end %>
           <% end %>
+          <div
+            :if={@create}
+            class="pc-combo-box__create"
+            data-pc-combo-create
+            role="option"
+            aria-selected="false"
+            hidden
+          >
+            <.icon name="hero-plus-mini" class="pc-combo-box__create-icon" />
+            <span>{@create_label} "<span data-pc-combo-create-query></span>"</span>
+          </div>
           <div class="pc-combo-box__empty" data-pc-combo-empty hidden>{@no_results_text}</div>
         </div>
         <div :if={@footer != []} class="pc-combo-box__footer">

--- a/lib/petal_components/showcase/combo_box.ex
+++ b/lib/petal_components/showcase/combo_box.ex
@@ -109,6 +109,23 @@ defmodule PetalComponents.Showcase.ComboBox do
     """
   end
 
+  example :creatable, "Create new options - free text",
+    description:
+      "create offers a keyboard-reachable \"Create\" row whenever the query matches no option - Enter at the empty stop commits typed text too (free_text alone gives you that without the row). The committed value becomes a real option in the hidden select, so the form posts it; the server owns whether it persists. An existing label is chosen instead of duplicated, case-insensitively." do
+    ~H"""
+    <div class="w-full max-w-sm mx-auto">
+      <.combo_box
+        id="sx-combo-create"
+        name="tags"
+        multiple
+        create
+        placeholder="Add tags…"
+        options={["elixir", "phoenix", "liveview"]}
+      />
+    </div>
+    """
+  end
+
   example :labels, "Label picker - the :selected slot",
     description:
       "The :selected slot renders rich CLOSED-state content in the trigger - here colored dots with a +N overflow, pure composition, no overflow attr. :let receives the list of chosen normalized options (label, value, meta). Client-side picks show the plain count until the LiveView patch re-renders the slot (server wins); a preset value shows the rich state immediately." do

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -857,6 +857,46 @@ describe("remote search", () => {
     vi.useRealTimers();
   });
 
+  it("a keystroke inside the next debounce window invalidates in-flight replies", () => {
+    vi.useFakeTimers();
+    const c = mountRemote();
+    c.control.click();
+    type(c.input, "am");
+    vi.advanceTimersByTime(300); // search 1 fired
+    type(c.input, "amel"); // debounce pending, nothing fired yet
+    // search 1's reply lands NOW - must be dropped against the newer query
+    c.hook.pushes[0].cb({ results: [{ text: "STALE", value: "stale" }] });
+    expect(c.items()).toHaveLength(0);
+    vi.useRealTimers();
+  });
+
+  it("closing the panel invalidates in-flight work and hides the loading row", () => {
+    vi.useFakeTimers();
+    const c = mountRemote();
+    c.control.click();
+    type(c.input, "am");
+    vi.advanceTimersByTime(300);
+    expect(c.loading().hidden).toBe(false);
+    key(c.input, "Escape");
+    expect(c.loading().hidden).toBe(true);
+    c.hook.pushes[0].cb({ results: [{ text: "STALE", value: "stale" }] });
+    expect(c.items()).toHaveLength(0);
+    vi.useRealTimers();
+  });
+
+  it("mode configuration patched by the server reaches the hook", () => {
+    const c = mountCombo({ options: CITIES });
+    expect(c.hook.freeText).toBe(false);
+    // server patch enables free_text
+    c.el.setAttribute("data-free-text", "true");
+    c.hook.updated();
+    expect(c.hook.freeText).toBe(true);
+    c.control.click();
+    type(c.input, "Osaka");
+    key(c.input, "Enter");
+    expect(c.select.value).toBe("Osaka");
+  });
+
   it("pushEventTo carries the target when configured", () => {
     vi.useFakeTimers();
     const c = mountCombo({ options: [], remote: true });

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -39,6 +39,8 @@ function mountCombo({
   maxItems = null,
   clearable = false,
   trigger = false,
+  freeText = false,
+  create = false,
 } = {}) {
   const selectOptions = [...options, ...groups.flatMap((g) => g.options)]
     .map(
@@ -64,6 +66,7 @@ function mountCombo({
   el.className = "pc-combo-box";
   el.setAttribute("phx-hook", "PetalComboBox");
   if (maxItems) el.setAttribute("data-max-items", String(maxItems));
+  if (freeText || create) el.setAttribute("data-free-text", "true");
   const inputHtml = `<input type="text" id="${id}-input" class="pc-combo-box__input" role="combobox"
           aria-expanded="false" aria-autocomplete="list" aria-controls="${id}-listbox"
           autocomplete="off" placeholder="Pick..." />`;
@@ -94,6 +97,7 @@ function mountCombo({
       ${trigger ? '<div class="pc-combo-box__search"><span class="hero-magnifying-glass-mini pc-combo-box__search-icon"></span>' + inputHtml + "</div>" : ""}
       <div role="listbox" id="${id}-listbox" class="pc-combo-box__list" aria-label="Options">
         ${listHtml}
+        ${create ? '<div class="pc-combo-box__create" data-pc-combo-create role="option" aria-selected="false" hidden><span>Create "<span data-pc-combo-create-query></span>"</span></div>' : ""}
         <div class="pc-combo-box__empty" data-pc-combo-empty hidden>No results found</div>
       </div>
     </div>
@@ -679,6 +683,81 @@ describe("the boundary cycle", () => {
     expect(c.highlighted()).toBe(null);
     key(c.input, "ArrowUp");
     expect(c.highlighted()?.dataset.value).toBe("sto");
+  });
+});
+
+describe("free text and create", () => {
+  it("free_text: Enter at the empty stop commits the typed value into the select", () => {
+    const c = mountCombo({ options: CITIES, freeText: true });
+    let changes = 0;
+    c.select.addEventListener("change", () => changes++);
+    c.control.click();
+    type(c.input, "Osaka");
+    // no match -> no highlight -> the empty stop
+    expect(c.highlighted()).toBeNull();
+    key(c.input, "Enter");
+    expect(c.select.value).toBe("Osaka");
+    expect(
+      c.select.querySelector("option[data-pc-combo-custom]"),
+    ).not.toBeNull();
+    expect(changes).toBe(1);
+    expect(c.panel.hidden).toBe(true);
+    expect(c.input.value).toBe("Osaka");
+  });
+
+  it("free_text: a case-insensitive existing label is chosen, never duplicated", () => {
+    const c = mountCombo({ options: CITIES, freeText: true });
+    c.control.click();
+    type(c.input, "TOKYO");
+    // exact-ish text but the ranking highlights Tokyo - clear the
+    // highlight to reach the empty stop deliberately
+    key(c.input, "End");
+    key(c.input, "ArrowDown");
+    expect(c.highlighted()).toBeNull();
+    key(c.input, "Enter");
+    expect(c.select.value).toBe("tyo");
+    expect(c.select.querySelector("option[data-pc-combo-custom]")).toBeNull();
+  });
+
+  it("create: the row appears for novel queries, hides on exact matches, and is the last keyboard stop", () => {
+    const c = mountCombo({ options: CITIES, create: true });
+    c.control.click();
+    const row = c.el.querySelector("[data-pc-combo-create]");
+    expect(row.hidden).toBe(true);
+    type(c.input, "Osa");
+    expect(row.hidden).toBe(false);
+    expect(row.textContent).toContain('Create "Osa"');
+    type(c.input, "Tokyo");
+    expect(row.hidden).toBe(true);
+    type(c.input, "Tok");
+    // End lands on the create row (the last stop), Enter commits
+    key(c.input, "End");
+    expect(row.hasAttribute("data-highlighted")).toBe(true);
+    key(c.input, "Enter");
+    expect(c.select.value).toBe("Tok");
+  });
+
+  it("create in multiple mode commits a chip and stays open", () => {
+    const c = mountCombo({ options: CITIES, multiple: true, create: true });
+    c.control.click();
+    type(c.input, "Osaka");
+    c.el.querySelector("[data-pc-combo-create]").click();
+    expect(c.chips().map((x) => x.dataset.value)).toEqual(["Osaka"]);
+    expect(c.panel.hidden).toBe(false);
+    expect(c.input.value).toBe("");
+    // and the empty row never fought the create row
+    type(c.input, "zzz");
+    expect(c.el.querySelector("[data-pc-combo-create]").hidden).toBe(false);
+    expect(c.empty().hidden).toBe(true);
+  });
+
+  it("strict mode is untouched: Enter at the empty stop does nothing", () => {
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    type(c.input, "Osaka");
+    key(c.input, "Enter");
+    expect(c.select.value).toBe("");
+    expect(c.panel.hidden).toBe(false);
   });
 });
 

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -897,6 +897,21 @@ describe("remote search", () => {
     expect(c.select.value).toBe("Osaka");
   });
 
+  it("a patched remote event invalidates the previous configuration's in-flight reply", () => {
+    vi.useFakeTimers();
+    const c = mountRemote();
+    c.control.click();
+    type(c.input, "am");
+    vi.advanceTimersByTime(300); // search fired under the OLD event
+    // server patch swaps the data source
+    c.el.setAttribute("data-remote-event", "other_search");
+    c.hook.updated();
+    // the old event's reply arrives late - must be dropped
+    c.hook.pushes[0].cb({ results: [{ text: "OBSOLETE", value: "x" }] });
+    expect(c.items()).toHaveLength(0);
+    vi.useRealTimers();
+  });
+
   it("pushEventTo carries the target when configured", () => {
     vi.useFakeTimers();
     const c = mountCombo({ options: [], remote: true });

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -41,6 +41,7 @@ function mountCombo({
   trigger = false,
   freeText = false,
   create = false,
+  remote = false,
 } = {}) {
   const selectOptions = [...options, ...groups.flatMap((g) => g.options)]
     .map(
@@ -67,6 +68,7 @@ function mountCombo({
   el.setAttribute("phx-hook", "PetalComboBox");
   if (maxItems) el.setAttribute("data-max-items", String(maxItems));
   if (freeText || create) el.setAttribute("data-free-text", "true");
+  if (remote) el.setAttribute("data-remote-event", "search");
   const inputHtml = `<input type="text" id="${id}-input" class="pc-combo-box__input" role="combobox"
           aria-expanded="false" aria-autocomplete="list" aria-controls="${id}-listbox"
           autocomplete="off" placeholder="Pick..." />`;
@@ -95,6 +97,7 @@ function mountCombo({
     ${bodyHtml}
     <div class="pc-combo-box__panel" data-pc-combo-panel hidden>
       ${trigger ? '<div class="pc-combo-box__search"><span class="hero-magnifying-glass-mini pc-combo-box__search-icon"></span>' + inputHtml + "</div>" : ""}
+      ${remote ? '<div class="pc-combo-box__loading" data-pc-combo-loading hidden><span>Searching…</span></div>' : ""}
       <div role="listbox" id="${id}-listbox" class="pc-combo-box__list" aria-label="Options">
         ${listHtml}
         ${create ? '<div class="pc-combo-box__create" data-pc-combo-create role="option" aria-selected="false" hidden><span>Create "<span data-pc-combo-create-query></span>"</span></div>' : ""}
@@ -758,6 +761,116 @@ describe("free text and create", () => {
     key(c.input, "Enter");
     expect(c.select.value).toBe("");
     expect(c.panel.hidden).toBe(false);
+  });
+});
+
+describe("remote search", () => {
+  function mountRemote(extra = {}) {
+    const c = mountCombo({ options: [], remote: true, ...extra });
+    c.hook.pushes = [];
+    c.hook.pushEvent = function (event, payload, cb) {
+      this.pushes.push({ event, payload, cb });
+    };
+    c.loading = () => c.el.querySelector("[data-pc-combo-loading]");
+    return c;
+  }
+
+  it("typing debounces, pushes the raw term, shows the loading row, renders the reply", () => {
+    vi.useFakeTimers();
+    const c = mountRemote();
+    c.control.click();
+    type(c.input, "am");
+    expect(c.hook.pushes).toHaveLength(0); // debounced
+    vi.advanceTimersByTime(300);
+    expect(c.hook.pushes).toHaveLength(1);
+    expect(c.hook.pushes[0].event).toBe("search");
+    expect(c.hook.pushes[0].payload).toBe("am");
+    expect(c.loading().hidden).toBe(false);
+    c.hook.pushes[0].cb({
+      results: [
+        { text: "Amelia Ward", value: "amelia" },
+        { text: "Amara Okafor", value: "amara" },
+      ],
+    });
+    expect(c.loading().hidden).toBe(true);
+    const rows = c.items();
+    expect(rows.map((r) => r.dataset.value)).toEqual(["amelia", "amara"]);
+    expect(rows[0].hasAttribute("data-highlighted")).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("choosing a remote row inserts the option into the select and dispatches change", () => {
+    vi.useFakeTimers();
+    const c = mountRemote();
+    let changes = 0;
+    c.select.addEventListener("change", () => changes++);
+    c.control.click();
+    type(c.input, "am");
+    vi.advanceTimersByTime(300);
+    c.hook.pushes[0].cb({
+      results: [{ text: "Amelia Ward", value: "amelia" }],
+    });
+    c.items()[0].click();
+    expect(c.select.value).toBe("amelia");
+    const opt = c.select.querySelector("option[data-pc-combo-custom]");
+    expect(opt.textContent).toBe("Amelia Ward");
+    expect(changes).toBe(1);
+    expect(c.input.value).toBe("Amelia Ward");
+    vi.useRealTimers();
+  });
+
+  it("a stale reply never clobbers a newer search", () => {
+    vi.useFakeTimers();
+    const c = mountRemote();
+    c.control.click();
+    type(c.input, "am");
+    vi.advanceTimersByTime(300);
+    type(c.input, "amel");
+    vi.advanceTimersByTime(300);
+    expect(c.hook.pushes).toHaveLength(2);
+    // newer reply lands first
+    c.hook.pushes[1].cb({
+      results: [{ text: "Amelia Ward", value: "amelia" }],
+    });
+    // the older reply arrives late - dropped
+    c.hook.pushes[0].cb({ results: [{ text: "WRONG", value: "wrong" }] });
+    expect(c.items().map((r) => r.dataset.label)).toEqual(["Amelia Ward"]);
+    vi.useRealTimers();
+  });
+
+  it("empty results show the empty row; remote multiple builds chips", () => {
+    vi.useFakeTimers();
+    const c = mountRemote({ multiple: true });
+    c.control.click();
+    type(c.input, "zz");
+    vi.advanceTimersByTime(300);
+    c.hook.pushes[0].cb({ results: [] });
+    expect(c.empty().hidden).toBe(false);
+    type(c.input, "am");
+    vi.advanceTimersByTime(300);
+    c.hook.pushes[1].cb({
+      results: [{ text: "Amelia Ward", value: "amelia" }],
+    });
+    c.items()[0].click();
+    expect(c.chips().map((x) => x.dataset.value)).toEqual(["amelia"]);
+    expect(c.panel.hidden).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("pushEventTo carries the target when configured", () => {
+    vi.useFakeTimers();
+    const c = mountCombo({ options: [], remote: true });
+    c.el.setAttribute("data-remote-target", "3");
+    c.hook.destroyed();
+    c.hook.mounted();
+    const calls = [];
+    c.hook.pushEventTo = (target, event, payload, cb) =>
+      calls.push({ target, event, payload });
+    c.control.click();
+    type(c.input, "x");
+    vi.advanceTimersByTime(300);
+    expect(calls).toEqual([{ target: "3", event: "search", payload: "x" }]);
+    vi.useRealTimers();
   });
 });
 

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -543,6 +543,62 @@ defmodule PetalComponents.ComboBoxTest do
     refute multi =~ "pc-combo-box__trigger-clear"
   end
 
+  describe "M3b modes" do
+    test "free_text and create mark the root; create renders the row" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="ft" name="ft" free_text options={["A"]} />
+        """)
+
+      assert html =~ ~s|data-free-text="true"|
+      refute html =~ "pc-combo-box__create"
+
+      created =
+        rendered_to_string(~H"""
+        <.combo_box id="cr" name="cr" create create_label="Add" options={["A"]} />
+        """)
+
+      assert created =~ ~s|data-free-text="true"|
+      assert created =~ "pc-combo-box__create"
+      assert created =~ "Add \""
+      assert created =~ "data-pc-combo-create-query"
+    end
+
+    test "remote mode: event/target attrs, loading row, hook-owned listbox" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box
+          id="rm"
+          name="rm"
+          remote_options_event_name="search"
+          remote_options_target="3"
+          loading_label="Looking…"
+          options={[]}
+        />
+        """)
+
+      assert html =~ ~s|data-remote-event="search"|
+      assert html =~ ~s|data-remote-target="3"|
+      assert html =~ "pc-combo-box__loading"
+      assert html =~ "Looking…"
+      # one writer per region: the hook renders result rows
+      assert html =~ ~r/role="listbox"[^>]*phx-update="ignore"/s or
+               html =~ ~r/phx-update="ignore"[^>]*role="listbox"/s
+
+      plain =
+        rendered_to_string(~H"""
+        <.combo_box id="pl" name="pl" options={["A"]} />
+        """)
+
+      refute plain =~ "pc-combo-box__loading"
+      refute plain =~ ~r/role="listbox"[^>]*phx-update/s
+    end
+  end
+
   test "raises without any id source" do
     assigns = %{}
 


### PR DESCRIPTION
The final Tom Select parity gap, closed on the new architecture. Two commits: local modes, then remote.

## free_text

Enter at the empty stop - the state the M1 keyboard grammar was chosen for - commits the typed text as a dynamic `data-pc-combo-custom` option in the hidden select, so the form posts it like any choice. A case-insensitively matching existing label is chosen instead, never duplicated. The server owns persistence: re-render the value into `options` to keep it past the next patch (documented).

## create

`free_text` plus an explicit **"Create ..."** row - the keyboard-reachable footer-region consumer the panel-slot ruling promised. Appears for novel queries (raw text displayed, exact matches suppress it), participates as the last arrow stop (`navItems`), hover-highlights, commits by click or Enter. `create_label` localizes.

## Remote search - contract verbatim

`remote_options_event_name` / `remote_options_target` exactly as the old Pro component documented them: typing pushes the **raw term** (debounced 300ms), the handler replies `{:reply, %{results: [%{text: ..., value: ...}]}, socket}`, `@myself` supported for LiveComponents. The hook renders results as the option list - **the listbox is hook-owned in remote mode** (`phx-update="ignore"`), applying the one-writer-per-region lesson from the chips container preemptively. Designed loading row (`loading_label`), stale replies dropped by sequence counter, and `ensureOption` inserts picked values into the select (shared with free_text).

## Demos

Live remote demo on the playground (60 world cities, server-side search) + creatable-tags registry example (fully client-side).

## Tests

10 new JS specs (empty-stop commit, no-dupe, create row lifecycle + keyboard, multiple create, strict-mode untouched, debounce/push/render, remote choose, stale reply, empty results + chips, LiveComponent target) and 2 Elixir mode tests. 808 Elixir / 96 JS green. Live-verified both modes on the playground.