### PR TITLE
feat(data_table): row selection - tri-state header, morphing toolbar (DT-M3a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@
   placeholder mirrored from a JSON stamp, and filter URLs now carry
   list/range values as Phoenix-style indexed params. Operator names
   localize via `filter_op_labels`.
+- **`<.data_table>` row selection (4.12 data table, milestone 3a).**
+  `selectable` renders a leading checkbox column keyed by `row_id`
+  (field atom or function); the header checkbox is tri-state (the
+  `PetalDataTable` hook mirrors an indeterminate stamp onto the DOM
+  property). While rows are selected the toolbar morphs into
+  "N selected" + the new `:bulk_action` slot (`:let` receives the
+  ids) + a clear button. Selection is UI state, not query state: it
+  rides an event in BOTH wiring modes (`on_ui`, defaulting to
+  `on_change`) with three ops - `select` (id), `select_all`,
+  `clear_selection` - and never touches URLs. `table`'s `:col` label
+  now accepts any rendered fragment, which is how the header checkbox
+  rides in.
 - **`data_table` filter popovers are viewport-aware**: the editors now
   ride the popover's top-layer mode, so `PetalPopover` flips and clamps
   them inside the viewport - a filter button at the screen edge no

--- a/assets/default.css
+++ b/assets/default.css
@@ -2694,6 +2694,12 @@
   .pc-data-table__filter-clear-icon.pc-data-table__filter-clear-icon {
     @apply w-4! h-4!;
   }
+  .pc-data-table__select-col {
+    @apply w-px pr-0;
+  }
+  .pc-data-table__selection-count {
+    @apply text-sm font-medium text-gray-700 dark:text-gray-200;
+  }
 
   /* Avatars - sizes */
 

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4659,6 +4659,19 @@ export const PetalDataTable = {
     this.el.addEventListener("input", this.onInput);
     this.el.addEventListener("change", this.onChange);
     this.el.addEventListener("submit", this.onSubmit);
+    this.syncIndeterminate();
+  },
+
+  updated() {
+    this.syncIndeterminate();
+  },
+
+  // indeterminate is a DOM property, not an attribute - mirror the
+  // server-stamped data attr onto it after every mount/patch
+  syncIndeterminate() {
+    this.el.querySelectorAll("[data-pc-dt-indeterminate]").forEach((box) => {
+      box.indeterminate = box.dataset.pcDtIndeterminate === "true";
+    });
   },
 
   destroyed() {

--- a/dev.exs
+++ b/dev.exs
@@ -748,6 +748,7 @@ defmodule Dev.PlaygroundLive do
        combo: %{disabled: false, chosen: nil},
        rich: %{labels: ~w(feat bug imp des), team: ~w(amelia jonah)},
        dt: PetalComponents.DataTable.State |> struct(page_size: 5) |> run_dt(),
+       dt_selected: [],
        radio: %{
          style: "cards",
          variant: "outline",
@@ -1446,7 +1447,31 @@ defmodule Dev.PlaygroundLive do
     {state, _rows} = socket.assigns.dt
 
     state = State.handle_op(state, params, fields: [:name, :email, :status, :amount])
-    {:noreply, assign(socket, :dt, run_dt(state))}
+
+    # selection is UI state, outside State - a MapSet and three clauses
+    selected = socket.assigns.dt_selected
+
+    selected =
+      case params do
+        %{"op" => "select", "id" => id} ->
+          if id in selected, do: List.delete(selected, id), else: selected ++ [id]
+
+        %{"op" => "select_all"} ->
+          {_state, rows} = socket.assigns.dt
+          page_ids = Enum.map(rows, &to_string(&1.id))
+
+          if Enum.all?(page_ids, &(&1 in selected)),
+            do: selected -- page_ids,
+            else: Enum.uniq(selected ++ page_ids)
+
+        %{"op" => "clear_selection"} ->
+          []
+
+        _ ->
+          selected
+      end
+
+    {:noreply, socket |> assign(:dt, run_dt(state)) |> assign(:dt_selected, selected)}
   end
 
   defp run_dt(state) do
@@ -7321,6 +7346,8 @@ defmodule Dev.PlaygroundLive do
           striped
           searchable
           page_size_options={[5, 10, 20]}
+          selectable
+          selected={@dt_selected}
         >
           <:col :let={row} field={:name} sortable>{row.name}</:col>
           <:col :let={row} field={:email} filterable="text">{row.email}</:col>
@@ -7346,6 +7373,17 @@ defmodule Dev.PlaygroundLive do
           <:col :let={row} field={:amount} sortable align="right" filterable="number">
             ${row.amount}
           </:col>
+          <:bulk_action :let={ids}>
+            <.button
+              size="sm"
+              variant="soft"
+              color="danger"
+              phx-click="pg_table"
+              phx-value-op="clear_selection"
+            >
+              Refund {length(ids)}
+            </.button>
+          </:bulk_action>
         </.data_table>
       </div>
 

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -30,6 +30,17 @@ defmodule PetalComponents.DataTable do
   by the `PetalDataTable` hook (patch URLs built from templates the
   component renders); event mode needs no JS.
 
+  Selection (`selectable`) is UI state, not query state - it rides an
+  event in BOTH wiring modes (`on_ui`, defaulting to `on_change`) and
+  never touches URLs. Its ops sit outside `State`: `select` (id),
+  `select_all`, `clear_selection` - a MapSet plus three clauses is the
+  whole backend. Selection is keyed by `row_id`, which must uniquely
+  identify a record across the whole dataset, not just the current
+  page (primary keys qualify, display fields do not) - a selection
+  retained while paging is only as sound as this key. Same-page
+  duplicates raise; cross-page uniqueness is the caller's contract,
+  exactly as with LiveView stream ids.
+
   Rows can be any enumerable of maps/structs; pair with
   `PetalComponents.DataTable.Engine.List` for zero-setup in-memory
   data, or run the state against your own query layer.
@@ -110,7 +121,12 @@ defmodule PetalComponents.DataTable do
 
   attr :row_id, :any,
     default: :id,
-    doc: "row identity for selection: a field (atom) or a 1-arity function of the row"
+    doc: """
+    row identity for selection: a field (atom) or a 1-arity function of
+    the row. The key must uniquely identify a record across ALL pages,
+    not just the visible one - a selection retained while paging is only
+    as sound as this key. Same-page duplicates raise.
+    """
 
   attr :on_ui, :string,
     default: nil,

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -223,15 +223,15 @@ defmodule PetalComponents.DataTable do
       <div
         :if={
           @toolbar != [] or @searchable or @filter_cols != [] or @state.filters != [] or
-            (@selectable and @selected != [])
+            @selected_ids != []
         }
         class="pc-data-table__toolbar"
       >
-        <%= if @selectable and @selected != [] do %>
+        <%= if @selected_ids != [] do %>
           <span class="pc-data-table__selection-count">
-            {length(@selected)} {@selected_label}
+            {length(@selected_ids)} {@selected_label}
           </span>
-          {render_slot(@bulk_action, @selected)}
+          {render_slot(@bulk_action, @selected_ids)}
           <.button
             type="button"
             size="sm"
@@ -551,11 +551,21 @@ defmodule PetalComponents.DataTable do
   # -- selection -------------------------------------------------------------
 
   defp selection_assigns(%{selectable: false} = assigns) do
-    assign(assigns, selected_set: MapSet.new(), all_selected?: false, some_selected?: false)
+    assign(assigns,
+      selected_ids: [],
+      selected_set: MapSet.new(),
+      all_selected?: false,
+      some_selected?: false
+    )
   end
 
   defp selection_assigns(assigns) do
-    selected_set = MapSet.new(assigns.selected, &to_string/1)
+    # normalize ONCE and use everywhere - checkboxes, the toolbar count
+    # and the :bulk_action ids must never disagree about what is selected
+    selected_ids =
+      assigns.selected |> Enum.map(&to_string/1) |> Enum.reject(&(&1 == "")) |> Enum.uniq()
+
+    selected_set = MapSet.new(selected_ids)
 
     page_keys =
       if assigns.loading,
@@ -573,6 +583,7 @@ defmodule PetalComponents.DataTable do
     picked = Enum.count(page_keys, &MapSet.member?(selected_set, &1))
 
     assign(assigns,
+      selected_ids: selected_ids,
       selected_set: selected_set,
       all_selected?: page_keys != [] and picked == length(page_keys),
       some_selected?: picked > 0

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -102,6 +102,33 @@ defmodule PetalComponents.DataTable do
     default: "Apply",
     doc: "the filter editors' submit label, localizable"
 
+  attr :selectable, :boolean, default: false, doc: "render a leading checkbox column"
+
+  attr :selected, :list,
+    default: [],
+    doc: "the currently selected row ids (any terms; compared as strings)"
+
+  attr :row_id, :any,
+    default: :id,
+    doc: "row identity for selection: a field (atom) or a 1-arity function of the row"
+
+  attr :on_ui, :string,
+    default: nil,
+    doc: """
+    the event UI-state ops (selection) push, both wiring modes. Defaults
+    to `on_change`; required alongside `selectable` in link mode.
+    """
+
+  attr :selected_label, :string,
+    default: "selected",
+    doc: "the selection count's word, localizable"
+
+  attr :clear_selection_label, :string, default: "Clear selection"
+
+  attr :select_all_label, :string,
+    default: "Select all rows",
+    doc: "the header checkbox's aria-label"
+
   attr :filter_op_labels, :map,
     default: %{},
     doc: "overrides for the operator display names, e.g. %{contains: \"enthält\"}"
@@ -125,12 +152,23 @@ defmodule PetalComponents.DataTable do
   end
 
   slot :action, doc: "trailing actions column, `:let` receives the row"
+
+  slot :bulk_action,
+    doc: "toolbar content while rows are selected; `:let` receives the selected ids"
+
   slot :toolbar, doc: "custom toolbar content rendered above the table"
   slot :empty, doc: "custom empty state; a filters-aware default renders otherwise"
 
   def data_table(assigns) do
     if is_nil(assigns.path) and is_nil(assigns.on_change) do
       raise ArgumentError, "data_table needs either path (link mode) or on_change (event mode)"
+    end
+
+    ui_event = assigns.on_ui || assigns.on_change
+
+    if assigns.selectable and is_nil(ui_event) do
+      raise ArgumentError,
+            "selectable needs an event for selection ops - pass on_ui (link mode) or on_change"
     end
 
     {sort_by, sort_dir} =
@@ -146,10 +184,11 @@ defmodule PetalComponents.DataTable do
     link_mode? = is_nil(assigns.on_change)
 
     # link mode: URL wiring. Either mode: filter popovers are native
-    # top-layer popovers the hook closes after an Apply.
+    # top-layer popovers the hook closes after an Apply, and selection's
+    # tri-state header checkbox needs its indeterminate property set.
     hooked? =
       (link_mode? and (assigns.searchable or assigns.page_size_options != [])) or
-        filter_cols != []
+        filter_cols != [] or assigns.selectable
 
     assigns =
       assigns
@@ -159,6 +198,8 @@ defmodule PetalComponents.DataTable do
       |> assign(:skeleton_rows, List.duplicate(%{}, min(assigns.state.page_size, 10)))
       |> assign(:filter_cols, filter_cols)
       |> assign(:op_labels, Map.merge(default_op_labels(), assigns.filter_op_labels))
+      |> assign(:ui_event, ui_event)
+      |> selection_assigns()
       |> assign(:hooked?, hooked?)
       |> assign(
         :nav_template,
@@ -180,72 +221,94 @@ defmodule PetalComponents.DataTable do
     >
       <a :if={@hooked?} data-pc-dt-nav data-phx-link="patch" data-phx-link-state="push" hidden></a>
       <div
-        :if={@toolbar != [] or @searchable or @filter_cols != [] or @state.filters != []}
+        :if={
+          @toolbar != [] or @searchable or @filter_cols != [] or @state.filters != [] or
+            (@selectable and @selected != [])
+        }
         class="pc-data-table__toolbar"
       >
-        <div :if={@searchable} class="pc-data-table__search">
-          <.icon name="hero-magnifying-glass" class="pc-data-table__search-icon" />
-          <%= if @on_change do %>
-            <form phx-change={@on_change} phx-submit={@on_change} phx-target={@target}>
-              <input type="hidden" name="op" value="search" />
-              <input
-                type="text"
-                name="term"
-                value={@state.search}
-                placeholder={@search_placeholder}
-                phx-debounce={@search_debounce}
-                autocomplete="off"
-                class="pc-text-input pc-data-table__search-input"
-              />
-            </form>
-          <% else %>
-            <input
-              type="text"
-              value={@state.search}
-              placeholder={@search_placeholder}
-              autocomplete="off"
-              data-pc-dt-search
-              class="pc-text-input pc-data-table__search-input"
-            />
-          <% end %>
-        </div>
-        <.filter_button
-          :for={col <- @filter_cols}
-          col={col}
-          table_id={@id}
-          state={@state}
-          path={@path}
-          on_change={@on_change}
-          target={@target}
-          op_labels={@op_labels}
-          apply_label={@apply_label}
-        />
-        {render_slot(@toolbar)}
-        <%= if @state.filters != [] do %>
+        <%= if @selectable and @selected != [] do %>
+          <span class="pc-data-table__selection-count">
+            {length(@selected)} {@selected_label}
+          </span>
+          {render_slot(@bulk_action, @selected)}
           <.button
-            :if={@on_change}
             type="button"
             size="sm"
             variant="ghost"
             color="gray"
             class="pc-data-table__reset"
-            phx-click={@on_change}
+            phx-click={@ui_event}
             phx-target={@target}
-            phx-value-op="clear_filters"
+            phx-value-op="clear_selection"
           >
-            {@reset_filters_label}
+            {@clear_selection_label}
           </.button>
-          <.button
-            :if={@path}
-            link_type="live_patch"
-            to={url_for(@path, State.clear_filters(@state))}
-            size="sm"
-            variant="ghost"
-            color="gray"
-            class="pc-data-table__reset"
-          >
-            {@reset_filters_label}
-          </.button>
+        <% else %>
+          <div :if={@searchable} class="pc-data-table__search">
+            <.icon name="hero-magnifying-glass" class="pc-data-table__search-icon" />
+            <%= if @on_change do %>
+              <form phx-change={@on_change} phx-submit={@on_change} phx-target={@target}>
+                <input type="hidden" name="op" value="search" />
+                <input
+                  type="text"
+                  name="term"
+                  value={@state.search}
+                  placeholder={@search_placeholder}
+                  phx-debounce={@search_debounce}
+                  autocomplete="off"
+                  class="pc-text-input pc-data-table__search-input"
+                />
+              </form>
+            <% else %>
+              <input
+                type="text"
+                value={@state.search}
+                placeholder={@search_placeholder}
+                autocomplete="off"
+                data-pc-dt-search
+                class="pc-text-input pc-data-table__search-input"
+              />
+            <% end %>
+          </div>
+          <.filter_button
+            :for={col <- @filter_cols}
+            col={col}
+            table_id={@id}
+            state={@state}
+            path={@path}
+            on_change={@on_change}
+            target={@target}
+            op_labels={@op_labels}
+            apply_label={@apply_label}
+          />
+          {render_slot(@toolbar)}
+          <%= if @state.filters != [] do %>
+            <.button
+              :if={@on_change}
+              type="button"
+              size="sm"
+              variant="ghost"
+              color="gray"
+              class="pc-data-table__reset"
+              phx-click={@on_change}
+              phx-target={@target}
+              phx-value-op="clear_filters"
+            >
+              {@reset_filters_label}
+            </.button>
+            <.button
+              :if={@path}
+              link_type="live_patch"
+              to={url_for(@path, State.clear_filters(@state))}
+              size="sm"
+              variant="ghost"
+              color="gray"
+              class="pc-data-table__reset"
+            >
+              {@reset_filters_label}
+            </.button>
+          <% end %>
         <% end %>
       </div>
 
@@ -261,6 +324,25 @@ defmodule PetalComponents.DataTable do
           sort_dir={@sort_dir}
           on_sort={@on_sort}
         >
+          <:col
+            :let={row}
+            :if={@selectable}
+            label={header_checkbox(assigns)}
+            class="pc-data-table__select-col"
+            row_class="pc-data-table__select-col"
+          >
+            <input
+              :if={!@loading}
+              type="checkbox"
+              class="pc-checkbox"
+              checked={row_key(row, @row_id) in @selected_set}
+              phx-click={@ui_event}
+              phx-target={@target}
+              phx-value-op="select"
+              phx-value-id={row_key(row, @row_id)}
+              aria-label={"Select row #{row_key(row, @row_id)}"}
+            />
+          </:col>
           <:col
             :let={row}
             :for={col <- @col}
@@ -464,6 +546,50 @@ defmodule PetalComponents.DataTable do
     do: Enum.map(map, fn {k, v} -> {"#{key}[#{k}]", v} end)
 
   defp filter_pairs(key, value), do: [{key, value}]
+
+  # -- selection -------------------------------------------------------------
+
+  defp selection_assigns(%{selectable: false} = assigns) do
+    assign(assigns, selected_set: MapSet.new(), all_selected?: false, some_selected?: false)
+  end
+
+  defp selection_assigns(assigns) do
+    selected_set = MapSet.new(assigns.selected, &to_string/1)
+
+    page_keys =
+      if assigns.loading,
+        do: [],
+        else: Enum.map(assigns.rows, &row_key(&1, assigns.row_id))
+
+    picked = Enum.count(page_keys, &MapSet.member?(selected_set, &1))
+
+    assign(assigns,
+      selected_set: selected_set,
+      all_selected?: page_keys != [] and picked == length(page_keys),
+      some_selected?: picked > 0
+    )
+  end
+
+  # rendered as the checkbox column's header via the table's label
+  # (which accepts any rendered fragment). indeterminate is a DOM
+  # property, not an attribute - the hook mirrors the data attr onto it.
+  defp header_checkbox(assigns) do
+    ~H"""
+    <input
+      type="checkbox"
+      class="pc-checkbox"
+      checked={@all_selected?}
+      data-pc-dt-indeterminate={to_string(@some_selected? and not @all_selected?)}
+      phx-click={@ui_event}
+      phx-target={@target}
+      phx-value-op="select_all"
+      aria-label={@select_all_label}
+    />
+    """
+  end
+
+  defp row_key(row, fun) when is_function(fun, 1), do: to_string(fun.(row))
+  defp row_key(row, field) when is_atom(field), do: to_string(Map.get(row, field))
 
   # -- filters ---------------------------------------------------------------
 

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -336,6 +336,7 @@ defmodule PetalComponents.DataTable do
               type="checkbox"
               class="pc-checkbox"
               checked={row_key(row, @row_id) in @selected_set}
+              disabled={row_key(row, @row_id) == ""}
               phx-click={@ui_event}
               phx-target={@target}
               phx-value-op="select"
@@ -559,7 +560,15 @@ defmodule PetalComponents.DataTable do
     page_keys =
       if assigns.loading,
         do: [],
-        else: Enum.map(assigns.rows, &row_key(&1, assigns.row_id))
+        else: assigns.rows |> Enum.map(&row_key(&1, assigns.row_id)) |> Enum.reject(&(&1 == ""))
+
+    # two rows sharing a key means one checkbox would select both - that
+    # is a misconfigured row_id, not a state to render through
+    if length(Enum.uniq(page_keys)) != length(page_keys) do
+      raise ArgumentError,
+            "data_table selection found duplicate row ids on this page - " <>
+              "pass a row_id (field or function) that uniquely identifies each row"
+    end
 
     picked = Enum.count(page_keys, &MapSet.member?(selected_set, &1))
 
@@ -579,6 +588,7 @@ defmodule PetalComponents.DataTable do
       type="checkbox"
       class="pc-checkbox"
       checked={@all_selected?}
+      disabled={@loading}
       data-pc-dt-indeterminate={to_string(@some_selected? and not @all_selected?)}
       phx-click={@ui_event}
       phx-target={@target}

--- a/lib/petal_components/table.ex
+++ b/lib/petal_components/table.ex
@@ -54,7 +54,7 @@ defmodule PetalComponents.Table do
     """
 
   slot :col do
-    attr :label, :string
+    attr :label, :any, doc: "header content - a string, or any rendered fragment"
     attr :class, :any
     attr :row_class, :any
     attr :sortable, :boolean, doc: "render the header as a sort button"

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -264,6 +264,23 @@ describe("PetalDataTable", () => {
     expect(wrap.style.display).toBe("none");
   });
 
+  it("mirrors the indeterminate stamp onto the DOM property on mount and update", () => {
+    const { hook, el } = mountBase({});
+    const box = document.createElement("input");
+    box.type = "checkbox";
+    box.dataset.pcDtIndeterminate = "true";
+    box.setAttribute("data-pc-dt-indeterminate", "true");
+    el.appendChild(box);
+
+    hook.syncIndeterminate();
+    expect(box.indeterminate).toBe(true);
+
+    // a patch flips the stamp; updated() must mirror it back off
+    box.dataset.pcDtIndeterminate = "false";
+    hook.updated();
+    expect(box.indeterminate).toBe(false);
+  });
+
   it("destroyed cancels a pending search patch", () => {
     const { hook, el, patched } = mount({
       navTemplate: "/orders?search=:term",

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -255,6 +255,43 @@ defmodule PetalComponents.DataTableTest do
     end
   end
 
+  test "selection identity edges: nil keys disable, duplicates raise, loading disables select-all" do
+    assigns = base(%{rows: [%{id: 1, name: "Amy"}, %{id: nil, name: "Bea"}]})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table" selectable selected={[]}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    # the keyless row renders an inert checkbox and stays out of select-all math
+    assert Regex.match?(~r/<input[^>]*disabled[^>]*phx-value-id=""/, html)
+
+    assigns = base(%{dupes: [%{id: 1, name: "Amy"}, %{id: 1, name: "Bea"}]})
+
+    assert_raise ArgumentError, ~r/duplicate row ids/, fn ->
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@dupes} state={@state} on_change="table" selectable selected={[]}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+    end
+
+    assigns = base(%{rows: [%{id: 1, name: "Amy"}]})
+
+    loading_html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table" selectable selected={[]} loading>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert loading_html =~ ~s(phx-value-op="select_all")
+    assert Regex.match?(~r/phx-value-op="select_all"[^>]*>/, loading_html)
+    assert loading_html =~ ~s(disabled data-pc-dt-indeterminate)
+  end
+
   test "a map-shaped between range renders instead of crashing" do
     assigns =
       base(%{

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -292,6 +292,28 @@ defmodule PetalComponents.DataTableTest do
     assert loading_html =~ ~s(disabled data-pc-dt-indeterminate)
   end
 
+  test "toolbar count and bulk ids come from the normalized selection" do
+    assigns =
+      base(%{
+        rows: [%{id: 1, name: "Amy"}, %{id: 2, name: "Bea"}],
+        messy: ["1", "1", nil, "", 1]
+      })
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table" selectable selected={@messy}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+        <:bulk_action :let={ids}>
+          <span>ids:{Enum.join(ids, ",")}</span>
+        </:bulk_action>
+      </.data_table>
+      """)
+
+    # dupes/nils/blanks collapse: one real id -> count 1, slot gets ["1"]
+    assert html =~ "1 selected"
+    assert html =~ "ids:1<"
+  end
+
   test "a map-shaped between range renders instead of crashing" do
     assigns =
       base(%{

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -141,6 +141,120 @@ defmodule PetalComponents.DataTableTest do
     refute html =~ ~s(href="/orders?filters)
   end
 
+  test "selectable renders the checkbox column with tri-state header and morphing toolbar" do
+    assigns =
+      base(%{
+        rows: [
+          %{id: 1, name: "Amy"},
+          %{id: 2, name: "Bea"}
+        ],
+        selected: ["1"]
+      })
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table" selectable selected={@selected}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+        <:bulk_action :let={ids}>
+          <button type="button">Archive {length(ids)}</button>
+        </:bulk_action>
+      </.data_table>
+      """)
+
+    # header checkbox: some-but-not-all selected -> indeterminate stamp
+    assert html =~ ~s(phx-value-op="select_all")
+    assert html =~ ~s(data-pc-dt-indeterminate="true")
+    # row checkboxes: selected row checked, keyed by row id
+    assert html =~ ~s(phx-value-op="select")
+    assert html =~ ~s(phx-value-id="1")
+    assert html =~ ~s(phx-value-id="2")
+    # toolbar morphs: count + bulk action + clear, search hidden
+    assert html =~ "1 selected"
+    assert html =~ "Archive 1"
+    assert html =~ ~s(phx-value-op="clear_selection")
+    # hook mounts for the indeterminate sync
+    assert html =~ ~s(phx-hook="PetalDataTable")
+  end
+
+  test "selectable: all page rows selected checks the header; none leaves the normal toolbar" do
+    assigns =
+      base(%{
+        rows: [%{id: 1, name: "Amy"}, %{id: 2, name: "Bea"}],
+        all: [1, 2]
+      })
+
+    all_html =
+      rendered_to_string(~H"""
+      <.data_table
+        id="t"
+        rows={@rows}
+        state={@state}
+        on_change="table"
+        selectable
+        selected={@all}
+        searchable
+      >
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert all_html =~ ~s(data-pc-dt-indeterminate="false")
+    refute all_html =~ "pc-data-table__search"
+
+    none_html =
+      rendered_to_string(~H"""
+      <.data_table
+        id="t"
+        rows={@rows}
+        state={@state}
+        on_change="table"
+        selectable
+        selected={[]}
+        searchable
+      >
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert none_html =~ "pc-data-table__search"
+    refute none_html =~ "clear_selection"
+  end
+
+  test "selectable supports a row_id function and requires a ui event in link mode" do
+    assigns =
+      base(%{
+        rows: [%{email: "amy@x.com", name: "Amy"}],
+        key: fn row -> row.email end
+      })
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table
+        id="t"
+        rows={@rows}
+        state={@state}
+        path={@path}
+        on_ui="table_ui"
+        selectable
+        selected={["amy@x.com"]}
+        row_id={@key}
+      >
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ ~s(phx-value-id="amy@x.com")
+    assert html =~ ~s(phx-click="table_ui")
+
+    assert_raise ArgumentError, ~r/on_ui/, fn ->
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path} selectable>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+    end
+  end
+
   test "a map-shaped between range renders instead of crashing" do
     assigns =
       base(%{


### PR DESCRIPTION
DT-M3a: row selection. The columns-visibility dropdown follows as M3b.

## Design
Selection is **UI state, not query state** - it rides an event in BOTH wiring modes (`on_ui`, defaulting to `on_change`) and never touches URLs, keeping link-mode state curl-able. Three ops: `select` (id), `select_all`, `clear_selection`. `State.handle_op/3` ignores them by design, so an event handler can pipe query ops through State and selection ops through a MapSet in one place. `selectable` in link mode without `on_ui` raises with guidance.

## Surface
- `selectable`, `selected` (ids, compared as strings), `row_id` (field atom or 1-arity function), `on_ui`, plus localizable `selected_label` / `clear_selection_label` / `select_all_label`.
- Leading checkbox column: rows keyed by `row_id`; header checkbox is tri-state - the server stamps `data-pc-dt-indeterminate`, and the `PetalDataTable` hook mirrors it onto the DOM property on mount and after every patch (indeterminate is a property, not an attribute).
- Toolbar morphs while rows are selected: "N selected" + the new `:bulk_action` slot (`:let` receives the selected ids) + a ghost Clear selection button; search/filters return when selection empties.
- Primitive touch: `table`'s `:col` `label` relaxes from `:string` to `:any` so the header checkbox rides in as a rendered fragment - `{col[:label]}` interpolation already renders both.

## Verified
- 841 Elixir / 112 JS (tri-state stamps, morph on/off, row_id function, link-mode raise, hook indeterminate sync on mount + update)
- Live in the playground demo (now selectable with a bulk Refund button): single pick -> "1 selected" morph + indeterminate header; select_all -> 5 checked + solid header; clear -> normal toolbar restored