### PR TITLE
feat(data_table): columns-visibility dropdown (DT-M3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@
   `clear_selection` - and never touches URLs. `table`'s `:col` label
   now accepts any rendered fragment, which is how the header checkbox
   rides in.
+- **`<.data_table>` columns-visibility dropdown (4.12 data table,
+  milestone 3b).** `column_toggle` renders a toolbar Columns dropdown
+  (top-layer popover, stays open for multi-toggling); `hidden_columns`
+  is presentation state riding the `on_ui` event as
+  `%{"op" => "toggle_column", "field" => f}` - never in URLs. The
+  last visible column's checkbox disables (a table needs one), and
+  filter buttons stay independent of visibility (filtering is not
+  display).
 - **`data_table` filter popovers are viewport-aware**: the editors now
   ride the popover's top-layer mode, so `PetalPopover` flips and clamps
   them inside the viewport - a filter button at the screen edge no

--- a/dev.exs
+++ b/dev.exs
@@ -749,6 +749,7 @@ defmodule Dev.PlaygroundLive do
        rich: %{labels: ~w(feat bug imp des), team: ~w(amelia jonah)},
        dt: PetalComponents.DataTable.State |> struct(page_size: 5) |> run_dt(),
        dt_selected: [],
+       dt_hidden: [],
        radio: %{
          style: "cards",
          variant: "outline",
@@ -1471,7 +1472,21 @@ defmodule Dev.PlaygroundLive do
           selected
       end
 
-    {:noreply, socket |> assign(:dt, run_dt(state)) |> assign(:dt_selected, selected)}
+    hidden =
+      case params do
+        %{"op" => "toggle_column", "field" => field} ->
+          hidden = socket.assigns.dt_hidden
+          if field in hidden, do: List.delete(hidden, field), else: hidden ++ [field]
+
+        _ ->
+          socket.assigns.dt_hidden
+      end
+
+    {:noreply,
+     socket
+     |> assign(:dt, run_dt(state))
+     |> assign(:dt_selected, selected)
+     |> assign(:dt_hidden, hidden)}
   end
 
   defp run_dt(state) do
@@ -7348,6 +7363,8 @@ defmodule Dev.PlaygroundLive do
           page_size_options={[5, 10, 20]}
           selectable
           selected={@dt_selected}
+          column_toggle
+          hidden_columns={@dt_hidden}
         >
           <:col :let={row} field={:name} sortable>{row.name}</:col>
           <:col :let={row} field={:email} filterable="text">{row.email}</:col>

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -145,6 +145,16 @@ defmodule PetalComponents.DataTable do
     default: "Select all rows",
     doc: "the header checkbox's aria-label"
 
+  attr :column_toggle, :boolean,
+    default: false,
+    doc: "render a columns-visibility dropdown in the toolbar (rides the `on_ui` event)"
+
+  attr :hidden_columns, :list,
+    default: [],
+    doc: "fields currently hidden (atoms or strings) - presentation state, never in URLs"
+
+  attr :column_toggle_label, :string, default: "Columns"
+
   attr :filter_op_labels, :map,
     default: %{},
     doc: "overrides for the operator display names, e.g. %{contains: \"enthält\"}"
@@ -187,6 +197,11 @@ defmodule PetalComponents.DataTable do
             "selectable needs an event for selection ops - pass on_ui (link mode) or on_change"
     end
 
+    if assigns.column_toggle and is_nil(ui_event) do
+      raise ArgumentError,
+            "column_toggle needs an event for its ops - pass on_ui (link mode) or on_change"
+    end
+
     {sort_by, sort_dir} =
       case assigns.state.order_by do
         [{field, dir} | _] -> {to_string(field), to_string(dir)}
@@ -194,6 +209,9 @@ defmodule PetalComponents.DataTable do
       end
 
     fields = Map.new(assigns.col, fn col -> {to_string(col.field), col.field} end)
+
+    hidden = Enum.map(assigns.hidden_columns, &to_string/1)
+    visible_cols = Enum.reject(assigns.col, &(to_string(&1.field) in hidden))
 
     filter_cols = Enum.filter(assigns.col, & &1[:filterable])
 
@@ -213,6 +231,8 @@ defmodule PetalComponents.DataTable do
       |> assign(:on_sort, sort_handler(assigns, fields))
       |> assign(:skeleton_rows, List.duplicate(%{}, min(assigns.state.page_size, 10)))
       |> assign(:filter_cols, filter_cols)
+      |> assign(:visible_cols, visible_cols)
+      |> assign(:hidden, hidden)
       |> assign(:op_labels, Map.merge(default_op_labels(), assigns.filter_op_labels))
       |> assign(:ui_event, ui_event)
       |> selection_assigns()
@@ -239,7 +259,7 @@ defmodule PetalComponents.DataTable do
       <div
         :if={
           @toolbar != [] or @searchable or @filter_cols != [] or @state.filters != [] or
-            @selected_ids != []
+            @selected_ids != [] or @column_toggle
         }
         class="pc-data-table__toolbar"
       >
@@ -299,6 +319,34 @@ defmodule PetalComponents.DataTable do
             apply_label={@apply_label}
           />
           {render_slot(@toolbar)}
+          <.popover
+            :if={@column_toggle}
+            id={"#{@id}-columns"}
+            top_layer
+            placement="bottom-end"
+            class="pc-data-table__columns"
+            trigger_class="pc-button pc-button--sm pc-button--gray-outline"
+          >
+            <:trigger>
+              <.icon name="hero-view-columns" class="pc-data-table__filter-icon" />
+              <span>{@column_toggle_label}</span>
+            </:trigger>
+            <div class="pc-data-table__filter-options" role="group" aria-label={@column_toggle_label}>
+              <label :for={col <- @col} class="pc-data-table__filter-option">
+                <input
+                  type="checkbox"
+                  class="pc-checkbox"
+                  checked={to_string(col.field) not in @hidden}
+                  disabled={length(@visible_cols) == 1 and to_string(col.field) not in @hidden}
+                  phx-click={@ui_event}
+                  phx-target={@target}
+                  phx-value-op="toggle_column"
+                  phx-value-field={col.field}
+                />
+                <span>{(is_binary(col[:label]) && col[:label]) || humanize(col.field)}</span>
+              </label>
+            </div>
+          </.popover>
           <%= if @state.filters != [] do %>
             <.button
               :if={@on_change}
@@ -362,7 +410,7 @@ defmodule PetalComponents.DataTable do
           </:col>
           <:col
             :let={row}
-            :for={col <- @col}
+            :for={col <- @visible_cols}
             label={col[:label] || humanize(col.field)}
             sortable={col[:sortable] || false}
             sort_key={to_string(col.field)}

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -213,6 +213,15 @@ defmodule PetalComponents.DataTable do
     hidden = Enum.map(assigns.hidden_columns, &to_string/1)
     visible_cols = Enum.reject(assigns.col, &(to_string(&1.field) in hidden))
 
+    # the UI can't reach all-hidden (the last checkbox disables), but a
+    # hand-built hidden_columns can - enforce the invariant here too by
+    # keeping the first declared column
+    {visible_cols, hidden} =
+      case {visible_cols, assigns.col} do
+        {[], [first | _]} -> {[first], hidden -- [to_string(first.field)]}
+        _ -> {visible_cols, hidden}
+      end
+
     filter_cols = Enum.filter(assigns.col, & &1[:filterable])
 
     link_mode? = is_nil(assigns.on_change)
@@ -343,7 +352,7 @@ defmodule PetalComponents.DataTable do
                   phx-value-op="toggle_column"
                   phx-value-field={col.field}
                 />
-                <span>{(is_binary(col[:label]) && col[:label]) || humanize(col.field)}</span>
+                <span>{col[:label] || humanize(col.field)}</span>
               </label>
             </div>
           </.popover>

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -349,6 +349,35 @@ defmodule PetalComponents.DataTableTest do
     end
   end
 
+  test "column_toggle invariants: all-hidden clamps to the first column; fragment labels render" do
+    assigns = %{}
+    em = ~H"<em>Nome</em>"
+    assigns = base(%{hidden: [:name, :email], em: em})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table
+        id="t"
+        rows={@rows}
+        state={@state}
+        on_change="table"
+        column_toggle
+        hidden_columns={@hidden}
+      >
+        <:col :let={row} field={:name} label={@em}>{row.name}</:col>
+        <:col :let={row} field={:email}>{row.email}</:col>
+      </.data_table>
+      """)
+
+    # a hand-built all-hidden state keeps the first declared column
+    assert html =~ "Amy"
+    refute html =~ "amy@x.com"
+    # its checkbox reads visible (and disabled, being the last one standing)
+    assert Regex.match?(~r/<input[^>]*checked[^>]*disabled[^>]*phx-value-field="name"/, html)
+    # the dropdown renders the fragment label, same identity as the header
+    assert length(String.split(html, "<em>Nome</em>")) - 1 == 2
+  end
+
   test "a map-shaped between range renders instead of crashing" do
     assigns =
       base(%{

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -314,6 +314,41 @@ defmodule PetalComponents.DataTableTest do
     assert html =~ "ids:1<"
   end
 
+  test "column_toggle renders the dropdown, hides columns, and guards the last one" do
+    assigns = base(%{hidden: [:email]})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table
+        id="t"
+        rows={@rows}
+        state={@state}
+        on_change="table"
+        column_toggle
+        hidden_columns={@hidden}
+      >
+        <:col :let={row} field={:name}>{row.name}</:col>
+        <:col :let={row} field={:email}>{row.email}</:col>
+      </.data_table>
+      """)
+
+    # the hidden column leaves the table but stays listed in the dropdown
+    refute html =~ "amy@x.com"
+    assert html =~ ~s(phx-value-op="toggle_column")
+    assert html =~ ~s(phx-value-field="email")
+    # the last visible column's checkbox is disabled - a table needs one
+    assert Regex.match?(~r/<input[^>]*checked[^>]*disabled[^>]*phx-value-field="name"/, html) or
+             Regex.match?(~r/<input[^>]*disabled[^>]*phx-value-field="name"/, html)
+
+    assert_raise ArgumentError, ~r/column_toggle/, fn ->
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path="/orders" column_toggle>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+    end
+  end
+
   test "a map-shaped between range renders instead of crashing" do
     assigns =
       base(%{


### PR DESCRIPTION
The last DT-M3 piece: column visibility.

- `column_toggle` renders a Columns dropdown in the toolbar - the same top-layer popover machinery as the filter editors (viewport-clamped), a checkbox row per `:col`. No Apply button: each toggle posts immediately and the native popover stays open through the LiveView patch, so multi-toggling flows.
- `hidden_columns` is presentation state: it rides the `on_ui` event (defaulting to `on_change`) as `%{"op" => "toggle_column", "field" => f}` and never touches URLs - link-mode state stays curl-able. `column_toggle` in link mode without `on_ui` raises with guidance, same as selection.
- Guards: the last visible column's checkbox disables (a table needs at least one); filter buttons stay independent of visibility - hiding a column doesn't strand or remove its active filter, because filtering is not display.

844 tests green. Verified live in the playground demo: toggling Email removes the column while the panel stays open, its checkbox unchecks, and its filter button remains.