### PR TITLE
feat(data_table): the component core (DT-M1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **`<.data_table>` - the component core (4.12 data table, milestone 1).**
+  Composed around `<.table>`, driven entirely by `DataTable.State`:
+  `:col` slots (field, label, sortable, align), sortable headers with
+  aria-sort in BOTH wiring modes - link mode patches per-column URLs
+  built via `State.to_params` (shareable state, working back button),
+  event mode pushes one op-grammar event (`sort`/`page`/
+  `clear_filters`) - a range-summary footer with pagination that
+  auto-picks numbered (total known) or simple (cursor mode), loading
+  skeleton rows, a filters-aware empty state with the clear-filters
+  way out, `:action`/`:toolbar`/`:empty` slots, and density/striped/
+  sticky pass-through. Toolbar search + filter editors arrive next
+  milestone (the combobox trigger listbox was built for them).
+- **`table` `on_sort` accepts a 1-arity function** of the sort key -
+  per-column events/JS, how the data table patches sort URLs.
+- **`pagination` event mode grows up**: `event` accepts a custom event
+  name (string) and `event_values` adds phx-value-* pairs - page
+  clicks can speak any consumer's event grammar.
+
 ### 4.12.0 - 2026-08-08
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -2585,6 +2585,41 @@
     @apply w-full! h-full!;
   }
 
+  /* Data table: composition chrome around pc-table */
+  .pc-data-table__toolbar {
+    @apply mb-3 flex flex-wrap items-center gap-2;
+  }
+  .pc-data-table__scroll {
+    @apply overflow-x-auto;
+  }
+  .pc-data-table__footer {
+    @apply mt-3 flex flex-wrap items-center justify-between gap-3;
+  }
+  .pc-data-table__range {
+    @apply text-sm text-gray-500 dark:text-gray-400;
+  }
+  .pc-data-table__cell--right {
+    @apply text-right;
+  }
+  .pc-data-table__cell--center {
+    @apply text-center;
+  }
+  .pc-data-table__actions {
+    @apply flex items-center justify-end gap-1;
+  }
+  .pc-data-table__actions-th {
+    @apply w-px;
+  }
+  .pc-data-table__empty {
+    @apply flex items-center justify-center gap-2 py-8 text-sm text-gray-500 dark:text-gray-400;
+  }
+  .pc-data-table__clear-filters {
+    @apply font-medium text-primary-600 hover:underline dark:text-primary-400;
+  }
+  .pc-data-table__skeleton.pc-data-table__skeleton {
+    @apply h-4 w-24 max-w-full;
+  }
+
   /* Avatars - sizes */
 
   /* dense contexts: chips, table cells - the reui/shadcn size-4/5 band */

--- a/dev.exs
+++ b/dev.exs
@@ -228,6 +228,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "checkbox", name: "Checkbox", ready: true},
         %{slug: "select", name: "Select", ready: true},
         %{slug: "combo-box", name: "Combobox", ready: true},
+        %{slug: "data-table", name: "Data table", ready: true},
         %{slug: "radio", name: "Radio", ready: true},
         %{slug: "switch", name: "Switch", ready: true},
         %{slug: "slider", name: "Slider", ready: true},
@@ -746,6 +747,7 @@ defmodule Dev.PlaygroundLive do
        select: %{disabled: false, error: false, help: false},
        combo: %{disabled: false, chosen: nil},
        rich: %{labels: ~w(feat bug imp des), team: ~w(amelia jonah)},
+       dt: PetalComponents.DataTable.State |> struct() |> run_dt(),
        radio: %{
          style: "cards",
          variant: "outline",
@@ -1435,6 +1437,40 @@ defmodule Dev.PlaygroundLive do
   # component, so the page proves it live
   def handle_event("pg_combo_change", %{"pg_city" => value}, socket),
     do: {:noreply, update(socket, :combo, &%{&1 | chosen: value})}
+
+  # the data table's event-mode op grammar, applied with State helpers and
+  # re-run through the free engine - the whole backend in one handler
+  def handle_event("pg_table", params, socket) do
+    alias PetalComponents.DataTable.State
+    {state, _rows} = socket.assigns.dt
+
+    state =
+      case params do
+        %{"op" => "sort", "field" => field} ->
+          State.toggle_sort(state, String.to_existing_atom(field))
+
+        %{"op" => "page", "page" => page} ->
+          %{state | page: String.to_integer(to_string(page))}
+
+        %{"op" => "clear_filters"} ->
+          State.clear_filters(state)
+
+        _ ->
+          state
+      end
+
+    {:noreply, assign(socket, :dt, run_dt(state))}
+  end
+
+  defp run_dt(state) do
+    {rows, state} =
+      PetalComponents.DataTable.Engine.List.run(
+        PetalComponents.Showcase.DataTable.sample_rows(),
+        %{state | page_size: 5}
+      )
+
+    {state, rows}
+  end
 
   def handle_event("pg_remote_search", term, socket) do
     term = String.downcase(to_string(term))
@@ -7273,6 +7309,61 @@ defmodule Dev.PlaygroundLive do
         registry - the same source petal.build renders, so the playground and the marketing
         docs can't drift.
       </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "data-table"} = assigns) do
+    ~H"""
+    <div class="max-w-3xl">
+      <h1 class="text-3xl font-bold tracking-tight">Data table</h1>
+      <p class="mt-2 mb-6 text-gray-600 dark:text-gray-300">
+        Sortable, paged and filter-aware, driven by one State struct. This live demo runs
+        EVENT mode: every interaction pushes a single op-grammar event, the handler applies it
+        with State helpers and re-runs the free in-memory engine. Link mode does the same
+        through patch URLs - state you can curl.
+      </p>
+
+      <div class="border border-gray-200 dark:border-gray-400/20 rounded-xl p-6">
+        <% {state, rows} = @dt %>
+        <.data_table id="pg-dt" rows={rows} state={state} on_change="pg_table" striped>
+          <:col :let={row} field={:name} sortable>{row.name}</:col>
+          <:col :let={row} field={:email}>{row.email}</:col>
+          <:col :let={row} field={:status}>
+            <.badge
+              size="sm"
+              color={
+                case row.status do
+                  "paid" -> "success"
+                  "pending" -> "warning"
+                  _ -> "danger"
+                end
+              }
+              label={row.status}
+            />
+          </:col>
+          <:col :let={row} field={:amount} sortable align="right">${row.amount}</:col>
+        </.data_table>
+      </div>
+
+      <div
+        :for={
+          ex <-
+            examples_for(
+              PetalComponents.Showcase.DataTable,
+              ~w(basic loading empty)a
+            )
+        }
+        class="mt-10"
+      >
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <.showcase_props component={PetalComponents.DataTable} function={:data_table} />
     </div>
     """
   end

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -41,6 +41,7 @@ defmodule PetalComponents do
         Icon,
         Input,
         ComboBox,
+        DataTable,
         Command,
         InputGroup,
         InputOtp,

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -1,0 +1,283 @@
+defmodule PetalComponents.DataTable do
+  @moduledoc """
+  A full data table composed around `PetalComponents.Table`: sortable
+  columns, paging, loading and empty states - driven entirely by a
+  `PetalComponents.DataTable.State`.
+
+  Two wiring modes, like pagination:
+
+    * **link mode** (default, pass `path`): every sort and page change is
+      a `patch` URL built via `State.to_params/1`. State is shareable,
+      the back button works, and `handle_params` + `State.from_params/2`
+      is the whole backend:
+
+          def handle_params(params, _uri, socket) do
+            state = State.from_params(params, fields: [:name, :email])
+            {rows, state} = Engine.List.run(all_rows(), state)
+            {:noreply, assign(socket, rows: rows, table: state)}
+          end
+
+    * **event mode** (pass `on_change`): one event, one grammar. Sorts
+      arrive as `%{"op" => "sort", "field" => f}`, page changes as
+      `%{"op" => "page", "page" => n}`, filter clears as
+      `%{"op" => "clear_filters"}`.
+
+  Rows can be any enumerable of maps/structs; pair with
+  `PetalComponents.DataTable.Engine.List` for zero-setup in-memory
+  data, or run the state against your own query layer.
+  """
+  use Phoenix.Component
+
+  import PetalComponents.Pagination
+  import PetalComponents.Skeleton
+  import PetalComponents.Table
+
+  alias PetalComponents.DataTable.State
+  alias Phoenix.LiveView.JS
+
+  attr :id, :string, required: true
+  attr :rows, :list, default: []
+  attr :state, State, required: true
+
+  attr :path, :string,
+    default: nil,
+    doc: """
+    link mode: the base path sort and page changes patch to, with the
+    state encoded as query params. Required unless `on_change` is set.
+    """
+
+  attr :on_change, :string,
+    default: nil,
+    doc: """
+    event mode: the event every table interaction pushes, with an
+    op-shaped payload (`op` of "sort" | "page" | "clear_filters").
+    """
+
+  attr :target, :any, default: nil, doc: "event mode: the phx-target (e.g. @myself)"
+  attr :loading, :boolean, default: false, doc: "render skeleton rows instead of data"
+  attr :density, :string, default: "comfortable", values: ["comfortable", "compact"]
+  attr :striped, :boolean, default: false
+  attr :sticky_header, :boolean, default: false
+  attr :variant, :string, default: "basic", values: ["ghost", "basic"]
+  attr :of_label, :string, default: "of", doc: "the range summary's connective, localizable"
+  attr :page_label, :string, default: "Page", doc: "cursor mode's page word, localizable"
+
+  attr :no_results_text, :string, default: "No results"
+
+  attr :no_filtered_results_text, :string,
+    default: "No results for these filters",
+    doc: "the empty message while filters are active"
+
+  attr :clear_filters_label, :string, default: "Clear filters"
+  attr :class, :any, default: nil
+
+  slot :col, required: true do
+    attr :field, :atom, required: true
+    attr :label, :string
+    attr :sortable, :boolean
+    attr :align, :string, values: ["left", "center", "right"]
+    attr :class, :any
+  end
+
+  slot :action, doc: "trailing actions column, `:let` receives the row"
+  slot :toolbar, doc: "custom toolbar content rendered above the table"
+  slot :empty, doc: "custom empty state; a filters-aware default renders otherwise"
+
+  def data_table(assigns) do
+    if is_nil(assigns.path) and is_nil(assigns.on_change) do
+      raise ArgumentError, "data_table needs either path (link mode) or on_change (event mode)"
+    end
+
+    {sort_by, sort_dir} =
+      case assigns.state.order_by do
+        [{field, dir} | _] -> {to_string(field), to_string(dir)}
+        [] -> {nil, "asc"}
+      end
+
+    fields = Map.new(assigns.col, fn col -> {to_string(col.field), col.field} end)
+
+    assigns =
+      assigns
+      |> assign(:sort_by, sort_by)
+      |> assign(:sort_dir, sort_dir)
+      |> assign(:on_sort, sort_handler(assigns, fields))
+      |> assign(:skeleton_rows, List.duplicate(%{}, min(assigns.state.page_size, 10)))
+
+    ~H"""
+    <div id={@id} class={["pc-data-table", @class]}>
+      <div :if={@toolbar != []} class="pc-data-table__toolbar">
+        {render_slot(@toolbar)}
+      </div>
+
+      <div class="pc-data-table__scroll">
+        <.table
+          id={"#{@id}-table"}
+          rows={if @loading, do: @skeleton_rows, else: @rows}
+          density={@density}
+          striped={@striped}
+          sticky_header={@sticky_header}
+          variant={@variant}
+          sort_by={@sort_by}
+          sort_dir={@sort_dir}
+          on_sort={@on_sort}
+        >
+          <:col
+            :let={row}
+            :for={col <- @col}
+            label={col[:label] || humanize(col.field)}
+            sortable={col[:sortable] || false}
+            sort_key={to_string(col.field)}
+            class={[col[:class], align_class(col[:align])]}
+            row_class={align_class(col[:align])}
+          >
+            <%= if @loading do %>
+              <.skeleton variant="text" class="pc-data-table__skeleton" />
+            <% else %>
+              {render_slot(col, row)}
+            <% end %>
+          </:col>
+          <:col :let={row} :if={@action != []} label="" class="pc-data-table__actions-th">
+            <span :if={!@loading} class="pc-data-table__actions">
+              {render_slot(@action, row)}
+            </span>
+          </:col>
+          <:empty_state :if={!@loading}>
+            <%= if @empty != [] do %>
+              {render_slot(@empty)}
+            <% else %>
+              <div class="pc-data-table__empty">
+                <%= if @state.filters == [] do %>
+                  {@no_results_text}
+                <% else %>
+                  <span>{@no_filtered_results_text}</span>
+                  <.link
+                    :if={@path}
+                    patch={url_for(@path, State.clear_filters(@state))}
+                    class="pc-data-table__clear-filters"
+                  >
+                    {@clear_filters_label}
+                  </.link>
+                  <button
+                    :if={@on_change}
+                    type="button"
+                    class="pc-data-table__clear-filters"
+                    phx-click={@on_change}
+                    phx-target={@target}
+                    phx-value-op="clear_filters"
+                  >
+                    {@clear_filters_label}
+                  </button>
+                <% end %>
+              </div>
+            <% end %>
+          </:empty_state>
+        </.table>
+      </div>
+
+      <div class="pc-data-table__footer">
+        <span class="pc-data-table__range">{range_text(@state, @of_label, @page_label)}</span>
+        <.pagination
+          :if={show_pagination?(@state)}
+          variant={if @state.total, do: "numbered", else: "simple"}
+          total_pages={State.total_pages(@state) || cursor_total(@state)}
+          current_page={@state.page}
+          path={@path && page_path_template(@path, @state)}
+          link_type="live_patch"
+          event={@on_change || false}
+          event_values={%{"op" => "page"}}
+          target={@target}
+        />
+      </div>
+    </div>
+    """
+  end
+
+  # -- wiring ----------------------------------------------------------------
+
+  # link mode patches per-column sort URLs; event mode pushes the op
+  # grammar. Both ride the table's function-valued on_sort.
+  defp sort_handler(%{on_change: nil} = assigns, fields) do
+    %{path: path, state: state} = assigns
+
+    fn key ->
+      case Map.fetch(fields, key) do
+        {:ok, field} -> JS.patch(url_for(path, State.toggle_sort(state, field)))
+        :error -> nil
+      end
+    end
+  end
+
+  defp sort_handler(%{on_change: event, target: target}, _fields) do
+    opts = [value: %{"op" => "sort"}] ++ if(target, do: [target: target], else: [])
+
+    fn key ->
+      JS.push(event, Keyword.put(opts, :value, %{"op" => "sort", "field" => key}))
+    end
+  end
+
+  defp url_for(path, %State{} = state) do
+    query = state |> State.to_params() |> flatten_params() |> URI.encode_query()
+    if query == "", do: path, else: path <> "?" <> query
+  end
+
+  # pagination's :page placeholder must survive URL encoding, so the
+  # template is assembled around the already-encoded rest of the query
+  defp page_path_template(path, %State{} = state) do
+    query =
+      state
+      |> State.to_params()
+      |> Map.delete("page")
+      |> flatten_params()
+      |> URI.encode_query()
+
+    if query == "" do
+      path <> "?page=:page"
+    else
+      path <> "?page=:page&" <> query
+    end
+  end
+
+  # filters encode as a list of maps - flatten to Phoenix-style indexed
+  # params so encode_query can carry them and from_params reads them back
+  defp flatten_params(params) do
+    case Map.pop(params, "filters") do
+      {nil, rest} ->
+        rest
+
+      {filters, rest} ->
+        filters
+        |> Enum.with_index()
+        |> Enum.reduce(rest, fn {filter, i}, acc ->
+          Enum.reduce(filter, acc, fn {k, v}, acc2 ->
+            Map.put(acc2, "filters[#{i}][#{k}]", v)
+          end)
+        end)
+    end
+  end
+
+  defp range_text(%State{total: nil} = state, _of_label, page_label),
+    do: "#{page_label} #{state.page}"
+
+  defp range_text(%State{total: 0}, _of_label, _page_label), do: nil
+
+  defp range_text(%State{} = state, of_label, _page_label) do
+    first = (state.page - 1) * state.page_size + 1
+    last = min(state.page * state.page_size, state.total)
+    "#{first}–#{last} #{of_label} #{state.total}"
+  end
+
+  defp show_pagination?(%State{total: nil}), do: true
+  defp show_pagination?(%State{} = state), do: State.total_pages(state) > 1
+
+  # simple variant in cursor mode: enable Next unconditionally by
+  # reporting one page more than the current
+  defp cursor_total(%State{page: page}), do: page + 1
+
+  defp align_class("right"), do: "pc-data-table__cell--right"
+  defp align_class("center"), do: "pc-data-table__cell--center"
+  defp align_class(_), do: nil
+
+  defp humanize(field) do
+    field |> to_string() |> String.replace("_", " ") |> String.capitalize()
+  end
+end

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -217,7 +217,7 @@ defmodule PetalComponents.DataTable do
 
   defp url_for(path, %State{} = state) do
     query = state |> State.to_params() |> flatten_params() |> URI.encode_query()
-    if query == "", do: path, else: path <> "?" <> query
+    join_query(path, query)
   end
 
   # pagination's :page placeholder must survive URL encoding, so the
@@ -230,11 +230,15 @@ defmodule PetalComponents.DataTable do
       |> flatten_params()
       |> URI.encode_query()
 
-    if query == "" do
-      path <> "?page=:page"
-    else
-      path <> "?page=:page&" <> query
-    end
+    join_query(path, if(query == "", do: "page=:page", else: "page=:page&" <> query))
+  end
+
+  # a base path may already carry a query string - join accordingly
+  defp join_query(path, ""), do: path
+
+  defp join_query(path, query) do
+    joiner = if String.contains?(path, "?"), do: "&", else: "?"
+    path <> joiner <> query
   end
 
   # filters encode as a list of maps - flatten to Phoenix-style indexed

--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -219,6 +219,9 @@ defmodule PetalComponents.Pagination do
   defp event_name(_event), do: "goto-page"
 
   defp phx_values(values) when values == %{}, do: []
+
+  # event_values keys are developer-authored component API (a handful of
+  # op names), never user input - the atom creation here is bounded
   defp phx_values(values), do: Enum.map(values, fn {k, v} -> {:"phx-value-#{k}", v} end)
 
   defp get_path(path, page_number, current_page) when is_binary(path) do

--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -28,10 +28,14 @@ defmodule PetalComponents.Pagination do
     default: "a",
     values: ["a", "live_patch", "live_redirect", "button"]
 
-  attr :event, :boolean,
+  attr :event, :any,
     default: false,
-    doc:
-      "whether to use `phx-click` events instead of linking. Enabling this will disable `link_type` and `path`."
+    doc: """
+    use `phx-click` events instead of linking (disables `link_type` and
+    `path`). `true` fires the classic "goto-page" event; a STRING fires
+    that event name instead - how the data table routes page changes
+    through its single on_change grammar.
+    """
 
   attr :target, :any,
     default: nil,
@@ -46,6 +50,10 @@ defmodule PetalComponents.Pagination do
   attr :show_boundary_chevrons, :boolean,
     default: false,
     doc: "whether to show prev & next buttons at boundary pages"
+
+  attr :event_values, :map,
+    default: %{},
+    doc: ~s|extra phx-value-* pairs sent with event-mode clicks, e.g. %{"op" => "page"}|
 
   attr :rest, :global
 
@@ -67,17 +75,19 @@ defmodule PetalComponents.Pagination do
       |> assign(:current_page, current_page)
       |> assign(:prev_enabled?, current_page > 1)
       |> assign(:next_enabled?, current_page < total_pages)
+      |> assign(:event?, assigns.event not in [false, nil])
 
     ~H"""
     <div {@rest} class={["pc-pagination", @class]}>
       <nav class="pc-pagination__simple" aria-label="Pagination">
         <Link.a
-          phx-click={if @event, do: "goto-page"}
-          phx-target={if @event, do: @target}
+          phx-click={event_name(@event)}
+          {phx_values(@event_values)}
+          phx-target={if @event?, do: @target}
           phx-value-page={@current_page - 1}
-          link_type={if @event, do: "button", else: @link_type}
-          to={if not @event, do: get_path(@path, "previous", @current_page)}
-          type={if @event or @link_type == "button", do: "button"}
+          link_type={if @event?, do: "button", else: @link_type}
+          to={if not @event?, do: get_path(@path, "previous", @current_page)}
+          type={if @event? or @link_type == "button", do: "button"}
           class="pc-pagination__simple-button"
           disabled={!@prev_enabled?}
         >
@@ -86,12 +96,13 @@ defmodule PetalComponents.Pagination do
         </Link.a>
 
         <Link.a
-          phx-click={if @event, do: "goto-page"}
-          phx-target={if @event, do: @target}
+          phx-click={event_name(@event)}
+          {phx_values(@event_values)}
+          phx-target={if @event?, do: @target}
           phx-value-page={@current_page + 1}
-          link_type={if @event, do: "button", else: @link_type}
-          to={if not @event, do: get_path(@path, "next", @current_page)}
-          type={if @event or @link_type == "button", do: "button"}
+          link_type={if @event?, do: "button", else: @link_type}
+          to={if not @event?, do: get_path(@path, "next", @current_page)}
+          type={if @event? or @link_type == "button", do: "button"}
           class="pc-pagination__simple-button"
           disabled={!@next_enabled?}
         >
@@ -104,6 +115,8 @@ defmodule PetalComponents.Pagination do
   end
 
   def pagination(assigns) do
+    assigns = assign(assigns, :event?, assigns.event not in [false, nil])
+
     ~H"""
     <div {@rest} class={["pc-pagination", @class]}>
       <ul class="pc-pagination__inner">
@@ -111,11 +124,12 @@ defmodule PetalComponents.Pagination do
           <%= if item.type == "prev" and (item.enabled? or @show_boundary_chevrons) do %>
             <li>
               <Link.a
-                phx-click={if @event, do: "goto-page"}
-                phx-target={if @event, do: @target}
+                phx-click={event_name(@event)}
+                {phx_values(@event_values)}
+                phx-target={if @event?, do: @target}
                 phx-value-page={item.number}
-                link_type={if @event, do: "button", else: @link_type}
-                to={if not @event, do: get_path(@path, item.number, @current_page)}
+                link_type={if @event?, do: "button", else: @link_type}
+                to={if not @event?, do: get_path(@path, item.number, @current_page)}
                 class="pc-pagination__item__previous"
                 disabled={!item.enabled?}
               >
@@ -130,11 +144,12 @@ defmodule PetalComponents.Pagination do
                 <span class={get_box_class(item)}>{item.number}</span>
               <% else %>
                 <Link.a
-                  phx-click={if @event, do: "goto-page"}
-                  phx-target={if @event, do: @target}
+                  phx-click={event_name(@event)}
+                  {phx_values(@event_values)}
+                  phx-target={if @event?, do: @target}
                   phx-value-page={item.number}
-                  link_type={if @event, do: "button", else: @link_type}
-                  to={if not @event, do: get_path(@path, item.number, @current_page)}
+                  link_type={if @event?, do: "button", else: @link_type}
+                  to={if not @event?, do: get_path(@path, item.number, @current_page)}
                   class={get_box_class(item)}
                 >
                   {item.number}
@@ -154,11 +169,12 @@ defmodule PetalComponents.Pagination do
           <%= if item.type == "next" and (item.enabled? or @show_boundary_chevrons) do %>
             <li>
               <Link.a
-                phx-click={if @event, do: "goto-page"}
-                phx-target={if @event, do: @target}
+                phx-click={event_name(@event)}
+                {phx_values(@event_values)}
+                phx-target={if @event?, do: @target}
                 phx-value-page={item.number}
-                link_type={if @event, do: "button", else: @link_type}
-                to={if not @event, do: get_path(@path, item.number, @current_page)}
+                link_type={if @event?, do: "button", else: @link_type}
+                to={if not @event?, do: get_path(@path, item.number, @current_page)}
                 class="pc-pagination__item__next"
                 disabled={!item.enabled?}
               >
@@ -197,6 +213,13 @@ defmodule PetalComponents.Pagination do
 
     [base_classes, active_classes, rounded_classes]
   end
+
+  defp event_name(event) when is_binary(event), do: event
+  defp event_name(event) when event in [false, nil], do: nil
+  defp event_name(_event), do: "goto-page"
+
+  defp phx_values(values) when values == %{}, do: []
+  defp phx_values(values), do: Enum.map(values, fn {k, v} -> {:"phx-value-#{k}", v} end)
 
   defp get_path(path, page_number, current_page) when is_binary(path) do
     # replace on `%3Apage` or `:page` in case we receive an URI encoded path

--- a/lib/petal_components/showcase/data_table.ex
+++ b/lib/petal_components/showcase/data_table.ex
@@ -1,0 +1,62 @@
+defmodule PetalComponents.Showcase.DataTable do
+  @moduledoc false
+  use PetalComponents.Showcase,
+    component: PetalComponents.DataTable,
+    title: "Data table"
+
+  alias PetalComponents.DataTable.Engine
+  alias PetalComponents.DataTable.State
+
+  def sample_rows do
+    people = ~w(Amy Bea Cal Dan Dee Eli Fay Gus Ida Joy Kim Lou Mia Ned Ola Pax Quin Rae Sol Tia)
+
+    for {name, i} <- Enum.with_index(people, 1) do
+      %{
+        id: i,
+        name: name,
+        email: String.downcase(name) <> "@example.com",
+        amount: rem(i * 137, 400) + 20,
+        status: Enum.at(~w(paid pending refunded), rem(i, 3))
+      }
+    end
+  end
+
+  example :basic, "Sorted, paged, engine-run",
+    description:
+      "The whole surface from one State struct: sortable headers (aria-sort included), the range summary, and pagination that picks numbered mode because total is known. This static example runs the free in-memory engine over 20 rows at render time - zero setup, no database. In your app the same State drives handle_params (link mode) or a single op-grammar event (event mode)." do
+    ~H"""
+    <% state = %State{order_by: [amount: :desc], page: 1, page_size: 5} %>
+    <% {rows, state} = Engine.List.run(PetalComponents.Showcase.DataTable.sample_rows(), state) %>
+    <.data_table id="sx-dt-basic" rows={rows} state={state} path="#">
+      <:col :let={row} field={:name} sortable>{row.name}</:col>
+      <:col :let={row} field={:email}>{row.email}</:col>
+      <:col :let={row} field={:amount} sortable align="right">${row.amount}</:col>
+    </.data_table>
+    """
+  end
+
+  example :loading, "Loading skeletons",
+    description:
+      "loading swaps the page for skeleton rows - one per page_size row, respecting column count and alignment. Flip it off when the query resolves." do
+    ~H"""
+    <% state = %State{total: 74, page_size: 4} %>
+    <.data_table id="sx-dt-loading" rows={[]} state={state} path="#" loading>
+      <:col :let={row} field={:name}>{row}</:col>
+      <:col :let={row} field={:email}>{row}</:col>
+      <:col :let={row} field={:amount} align="right">{row}</:col>
+    </.data_table>
+    """
+  end
+
+  example :empty, "The filters-aware empty state",
+    description:
+      "An empty result set with active filters says so and offers the way out - a clear-filters patch link in link mode, the op-grammar event in event mode. Without filters it is a plain no-results line. Override either with the :empty slot." do
+    ~H"""
+    <% state = %State{total: 0, filters: [%{field: :name, op: :contains, value: "zz"}]} %>
+    <.data_table id="sx-dt-empty" rows={[]} state={state} path="#">
+      <:col :let={row} field={:name}>{row}</:col>
+      <:col :let={row} field={:email}>{row}</:col>
+    </.data_table>
+    """
+  end
+end

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -24,6 +24,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.Chat,
     PetalComponents.Showcase.ColorSchemeSwitch,
     PetalComponents.Showcase.ComboBox,
+    PetalComponents.Showcase.DataTable,
     PetalComponents.Showcase.Command,
     PetalComponents.Showcase.Confetti,
     PetalComponents.Showcase.Dropdown,

--- a/lib/petal_components/table.ex
+++ b/lib/petal_components/table.ex
@@ -46,8 +46,12 @@ defmodule PetalComponents.Table do
 
   attr :on_sort, :any,
     default: "sort",
-    doc:
-      "event name (or JS command) fired when a sortable header is clicked; receives phx-value-sort of the column's sort_key"
+    doc: """
+    event name (or JS command) fired when a sortable header is clicked;
+    receives phx-value-sort of the column's sort_key. May also be a
+    1-arity function of the sort_key returning the event/JS per column -
+    how the data table patches per-column sort URLs in link mode.
+    """
 
   slot :col do
     attr :label, :string
@@ -98,7 +102,7 @@ defmodule PetalComponents.Table do
                 <button
                   type="button"
                   class="pc-table__sort"
-                  phx-click={@on_sort}
+                  phx-click={resolve_on_sort(@on_sort, sort_key(col))}
                   phx-value-sort={sort_key(col)}
                 >
                   {col[:label]}
@@ -153,6 +157,9 @@ defmodule PetalComponents.Table do
     </table>
     """
   end
+
+  defp resolve_on_sort(on_sort, key) when is_function(on_sort, 1), do: on_sort.(key)
+  defp resolve_on_sort(on_sort, _key), do: on_sort
 
   defp sort_key(col), do: col[:sort_key] || String.downcase(col[:label] || "")
 

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -1,0 +1,181 @@
+defmodule PetalComponents.DataTableTest do
+  use ComponentCase
+
+  import PetalComponents.DataTable
+
+  alias PetalComponents.DataTable.State
+
+  @rows [
+    %{name: "Amy", email: "amy@x.com", amount: 300},
+    %{name: "Bea", email: "bea@x.com", amount: 40}
+  ]
+
+  defp base(assigns \\ %{}) do
+    Map.merge(%{rows: @rows, state: %State{total: 74}, path: "/orders"}, assigns)
+  end
+
+  test "renders rows through col slots with explicit and humanized labels" do
+    assigns = base()
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:name} label="Person">{row.name}</:col>
+        <:col :let={row} field={:email}>{row.email}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ "Person"
+    assert html =~ "Email"
+    assert html =~ "amy@x.com"
+    assert html =~ "Bea"
+  end
+
+  test "link mode: sortable headers patch toggled sort URLs; current sort carries aria-sort" do
+    assigns = base(%{state: %State{total: 74, order_by: [name: :asc]}})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:name} sortable>{row.name}</:col>
+      </.data_table>
+      """)
+
+    # toggling an asc sort patches to desc
+    assert html =~ "order_by=name%3Adesc" or html =~ "order_by=name:desc"
+    assert html =~ ~s|aria-sort="ascending"|
+  end
+
+  test "event mode: sort pushes the op grammar through on_change" do
+    assigns = base(%{path: nil})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table">
+        <:col :let={row} field={:name} sortable>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ "phx-click"
+    assert html =~ "table"
+    assert html =~ "sort"
+    assert html =~ "name"
+  end
+
+  test "footer range and numbered pagination when total is known" do
+    assigns = base(%{state: %State{total: 74, page: 2}})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ "11–20 of 74"
+    assert html =~ "pc-pagination__inner"
+    # the page template keeps the rest of the query
+    assert html =~ "page=:page" or html =~ "/orders?page="
+  end
+
+  test "cursor mode (nil total) renders the page word and the simple pagination" do
+    assigns = base(%{state: %State{total: nil, page: 3}})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ "Page 3"
+    assert html =~ "pc-pagination__simple"
+  end
+
+  test "loading renders skeleton rows instead of data" do
+    assigns = base(%{state: %State{total: 74, page_size: 3}})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path} loading>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    refute html =~ "Amy"
+    assert length(String.split(html, "pc-data-table__skeleton")) - 1 >= 3
+  end
+
+  test "empty default is filters-aware: plain text bare, clear affordance when filtered" do
+    assigns = base(%{rows: [], state: %State{total: 0}})
+
+    plain =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert plain =~ "No results"
+    refute plain =~ "Clear filters"
+
+    assigns =
+      base(%{
+        rows: [],
+        state: %State{total: 0, filters: [%{field: :name, op: :contains, value: "zz"}]}
+      })
+
+    filtered =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert filtered =~ "No results for these filters"
+    assert filtered =~ "Clear filters"
+    # the clear link drops the filters from the query
+    refute filtered =~ ~s|href="/orders?filters|
+  end
+
+  test "filters flatten into indexed query params the State can read back" do
+    state = %State{total: 74, filters: [%{field: :name, op: :contains, value: "am"}]}
+    assigns = base(%{state: state})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:name} sortable>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ "filters%5B0%5D%5Bfield%5D=name" or html =~ "filters[0][field]=name"
+  end
+
+  test "action slot renders a trailing column" do
+    assigns = base()
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+        <:action :let={row}><button type="button">Edit {row.name}</button></:action>
+      </.data_table>
+      """)
+
+    assert html =~ "Edit Amy"
+    assert html =~ "pc-data-table__actions"
+  end
+
+  test "raises without either wiring mode" do
+    assigns = base(%{path: nil})
+
+    assert_raise ArgumentError, ~r/path.*on_change/, fn ->
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+    end
+  end
+end

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -152,6 +152,20 @@ defmodule PetalComponents.DataTableTest do
     assert html =~ "filters%5B0%5D%5Bfield%5D=name" or html =~ "filters[0][field]=name"
   end
 
+  test "a base path already carrying a query joins with & not ?" do
+    assigns = base(%{path: "/orders?tab=all"})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:name} sortable>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ "/orders?tab=all&amp;" or html =~ "/orders?tab=all&"
+    refute html =~ "tab=all?"
+  end
+
   test "action slot renders a trailing column" do
     assigns = base()
 


### PR DESCRIPTION
First component milestone of the 4.12 data table, on the merged State + engine foundation.

## `<.data_table>`

- **`:col` slots** - field, label (humanized default), sortable, align
- **Sortable headers, both wiring modes**: link mode patches per-column toggle URLs via `State.to_params` (filters flatten to Phoenix-style indexed params, so `from_params` reads them straight back - shareable state, working back button); event mode pushes **one op-grammar event** (`{"op": "sort"|"page"|"clear_filters"}`) with optional `target`
- **Footer**: range summary + pagination auto-picking numbered (total known) vs simple (cursor mode - Next stays enabled by reporting page+1)
- **Loading** skeleton rows, **filters-aware empty state** with a clear-filters patch link / op event, `:empty` override, `:action` trailing column, `:toolbar` slot, density/striped/sticky/variant pass-through

## Primitive extensions

- `table`: `on_sort` accepts a 1-arity function of the sort key (per-column JS/events)
- `pagination`: `event` accepts a custom event name; new `event_values` adds phx-value-* pairs; all `@event` boolean logic made truthiness-safe

## Demos + tests

Showcase registry (engine-run basic, loading, empty) + a live event-mode playground page at /c/data-table. 10 component tests; suites 822 Elixir / 100 JS. Live-verified sorting (aria-sort both directions), paging, alignment, skeleton counts, and the empty-state clear affordance.

Next milestone: the toolbar - quick search + per-column filter popovers built on the combobox trigger listbox (what the whole combobox-first sequencing was for).