### PR TITLE
feat(combo_box): M4 - field citizenship and sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 
 #### Added
 
+- **`combo_box` M4 - field citizenship and sizes.**
+  `<.field type="combobox">` brings the full field grammar - label,
+  changeset errors (with the wrapper error ring on the control and
+  trigger), `help_text`, required - and forwards every combobox attr;
+  `combo_variant` selects the anatomy (`:variant` belongs to
+  radio-card), the field size family maps onto the new combobox
+  `size` attr (`sm`/`md`/`lg`; `xs`/`xl` clamp), and `clearable`
+  passes through. Multiple gets the empty hidden input so forms post
+  cleanly. Rich slots (`:option`, `:selected`, `:chip`,
+  `:header`/`:footer`) stay on the bare component by design.
+
+#### Added
+
 - **`combo_box` M3b - the modes: `free_text`, `create`, remote search.**
   The last of the Tom Select parity surface, on the new architecture:
   - `free_text`: Enter at the empty stop commits the typed text as a

--- a/assets/default.css
+++ b/assets/default.css
@@ -1141,6 +1141,10 @@
     @apply mb-0;
   }
 
+  .pc-form-field-wrapper--error .pc-combo-box__control,
+  .pc-form-field-wrapper--error .pc-combo-box__trigger {
+    @apply border-danger-500 focus-within:border-danger-500 focus-within:ring-danger-500/50 dark:border-danger-400;
+  }
   .pc-form-field-wrapper--error input,
   .pc-form-field-wrapper--error select,
   .pc-form-field-wrapper--error textarea {
@@ -2161,6 +2165,20 @@
        deviating from it was the whole iOS first-tap bug. */
     @apply w-full min-w-0 bg-transparent border-0 px-3 py-2 text-base sm:text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed dark:text-gray-100 dark:placeholder-gray-500;
     border-radius: inherit;
+  }
+  /* sizes: the field-size family. sm keeps text-base below the sm
+     breakpoint - the iOS auto-zoom rule outranks density everywhere */
+  .pc-combo-box--sm .pc-combo-box__input {
+    @apply px-2.5 py-1.5 sm:text-xs;
+  }
+  .pc-combo-box--sm .pc-combo-box__trigger {
+    @apply px-2.5 py-1.5 text-xs;
+  }
+  .pc-combo-box--lg .pc-combo-box__input {
+    @apply py-2.5 sm:text-base;
+  }
+  .pc-combo-box--lg .pc-combo-box__trigger {
+    @apply py-2.5 text-base;
   }
   .pc-combo-box__chevron {
     @apply shrink-0 pointer-events-none text-gray-400 dark:text-gray-500;

--- a/dev.exs
+++ b/dev.exs
@@ -7344,6 +7344,43 @@ defmodule Dev.PlaygroundLive do
         </div>
       </div>
 
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Field citizenship + sizes</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        &lt;.field type="combobox"&gt; brings label, changeset errors and help_text; size spans
+        the field family (xs/xl clamp to sm/lg). Rich slots stay on the bare component.
+      </p>
+      <div class="border border-gray-200 dark:border-gray-400/20 rounded-xl px-6 py-10">
+        <div class="mx-auto flex w-full max-w-sm flex-col gap-1">
+          <.field
+            type="combobox"
+            name="fc_city"
+            value={nil}
+            label="Destination"
+            help_text="Where the team offsite lands"
+            clearable
+            options={[{"🇯🇵 Tokyo", "tyo"}, {"🇵🇹 Lisbon", "lis"}, {"🇸🇪 Stockholm", "sto"}]}
+          />
+          <.field
+            type="combobox"
+            name="fc_size_sm"
+            value={nil}
+            label="Small"
+            size="sm"
+            options={["Alpha", "Beta"]}
+          />
+          <.field
+            type="combobox"
+            name="fc_size_lg"
+            value={nil}
+            label="Large"
+            size="lg"
+            combo_variant="trigger"
+            placeholder="Trigger, lg"
+            options={["Alpha", "Beta"]}
+          />
+        </div>
+      </div>
+
       <h2 class="mt-10 mb-1 text-lg font-semibold">Remote search - live</h2>
       <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
         The LiveView is the data source: typing pushes a debounced event with the raw term, the

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -149,6 +149,11 @@ defmodule PetalComponents.ComboBox do
     default: "Searching…",
     doc: "the remote loading row's text, localizable"
 
+  attr :size, :string,
+    default: "md",
+    values: ["sm", "md", "lg"],
+    doc: "control density - follows the field-size family"
+
   attr :placeholder, :string, default: "Select an option…"
   attr :disabled, :boolean, default: false
 
@@ -239,7 +244,7 @@ defmodule PetalComponents.ComboBox do
     ~H"""
     <div
       id={@id}
-      class={["pc-combo-box", @class]}
+      class={["pc-combo-box", @size != "md" && "pc-combo-box--#{@size}", @class]}
       phx-hook="PetalComboBox"
       data-max-items={@max_items}
       data-free-text={(@free_text || @create) && "true"}

--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -43,6 +43,10 @@ defmodule PetalComponents.Field do
 
   attr :variant, :any, default: "outline", doc: "outline, classic - used by radio-card"
 
+  attr :combo_variant, :string,
+    values: ["input", "trigger"],
+    doc: "combobox only: the anatomy - searchable input (default) or select-like trigger button"
+
   attr :indicator_position, :string,
     default: "end",
     values: ~w(start end corner),
@@ -149,7 +153,8 @@ defmodule PetalComponents.Field do
   attr :rest, :global,
     include:
       ~w(autocomplete autocorrect autocapitalize disabled form max maxlength min minlength list
-    pattern placeholder readonly required size step value name multiple prompt default year month day hour minute second builder options layout cols rows wrap checked accept),
+    pattern placeholder readonly required size step value name multiple prompt default year month day hour minute second builder options layout cols rows wrap checked accept
+    free_text create create_label max_items count_label search_placeholder listbox_label no_results_text results_label clear_label remove_label loading_label remote_options_event_name remote_options_target form_id),
     doc: "All other props go on the input"
 
   def field(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
@@ -235,6 +240,48 @@ defmodule PetalComponents.Field do
         <option :if={@prompt} value="">{@prompt}</option>
         {Phoenix.HTML.Form.options_for_select(@options, @selected || @value)}
       </select>
+      <.field_error :for={msg <- @errors}>{msg}</.field_error>
+      <.field_help_text help_text={@help_text} />
+    </.field_wrapper>
+    """
+  end
+
+  def field(%{type: "combobox"} = assigns) do
+    assigns =
+      assigns
+      |> assign_new(:options, fn -> [] end)
+      # the field size family spans xs-xl; the combobox speaks sm/md/lg
+      |> assign(
+        :combo_size,
+        case assigns.size do
+          "xs" -> "sm"
+          "xl" -> "lg"
+          s -> s
+        end
+      )
+      # :variant belongs to radio-card here - the combobox anatomy rides
+      # combo_variant ("input" | "trigger")
+      |> assign_new(:combo_variant, fn -> "input" end)
+
+    ~H"""
+    <.field_wrapper errors={@errors} name={@name} class={@wrapper_class} no_margin={@no_margin}>
+      <.field_label required={@required} for={@id} class={@label_class}>
+        {@label}
+      </.field_label>
+      <input :if={@multiple} type="hidden" name={@name} value="" />
+      <PetalComponents.ComboBox.combo_box
+        id={@id}
+        name={@name}
+        value={@selected || @value}
+        options={@options}
+        multiple={@multiple}
+        required={@required}
+        size={@combo_size}
+        variant={@combo_variant}
+        clearable={@clearable}
+        class={@class}
+        {@rest}
+      />
       <.field_error :for={msg <- @errors}>{msg}</.field_error>
       <.field_help_text help_text={@help_text} />
     </.field_wrapper>

--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -262,13 +262,26 @@ defmodule PetalComponents.Field do
       # :variant belongs to radio-card here - the combobox anatomy rides
       # combo_variant ("input" | "trigger")
       |> assign_new(:combo_variant, fn -> "input" end)
+      # the combobox appends [] itself for multiple; the hidden empty
+      # input must post the SAME name or a bare-name field submits a
+      # mixed shape (the FormField path appends [] upstream already)
+      |> then(fn a ->
+        assign(
+          a,
+          :hidden_name,
+          if(a.multiple && a.name && !String.ends_with?(a.name, "[]"),
+            do: a.name <> "[]",
+            else: a.name
+          )
+        )
+      end)
 
     ~H"""
     <.field_wrapper errors={@errors} name={@name} class={@wrapper_class} no_margin={@no_margin}>
       <.field_label required={@required} for={@id} class={@label_class}>
         {@label}
       </.field_label>
-      <input :if={@multiple} type="hidden" name={@name} value="" />
+      <input :if={@multiple} type="hidden" name={@hidden_name} value="" />
       <PetalComponents.ComboBox.combo_box
         id={@id}
         name={@name}

--- a/test/petal/field_test.exs
+++ b/test/petal/field_test.exs
@@ -1386,6 +1386,18 @@ defmodule PetalComponents.FieldTest do
       refute html =~ "user[tags][][]"
     end
 
+    test "a bare-name multiple posts one shape: hidden input and select share the [] name" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.field type="combobox" name="tags" value={[]} label="Tags" multiple options={[{"A", "a"}]} />
+        """)
+
+      assert html =~ ~s|type="hidden" name="tags[]" value=""|
+      assert html =~ ~s|<select id="combo_box_tags-select" name="tags[]"|
+    end
+
     test "size maps the field family onto the combobox family; combo_variant reaches the anatomy" do
       assigns = %{}
 

--- a/test/petal/field_test.exs
+++ b/test/petal/field_test.exs
@@ -1338,4 +1338,72 @@ defmodule PetalComponents.FieldTest do
     assert html =~ ~s|data-value-prefix="$"|
     assert html =~ ~s|data-value-suffix="%"|
   end
+
+  describe "combobox field" do
+    test "renders label, combobox, errors and help under the wrapper" do
+      assigns = %{
+        form:
+          Phoenix.Component.to_form(%{"city" => "syd"},
+            as: :user,
+            errors: [city: {"is invalid", []}],
+            action: :validate
+          )
+      }
+
+      html =
+        rendered_to_string(~H"""
+        <.field
+          type="combobox"
+          field={@form[:city]}
+          label="City"
+          help_text="Pick one"
+          options={[{"Sydney", "syd"}]}
+          clearable
+        />
+        """)
+
+      assert html =~ "pc-combo-box"
+      assert html =~ "City"
+      assert html =~ "Pick one"
+      assert html =~ "is invalid"
+      assert html =~ "pc-form-field-wrapper--error"
+      assert html =~ ~s|name="user[city]"|
+      # the chosen value flowed from the form field
+      assert html =~ ~s|data-has-value="true"|
+      # clearable rode @rest through the include list
+      assert html =~ "pc-combo-box__clear"
+    end
+
+    test "multiple appends [] once and adds the empty hidden input" do
+      assigns = %{form: Phoenix.Component.to_form(%{}, as: :user)}
+
+      html =
+        rendered_to_string(~H"""
+        <.field type="combobox" field={@form[:tags]} multiple options={[{"A", "a"}]} />
+        """)
+
+      assert html =~ ~s|type="hidden" name="user[tags][]" value=""|
+      refute html =~ "user[tags][][]"
+    end
+
+    test "size maps the field family onto the combobox family; combo_variant reaches the anatomy" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.field
+          type="combobox"
+          name="who"
+          value={nil}
+          label="Who"
+          size="xs"
+          combo_variant="trigger"
+          options={[{"A", "a"}]}
+        />
+        """)
+
+      assert html =~ "pc-combo-box--sm"
+      assert html =~ "pc-combo-box__trigger"
+    end
+  end
 end


### PR DESCRIPTION
The combobox arc's final milestone (docs land separately in petal_marketing).

## `<.field type="combobox">`

Full field grammar: label, changeset errors, `help_text`, `required`, and the empty hidden input for `multiple`. The wrapper's error ring now styles the combobox control and trigger surfaces like every other input.

**Attr collision resolution** (field already declares these for other types, so they'd never reach `@rest`):
- `size`: the field family (xs–xl) maps onto the new combobox `size` attr — sm/md/lg, with xs/xl clamping.
- `combo_variant` ("input" | "trigger") carries the anatomy; `:variant` stays radio-card's.
- `clearable` passed through explicitly.
- Everything else (`free_text`, `create`, `max_items`, remote attrs, labels…) rides the rest include list.

Rich slots stay on the bare component by design — a field wrapper can't meaningfully proxy slots.

## Sizes

`size` on the component: sm/lg densities for input and trigger surfaces. The sub-`sm`-breakpoint `text-base` iOS auto-zoom rule outranks density at every size.

## Tests

3 field integration tests (error/label/help/name/value/clearable wiring, multiple bracket-guard + hidden input, size clamp + variant pass-through). 811 Elixir / 100 JS green. Playground has a live field + sizes section.