### PR TITLE
feat(data_table): column filters - typed popover editors (DT-M2 part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@
   `search`/`page_size` ops through plain forms; link mode wires both
   through the new `PetalDataTable` hook, which fills in URL templates
   and clicks a hidden patch link so navigation stays LiveView's own.
+- **`<.data_table>` column filters (4.12 data table, milestone 2,
+  part 2).** `:col` gains `filterable` ("text" | "number" | "select" |
+  "date") and `options`; each filterable column renders a toolbar
+  filter button that opens a popover editor typed per column -
+  operator select + value for text/number/date (`between` reveals its
+  second bound via `:has()`, no JS), a checkbox list posting `:in`
+  for select. Active buttons read their predicate ("Email contains d",
+  "Amount between 300\u2013320", "+N" overflow for long picks) with an
+  inline clear. `State.handle_op/3` speaks the entire event grammar
+  (sort/page/search/page_size/filter/clear_filters, whitelisted
+  fields, no atom creation) so an event-mode handler is one call;
+  link mode extends the `PetalDataTable` hook with a `:filters`
+  placeholder mirrored from a JSON stamp, and filter URLs now carry
+  list/range values as Phoenix-style indexed params. Operator names
+  localize via `filter_op_labels`.
 - **`table` `on_sort` accepts a 1-arity function** of the sort key -
   per-column events/JS, how the data table patches sort URLs.
 - **`pagination` event mode grows up**: `event` accepts a custom event

--- a/assets/default.css
+++ b/assets/default.css
@@ -2644,6 +2644,47 @@
   .pc-data-table__page-size-select.pc-data-table__page-size-select {
     @apply h-9 w-auto py-0 pr-8 text-sm;
   }
+  .pc-data-table__filter {
+    @apply flex items-center gap-1;
+  }
+  /* Doubled selector + !important: icon sizing contract (see pagination chevrons). */
+  .pc-data-table__filter-icon.pc-data-table__filter-icon {
+    @apply w-3.5! h-3.5! mr-1.5;
+  }
+  .pc-data-table__filter-form {
+    @apply flex w-56 flex-col gap-2;
+  }
+  .pc-data-table__filter-form--select {
+    @apply w-48;
+  }
+  .pc-data-table__filter-op.pc-data-table__filter-op,
+  .pc-data-table__filter-value.pc-data-table__filter-value {
+    @apply h-9 text-sm;
+  }
+  .pc-data-table__filter-value2 {
+    @apply hidden;
+  }
+  /* the between op needs its second bound; :has keeps this JS-free in both wiring modes */
+  .pc-data-table__filter-form:has(select[name="filter_op"] option[value="between"]:checked)
+    .pc-data-table__filter-value2 {
+    @apply block;
+  }
+  .pc-data-table__filter-options {
+    @apply flex max-h-56 flex-col gap-1 overflow-y-auto;
+  }
+  .pc-data-table__filter-option {
+    @apply flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-400/10;
+  }
+  .pc-data-table__filter-apply {
+    @apply self-end;
+  }
+  .pc-data-table__filter-clear {
+    @apply inline-flex h-6 w-6 items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-400/10 dark:hover:text-gray-300;
+  }
+  /* Doubled selector + !important: icon sizing contract (see pagination chevrons). */
+  .pc-data-table__filter-clear-icon.pc-data-table__filter-clear-icon {
+    @apply w-4! h-4!;
+  }
 
   /* Avatars - sizes */
 

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4629,20 +4629,82 @@ export const PetalDataTable = {
       this.patchTo(this.navUrl());
     };
 
+    // link mode has no events, so a filter editor's Apply becomes a
+    // patch built from the form's inputs: replace this field's entry in
+    // the committed filter list (an empty editor removes it), close the
+    // popover, navigate
+    this.onSubmit = (e) => {
+      const form = e.target.closest("[data-pc-dt-filter]");
+      if (!form) return;
+      e.preventDefault();
+      clearTimeout(this.searchTimer);
+
+      const field = form.dataset.field;
+      const filters = this.committedFilters().filter((f) => f.field !== field);
+      const next = this.readFilter(form, field);
+      if (next) filters.push(next);
+
+      this.closePopover(form);
+      this.patchTo(this.navUrl(filters));
+    };
+
     this.el.addEventListener("input", this.onInput);
     this.el.addEventListener("change", this.onChange);
+    this.el.addEventListener("submit", this.onSubmit);
   },
 
   destroyed() {
     clearTimeout(this.searchTimer);
     this.el.removeEventListener("input", this.onInput);
     this.el.removeEventListener("change", this.onChange);
+    this.el.removeEventListener("submit", this.onSubmit);
+  },
+
+  committedFilters() {
+    try {
+      return JSON.parse(this.el.dataset.filters || "[]");
+    } catch {
+      return [];
+    }
+  },
+
+  readFilter(form, field) {
+    if (form.querySelector('input[name="values[]"]')) {
+      const values = Array.from(
+        form.querySelectorAll('input[name="values[]"]:checked'),
+        (i) => i.value,
+      );
+      return values.length ? { field, op: "in", value: values } : null;
+    }
+
+    const op = form.querySelector('select[name="filter_op"]')?.value || "eq";
+    const value = (form.querySelector('[name="value"]')?.value || "").trim();
+
+    if (op === "between") {
+      const value2 = (
+        form.querySelector('[name="value2"]')?.value || ""
+      ).trim();
+      // a half-empty range can't match anything, so it reads as removal
+      return value === "" || value2 === ""
+        ? null
+        : { field, op, value: [value, value2] };
+    }
+
+    return value === "" ? null : { field, op, value };
+  },
+
+  closePopover(form) {
+    const panel = form.closest(".pc-popover__panel");
+    if (!panel) return;
+    panel.style.display = "none";
+    const trigger = document.getElementById(`${panel.id}-trigger`);
+    if (trigger) trigger.setAttribute("aria-expanded", "false");
   },
 
   // Both placeholders resolve from the live DOM in one pass, so
   // whichever control triggers the patch carries the other's current
   // (possibly uncommitted) value instead of a stale committed one.
-  navUrl() {
+  navUrl(filtersOverride) {
     let url = this.el.dataset.navTemplate;
 
     if (url.includes(":term")) {
@@ -4660,7 +4722,43 @@ export const PetalDataTable = {
       url = url.replace(":page_size", encodeURIComponent(select.value));
     }
 
+    if (url.includes(":filters")) {
+      const encoded = this.encodeFilters(
+        filtersOverride || this.committedFilters(),
+      );
+      url =
+        encoded === ""
+          ? url.replace(/:filters&?/, "")
+          : url.replace(":filters", encoded);
+    }
+
     return url.replace(/[?&]$/, "");
+  },
+
+  // mirrors the server's Phoenix-style indexed flattening, list values
+  // as repeated "[value][]" keys - from_params reads either side back
+  encodeFilters(filters) {
+    const enc = encodeURIComponent;
+    const pairs = [];
+
+    filters.forEach((f, i) => {
+      const base = `filters[${i}]`;
+      pairs.push(`${enc(`${base}[field]`)}=${enc(f.field)}`);
+      pairs.push(`${enc(`${base}[op]`)}=${enc(f.op)}`);
+      if (Array.isArray(f.value)) {
+        f.value.forEach((v) =>
+          pairs.push(`${enc(`${base}[value][]`)}=${enc(v)}`),
+        );
+      } else if (f.value && typeof f.value === "object") {
+        Object.entries(f.value).forEach(([k, v]) =>
+          pairs.push(`${enc(`${base}[value][${k}]`)}=${enc(v)}`),
+        );
+      } else {
+        pairs.push(`${enc(`${base}[value]`)}=${enc(f.value)}`);
+      }
+    });
+
+    return pairs.join("&");
   },
 
   patchTo(url) {

--- a/dev.exs
+++ b/dev.exs
@@ -1438,33 +1438,14 @@ defmodule Dev.PlaygroundLive do
   def handle_event("pg_combo_change", %{"pg_city" => value}, socket),
     do: {:noreply, update(socket, :combo, &%{&1 | chosen: value})}
 
-  # the data table's event-mode op grammar, applied with State helpers and
-  # re-run through the free engine - the whole backend in one handler
+  # the data table's event-mode op grammar: State.handle_op speaks all of
+  # it (sort/page/search/page_size/filter/clear_filters), so the whole
+  # backend is one call plus a re-run through the free engine
   def handle_event("pg_table", params, socket) do
     alias PetalComponents.DataTable.State
     {state, _rows} = socket.assigns.dt
 
-    state =
-      case params do
-        %{"op" => "sort", "field" => field} ->
-          State.toggle_sort(state, String.to_existing_atom(field))
-
-        %{"op" => "page", "page" => page} ->
-          %{state | page: String.to_integer(to_string(page))}
-
-        %{"op" => "search", "term" => term} ->
-          State.put_search(state, term)
-
-        %{"op" => "page_size", "page_size" => size} ->
-          State.put_page_size(state, size)
-
-        %{"op" => "clear_filters"} ->
-          State.clear_filters(state)
-
-        _ ->
-          state
-      end
-
+    state = State.handle_op(state, params, fields: [:name, :email, :status, :amount])
     {:noreply, assign(socket, :dt, run_dt(state))}
   end
 
@@ -7342,8 +7323,13 @@ defmodule Dev.PlaygroundLive do
           page_size_options={[5, 10, 20]}
         >
           <:col :let={row} field={:name} sortable>{row.name}</:col>
-          <:col :let={row} field={:email}>{row.email}</:col>
-          <:col :let={row} field={:status}>
+          <:col :let={row} field={:email} filterable="text">{row.email}</:col>
+          <:col
+            :let={row}
+            field={:status}
+            filterable="select"
+            options={[{"Paid", "paid"}, {"Pending", "pending"}, {"Refunded", "refunded"}]}
+          >
             <.badge
               size="sm"
               variant="soft"
@@ -7357,7 +7343,9 @@ defmodule Dev.PlaygroundLive do
               label={row.status}
             />
           </:col>
-          <:col :let={row} field={:amount} sortable align="right">${row.amount}</:col>
+          <:col :let={row} field={:amount} sortable align="right" filterable="number">
+            ${row.amount}
+          </:col>
         </.data_table>
       </div>
 

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -689,7 +689,10 @@ defmodule PetalComponents.DataTable do
   defp current_values(nil), do: []
   defp current_values(%{value: value}), do: List.wrap(value)
 
+  # the engine accepts both range shapes, so both must render
   defp current_pair(%{op: :between, value: [min, max]}), do: {min, max}
+  defp current_pair(%{op: :between, value: %{"min" => min, "max" => max}}), do: {min, max}
+  defp current_pair(%{op: :between}), do: {nil, nil}
   defp current_pair(%{value: value}) when not is_list(value), do: {value, nil}
   defp current_pair(_other), do: {nil, nil}
 
@@ -708,6 +711,16 @@ defmodule PetalComponents.DataTable do
   end
 
   defp display_value(%{op: :between, value: [min, max]}, _options), do: "#{min}\u2013#{max}"
+
+  defp display_value(%{op: :between, value: %{"min" => min, "max" => max}}, _options),
+    do: "#{min}\u2013#{max}"
+
+  # hand-built states can carry shapes no editor produces - never crash
+  # the toolbar over one
+  defp display_value(%{value: value}, _options) when is_list(value),
+    do: Enum.map_join(value, ", ", &to_string/1)
+
+  defp display_value(%{value: %{} = value}, _options), do: inspect(value)
   defp display_value(%{value: value}, _options), do: to_string(value)
 
   defp range_text(%State{total: nil} = state, _of_label, page_label),

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -21,8 +21,10 @@ defmodule PetalComponents.DataTable do
       arrive as `%{"op" => "sort", "field" => f}`, page changes as
       `%{"op" => "page", "page" => n}`, quick-search as
       `%{"op" => "search", "term" => t}`, page-size changes as
-      `%{"op" => "page_size", "page_size" => n}`, filter clears as
-      `%{"op" => "clear_filters"}`. `State` has a helper for each op.
+      `%{"op" => "page_size", "page_size" => n}`, filter edits as
+      `%{"op" => "filter", "field" => f, ...editor inputs}`, filter
+      clears as `%{"op" => "clear_filters"}`. `State.handle_op/3`
+      speaks the whole grammar, so the handler is a one-liner.
 
   In link mode the quick-search input and rows-per-page select are wired
   by the `PetalDataTable` hook (patch URLs built from templates the
@@ -37,6 +39,7 @@ defmodule PetalComponents.DataTable do
   import PetalComponents.Button
   import PetalComponents.Icon
   import PetalComponents.Pagination
+  import PetalComponents.Popover
   import PetalComponents.Skeleton
   import PetalComponents.Table
 
@@ -94,12 +97,29 @@ defmodule PetalComponents.DataTable do
 
   attr :per_page_label, :string, default: "Per page", doc: "the rows-per-page label, localizable"
   attr :reset_filters_label, :string, default: "Reset filters"
+
+  attr :apply_label, :string,
+    default: "Apply",
+    doc: "the filter editors' submit label, localizable"
+
+  attr :filter_op_labels, :map,
+    default: %{},
+    doc: "overrides for the operator display names, e.g. %{contains: \"enthält\"}"
+
   attr :class, :any, default: nil
 
   slot :col, required: true do
     attr :field, :atom, required: true
     attr :label, :string
     attr :sortable, :boolean
+
+    attr :filterable, :string,
+      values: ["text", "number", "select", "date"],
+      doc: "render a typed filter button + popover editor for this column"
+
+    attr :options, :list,
+      doc: "select filters: the pickable values, as strings or {label, value} tuples"
+
     attr :align, :string, values: ["left", "center", "right"]
     attr :class, :any
   end
@@ -121,8 +141,11 @@ defmodule PetalComponents.DataTable do
 
     fields = Map.new(assigns.col, fn col -> {to_string(col.field), col.field} end)
 
+    filter_cols = Enum.filter(assigns.col, & &1[:filterable])
+
     hooked? =
-      is_nil(assigns.on_change) and (assigns.searchable or assigns.page_size_options != [])
+      is_nil(assigns.on_change) and
+        (assigns.searchable or assigns.page_size_options != [] or filter_cols != [])
 
     assigns =
       assigns
@@ -130,8 +153,17 @@ defmodule PetalComponents.DataTable do
       |> assign(:sort_dir, sort_dir)
       |> assign(:on_sort, sort_handler(assigns, fields))
       |> assign(:skeleton_rows, List.duplicate(%{}, min(assigns.state.page_size, 10)))
+      |> assign(:filter_cols, filter_cols)
+      |> assign(:op_labels, Map.merge(default_op_labels(), assigns.filter_op_labels))
       |> assign(:hooked?, hooked?)
-      |> assign(:nav_template, hooked? && nav_template(assigns))
+      |> assign(
+        :nav_template,
+        hooked? && nav_template(assigns.path, assigns.state, assigns, filter_cols)
+      )
+      |> assign(
+        :filters_json,
+        hooked? && filter_cols != [] && Jason.encode!(assigns.state.filters)
+      )
 
     ~H"""
     <div
@@ -140,10 +172,11 @@ defmodule PetalComponents.DataTable do
       phx-hook={@hooked? && "PetalDataTable"}
       data-debounce={@hooked? && @search_debounce}
       data-nav-template={@nav_template || nil}
+      data-filters={@filters_json || nil}
     >
       <a :if={@hooked?} data-pc-dt-nav data-phx-link="patch" data-phx-link-state="push" hidden></a>
       <div
-        :if={@toolbar != [] or @searchable or @state.filters != []}
+        :if={@toolbar != [] or @searchable or @filter_cols != [] or @state.filters != []}
         class="pc-data-table__toolbar"
       >
         <div :if={@searchable} class="pc-data-table__search">
@@ -172,6 +205,17 @@ defmodule PetalComponents.DataTable do
             />
           <% end %>
         </div>
+        <.filter_button
+          :for={col <- @filter_cols}
+          col={col}
+          table_id={@id}
+          state={@state}
+          path={@path}
+          on_change={@on_change}
+          target={@target}
+          op_labels={@op_labels}
+          apply_label={@apply_label}
+        />
         {render_slot(@toolbar)}
         <%= if @state.filters != [] do %>
           <.button
@@ -360,9 +404,10 @@ defmodule PetalComponents.DataTable do
   # assembled around the already-encoded rest of the query (the
   # pagination :page trick); a control the table doesn't render keeps
   # its committed value in the rest instead of a placeholder.
-  defp nav_template(%{path: path, state: state} = assigns) do
+  defp nav_template(path, state, assigns, filter_cols) do
     state = %{state | page: 1}
     state = if assigns.searchable, do: State.put_search(state, ""), else: state
+    state = if filter_cols != [], do: %{state | filters: []}, else: state
 
     params = State.to_params(state)
 
@@ -373,7 +418,8 @@ defmodule PetalComponents.DataTable do
       Enum.filter(
         [
           assigns.searchable && "search=:term",
-          assigns.page_size_options != [] && "page_size=:page_size"
+          assigns.page_size_options != [] && "page_size=:page_size",
+          filter_cols != [] && ":filters"
         ],
         & &1
       )
@@ -392,22 +438,277 @@ defmodule PetalComponents.DataTable do
   end
 
   # filters encode as a list of maps - flatten to Phoenix-style indexed
-  # params so encode_query can carry them and from_params reads them back
+  # params so encode_query can carry them and from_params reads them
+  # back. Returns pairs, not a map: a list value (the :in op) needs the
+  # same key repeated ("...[value][]"), which a map cannot hold.
   defp flatten_params(params) do
-    case Map.pop(params, "filters") do
-      {nil, rest} ->
-        rest
+    {filters, rest} = Map.pop(params, "filters")
 
-      {filters, rest} ->
-        filters
-        |> Enum.with_index()
-        |> Enum.reduce(rest, fn {filter, i}, acc ->
-          Enum.reduce(filter, acc, fn {k, v}, acc2 ->
-            Map.put(acc2, "filters[#{i}][#{k}]", v)
-          end)
-        end)
+    Enum.sort(rest) ++
+      (filters
+       |> List.wrap()
+       |> Enum.with_index()
+       |> Enum.flat_map(fn {filter, i} ->
+         Enum.flat_map(filter, fn {k, v} -> filter_pairs("filters[#{i}][#{k}]", v) end)
+       end))
+  end
+
+  defp filter_pairs(key, values) when is_list(values),
+    do: Enum.map(values, &{"#{key}[]", &1})
+
+  defp filter_pairs(key, %{} = map),
+    do: Enum.map(map, fn {k, v} -> {"#{key}[#{k}]", v} end)
+
+  defp filter_pairs(key, value), do: [{key, value}]
+
+  # -- filters ---------------------------------------------------------------
+
+  @text_ops ~w(contains eq starts_with)a
+  @number_ops ~w(eq neq gt lt between)a
+  @date_ops ~w(before on after)a
+
+  defp default_op_labels do
+    %{
+      contains: "contains",
+      eq: "is",
+      starts_with: "starts with",
+      neq: "is not",
+      gt: ">",
+      lt: "<",
+      between: "between",
+      in: "is any of",
+      before: "before",
+      on: "on",
+      after: "after"
+    }
+  end
+
+  defp filter_button(assigns) do
+    col = assigns.col
+    field_str = to_string(col.field)
+    label = col[:label] || humanize(col.field)
+    filter = Enum.find(assigns.state.filters, &(&1.field == col.field))
+    options = normalize_options(col[:options] || [])
+    pop_id = "#{assigns.table_id}-filter-#{field_str}"
+
+    assigns =
+      assigns
+      |> assign(:field_str, field_str)
+      |> assign(:label, label)
+      |> assign(:filter, filter)
+      |> assign(:options, options)
+      |> assign(:pop_id, pop_id)
+      |> assign(:type, col[:filterable])
+      |> assign(:submit_js, filter_submit_js(assigns.on_change, assigns.target, pop_id))
+      |> assign(
+        :clear_url,
+        assigns.path && url_for(assigns.path, State.put_filter(assigns.state, col.field, :eq, ""))
+      )
+
+    ~H"""
+    <div class="pc-data-table__filter">
+      <.popover
+        id={@pop_id}
+        placement="bottom-start"
+        class="pc-data-table__filter-popover"
+        trigger_class={[
+          "pc-button pc-button--sm",
+          (@filter && "pc-button--primary-soft pc-data-table__filter-trigger--active") ||
+            "pc-button--gray-outline"
+        ]}
+      >
+        <:trigger>
+          <.icon :if={!@filter} name="hero-funnel" class="pc-data-table__filter-icon" />
+          <span>{(@filter && predicate_text(@label, @filter, @op_labels, @options)) || @label}</span>
+        </:trigger>
+        <form
+          class={["pc-data-table__filter-form", "pc-data-table__filter-form--#{@type}"]}
+          phx-submit={@submit_js}
+          data-pc-dt-filter={is_nil(@on_change) || nil}
+          data-field={@field_str}
+        >
+          <input :if={@on_change} type="hidden" name="op" value="filter" />
+          <input :if={@on_change} type="hidden" name="field" value={@field_str} />
+          <.filter_editor
+            type={@type}
+            filter={@filter}
+            options={@options}
+            op_labels={@op_labels}
+            label={@label}
+          />
+          <.button size="sm" type="submit" class="pc-data-table__filter-apply">
+            {@apply_label}
+          </.button>
+        </form>
+      </.popover>
+      <%= if @filter do %>
+        <.link
+          :if={@path}
+          patch={@clear_url}
+          class="pc-data-table__filter-clear"
+          aria-label={"Clear #{@label} filter"}
+        >
+          <.icon name="hero-x-mark" class="pc-data-table__filter-clear-icon" />
+        </.link>
+        <button
+          :if={@on_change}
+          type="button"
+          class="pc-data-table__filter-clear"
+          phx-click={@on_change}
+          phx-target={@target}
+          phx-value-op="filter"
+          phx-value-field={@field_str}
+          aria-label={"Clear #{@label} filter"}
+        >
+          <.icon name="hero-x-mark" class="pc-data-table__filter-clear-icon" />
+        </button>
+      <% end %>
+    </div>
+    """
+  end
+
+  defp filter_editor(%{type: "select"} = assigns) do
+    current = assigns.filter |> current_values() |> Enum.map(&to_string/1)
+    assigns = assign(assigns, :current, current)
+
+    ~H"""
+    <div class="pc-data-table__filter-options" role="group" aria-label={"#{@label} options"}>
+      <label :for={{label, value} <- @options} class="pc-data-table__filter-option">
+        <input
+          type="checkbox"
+          name="values[]"
+          value={value}
+          checked={to_string(value) in @current}
+          class="pc-checkbox"
+        />
+        <span>{label}</span>
+      </label>
+    </div>
+    """
+  end
+
+  defp filter_editor(%{type: "number"} = assigns) do
+    {value, value2} = current_pair(assigns.filter)
+
+    assigns =
+      assigns
+      |> assign(:ops, @number_ops)
+      |> assign(:current_op, (assigns.filter && assigns.filter.op) || :eq)
+      |> assign(:value, value)
+      |> assign(:value2, value2)
+
+    ~H"""
+    <.filter_op_select ops={@ops} current_op={@current_op} op_labels={@op_labels} label={@label} />
+    <input
+      type="number"
+      step="any"
+      name="value"
+      value={@value}
+      class="pc-text-input pc-data-table__filter-value"
+    />
+    <input
+      type="number"
+      step="any"
+      name="value2"
+      value={@value2}
+      class="pc-text-input pc-data-table__filter-value pc-data-table__filter-value2"
+      aria-label={"#{@label} upper bound"}
+    />
+    """
+  end
+
+  defp filter_editor(%{type: "date"} = assigns) do
+    assigns =
+      assigns
+      |> assign(:ops, @date_ops)
+      |> assign(:current_op, (assigns.filter && assigns.filter.op) || :on)
+      |> assign(:value, (assigns.filter && to_string(assigns.filter.value)) || nil)
+
+    ~H"""
+    <.filter_op_select ops={@ops} current_op={@current_op} op_labels={@op_labels} label={@label} />
+    <input
+      type="date"
+      name="value"
+      value={@value}
+      class="pc-text-input pc-data-table__filter-value"
+    />
+    """
+  end
+
+  defp filter_editor(assigns) do
+    assigns =
+      assigns
+      |> assign(:ops, @text_ops)
+      |> assign(:current_op, (assigns.filter && assigns.filter.op) || :contains)
+      |> assign(:value, (assigns.filter && to_string(assigns.filter.value)) || nil)
+
+    ~H"""
+    <.filter_op_select ops={@ops} current_op={@current_op} op_labels={@op_labels} label={@label} />
+    <input
+      type="text"
+      name="value"
+      value={@value}
+      class="pc-text-input pc-data-table__filter-value"
+    />
+    """
+  end
+
+  defp filter_op_select(assigns) do
+    ~H"""
+    <select
+      name="filter_op"
+      class="pc-select pc-data-table__filter-op"
+      aria-label={"#{@label} operator"}
+    >
+      <option :for={op <- @ops} value={op} selected={op == @current_op}>
+        {Map.fetch!(@op_labels, op)}
+      </option>
+    </select>
+    """
+  end
+
+  # event mode: push the form, then close the popover panel the same way
+  # its own Escape path does
+  defp filter_submit_js(nil, _target, _pop_id), do: nil
+
+  defp filter_submit_js(event, target, pop_id) do
+    push = if target, do: JS.push(event, target: target), else: JS.push(event)
+
+    push
+    |> JS.hide(to: "##{pop_id}")
+    |> JS.set_attribute({"aria-expanded", "false"}, to: "##{pop_id}-trigger")
+  end
+
+  defp normalize_options(options) do
+    Enum.map(options, fn
+      {label, value} -> {label, value}
+      value -> {humanize(value), value}
+    end)
+  end
+
+  defp current_values(nil), do: []
+  defp current_values(%{value: value}), do: List.wrap(value)
+
+  defp current_pair(%{op: :between, value: [min, max]}), do: {min, max}
+  defp current_pair(%{value: value}) when not is_list(value), do: {value, nil}
+  defp current_pair(_other), do: {nil, nil}
+
+  defp predicate_text(label, filter, op_labels, options) do
+    "#{label} #{Map.fetch!(op_labels, filter.op)} #{display_value(filter, options)}"
+  end
+
+  defp display_value(%{op: :in, value: values}, options) do
+    labels = Map.new(options, fn {label, value} -> {to_string(value), label} end)
+    shown = values |> List.wrap() |> Enum.map(&Map.get(labels, to_string(&1), to_string(&1)))
+
+    case Enum.split(shown, 2) do
+      {first_two, []} -> Enum.join(first_two, ", ")
+      {first_two, rest} -> Enum.join(first_two, ", ") <> " +#{length(rest)}"
     end
   end
+
+  defp display_value(%{op: :between, value: [min, max]}, _options), do: "#{min}\u2013#{max}"
+  defp display_value(%{value: value}, _options), do: to_string(value)
 
   defp range_text(%State{total: nil} = state, _of_label, page_label),
     do: "#{page_label} #{state.page}"

--- a/lib/petal_components/data_table/state.ex
+++ b/lib/petal_components/data_table/state.ex
@@ -146,6 +146,81 @@ defmodule PetalComponents.DataTable.State do
     %{state | page_size: parse_pos_int(size, state.page_size), page: 1}
   end
 
+  @doc """
+  Applies one event-mode op payload - the entire `data_table` event
+  grammar in one call, so an event-mode handler is a one-liner:
+
+      def handle_event("table", params, socket) do
+        state = State.handle_op(socket.assigns.table, params, fields: [:name, :email])
+        {rows, state} = Engine.List.run(all_rows(), state)
+        {:noreply, assign(socket, rows: rows, table: state)}
+      end
+
+  Ops: `sort` (field), `page` (page), `search` (term), `page_size`
+  (page_size), `filter` (field, filter_op, value/value2/values), and
+  `clear_filters`. Unknown ops and non-whitelisted fields leave the
+  state unchanged; like `from_params/2`, no atoms are ever created
+  from input.
+
+  A `filter` op's value normalizes by editor shape: a `values` list
+  posts as-is (the select editor's `:in`), `between` pairs
+  `value`/`value2` into `[min, max]`, anything blank removes the
+  field's filter.
+  """
+  def handle_op(%__MODULE__{} = state, params, opts) when is_map(params) and is_list(opts) do
+    fields = Keyword.fetch!(opts, :fields)
+    field_strings = Map.new(fields, &{Atom.to_string(&1), &1})
+
+    case params do
+      %{"op" => "sort", "field" => field} ->
+        case Map.fetch(field_strings, to_string(field)) do
+          {:ok, field} -> toggle_sort(state, field)
+          :error -> state
+        end
+
+      %{"op" => "page", "page" => page} ->
+        %{state | page: parse_pos_int(to_string(page), state.page)}
+
+      %{"op" => "search", "term" => term} ->
+        put_search(state, term)
+
+      %{"op" => "page_size", "page_size" => size} ->
+        put_page_size(state, size)
+
+      %{"op" => "filter", "field" => field} ->
+        case Map.fetch(field_strings, to_string(field)) do
+          {:ok, field} -> apply_filter_op(state, field, params)
+          :error -> state
+        end
+
+      %{"op" => "clear_filters"} ->
+        clear_filters(state)
+
+      _other ->
+        state
+    end
+  end
+
+  defp apply_filter_op(state, field, params) do
+    {op, value} =
+      if is_list(params["values"]) do
+        # the select editor's shape - its grammar is always :in, whether
+        # or not the form said so
+        {:in, Enum.reject(params["values"], &(&1 in [nil, ""]))}
+      else
+        case Map.get(@op_strings, params["filter_op"], :eq) do
+          :between -> {:between, normalize_between(params["value"], params["value2"])}
+          op -> {op, params["value"]}
+        end
+      end
+
+    put_filter(state, field, op, value)
+  end
+
+  # a half-empty range can't match anything, so it reads as removal
+  defp normalize_between(min, max) when min in [nil, ""] or max in [nil, ""], do: ""
+  defp normalize_between(min, max), do: [min, max]
+
   @doc "Removes every filter, resetting to page 1."
   def clear_filters(%__MODULE__{} = state), do: %{state | filters: [], page: 1}
 

--- a/lib/petal_components/data_table/state.ex
+++ b/lib/petal_components/data_table/state.ex
@@ -208,9 +208,13 @@ defmodule PetalComponents.DataTable.State do
         # or not the form said so
         {:in, Enum.reject(params["values"], &(&1 in [nil, ""]))}
       else
-        case Map.get(@op_strings, params["filter_op"], :eq) do
-          :between -> {:between, normalize_between(params["value"], params["value2"])}
-          op -> {op, params["value"]}
+        case Map.fetch(@op_strings, params["filter_op"] || "") do
+          {:ok, :between} -> {:between, normalize_between(params["value"], params["value2"])}
+          {:ok, op} -> {op, params["value"]}
+          # missing/unknown operator: from_params-grade rejection - the
+          # only safe application is removing this field's filter (the
+          # clear button's payload is exactly this shape)
+          :error -> {:eq, ""}
         end
       end
 

--- a/lib/petal_components/data_table/state.ex
+++ b/lib/petal_components/data_table/state.ex
@@ -202,23 +202,31 @@ defmodule PetalComponents.DataTable.State do
   end
 
   defp apply_filter_op(state, field, params) do
-    {op, value} =
-      if is_list(params["values"]) do
+    resolved =
+      cond do
         # the select editor's shape - its grammar is always :in, whether
         # or not the form said so
-        {:in, Enum.reject(params["values"], &(&1 in [nil, ""]))}
-      else
-        case Map.fetch(@op_strings, params["filter_op"] || "") do
-          {:ok, :between} -> {:between, normalize_between(params["value"], params["value2"])}
-          {:ok, op} -> {op, params["value"]}
-          # missing/unknown operator: from_params-grade rejection - the
-          # only safe application is removing this field's filter (the
-          # clear button's payload is exactly this shape)
-          :error -> {:eq, ""}
-        end
+        is_list(params["values"]) ->
+          {:in, Enum.reject(params["values"], &(&1 in [nil, ""]))}
+
+        # no operator at all is the clear button's payload: removal
+        is_nil(params["filter_op"]) ->
+          {:eq, ""}
+
+        true ->
+          case Map.fetch(@op_strings, params["filter_op"]) do
+            {:ok, :between} -> {:between, normalize_between(params["value"], params["value2"])}
+            {:ok, op} -> {op, params["value"]}
+            # a present-but-unknown operator gets from_params-grade
+            # rejection: the state stays exactly as it was
+            :error -> :reject
+          end
       end
 
-    put_filter(state, field, op, value)
+    case resolved do
+      :reject -> state
+      {op, value} -> put_filter(state, field, op, value)
+    end
   end
 
   # a half-empty range can't match anything, so it reads as removal

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -8,7 +8,7 @@ import hooks from "../../assets/js/petal_components.js";
 
 const mounted = [];
 
-function mount({ navTemplate, debounce } = {}) {
+function mountBase({ navTemplate, debounce } = {}) {
   const el = document.createElement("div");
   el.id = "dt";
   el.className = "pc-data-table";
@@ -36,6 +36,23 @@ function mount({ navTemplate, debounce } = {}) {
   });
 
   return { hook, el, patched };
+}
+
+const mount = mountBase;
+
+function mountWithFilter({ navTemplate, filters, formHtml }) {
+  const { hook, el, patched } = mountBase({ navTemplate });
+  if (filters) el.dataset.filters = JSON.stringify(filters);
+  const wrap = document.createElement("div");
+  wrap.className = "pc-popover__panel";
+  wrap.id = "pop";
+  wrap.innerHTML = formHtml;
+  el.appendChild(wrap);
+  return { hook, el, patched, form: wrap.querySelector("form") };
+}
+
+function submit(form) {
+  form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
 }
 
 function type(el, value) {
@@ -116,6 +133,92 @@ describe("PetalDataTable", () => {
     // the debounced search patch must NOT fire a second, stale navigation
     vi.advanceTimersByTime(1000);
     expect(patched).toEqual(["/orders?search=amy&page_size=20"]);
+  });
+
+  it("filter apply replaces this field's committed entry and closes the popover", () => {
+    const { el, patched, form } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [
+        { field: "email", op: "contains", value: "d" },
+        { field: "amount", op: "gt", value: "5" },
+      ],
+      formHtml: `
+        <form data-pc-dt-filter data-field="email">
+          <select name="filter_op">
+            <option value="contains">contains</option>
+            <option value="starts_with" selected>starts with</option>
+          </select>
+          <input name="value" value="amy" />
+        </form>
+      `,
+    });
+
+    submit(form);
+
+    expect(patched).toHaveLength(1);
+    const url = decodeURIComponent(patched[0]);
+    expect(url).toContain("filters[0][field]=amount");
+    expect(url).toContain("filters[1][field]=email");
+    expect(url).toContain("filters[1][op]=starts_with");
+    expect(url).toContain("filters[1][value]=amy");
+    expect(el.querySelector(".pc-popover__panel").style.display).toBe("none");
+  });
+
+  it("a select editor posts checked values as :in; none checked removes the filter", () => {
+    const { patched, form } = mountWithFilter({
+      navTemplate: "/orders?:filters&order_by=name",
+      filters: [{ field: "status", op: "in", value: ["pending"] }],
+      formHtml: `
+        <form data-pc-dt-filter data-field="status">
+          <input type="checkbox" name="values[]" value="paid" checked />
+          <input type="checkbox" name="values[]" value="refunded" checked />
+          <input type="checkbox" name="values[]" value="pending" />
+        </form>
+      `,
+    });
+
+    submit(form);
+    const url = decodeURIComponent(patched[0]);
+    expect(url).toContain("filters[0][value][]=paid");
+    expect(url).toContain("filters[0][value][]=refunded");
+    expect(url).not.toContain("pending");
+
+    form.querySelectorAll("input:checked").forEach((i) => (i.checked = false));
+    submit(form);
+    expect(patched[1]).toBe("/orders?order_by=name");
+  });
+
+  it("a half-empty between range reads as removal", () => {
+    const { patched, form } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [{ field: "amount", op: "between", value: ["1", "9"] }],
+      formHtml: `
+        <form data-pc-dt-filter data-field="amount">
+          <select name="filter_op"><option value="between" selected>between</option></select>
+          <input name="value" value="10" />
+          <input name="value2" value="" />
+        </form>
+      `,
+    });
+
+    submit(form);
+    expect(patched).toEqual(["/orders"]);
+  });
+
+  it("search patches carry the committed filters through :filters", () => {
+    const { el, patched } = mountBase({
+      navTemplate: "/orders?search=:term&:filters",
+      debounce: "300",
+    });
+    el.dataset.filters = JSON.stringify([
+      { field: "email", op: "contains", value: "d" },
+    ]);
+
+    type(el, "amy");
+    vi.advanceTimersByTime(300);
+    const url = decodeURIComponent(patched[0]);
+    expect(url).toContain("search=amy");
+    expect(url).toContain("filters[0][field]=email");
   });
 
   it("destroyed cancels a pending search patch", () => {

--- a/test/petal/data_table/state_test.exs
+++ b/test/petal/data_table/state_test.exs
@@ -228,6 +228,17 @@ defmodule PetalComponents.DataTable.StateTest do
 
       removed = State.handle_op(text, %{"op" => "filter", "field" => "name"}, @opts)
       assert removed.filters == []
+
+      # an unknown operator must not become an equality filter - the
+      # safe application is removal, same shape as the clear button
+      bogus =
+        State.handle_op(
+          text,
+          %{"op" => "filter", "field" => "name", "filter_op" => "regex", "value" => ".*"},
+          @opts
+        )
+
+      assert bogus.filters == []
     end
   end
 

--- a/test/petal/data_table/state_test.exs
+++ b/test/petal/data_table/state_test.exs
@@ -229,8 +229,8 @@ defmodule PetalComponents.DataTable.StateTest do
       removed = State.handle_op(text, %{"op" => "filter", "field" => "name"}, @opts)
       assert removed.filters == []
 
-      # an unknown operator must not become an equality filter - the
-      # safe application is removal, same shape as the clear button
+      # a present-but-unknown operator is rejected outright - the state
+      # (including this field's active filter) stays exactly as it was
       bogus =
         State.handle_op(
           text,
@@ -238,7 +238,7 @@ defmodule PetalComponents.DataTable.StateTest do
           @opts
         )
 
-      assert bogus.filters == []
+      assert bogus == text
     end
   end
 

--- a/test/petal/data_table/state_test.exs
+++ b/test/petal/data_table/state_test.exs
@@ -140,6 +140,97 @@ defmodule PetalComponents.DataTable.StateTest do
     end
   end
 
+  describe "handle_op/3" do
+    @opts [fields: [:name, :amount, :status]]
+
+    test "dispatches the whole event grammar" do
+      state = %State{page: 3}
+
+      assert State.handle_op(state, %{"op" => "sort", "field" => "name"}, @opts).order_by ==
+               [name: :asc]
+
+      assert State.handle_op(state, %{"op" => "page", "page" => "2"}, @opts).page == 2
+      assert State.handle_op(state, %{"op" => "search", "term" => "x"}, @opts).search == "x"
+
+      assert State.handle_op(state, %{"op" => "page_size", "page_size" => "50"}, @opts).page_size ==
+               50
+
+      filtered = %{state | filters: [%{field: :name, op: :contains, value: "a"}]}
+      assert State.handle_op(filtered, %{"op" => "clear_filters"}, @opts).filters == []
+    end
+
+    test "unknown ops and non-whitelisted fields leave the state unchanged" do
+      state = %State{}
+      assert State.handle_op(state, %{"op" => "drop_tables"}, @opts) == state
+      assert State.handle_op(state, %{"op" => "sort", "field" => "secret"}, @opts) == state
+
+      assert State.handle_op(
+               state,
+               %{"op" => "filter", "field" => "secret", "value" => "x"},
+               @opts
+             ) == state
+    end
+
+    test "filter op normalizes by editor shape" do
+      state = %State{}
+
+      text =
+        State.handle_op(
+          state,
+          %{"op" => "filter", "field" => "name", "filter_op" => "contains", "value" => "am"},
+          @opts
+        )
+
+      assert text.filters == [%{field: :name, op: :contains, value: "am"}]
+
+      selected =
+        State.handle_op(
+          state,
+          %{"op" => "filter", "field" => "status", "filter_op" => "in", "values" => ["a", "b"]},
+          @opts
+        )
+
+      assert selected.filters == [%{field: :status, op: :in, value: ["a", "b"]}]
+
+      # the select editor posts values[] with no filter_op - still :in
+      bare =
+        State.handle_op(
+          state,
+          %{"op" => "filter", "field" => "status", "values" => ["a"]},
+          @opts
+        )
+
+      assert bare.filters == [%{field: :status, op: :in, value: ["a"]}]
+
+      between =
+        State.handle_op(
+          state,
+          %{
+            "op" => "filter",
+            "field" => "amount",
+            "filter_op" => "between",
+            "value" => "10",
+            "value2" => "90"
+          },
+          @opts
+        )
+
+      assert between.filters == [%{field: :amount, op: :between, value: ["10", "90"]}]
+
+      half_range =
+        State.handle_op(
+          between,
+          %{"op" => "filter", "field" => "amount", "filter_op" => "between", "value" => "10"},
+          @opts
+        )
+
+      assert half_range.filters == []
+
+      removed = State.handle_op(text, %{"op" => "filter", "field" => "name"}, @opts)
+      assert removed.filters == []
+    end
+  end
+
   describe "toggle_sort/2" do
     test "cycles asc -> desc -> removed and resets the page" do
       state = %State{page: 7}

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -71,6 +71,72 @@ defmodule PetalComponents.DataTableTest do
     assert link_html =~ ~s(data-nav-template="/orders?page_size=:page_size")
   end
 
+  test "filterable columns render popover editors typed per column" do
+    assigns =
+      base(%{
+        rows: [
+          %{name: "Amy", email: "amy@x.com", amount: 300, status: "pending"},
+          %{name: "Bea", email: "bea@x.com", amount: 40, status: "paid"}
+        ],
+        state: %State{
+          total: 74,
+          filters: [%{field: :status, op: :in, value: ["pending", "paid"]}]
+        }
+      })
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table">
+        <:col :let={row} field={:email} filterable="text">{row.email}</:col>
+        <:col :let={row} field={:amount} filterable="number">{row.amount}</:col>
+        <:col :let={row} field={:status} filterable="select" options={["pending", "paid", "refunded"]}>
+          {row.status}
+        </:col>
+      </.data_table>
+      """)
+
+    # text editor: op select with the text grammar
+    assert html =~ ~s(name="filter_op")
+    assert html =~ ~s(value="starts_with")
+    # number editor: between + second bound input
+    assert html =~ ~s(value="between")
+    assert html =~ ~s(name="value2")
+    # select editor: checkboxes, current picks checked
+    assert html =~ ~s(name="values[]")
+    assert html =~ ~s(value="pending" checked)
+    refute html =~ ~s(value="refunded" checked)
+    # active trigger reads the predicate; its clear button posts removal
+    assert html =~ "Status is any of Pending, Paid"
+    assert html =~ ~s(aria-label="Clear Status filter")
+    # event mode carries the op grammar in hidden inputs, no hook
+    assert html =~ ~s(name="op" value="filter")
+    refute html =~ "PetalDataTable"
+  end
+
+  test "filterable link mode: hook + :filters placeholder + JSON stamp + clear URL" do
+    assigns =
+      base(%{
+        state: %State{total: 74, filters: [%{field: :email, op: :contains, value: "d"}]}
+      })
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:email} filterable="text">{row.email}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ ~s(phx-hook="PetalDataTable")
+    assert html =~ "data-pc-dt-filter"
+    assert html =~ ~s(data-field="email")
+    assert html =~ ~s(data-nav-template="/orders?:filters")
+    assert html =~ ~s(data-filters=)
+    assert html =~ "contains"
+    # the clear affordance patches to a filterless URL
+    assert html =~ ~s(aria-label="Clear Email filter")
+    refute html =~ ~s(href="/orders?filters)
+  end
+
   test "reset filters button appears only while filters are active" do
     filtered = %State{total: 74, filters: [%{field: :name, op: :contains, value: "a"}]}
     assigns = base(%{filtered: filtered})

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -137,6 +137,27 @@ defmodule PetalComponents.DataTableTest do
     refute html =~ ~s(href="/orders?filters)
   end
 
+  test "a map-shaped between range renders instead of crashing" do
+    assigns =
+      base(%{
+        state: %State{
+          total: 74,
+          filters: [%{field: :amount, op: :between, value: %{"min" => "10", "max" => "90"}}]
+        }
+      })
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table">
+        <:col :let={row} field={:amount} filterable="number">{row.amount}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ "Amount between 10–90"
+    assert html =~ ~s(name="value" value="10")
+    assert html =~ ~s(name="value2" value="90")
+  end
+
   test "reset filters button appears only while filters are active" do
     filtered = %State{total: 74, filters: [%{field: :name, op: :contains, value: "a"}]}
     assigns = base(%{filtered: filtered})


### PR DESCRIPTION
The DT-M2 centerpiece: per-column filter buttons with typed popover editors, on the house popover (JS commands only - works identically in both wiring modes).

## Surface
- `:col` gains `filterable` (`"text" | "number" | "select" | "date"`) and `options` (strings or `{label, value}`).
- Idle button: funnel + column label. Active: the predicate ("Email contains d", "Amount between 300–320", "Status is any of Pending, Paid +2") with an inline × that removes just that filter. Operator names localize via `filter_op_labels`.
- Editors: operator select + value for text (`contains/is/starts with`), number (`= ≠ > < between` - the second bound reveals via CSS `:has()`, zero JS), date (`before/on/after`); a checkbox list posting `:in` for select.

## Wiring
- **Event mode**: the editor is a plain `phx-submit` form carrying the op grammar; Apply chains `JS.push |> JS.hide` so the popover closes itself. New `State.handle_op/3` speaks the entire grammar (sort/page/search/page_size/filter/clear_filters) with `from_params`-grade hygiene - whitelisted fields, no atom creation - so an event-mode handler is one call. Found live: the select editor posts `values[]` without `filter_op`, and the old default op `:eq` matched nothing against a list - the values-list shape now forces `:in`, with a regression test.
- **Link mode**: the hook gains a `:filters` placeholder resolved from a `data-filters` JSON stamp; an editor's Apply intercepts submit, swaps that field's entry, closes the popover, and patches. `flatten_params` now emits pairs (not a map) so `:in`/`:between` list values ride URLs as `filters[0][value][]=...` - which `from_params` already reads back.

## Verified
- 837 Elixir / 109 JS (handle_op grammar + normalization, editor rendering per type, hook filter apply/replace/remove, select-`:in`, half-empty between = removal, search patches carrying committed filters)
- Live in the playground: select filter 20→7 rows with predicate label, between 300–320 → 2 rows with `:has()` revealing the bound input, text + number filters composing to 1 row, clear × and Reset both restoring