### PR TITLE
fix(playground+data_table): mobile containment, page consistency, sidebar group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
   placeholder mirrored from a JSON stamp, and filter URLs now carry
   list/range values as Phoenix-style indexed params. Operator names
   localize via `filter_op_labels`.
+- **`data_table` never widens its container**: the root carries
+  `min-w-0 max-w-full` so flex/grid parents can't size it to the
+  table's min-content; footer children shrink and wrap. Wide tables
+  scroll inside `pc-data-table__scroll`, never the page.
 - **`table` `on_sort` accepts a 1-arity function** of the sort key -
   per-column events/JS, how the data table patches sort URLs.
 - **`pagination` event mode grows up**: `event` accepts a custom event

--- a/assets/default.css
+++ b/assets/default.css
@@ -2586,6 +2586,12 @@
   }
 
   /* Data table: composition chrome around pc-table */
+  /* as a flex/grid item (showcase previews, app layouts) the root must
+     never size to the table's min-content - the scroll region below is
+     the release valve */
+  .pc-data-table {
+    @apply min-w-0 max-w-full;
+  }
   .pc-data-table__toolbar {
     @apply mb-3 flex flex-wrap items-center gap-2;
   }
@@ -2594,6 +2600,9 @@
   }
   .pc-data-table__footer {
     @apply mt-3 flex flex-wrap items-center justify-between gap-3;
+  }
+  .pc-data-table__footer > * {
+    @apply max-w-full min-w-0;
   }
   .pc-data-table__range {
     @apply text-sm text-gray-500 dark:text-gray-400;

--- a/dev.exs
+++ b/dev.exs
@@ -228,7 +228,6 @@ defmodule Dev.PlaygroundLive do
         %{slug: "checkbox", name: "Checkbox", ready: true},
         %{slug: "select", name: "Select", ready: true},
         %{slug: "combo-box", name: "Combobox", ready: true},
-        %{slug: "data-table", name: "Data table", ready: true},
         %{slug: "radio", name: "Radio", ready: true},
         %{slug: "switch", name: "Switch", ready: true},
         %{slug: "slider", name: "Slider", ready: true},
@@ -265,6 +264,7 @@ defmodule Dev.PlaygroundLive do
       group: "Data",
       items: [
         %{slug: "table", name: "Table", ready: true},
+        %{slug: "data-table", name: "Data table", ready: true},
         %{slug: "chart", name: "Chart", ready: true},
         %{slug: "local-time", name: "Local time", ready: true}
       ]
@@ -2537,7 +2537,7 @@ defmodule Dev.PlaygroundLive do
           </div>
         </nav>
 
-        <main class="flex-1 overflow-y-auto">
+        <main class="flex-1 min-w-0 overflow-y-auto">
           {render_page(assigns)}
         </main>
       </div>
@@ -6250,7 +6250,7 @@ defmodule Dev.PlaygroundLive do
       </p>
 
       <div class="mt-8 border border-gray-200 rounded-xl dark:border-gray-800">
-        <div class="px-6 py-8">
+        <div class="px-6 py-8 overflow-x-auto">
           <.table
             rows={if @table.empty, do: [], else: table_rows(@table)}
             variant={@table.variant}
@@ -7302,7 +7302,7 @@ defmodule Dev.PlaygroundLive do
 
   defp render_page(%{active: "data-table"} = assigns) do
     ~H"""
-    <div class="max-w-3xl">
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
       <h1 class="text-3xl font-bold tracking-tight">Data table</h1>
       <p class="mt-2 mb-6 text-gray-600 dark:text-gray-300">
         Sortable, paged and filter-aware, driven by one State struct. This live demo runs

--- a/lib/petal_components/showcase/table.ex
+++ b/lib/petal_components/showcase/table.ex
@@ -9,32 +9,34 @@ defmodule PetalComponents.Showcase.Table do
     description:
       "Rows in, markup out - and honest sorting: a sortable header is a real button that fires on_sort (default event \"sort\") with the column's sort_key, aria-sort announces the state, and your app owns the actual reorder. The :footer slot pins a totals row (colspan works); :empty_state renders whenever rows is empty. density=\"compact\", striped, sticky_header and the frameless variant=\"ghost\" restyle it; LiveView streams work unchanged." do
     ~H"""
-    <.table
-      sort_by="age"
-      sort_dir="asc"
-      rows={[
-        %{name: "Sarah Chen", role: "Engineering", age: 34, status: "Active"},
-        %{name: "Alex Rivera", role: "Design", age: 29, status: "Active"},
-        %{name: "Jordan Lee", role: "Support", age: 41, status: "Away"}
-      ]}
-    >
-      <:col :let={p} label="Name" sortable sort_key="name">{p.name}</:col>
-      <:col :let={p} label="Role">{p.role}</:col>
-      <:col :let={p} label="Age" sortable sort_key="age">{p.age}</:col>
-      <:col :let={p} label="Status">
-        <.badge
-          color={if p.status == "Active", do: "success", else: "gray"}
-          variant="soft"
-          size="sm"
-          label={p.status}
-        />
-      </:col>
-      <:footer>
-        <.td colspan={2}>3 people</.td>
-        <.td>avg 35</.td>
-        <.td></.td>
-      </:footer>
-    </.table>
+    <div class="max-w-full overflow-x-auto">
+      <.table
+        sort_by="age"
+        sort_dir="asc"
+        rows={[
+          %{name: "Sarah Chen", role: "Engineering", age: 34, status: "Active"},
+          %{name: "Alex Rivera", role: "Design", age: 29, status: "Active"},
+          %{name: "Jordan Lee", role: "Support", age: 41, status: "Away"}
+        ]}
+      >
+        <:col :let={p} label="Name" sortable sort_key="name">{p.name}</:col>
+        <:col :let={p} label="Role">{p.role}</:col>
+        <:col :let={p} label="Age" sortable sort_key="age">{p.age}</:col>
+        <:col :let={p} label="Status">
+          <.badge
+            color={if p.status == "Active", do: "success", else: "gray"}
+            variant="soft"
+            size="sm"
+            label={p.status}
+          />
+        </:col>
+        <:footer>
+          <.td colspan={2}>3 people</.td>
+          <.td>avg 35</.td>
+          <.td></.td>
+        </:footer>
+      </.table>
+    </div>
     """
   end
 
@@ -42,19 +44,21 @@ defmodule PetalComponents.Showcase.Table do
     description:
       "user_inner_td is the avatar + name + sub-label cell in one helper - avatar_assigns passes straight through to the avatar, so name-hashed initials work with no photos anywhere." do
     ~H"""
-    <.table rows={[
-      %{name: "Alex Rivera", email: "alex@example.com", plan: "Team"},
-      %{name: "Ada Lovelace", email: "ada@analytical.engine", plan: "Pro"}
-    ]}>
-      <:col :let={u} label="User">
-        <.user_inner_td
-          label={u.name}
-          sub_label={u.email}
-          avatar_assigns={%{name: u.name, size: "sm"}}
-        />
-      </:col>
-      <:col :let={u} label="Plan">{u.plan}</:col>
-    </.table>
+    <div class="max-w-full overflow-x-auto">
+      <.table rows={[
+        %{name: "Alex Rivera", email: "alex@example.com", plan: "Team"},
+        %{name: "Ada Lovelace", email: "ada@analytical.engine", plan: "Pro"}
+      ]}>
+        <:col :let={u} label="User">
+          <.user_inner_td
+            label={u.name}
+            sub_label={u.email}
+            avatar_assigns={%{name: u.name, size: "sm"}}
+          />
+        </:col>
+        <:col :let={u} label="Plan">{u.plan}</:col>
+      </.table>
+    </div>
     """
   end
 end


### PR DESCRIPTION
Nic's eye-test findings on the playground data-table page, plus the containment contract they exposed in the component itself.

- **Page consistency**: the data-table page shipped with a bare `max-w-3xl` instead of the standard `max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10` wrapper every other page uses - unintentional, now matching.
- **Sidebar**: Data table moves from the Inputs group to Data, next to Table.
- **Mobile horizontal scroll**: `main` gains `min-w-0` so no page ever scrolls horizontally; the table page's live demo and both `Showcase.Table` examples get `overflow-x-auto` wrappers (visible in the example code on purpose - it's the pattern users should copy, same as shadcn's docs).
- **Component fix that fell out**: in a flex/grid parent (showcase previews, app layouts) `.pc-data-table` sized itself to the table's min-content and overflowed its container. The root now carries `min-w-0 max-w-full` and footer children shrink - wide tables scroll inside `pc-data-table__scroll`, never the page.

Verified at 375px on /c/table and /c/data-table: `document` and `main` scrollWidth == clientWidth, tables scroll internally. 838 tests green.