### PR TITLE
chore: release v4.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-### Unreleased
+### 4.12.0 - 2026-08-08
 
 #### Added
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PetalComponents.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/petalframework/petal_components"
-  @version "4.11.3"
+  @version "4.12.0"
 
   def project do
     [


### PR DESCRIPTION
Version bump + changelog date for the 4.12.0 release.

Headlines: the complete combobox (M1-M4 - parity, trigger variant, slot family, modes + remote, field citizenship + sizes), the DataTable State contract + in-memory engine, avatar `2xs`.

After merge, Nic publishes to Hex (TTY-gated), then: marketing docs PR (`feat/combobox-docs`, ready and compile-verified), MCP schema sync, and the data table component build begins.

Suites at the bump: 812 Elixir / 100 JS green.