### PR TITLE
polish(playground): soft badges in the data table demo

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -7332,6 +7332,7 @@ defmodule Dev.PlaygroundLive do
           <:col :let={row} field={:status}>
             <.badge
               size="sm"
+              variant="soft"
               color={
                 case row.status do
                   "paid" -> "success"


### PR DESCRIPTION
One-liner: the status badges in the /c/data-table demo used the default light variant, whose solid pastel fill is loud against dark rows. Swapped to soft (low-alpha tint), matching the primitive table page's own status demo.