### PR TITLE
fix(data_table): viewport-aware filter popovers via top-layer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@
   placeholder mirrored from a JSON stamp, and filter URLs now carry
   list/range values as Phoenix-style indexed params. Operator names
   localize via `filter_op_labels`.
+- **`data_table` filter popovers are viewport-aware**: the editors now
+  ride the popover's top-layer mode, so `PetalPopover` flips and clamps
+  them inside the viewport - a filter button at the screen edge no
+  longer opens its editor off-screen (mobile). The `PetalDataTable`
+  hook closes them through the native popover API after an Apply, in
+  both wiring modes.
 - **`data_table` never widens its container**: the root carries
   `min-w-0 max-w-full` so flex/grid parents can't size it to the
   table's min-content; footer children shrink and wrap. Wide tables

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4634,8 +4634,16 @@ export const PetalDataTable = {
     // the committed filter list (an empty editor removes it), close the
     // popover, navigate
     this.onSubmit = (e) => {
-      const form = e.target.closest("[data-pc-dt-filter]");
+      const form = e.target.closest(".pc-data-table__filter-form");
       if (!form) return;
+
+      // event mode: the form pushes its own phx-submit - only the
+      // popover close is ours
+      if (!form.hasAttribute("data-pc-dt-filter")) {
+        this.closePopover(form);
+        return;
+      }
+
       e.preventDefault();
       clearTimeout(this.searchTimer);
 
@@ -4696,6 +4704,15 @@ export const PetalDataTable = {
   closePopover(form) {
     const panel = form.closest(".pc-popover__panel");
     if (!panel) return;
+    if (
+      panel.hasAttribute("popover") &&
+      typeof panel.hidePopover === "function"
+    ) {
+      // top-layer panels close through the native API, which also
+      // restores focus and light-dismiss state
+      panel.hidePopover();
+      return;
+    }
     panel.style.display = "none";
     const trigger = document.getElementById(`${panel.id}-trigger`);
     if (trigger) trigger.setAttribute("aria-expanded", "false");

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -143,9 +143,13 @@ defmodule PetalComponents.DataTable do
 
     filter_cols = Enum.filter(assigns.col, & &1[:filterable])
 
+    link_mode? = is_nil(assigns.on_change)
+
+    # link mode: URL wiring. Either mode: filter popovers are native
+    # top-layer popovers the hook closes after an Apply.
     hooked? =
-      is_nil(assigns.on_change) and
-        (assigns.searchable or assigns.page_size_options != [] or filter_cols != [])
+      (link_mode? and (assigns.searchable or assigns.page_size_options != [])) or
+        filter_cols != []
 
     assigns =
       assigns
@@ -158,11 +162,11 @@ defmodule PetalComponents.DataTable do
       |> assign(:hooked?, hooked?)
       |> assign(
         :nav_template,
-        hooked? && nav_template(assigns.path, assigns.state, assigns, filter_cols)
+        link_mode? && hooked? && nav_template(assigns.path, assigns.state, assigns, filter_cols)
       )
       |> assign(
         :filters_json,
-        hooked? && filter_cols != [] && Jason.encode!(assigns.state.filters)
+        link_mode? && filter_cols != [] && Jason.encode!(assigns.state.filters)
       )
 
     ~H"""
@@ -509,6 +513,7 @@ defmodule PetalComponents.DataTable do
     <div class="pc-data-table__filter">
       <.popover
         id={@pop_id}
+        top_layer
         placement="bottom-start"
         class="pc-data-table__filter-popover"
         trigger_class={[
@@ -667,16 +672,12 @@ defmodule PetalComponents.DataTable do
     """
   end
 
-  # event mode: push the form, then close the popover panel the same way
-  # its own Escape path does
+  # event mode pushes the form; the hook closes the native popover on
+  # submit (a top-layer panel needs hidePopover(), not a display toggle)
   defp filter_submit_js(nil, _target, _pop_id), do: nil
 
-  defp filter_submit_js(event, target, pop_id) do
-    push = if target, do: JS.push(event, target: target), else: JS.push(event)
-
-    push
-    |> JS.hide(to: "##{pop_id}")
-    |> JS.set_attribute({"aria-expanded", "false"}, to: "##{pop_id}-trigger")
+  defp filter_submit_js(event, target, _pop_id) do
+    if target, do: JS.push(event, target: target), else: JS.push(event)
   end
 
   defp normalize_options(options) do

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -143,7 +143,7 @@ describe("PetalDataTable", () => {
         { field: "amount", op: "gt", value: "5" },
       ],
       formHtml: `
-        <form data-pc-dt-filter data-field="email">
+        <form class="pc-data-table__filter-form" data-pc-dt-filter data-field="email">
           <select name="filter_op">
             <option value="contains">contains</option>
             <option value="starts_with" selected>starts with</option>
@@ -169,7 +169,7 @@ describe("PetalDataTable", () => {
       navTemplate: "/orders?:filters&order_by=name",
       filters: [{ field: "status", op: "in", value: ["pending"] }],
       formHtml: `
-        <form data-pc-dt-filter data-field="status">
+        <form class="pc-data-table__filter-form" data-pc-dt-filter data-field="status">
           <input type="checkbox" name="values[]" value="paid" checked />
           <input type="checkbox" name="values[]" value="refunded" checked />
           <input type="checkbox" name="values[]" value="pending" />
@@ -193,7 +193,7 @@ describe("PetalDataTable", () => {
       navTemplate: "/orders?:filters",
       filters: [{ field: "amount", op: "between", value: ["1", "9"] }],
       formHtml: `
-        <form data-pc-dt-filter data-field="amount">
+        <form class="pc-data-table__filter-form" data-pc-dt-filter data-field="amount">
           <select name="filter_op"><option value="between" selected>between</option></select>
           <input name="value" value="10" />
           <input name="value2" value="" />
@@ -219,6 +219,49 @@ describe("PetalDataTable", () => {
     const url = decodeURIComponent(patched[0]);
     expect(url).toContain("search=amy");
     expect(url).toContain("filters[0][field]=email");
+  });
+
+  it("closes a top-layer panel through the native popover API", () => {
+    const { el, patched, form } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `
+        <form class="pc-data-table__filter-form" data-pc-dt-filter data-field="email">
+          <select name="filter_op"><option value="contains" selected>contains</option></select>
+          <input name="value" value="x" />
+        </form>
+      `,
+    });
+
+    const panel = el.querySelector(".pc-popover__panel");
+    panel.setAttribute("popover", "auto");
+    const hidden = [];
+    panel.hidePopover = () => hidden.push(true);
+
+    submit(form);
+    expect(hidden).toEqual([true]);
+    expect(patched).toHaveLength(1);
+  });
+
+  it("event mode: submit only closes the popover - no interception, no navigation", () => {
+    const { el, patched } = mountBase({});
+    delete el.dataset.navTemplate;
+    const wrap = document.createElement("div");
+    wrap.className = "pc-popover__panel";
+    wrap.innerHTML = `
+      <form class="pc-data-table__filter-form" phx-submit="table">
+        <input name="value" value="x" />
+      </form>
+    `;
+    el.appendChild(wrap);
+
+    const form = wrap.querySelector("form");
+    const e = new Event("submit", { bubbles: true, cancelable: true });
+    form.dispatchEvent(e);
+
+    expect(e.defaultPrevented).toBe(false);
+    expect(patched).toEqual([]);
+    expect(wrap.style.display).toBe("none");
   });
 
   it("destroyed cancels a pending search patch", () => {

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -108,9 +108,13 @@ defmodule PetalComponents.DataTableTest do
     # active trigger reads the predicate; its clear button posts removal
     assert html =~ "Status is any of Pending, Paid"
     assert html =~ ~s(aria-label="Clear Status filter")
-    # event mode carries the op grammar in hidden inputs, no hook
+    # event mode carries the op grammar in hidden inputs; the hook mounts
+    # only to close top-layer popovers - no URL wiring
     assert html =~ ~s(name="op" value="filter")
-    refute html =~ "PetalDataTable"
+    assert html =~ ~s(phx-hook="PetalDataTable")
+    assert html =~ ~s(popover="auto")
+    refute html =~ "data-nav-template"
+    refute html =~ "data-filters="
   end
 
   test "filterable link mode: hook + :filters placeholder + JSON stamp + clear URL" do


### PR DESCRIPTION
Nic's mobile find: a filter button sitting near the right screen edge opened its popover editor off-screen. Anchored popovers are CSS-positioned relative to the trigger and can't see the viewport.

- Filter editors now use the house popover's **top-layer mode**: native `popover=\"auto\"` + the existing `PetalPopover` hook, which flips sides when space runs out and clamps the panel inside the viewport (8px padding) - and escapes `overflow` containers for free.
- Closing after Apply moves fully into the `PetalDataTable` hook: a top-layer panel closes through the native `hidePopover()` API (restoring focus/light-dismiss state), so the event-mode `JS.hide` chain is gone. The hook now mounts in event mode too, with a close-only role there - no URL wiring (`data-nav-template`/`data-filters` stay link-mode-only, and tests pin that).
- 838 Elixir / 111 JS. Verified live at 375px with the trigger pinned at the right screen edge (right: 371/375): panel renders fully in-viewport (left 41, right 299).