### PR TITLE
feat(data_table): quick search, rows-per-page, reset filters (DT-M2 part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@
   way out, `:action`/`:toolbar`/`:empty` slots, and density/striped/
   sticky pass-through. Toolbar search + filter editors arrive next
   milestone (the combobox trigger listbox was built for them).
+- **`<.data_table>` quick search + rows-per-page (4.12 data table,
+  milestone 2, part 1).** `searchable` renders a debounced toolbar
+  search input driving the new `State.search` term (trimmed, blank
+  drops the param, always resets to page 1); `Engine.List` sweeps it
+  case-insensitively across string fields (scope with the new
+  `:search_fields` option) before filters so totals stay honest.
+  `page_size_options` renders a rows-per-page footer select
+  (`State.put_page_size/2`). A "Reset filters" ghost button appears
+  in the toolbar while filters are active. Event mode posts new
+  `search`/`page_size` ops through plain forms; link mode wires both
+  through the new `PetalDataTable` hook, which fills in URL templates
+  and clicks a hidden patch link so navigation stays LiveView's own.
 - **`table` `on_sort` accepts a 1-arity function** of the sort key -
   per-column events/JS, how the data table patches sort URLs.
 - **`pagination` event mode grows up**: `event` accepts a custom event

--- a/assets/default.css
+++ b/assets/default.css
@@ -2619,6 +2619,31 @@
   .pc-data-table__skeleton.pc-data-table__skeleton {
     @apply h-4 w-24 max-w-full;
   }
+  .pc-data-table__search {
+    @apply relative;
+  }
+  .pc-data-table__search-icon {
+    @apply pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500;
+  }
+  /* Doubled selector + !important: icon sizing contract (see pagination chevrons). */
+  .pc-data-table__search-icon.pc-data-table__search-icon {
+    @apply w-4! h-4!;
+  }
+  .pc-data-table__search-input.pc-data-table__search-input {
+    @apply h-9 w-56 max-w-full pl-8 text-sm;
+  }
+  .pc-data-table__reset {
+    @apply ml-auto;
+  }
+  .pc-data-table__page-size {
+    @apply flex items-center gap-2;
+  }
+  .pc-data-table__page-size-label {
+    @apply text-sm text-gray-500 dark:text-gray-400;
+  }
+  .pc-data-table__page-size-select.pc-data-table__page-size-select {
+    @apply h-9 w-auto py-0 pr-8 text-sm;
+  }
 
   /* Avatars - sizes */
 

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4601,6 +4601,69 @@ export const PetalComboBox = {
   },
 };
 
+// Link-mode wiring for the data table's quick search and rows-per-page
+// select. Event mode posts through plain phx-change forms and never
+// mounts this hook; link mode has no events by design (handle_params is
+// the whole backend), so state changes must become patch URLs. The
+// component renders URL templates (:term / :page_size placeholders,
+// assembled around the already-encoded rest of the query) and a hidden
+// data-phx-link anchor; the hook fills a template in and clicks the
+// anchor so navigation stays LiveView's own.
+export const PetalDataTable = {
+  mounted() {
+    this.searchTimer = null;
+
+    this.onInput = (e) => {
+      const input = e.target.closest("[data-pc-dt-search]");
+      if (!input) return;
+      clearTimeout(this.searchTimer);
+      const wait = parseInt(this.el.dataset.debounce || "300", 10);
+      this.searchTimer = setTimeout(
+        () => this.patchTo(this.searchUrl(input.value)),
+        wait,
+      );
+    };
+
+    this.onChange = (e) => {
+      const select = e.target.closest("[data-pc-dt-page-size]");
+      if (select) this.patchTo(this.pageSizeUrl(select.value));
+    };
+
+    this.el.addEventListener("input", this.onInput);
+    this.el.addEventListener("change", this.onChange);
+  },
+
+  destroyed() {
+    clearTimeout(this.searchTimer);
+    this.el.removeEventListener("input", this.onInput);
+    this.el.removeEventListener("change", this.onChange);
+  },
+
+  searchUrl(term) {
+    const template = this.el.dataset.searchTemplate;
+    const trimmed = term.trim();
+    if (trimmed === "") {
+      // a blank term drops the search param entirely so URLs stay clean
+      return template.replace(/search=:term&?/, "").replace(/[?&]$/, "");
+    }
+    return template.replace(":term", encodeURIComponent(trimmed));
+  },
+
+  pageSizeUrl(size) {
+    return this.el.dataset.pageSizeTemplate.replace(
+      ":page_size",
+      encodeURIComponent(size),
+    );
+  },
+
+  patchTo(url) {
+    const nav = this.el.querySelector("[data-pc-dt-nav]");
+    if (!nav) return;
+    nav.setAttribute("href", url);
+    nav.click();
+  },
+};
+
 export default {
   PetalChart,
   PetalColorScheme,
@@ -4630,4 +4693,5 @@ export default {
   PetalNavMenu,
   PetalCommandDialog,
   PetalComboBox,
+  PetalDataTable,
 };

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4614,19 +4614,19 @@ export const PetalDataTable = {
     this.searchTimer = null;
 
     this.onInput = (e) => {
-      const input = e.target.closest("[data-pc-dt-search]");
-      if (!input) return;
+      if (!e.target.closest("[data-pc-dt-search]")) return;
       clearTimeout(this.searchTimer);
       const wait = parseInt(this.el.dataset.debounce || "300", 10);
-      this.searchTimer = setTimeout(
-        () => this.patchTo(this.searchUrl(input.value)),
-        wait,
-      );
+      this.searchTimer = setTimeout(() => this.patchTo(this.navUrl()), wait);
     };
 
     this.onChange = (e) => {
-      const select = e.target.closest("[data-pc-dt-page-size]");
-      if (select) this.patchTo(this.pageSizeUrl(select.value));
+      if (!e.target.closest("[data-pc-dt-page-size]")) return;
+      // the nav URL reads the live search input too, so the pending
+      // debounced patch is redundant - and letting it fire later would
+      // navigate with a template predating this pick
+      clearTimeout(this.searchTimer);
+      this.patchTo(this.navUrl());
     };
 
     this.el.addEventListener("input", this.onInput);
@@ -4639,21 +4639,28 @@ export const PetalDataTable = {
     this.el.removeEventListener("change", this.onChange);
   },
 
-  searchUrl(term) {
-    const template = this.el.dataset.searchTemplate;
-    const trimmed = term.trim();
-    if (trimmed === "") {
-      // a blank term drops the search param entirely so URLs stay clean
-      return template.replace(/search=:term&?/, "").replace(/[?&]$/, "");
-    }
-    return template.replace(":term", encodeURIComponent(trimmed));
-  },
+  // Both placeholders resolve from the live DOM in one pass, so
+  // whichever control triggers the patch carries the other's current
+  // (possibly uncommitted) value instead of a stale committed one.
+  navUrl() {
+    let url = this.el.dataset.navTemplate;
 
-  pageSizeUrl(size) {
-    return this.el.dataset.pageSizeTemplate.replace(
-      ":page_size",
-      encodeURIComponent(size),
-    );
+    if (url.includes(":term")) {
+      const input = this.el.querySelector("[data-pc-dt-search]");
+      const trimmed = (input ? input.value : "").trim();
+      url =
+        trimmed === ""
+          ? // a blank term drops the search param entirely so URLs stay clean
+            url.replace(/search=:term&?/, "")
+          : url.replace(":term", encodeURIComponent(trimmed));
+    }
+
+    if (url.includes(":page_size")) {
+      const select = this.el.querySelector("[data-pc-dt-page-size]");
+      url = url.replace(":page_size", encodeURIComponent(select.value));
+    }
+
+    return url.replace(/[?&]$/, "");
   },
 
   patchTo(url) {

--- a/dev.exs
+++ b/dev.exs
@@ -747,7 +747,7 @@ defmodule Dev.PlaygroundLive do
        select: %{disabled: false, error: false, help: false},
        combo: %{disabled: false, chosen: nil},
        rich: %{labels: ~w(feat bug imp des), team: ~w(amelia jonah)},
-       dt: PetalComponents.DataTable.State |> struct() |> run_dt(),
+       dt: PetalComponents.DataTable.State |> struct(page_size: 5) |> run_dt(),
        radio: %{
          style: "cards",
          variant: "outline",
@@ -1452,6 +1452,12 @@ defmodule Dev.PlaygroundLive do
         %{"op" => "page", "page" => page} ->
           %{state | page: String.to_integer(to_string(page))}
 
+        %{"op" => "search", "term" => term} ->
+          State.put_search(state, term)
+
+        %{"op" => "page_size", "page_size" => size} ->
+          State.put_page_size(state, size)
+
         %{"op" => "clear_filters"} ->
           State.clear_filters(state)
 
@@ -1466,7 +1472,7 @@ defmodule Dev.PlaygroundLive do
     {rows, state} =
       PetalComponents.DataTable.Engine.List.run(
         PetalComponents.Showcase.DataTable.sample_rows(),
-        %{state | page_size: 5}
+        state
       )
 
     {state, rows}
@@ -7326,7 +7332,15 @@ defmodule Dev.PlaygroundLive do
 
       <div class="border border-gray-200 dark:border-gray-400/20 rounded-xl p-6">
         <% {state, rows} = @dt %>
-        <.data_table id="pg-dt" rows={rows} state={state} on_change="pg_table" striped>
+        <.data_table
+          id="pg-dt"
+          rows={rows}
+          state={state}
+          on_change="pg_table"
+          striped
+          searchable
+          page_size_options={[5, 10, 20]}
+        >
           <:col :let={row} field={:name} sortable>{row.name}</:col>
           <:col :let={row} field={:email}>{row.email}</:col>
           <:col :let={row} field={:status}>

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -19,8 +19,14 @@ defmodule PetalComponents.DataTable do
 
     * **event mode** (pass `on_change`): one event, one grammar. Sorts
       arrive as `%{"op" => "sort", "field" => f}`, page changes as
-      `%{"op" => "page", "page" => n}`, filter clears as
-      `%{"op" => "clear_filters"}`.
+      `%{"op" => "page", "page" => n}`, quick-search as
+      `%{"op" => "search", "term" => t}`, page-size changes as
+      `%{"op" => "page_size", "page_size" => n}`, filter clears as
+      `%{"op" => "clear_filters"}`. `State` has a helper for each op.
+
+  In link mode the quick-search input and rows-per-page select are wired
+  by the `PetalDataTable` hook (patch URLs built from templates the
+  component renders); event mode needs no JS.
 
   Rows can be any enumerable of maps/structs; pair with
   `PetalComponents.DataTable.Engine.List` for zero-setup in-memory
@@ -28,6 +34,8 @@ defmodule PetalComponents.DataTable do
   """
   use Phoenix.Component
 
+  import PetalComponents.Button
+  import PetalComponents.Icon
   import PetalComponents.Pagination
   import PetalComponents.Skeleton
   import PetalComponents.Table
@@ -69,6 +77,23 @@ defmodule PetalComponents.DataTable do
     doc: "the empty message while filters are active"
 
   attr :clear_filters_label, :string, default: "Clear filters"
+
+  attr :searchable, :boolean,
+    default: false,
+    doc: "render the quick-search input in the toolbar (drives `state.search`)"
+
+  attr :search_placeholder, :string, default: "Search…"
+
+  attr :search_debounce, :integer,
+    default: 300,
+    doc: "quick-search debounce in ms, both wiring modes"
+
+  attr :page_size_options, :list,
+    default: [],
+    doc: "when non-empty, render a rows-per-page select in the footer"
+
+  attr :per_page_label, :string, default: "Per page", doc: "the rows-per-page label, localizable"
+  attr :reset_filters_label, :string, default: "Reset filters"
   attr :class, :any, default: nil
 
   slot :col, required: true do
@@ -96,17 +121,86 @@ defmodule PetalComponents.DataTable do
 
     fields = Map.new(assigns.col, fn col -> {to_string(col.field), col.field} end)
 
+    hooked? =
+      is_nil(assigns.on_change) and (assigns.searchable or assigns.page_size_options != [])
+
     assigns =
       assigns
       |> assign(:sort_by, sort_by)
       |> assign(:sort_dir, sort_dir)
       |> assign(:on_sort, sort_handler(assigns, fields))
       |> assign(:skeleton_rows, List.duplicate(%{}, min(assigns.state.page_size, 10)))
+      |> assign(:hooked?, hooked?)
+      |> assign(:search_template, hooked? && search_template(assigns.path, assigns.state))
+      |> assign(:page_size_template, hooked? && page_size_template(assigns.path, assigns.state))
 
     ~H"""
-    <div id={@id} class={["pc-data-table", @class]}>
-      <div :if={@toolbar != []} class="pc-data-table__toolbar">
+    <div
+      id={@id}
+      class={["pc-data-table", @class]}
+      phx-hook={@hooked? && "PetalDataTable"}
+      data-debounce={@hooked? && @search_debounce}
+      data-search-template={@search_template || nil}
+      data-page-size-template={@page_size_template || nil}
+    >
+      <a :if={@hooked?} data-pc-dt-nav data-phx-link="patch" data-phx-link-state="push" hidden></a>
+      <div
+        :if={@toolbar != [] or @searchable or @state.filters != []}
+        class="pc-data-table__toolbar"
+      >
+        <div :if={@searchable} class="pc-data-table__search">
+          <.icon name="hero-magnifying-glass" class="pc-data-table__search-icon" />
+          <%= if @on_change do %>
+            <form phx-change={@on_change} phx-submit={@on_change} phx-target={@target}>
+              <input type="hidden" name="op" value="search" />
+              <input
+                type="text"
+                name="term"
+                value={@state.search}
+                placeholder={@search_placeholder}
+                phx-debounce={@search_debounce}
+                autocomplete="off"
+                class="pc-text-input pc-data-table__search-input"
+              />
+            </form>
+          <% else %>
+            <input
+              type="text"
+              value={@state.search}
+              placeholder={@search_placeholder}
+              autocomplete="off"
+              data-pc-dt-search
+              class="pc-text-input pc-data-table__search-input"
+            />
+          <% end %>
+        </div>
         {render_slot(@toolbar)}
+        <%= if @state.filters != [] do %>
+          <.button
+            :if={@on_change}
+            type="button"
+            size="sm"
+            variant="ghost"
+            color="gray"
+            class="pc-data-table__reset"
+            phx-click={@on_change}
+            phx-target={@target}
+            phx-value-op="clear_filters"
+          >
+            {@reset_filters_label}
+          </.button>
+          <.button
+            :if={@path}
+            link_type="live_patch"
+            to={url_for(@path, State.clear_filters(@state))}
+            size="sm"
+            variant="ghost"
+            color="gray"
+            class="pc-data-table__reset"
+          >
+            {@reset_filters_label}
+          </.button>
+        <% end %>
       </div>
 
       <div class="pc-data-table__scroll">
@@ -176,6 +270,35 @@ defmodule PetalComponents.DataTable do
 
       <div class="pc-data-table__footer">
         <span class="pc-data-table__range">{range_text(@state, @of_label, @page_label)}</span>
+        <div :if={@page_size_options != []} class="pc-data-table__page-size">
+          <label for={"#{@id}-page-size"} class="pc-data-table__page-size-label">
+            {@per_page_label}
+          </label>
+          <%= if @on_change do %>
+            <form phx-change={@on_change} phx-target={@target}>
+              <input type="hidden" name="op" value="page_size" />
+              <select
+                id={"#{@id}-page-size"}
+                name="page_size"
+                class="pc-select pc-data-table__page-size-select"
+              >
+                <option :for={n <- @page_size_options} value={n} selected={n == @state.page_size}>
+                  {n}
+                </option>
+              </select>
+            </form>
+          <% else %>
+            <select
+              id={"#{@id}-page-size"}
+              data-pc-dt-page-size
+              class="pc-select pc-data-table__page-size-select"
+            >
+              <option :for={n <- @page_size_options} value={n} selected={n == @state.page_size}>
+                {n}
+              </option>
+            </select>
+          <% end %>
+        </div>
         <.pagination
           :if={show_pagination?(@state)}
           variant={if @state.total, do: "numbered", else: "simple"}
@@ -231,6 +354,34 @@ defmodule PetalComponents.DataTable do
       |> URI.encode_query()
 
     join_query(path, if(query == "", do: "page=:page", else: "page=:page&" <> query))
+  end
+
+  # the hook substitutes :term / :page_size client-side, so both
+  # placeholders are assembled around the already-encoded rest of the
+  # query, same trick as the pagination :page template
+  defp search_template(path, %State{} = state) do
+    query =
+      state
+      |> State.put_search("")
+      |> State.to_params()
+      |> flatten_params()
+      |> URI.encode_query()
+
+    join_query(path, if(query == "", do: "search=:term", else: "search=:term&" <> query))
+  end
+
+  defp page_size_template(path, %State{} = state) do
+    query =
+      %{state | page: 1}
+      |> State.to_params()
+      |> Map.drop(["page", "page_size"])
+      |> flatten_params()
+      |> URI.encode_query()
+
+    join_query(
+      path,
+      if(query == "", do: "page_size=:page_size", else: "page_size=:page_size&" <> query)
+    )
   end
 
   # a base path may already carry a query string - join accordingly

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -131,8 +131,7 @@ defmodule PetalComponents.DataTable do
       |> assign(:on_sort, sort_handler(assigns, fields))
       |> assign(:skeleton_rows, List.duplicate(%{}, min(assigns.state.page_size, 10)))
       |> assign(:hooked?, hooked?)
-      |> assign(:search_template, hooked? && search_template(assigns.path, assigns.state))
-      |> assign(:page_size_template, hooked? && page_size_template(assigns.path, assigns.state))
+      |> assign(:nav_template, hooked? && nav_template(assigns))
 
     ~H"""
     <div
@@ -140,8 +139,7 @@ defmodule PetalComponents.DataTable do
       class={["pc-data-table", @class]}
       phx-hook={@hooked? && "PetalDataTable"}
       data-debounce={@hooked? && @search_debounce}
-      data-search-template={@search_template || nil}
-      data-page-size-template={@page_size_template || nil}
+      data-nav-template={@nav_template || nil}
     >
       <a :if={@hooked?} data-pc-dt-nav data-phx-link="patch" data-phx-link-state="push" hidden></a>
       <div
@@ -356,32 +354,33 @@ defmodule PetalComponents.DataTable do
     join_query(path, if(query == "", do: "page=:page", else: "page=:page&" <> query))
   end
 
-  # the hook substitutes :term / :page_size client-side, so both
-  # placeholders are assembled around the already-encoded rest of the
-  # query, same trick as the pagination :page template
-  defp search_template(path, %State{} = state) do
-    query =
-      state
-      |> State.put_search("")
-      |> State.to_params()
-      |> flatten_params()
-      |> URI.encode_query()
+  # One template, both placeholders: the hook fills :term / :page_size
+  # from the live DOM at patch time, so an uncommitted search term and a
+  # fresh page-size pick can never revert each other. Placeholders are
+  # assembled around the already-encoded rest of the query (the
+  # pagination :page trick); a control the table doesn't render keeps
+  # its committed value in the rest instead of a placeholder.
+  defp nav_template(%{path: path, state: state} = assigns) do
+    state = %{state | page: 1}
+    state = if assigns.searchable, do: State.put_search(state, ""), else: state
 
-    join_query(path, if(query == "", do: "search=:term", else: "search=:term&" <> query))
-  end
+    params = State.to_params(state)
 
-  defp page_size_template(path, %State{} = state) do
-    query =
-      %{state | page: 1}
-      |> State.to_params()
-      |> Map.drop(["page", "page_size"])
-      |> flatten_params()
-      |> URI.encode_query()
+    params =
+      if assigns.page_size_options != [], do: Map.delete(params, "page_size"), else: params
 
-    join_query(
-      path,
-      if(query == "", do: "page_size=:page_size", else: "page_size=:page_size&" <> query)
-    )
+    placeholders =
+      Enum.filter(
+        [
+          assigns.searchable && "search=:term",
+          assigns.page_size_options != [] && "page_size=:page_size"
+        ],
+        & &1
+      )
+
+    rest = params |> flatten_params() |> URI.encode_query()
+    query = Enum.join(placeholders ++ if(rest == "", do: [], else: [rest]), "&")
+    join_query(path, query)
   end
 
   # a base path may already carry a query string - join accordingly

--- a/lib/petal_components/data_table/engine/list.ex
+++ b/lib/petal_components/data_table/engine/list.ex
@@ -32,15 +32,29 @@ defmodule PetalComponents.DataTable.Engine.List do
   # values, which arrive raw from params.
   defguardp is_scalar(v) when is_binary(v) or is_number(v) or is_atom(v)
 
-  @doc "Runs the full pipeline: filter -> sort -> count -> paginate."
-  def run(rows, %State{} = state) when is_list(rows) do
+  @doc """
+  Runs the full pipeline: search -> filter -> sort -> count -> paginate.
+
+  Options:
+
+    * `:search_fields` - the fields the quick-search term matches
+      against (case-insensitive contains). Defaults to every field of
+      the first row whose value is a string.
+  """
+  def run(rows, state, opts \\ [])
+
+  def run(rows, %State{} = state, opts) when is_list(rows) do
     # from_params clamps, but hand-built structs can carry page 0 or a
     # non-positive size - a negative slice offset would silently take
     # rows from the END of the list, so clamp here too
     page = max(state.page, 1)
     page_size = max(state.page_size, 1)
 
-    filtered = Enum.reduce(state.filters, rows, &apply_filter(&2, &1))
+    filtered =
+      rows
+      |> apply_search(state.search, Keyword.get(opts, :search_fields))
+      |> then(&Enum.reduce(state.filters, &1, fn f, acc -> apply_filter(acc, f) end))
+
     total = length(filtered)
 
     page_rows =
@@ -49,6 +63,28 @@ defmodule PetalComponents.DataTable.Engine.List do
       |> Enum.slice((page - 1) * page_size, page_size)
 
     {page_rows, %{state | page: page, page_size: page_size, total: total}}
+  end
+
+  # -- search ----------------------------------------------------------------
+
+  defp apply_search(rows, nil, _fields), do: rows
+  defp apply_search([], _term, _fields), do: []
+
+  defp apply_search([first | _] = rows, term, fields) do
+    fields =
+      fields ||
+        for {k, v} <- first, is_binary(v), do: k
+
+    needle = String.downcase(term)
+
+    Enum.filter(rows, fn row ->
+      Enum.any?(fields, fn field ->
+        case fetch(row, field) do
+          v when is_binary(v) -> String.contains?(String.downcase(v), needle)
+          _ -> false
+        end
+      end)
+    end)
   end
 
   # -- sorting ---------------------------------------------------------------

--- a/lib/petal_components/data_table/state.ex
+++ b/lib/petal_components/data_table/state.ex
@@ -141,6 +141,11 @@ defmodule PetalComponents.DataTable.State do
     %{state | search: parse_search(term), page: 1}
   end
 
+  @doc "Sets the page size (invalid values keep the current one), resetting to page 1."
+  def put_page_size(%__MODULE__{} = state, size) do
+    %{state | page_size: parse_pos_int(size, state.page_size), page: 1}
+  end
+
   @doc "Removes every filter, resetting to page 1."
   def clear_filters(%__MODULE__{} = state), do: %{state | filters: [], page: 1}
 

--- a/lib/petal_components/data_table/state.ex
+++ b/lib/petal_components/data_table/state.ex
@@ -35,13 +35,14 @@ defmodule PetalComponents.DataTable.State do
   """
 
   @enforce_keys []
-  defstruct order_by: [], filters: [], page: 1, page_size: 10, total: nil
+  defstruct order_by: [], filters: [], search: nil, page: 1, page_size: 10, total: nil
 
   @type order :: {atom(), :asc | :desc}
   @type filter :: %{field: atom(), op: atom(), value: term()}
   @type t :: %__MODULE__{
           order_by: [order()],
           filters: [filter()],
+          search: String.t() | nil,
           page: pos_integer(),
           page_size: pos_integer(),
           total: non_neg_integer() | nil
@@ -80,6 +81,7 @@ defmodule PetalComponents.DataTable.State do
     %__MODULE__{
       order_by: parse_order_by(params["order_by"], field_strings),
       filters: parse_filters(params["filters"], field_strings),
+      search: parse_search(params["search"]),
       page: parse_pos_int(params["page"], 1),
       page_size: params["page_size"] |> parse_pos_int(default_size) |> min(max_size)
     }
@@ -100,6 +102,7 @@ defmodule PetalComponents.DataTable.State do
     %{}
     |> put_order_by(state.order_by)
     |> put_filters(state.filters)
+    |> encode_search(state.search)
     |> put_unless("page", state.page, 1)
     |> put_unless("page_size", state.page_size, default_size)
   end
@@ -131,6 +134,11 @@ defmodule PetalComponents.DataTable.State do
     filter = %{field: field, op: op, value: value}
     rest = Enum.reject(state.filters, &(&1.field == field))
     %{state | filters: rest ++ [filter], page: 1}
+  end
+
+  @doc "Sets (or clears, for blank terms) the quick-search term, resetting to page 1."
+  def put_search(%__MODULE__{} = state, term) do
+    %{state | search: parse_search(term), page: 1}
   end
 
   @doc "Removes every filter, resetting to page 1."
@@ -192,6 +200,18 @@ defmodule PetalComponents.DataTable.State do
   end
 
   defp parse_filters(_other, _fields), do: []
+
+  defp parse_search(term) when is_binary(term) do
+    case String.trim(term) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp parse_search(_other), do: nil
+
+  defp encode_search(params, nil), do: params
+  defp encode_search(params, term), do: Map.put(params, "search", term)
 
   defp parse_pos_int(value, default) when is_binary(value) do
     case Integer.parse(value) do

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -8,18 +8,17 @@ import hooks from "../../assets/js/petal_components.js";
 
 const mounted = [];
 
-function mount({ searchTemplate, pageSizeTemplate, debounce } = {}) {
+function mount({ navTemplate, debounce } = {}) {
   const el = document.createElement("div");
   el.id = "dt";
   el.className = "pc-data-table";
-  if (searchTemplate) el.dataset.searchTemplate = searchTemplate;
-  if (pageSizeTemplate) el.dataset.pageSizeTemplate = pageSizeTemplate;
+  if (navTemplate) el.dataset.navTemplate = navTemplate;
   if (debounce) el.dataset.debounce = debounce;
   el.innerHTML = `
     <a data-pc-dt-nav data-phx-link="patch" data-phx-link-state="push" hidden></a>
     <input type="text" data-pc-dt-search />
     <select data-pc-dt-page-size>
-      <option value="10">10</option>
+      <option value="10" selected>10</option>
       <option value="20">20</option>
     </select>
   `;
@@ -56,9 +55,9 @@ describe("PetalDataTable", () => {
     vi.useRealTimers();
   });
 
-  it("debounces typing, then patches the :term template with the encoded value", () => {
+  it("debounces typing, then patches with the encoded term and current page size", () => {
     const { el, patched } = mount({
-      searchTemplate: "/orders?search=:term&order_by=name",
+      navTemplate: "/orders?search=:term&page_size=:page_size&order_by=name",
       debounce: "300",
     });
 
@@ -69,36 +68,59 @@ describe("PetalDataTable", () => {
     vi.advanceTimersByTime(299);
     expect(patched).toEqual([]);
     vi.advanceTimersByTime(1);
-    expect(patched).toEqual(["/orders?search=am%20y&order_by=name"]);
+    expect(patched).toEqual([
+      "/orders?search=am%20y&page_size=10&order_by=name",
+    ]);
   });
 
   it("a blank term drops the search param and any dangling joiner", () => {
-    const { el, patched } = mount({ searchTemplate: "/orders?search=:term" });
+    const { el, patched } = mount({ navTemplate: "/orders?search=:term" });
     type(el, "   ");
     vi.advanceTimersByTime(300);
     expect(patched).toEqual(["/orders"]);
 
     const withRest = mount({
-      searchTemplate: "/orders?search=:term&page_size=20",
+      navTemplate: "/orders?search=:term&order_by=name",
     });
     type(withRest.el, "");
     vi.advanceTimersByTime(300);
-    expect(withRest.patched).toEqual(["/orders?page_size=20"]);
+    expect(withRest.patched).toEqual(["/orders?order_by=name"]);
   });
 
-  it("page-size changes patch immediately, no debounce", () => {
+  it("page-size changes patch immediately and carry the live search term", () => {
     const { el, patched } = mount({
-      pageSizeTemplate: "/orders?page_size=:page_size",
+      navTemplate: "/orders?search=:term&page_size=:page_size",
     });
+    const input = el.querySelector("[data-pc-dt-search]");
+    input.value = "amy";
     const select = el.querySelector("[data-pc-dt-page-size]");
     select.value = "20";
     select.dispatchEvent(new Event("change", { bubbles: true }));
-    expect(patched).toEqual(["/orders?page_size=20"]);
+    expect(patched).toEqual(["/orders?search=amy&page_size=20"]);
+  });
+
+  it("a page-size pick cancels a pending search patch instead of racing it", () => {
+    const { el, patched } = mount({
+      navTemplate: "/orders?search=:term&page_size=:page_size",
+      debounce: "300",
+    });
+
+    type(el, "amy");
+    vi.advanceTimersByTime(100);
+
+    const select = el.querySelector("[data-pc-dt-page-size]");
+    select.value = "20";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(patched).toEqual(["/orders?search=amy&page_size=20"]);
+
+    // the debounced search patch must NOT fire a second, stale navigation
+    vi.advanceTimersByTime(1000);
+    expect(patched).toEqual(["/orders?search=amy&page_size=20"]);
   });
 
   it("destroyed cancels a pending search patch", () => {
     const { hook, el, patched } = mount({
-      searchTemplate: "/orders?search=:term",
+      navTemplate: "/orders?search=:term",
     });
     type(el, "amy");
     hook.destroyed();

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -1,0 +1,110 @@
+// PetalDataTable hook: link-mode wiring for quick search and rows-per-page.
+// The markup here mirrors what PetalComponents.DataTable renders in link
+// mode - test/petal/data_table_test.exs pins that structure on the Elixir
+// side; update both together if the anatomy changes.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import hooks from "../../assets/js/petal_components.js";
+
+const mounted = [];
+
+function mount({ searchTemplate, pageSizeTemplate, debounce } = {}) {
+  const el = document.createElement("div");
+  el.id = "dt";
+  el.className = "pc-data-table";
+  if (searchTemplate) el.dataset.searchTemplate = searchTemplate;
+  if (pageSizeTemplate) el.dataset.pageSizeTemplate = pageSizeTemplate;
+  if (debounce) el.dataset.debounce = debounce;
+  el.innerHTML = `
+    <a data-pc-dt-nav data-phx-link="patch" data-phx-link-state="push" hidden></a>
+    <input type="text" data-pc-dt-search />
+    <select data-pc-dt-page-size>
+      <option value="10">10</option>
+      <option value="20">20</option>
+    </select>
+  `;
+  document.body.appendChild(el);
+
+  const hook = Object.create(hooks.PetalDataTable);
+  hook.el = el;
+  hook.mounted();
+  mounted.push(hook);
+
+  const patched = [];
+  el.querySelector("[data-pc-dt-nav]").addEventListener("click", (e) => {
+    e.preventDefault();
+    patched.push(e.target.getAttribute("href"));
+  });
+
+  return { hook, el, patched };
+}
+
+function type(el, value) {
+  const input = el.querySelector("[data-pc-dt-search]");
+  input.value = value;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("PetalDataTable", () => {
+  beforeEach(() => vi.useFakeTimers());
+
+  afterEach(() => {
+    mounted.splice(0).forEach((hook) => {
+      hook.destroyed();
+      hook.el.remove();
+    });
+    vi.useRealTimers();
+  });
+
+  it("debounces typing, then patches the :term template with the encoded value", () => {
+    const { el, patched } = mount({
+      searchTemplate: "/orders?search=:term&order_by=name",
+      debounce: "300",
+    });
+
+    type(el, "a");
+    type(el, "am y");
+    expect(patched).toEqual([]);
+
+    vi.advanceTimersByTime(299);
+    expect(patched).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(patched).toEqual(["/orders?search=am%20y&order_by=name"]);
+  });
+
+  it("a blank term drops the search param and any dangling joiner", () => {
+    const { el, patched } = mount({ searchTemplate: "/orders?search=:term" });
+    type(el, "   ");
+    vi.advanceTimersByTime(300);
+    expect(patched).toEqual(["/orders"]);
+
+    const withRest = mount({
+      searchTemplate: "/orders?search=:term&page_size=20",
+    });
+    type(withRest.el, "");
+    vi.advanceTimersByTime(300);
+    expect(withRest.patched).toEqual(["/orders?page_size=20"]);
+  });
+
+  it("page-size changes patch immediately, no debounce", () => {
+    const { el, patched } = mount({
+      pageSizeTemplate: "/orders?page_size=:page_size",
+    });
+    const select = el.querySelector("[data-pc-dt-page-size]");
+    select.value = "20";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(patched).toEqual(["/orders?page_size=20"]);
+  });
+
+  it("destroyed cancels a pending search patch", () => {
+    const { hook, el, patched } = mount({
+      searchTemplate: "/orders?search=:term",
+    });
+    type(el, "amy");
+    hook.destroyed();
+    mounted.splice(mounted.indexOf(hook), 1);
+    vi.advanceTimersByTime(300);
+    expect(patched).toEqual([]);
+    el.remove();
+  });
+});

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -49,6 +49,31 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
     end
   end
 
+  describe "search" do
+    test "matches case-insensitively across string fields by default" do
+      assert ids(run(search: "AM")) == [3]
+      assert ids(run(search: "@a.com")) == [1]
+    end
+
+    test "search_fields scopes the sweep" do
+      {rows, _} =
+        Engine.run(@rows, struct!(State, search: "amy"), search_fields: [:email])
+
+      assert Enum.map(rows, & &1.id) == [3]
+
+      {rows, _} = Engine.run(@rows, struct!(State, search: "amy"), search_fields: [:name])
+      assert Enum.map(rows, & &1.id) == [3]
+
+      {rows, _} = Engine.run(@rows, struct!(State, search: "a.com"), search_fields: [:name])
+      assert rows == []
+    end
+
+    test "search composes with filters and fills the filtered total" do
+      {_, state} = run(search: "e", filters: [%{field: :amount, op: :lt, value: "100"}])
+      assert state.total == 2
+    end
+  end
+
   describe "sorting" do
     test "sorts strings case-insensitively" do
       assert ids(run(order_by: [name: :asc], page_size: 10)) == [3, 2, 1, 5, 4]

--- a/test/petal/data_table/state_test.exs
+++ b/test/petal/data_table/state_test.exs
@@ -123,6 +123,23 @@ defmodule PetalComponents.DataTable.StateTest do
     end
   end
 
+  describe "search" do
+    test "round-trips, trims, and blanks to nil" do
+      state = State.from_params(%{"search" => "  amy "}, fields: @fields)
+      assert state.search == "amy"
+      assert State.to_params(state) == %{"search" => "amy"}
+      assert State.from_params(%{"search" => "   "}, fields: @fields).search == nil
+      assert State.to_params(%State{}) == %{}
+    end
+
+    test "put_search/2 sets, clears on blank, and resets the page" do
+      state = State.put_search(%State{page: 5}, "amy")
+      assert state.search == "amy"
+      assert state.page == 1
+      assert State.put_search(state, "").search == nil
+    end
+  end
+
   describe "toggle_sort/2" do
     test "cycles asc -> desc -> removed and resets the page" do
       state = %State{page: 7}

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -44,7 +44,7 @@ defmodule PetalComponents.DataTableTest do
     assert html =~ ~s(phx-hook="PetalDataTable")
     assert html =~ "data-pc-dt-search"
     assert html =~ "data-pc-dt-nav"
-    assert html =~ ~s(data-search-template="/orders?search=:term&amp;order_by=name%3Adesc")
+    assert html =~ ~s(data-nav-template="/orders?search=:term&amp;order_by=name%3Adesc")
   end
 
   test "page_size_options renders the footer select in both wiring modes" do
@@ -68,7 +68,7 @@ defmodule PetalComponents.DataTableTest do
       """)
 
     assert link_html =~ "data-pc-dt-page-size"
-    assert link_html =~ ~s(data-page-size-template="/orders?page_size=:page_size")
+    assert link_html =~ ~s(data-nav-template="/orders?page_size=:page_size")
   end
 
   test "reset filters button appears only while filters are active" do

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -14,6 +14,97 @@ defmodule PetalComponents.DataTableTest do
     Map.merge(%{rows: @rows, state: %State{total: 74}, path: "/orders"}, assigns)
   end
 
+  test "searchable event mode: a phx-change form posts the search op with debounce" do
+    assigns = base(%{state: %State{total: 74, search: "amy"}})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table" searchable>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ ~s(phx-change="table")
+    assert html =~ ~s(name="op" value="search")
+    assert html =~ ~s(phx-debounce="300")
+    assert html =~ ~s(value="amy")
+    refute html =~ "PetalDataTable"
+  end
+
+  test "searchable link mode: the hook mounts with a :term URL template and a nav anchor" do
+    assigns = base(%{state: %State{total: 74, order_by: [name: :desc]}})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path} searchable>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ ~s(phx-hook="PetalDataTable")
+    assert html =~ "data-pc-dt-search"
+    assert html =~ "data-pc-dt-nav"
+    assert html =~ ~s(data-search-template="/orders?search=:term&amp;order_by=name%3Adesc")
+  end
+
+  test "page_size_options renders the footer select in both wiring modes" do
+    assigns = base(%{state: %State{total: 74, page_size: 20}})
+
+    event_html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table" page_size_options={[10, 20, 50]}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert event_html =~ ~s(name="op" value="page_size")
+    assert event_html =~ ~s(<option value="20" selected>)
+
+    link_html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path} page_size_options={[10, 20, 50]}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert link_html =~ "data-pc-dt-page-size"
+    assert link_html =~ ~s(data-page-size-template="/orders?page_size=:page_size")
+  end
+
+  test "reset filters button appears only while filters are active" do
+    filtered = %State{total: 74, filters: [%{field: :name, op: :contains, value: "a"}]}
+    assigns = base(%{filtered: filtered})
+
+    clean_html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    refute clean_html =~ "Reset filters"
+
+    link_html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@filtered} path={@path}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert link_html =~ "Reset filters"
+    assert link_html =~ ~s(href="/orders")
+
+    event_html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@filtered} on_change="table">
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert event_html =~ "Reset filters"
+    assert event_html =~ ~s(phx-value-op="clear_filters")
+  end
+
   test "renders rows through col slots with explicit and humanized labels" do
     assigns = base()
 


### PR DESCRIPTION
First slab of the DT-M2 toolbar. Filter buttons + typed popover editors land next.

## The contract
- **State**: new `search` field - trimmed, blank drops the param from URLs, every change resets to page 1 (`put_search/2`); `put_page_size/2` same discipline. `Engine.List.run/3` gains `:search_fields` (defaults to every string-valued field of the first row) and sweeps case-insensitively BEFORE filters so `total` reflects both.
- **Component**: `searchable`, `search_placeholder`, `search_debounce`, `page_size_options`, `per_page_label`, `reset_filters_label`. Reset button appears only while filters are active, both wiring modes.
- **Event mode**: zero JS - plain forms posting the op grammar's new `search` (term) and `page_size` ops.
- **Link mode**: the new `PetalDataTable` hook. The component renders `:term`/`:page_size` URL templates (assembled around the already-encoded rest of the query - the pagination `:page` trick) plus a hidden `data-phx-link` patch anchor; the hook substitutes and clicks, so navigation stays LiveView's own - no private liveSocket APIs.

## Verified
- 832 Elixir / 104 JS green (4 new hook specs: debounce timing, blank-term URL cleanup incl. dangling joiners, immediate page-size patch, destroy cancels pending patch)
- Live in the playground event-mode demo: typing "refund" filters 20 -> 7 with the range following, per-page 20 collapses pagination away, the term survives patches (focused-input preservation)