### PR TITLE
feat(data_table): showcase examples + rules.md pattern (DT-M4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@
   last visible column's checkbox disables (a table needs one), and
   filter buttons stay independent of visibility (filtering is not
   display).
+- **Data table showcase + rules (4.12 data table, milestone 4).**
+  Three new registry examples - the full toolbar (search + typed
+  filters + per-page), row selection with the morphing toolbar, and
+  columns visibility - powering the playground page and the upcoming
+  petal.build docs. `rules.md` gains the data table pattern (the
+  two-call event-mode backend, UI-state-vs-URL-state doctrine) for AI
+  assistants.
 - **`data_table` filter popovers are viewport-aware**: the editors now
   ride the popover's top-layer mode, so `PetalPopover` flips and clamps
   them inside the viewport - a filter button at the screen edge no

--- a/lib/petal_components/showcase/data_table.ex
+++ b/lib/petal_components/showcase/data_table.ex
@@ -41,7 +41,7 @@ defmodule PetalComponents.Showcase.DataTable do
       "searchable sweeps string fields case-insensitively before filters (totals stay honest); filterable columns get buttons that open typed popover editors - operator + value for text/number/date (between reveals its second bound, no JS), a checkbox list for select - and read their predicate while active, with an inline clear. page_size_options adds the per-page select; Reset filters appears while any filter is active. Event mode posts one op-grammar event for all of it (State.handle_op/3 is the whole handler); link mode patches curl-able URLs." do
     ~H"""
     <% state = %State{
-      search: "e",
+      search: "i",
       filters: [%{field: :status, op: :in, value: ["pending", "refunded"]}],
       page_size: 5
     } %>

--- a/lib/petal_components/showcase/data_table.ex
+++ b/lib/petal_components/showcase/data_table.ex
@@ -120,7 +120,7 @@ defmodule PetalComponents.Showcase.DataTable do
       state={state}
       on_change="table"
       column_toggle
-      hidden_columns={[:email]}
+      hidden_columns={["email"]}
     >
       <:col :let={row} field={:name} sortable>{row.name}</:col>
       <:col :let={row} field={:email}>{row.email}</:col>

--- a/lib/petal_components/showcase/data_table.ex
+++ b/lib/petal_components/showcase/data_table.ex
@@ -35,6 +35,100 @@ defmodule PetalComponents.Showcase.DataTable do
     """
   end
 
+  example :toolbar, "The full toolbar: search, typed filters, per-page",
+    inert: true,
+    description:
+      "searchable sweeps string fields case-insensitively before filters (totals stay honest); filterable columns get buttons that open typed popover editors - operator + value for text/number/date (between reveals its second bound, no JS), a checkbox list for select - and read their predicate while active, with an inline clear. page_size_options adds the per-page select; Reset filters appears while any filter is active. Event mode posts one op-grammar event for all of it (State.handle_op/3 is the whole handler); link mode patches curl-able URLs." do
+    ~H"""
+    <% state = %State{
+      search: "e",
+      filters: [%{field: :status, op: :in, value: ["pending", "refunded"]}],
+      page_size: 5
+    } %>
+    <% {rows, state} = Engine.List.run(PetalComponents.Showcase.DataTable.sample_rows(), state) %>
+    <.data_table
+      id="sx-dt-toolbar"
+      rows={rows}
+      state={state}
+      on_change="table"
+      searchable
+      page_size_options={[5, 10, 20]}
+    >
+      <:col :let={row} field={:name} sortable>{row.name}</:col>
+      <:col :let={row} field={:email} filterable="text">{row.email}</:col>
+      <:col
+        :let={row}
+        field={:status}
+        filterable="select"
+        options={[{"Paid", "paid"}, {"Pending", "pending"}, {"Refunded", "refunded"}]}
+      >
+        <.badge
+          size="sm"
+          variant="soft"
+          color={
+            case row.status do
+              "paid" -> "success"
+              "pending" -> "warning"
+              _ -> "danger"
+            end
+          }
+          label={row.status}
+        />
+      </:col>
+      <:col :let={row} field={:amount} sortable align="right" filterable="number">
+        ${row.amount}
+      </:col>
+    </.data_table>
+    """
+  end
+
+  example :selection, "Row selection with a morphing toolbar",
+    inert: true,
+    description:
+      "selectable adds a checkbox column keyed by row_id (a field or a function - it must uniquely identify records across ALL pages). The header checkbox is tri-state; while rows are selected the toolbar morphs into the count, your :bulk_action slot (:let receives the ids) and a clear button. Selection is UI state: it rides the on_ui event (defaulting to on_change) with select / select_all / clear_selection ops and never touches URLs - a MapSet plus three clauses is the whole backend." do
+    ~H"""
+    <% state = %State{page_size: 4} %>
+    <% {rows, state} = Engine.List.run(PetalComponents.Showcase.DataTable.sample_rows(), state) %>
+    <.data_table
+      id="sx-dt-selection"
+      rows={rows}
+      state={state}
+      on_change="table"
+      selectable
+      selected={["1", "3"]}
+    >
+      <:col :let={row} field={:name} sortable>{row.name}</:col>
+      <:col :let={row} field={:email}>{row.email}</:col>
+      <:col :let={row} field={:amount} align="right">${row.amount}</:col>
+      <:bulk_action :let={ids}>
+        <.button size="sm" variant="soft" color="danger">Archive {length(ids)}</.button>
+      </:bulk_action>
+    </.data_table>
+    """
+  end
+
+  example :columns, "Columns visibility",
+    inert: true,
+    description:
+      "column_toggle renders a Columns dropdown - every declared column with a checkbox, toggling immediately (the panel stays open for multi-toggling). hidden_columns is presentation state on the on_ui event, never in URLs; the last visible column can't be hidden, and filter buttons stay independent of visibility because filtering is not display." do
+    ~H"""
+    <% state = %State{page_size: 4} %>
+    <% {rows, state} = Engine.List.run(PetalComponents.Showcase.DataTable.sample_rows(), state) %>
+    <.data_table
+      id="sx-dt-columns"
+      rows={rows}
+      state={state}
+      on_change="table"
+      column_toggle
+      hidden_columns={[:email]}
+    >
+      <:col :let={row} field={:name} sortable>{row.name}</:col>
+      <:col :let={row} field={:email}>{row.email}</:col>
+      <:col :let={row} field={:amount} align="right">${row.amount}</:col>
+    </.data_table>
+    """
+  end
+
   example :loading, "Loading skeletons",
     description:
       "loading swaps the page for skeleton rows - one per page_size row, respecting column count and alignment. Flip it off when the query resolves." do

--- a/rules.md
+++ b/rules.md
@@ -229,6 +229,8 @@ For anything beyond a static table, reach for `<.data_table>` instead of hand-wi
 
 The event-mode backend: UI-state ops (selection, column visibility) get their own clauses, and everything else is query state through `State.handle_op/3` (sort/page/search/page_size/filter/clear_filters). Do NOT skip the UI clauses when using `selectable`/`column_toggle` - `handle_op` ignores those ops by design:
 
+Events post STRING values, so keep the `selected` and `hidden` assigns as string lists (`["1", "7"]`, `["amount"]`) - mixing in integers or atoms makes the membership checks below silently miss:
+
 ```elixir
 def handle_event("table", %{"op" => "select", "id" => id}, socket) do
   {:noreply, update(socket, :selected, fn sel ->
@@ -237,6 +239,8 @@ def handle_event("table", %{"op" => "select", "id" => id}, socket) do
 end
 
 def handle_event("table", %{"op" => "select_all"}, socket) do
+  # derive page ids with the SAME identity you pass as row_id
+  # (default :id) - a different key here desyncs the header checkbox
   page_ids = Enum.map(socket.assigns.rows, &to_string(&1.id))
   sel = socket.assigns.selected
 

--- a/rules.md
+++ b/rules.md
@@ -227,9 +227,34 @@ For anything beyond a static table, reach for `<.data_table>` instead of hand-wi
 </.data_table>
 ```
 
-The event-mode backend is two calls - `State.handle_op/3` speaks every query op (sort/page/search/page_size/filter/clear_filters):
+The event-mode backend: UI-state ops (selection, column visibility) get their own clauses, and everything else is query state through `State.handle_op/3` (sort/page/search/page_size/filter/clear_filters). Do NOT skip the UI clauses when using `selectable`/`column_toggle` - `handle_op` ignores those ops by design:
 
 ```elixir
+def handle_event("table", %{"op" => "select", "id" => id}, socket) do
+  {:noreply, update(socket, :selected, fn sel ->
+    if id in sel, do: List.delete(sel, id), else: sel ++ [id]
+  end)}
+end
+
+def handle_event("table", %{"op" => "select_all"}, socket) do
+  page_ids = Enum.map(socket.assigns.rows, &to_string(&1.id))
+  sel = socket.assigns.selected
+
+  {:noreply,
+   assign(socket, :selected,
+     if(Enum.all?(page_ids, &(&1 in sel)), do: sel -- page_ids, else: Enum.uniq(sel ++ page_ids))
+   )}
+end
+
+def handle_event("table", %{"op" => "clear_selection"}, socket),
+  do: {:noreply, assign(socket, :selected, [])}
+
+def handle_event("table", %{"op" => "toggle_column", "field" => f}, socket) do
+  {:noreply, update(socket, :hidden, fn h ->
+    if f in h, do: List.delete(h, f), else: h ++ [f]
+  end)}
+end
+
 def handle_event("table", params, socket) do
   state = State.handle_op(socket.assigns.table, params, fields: [:customer, :status, :amount])
   {rows, state} = Engine.List.run(all_orders(), state)
@@ -237,7 +262,7 @@ def handle_event("table", params, socket) do
 end
 ```
 
-Selection and column visibility are UI state (ops `select`/`select_all`/`clear_selection`/`toggle_column` on the same event, or a separate `on_ui`) - keep them in assigns, never in URLs. For URL-driven tables pass `path` instead of `on_change`: every interaction becomes a patch URL and `State.from_params/2` in `handle_params` is the whole backend. `row_id` must uniquely identify records across all pages.
+Selection and column visibility are UI state (the clauses above; move them to a separate `on_ui` event if you prefer) - keep them in assigns, never in URLs. For URL-driven tables pass `path` instead of `on_change`: every interaction becomes a patch URL and `State.from_params/2` in `handle_params` is the whole backend. `row_id` must uniquely identify records across all pages.
 
 ### Alert / inline feedback
 

--- a/rules.md
+++ b/rules.md
@@ -210,6 +210,7 @@ For anything beyond a static table, reach for `<.data_table>` instead of hand-wi
   searchable
   selectable
   selected={@selected}
+  row_id={&row_key/1}
   column_toggle
   hidden_columns={@hidden}
   page_size_options={[10, 25, 50]}
@@ -239,9 +240,7 @@ def handle_event("table", %{"op" => "select", "id" => id}, socket) do
 end
 
 def handle_event("table", %{"op" => "select_all"}, socket) do
-  # derive page ids with the SAME identity you pass as row_id
-  # (default :id) - a different key here desyncs the header checkbox
-  page_ids = Enum.map(socket.assigns.rows, &to_string(&1.id))
+  page_ids = Enum.map(socket.assigns.rows, &row_key/1)
   sel = socket.assigns.selected
 
   {:noreply,
@@ -258,6 +257,10 @@ def handle_event("table", %{"op" => "toggle_column", "field" => f}, socket) do
     if f in h, do: List.delete(h, f), else: h ++ [f]
   end)}
 end
+
+# ONE identity function, used as both the component's row_id and
+# select_all's page sweep - they must never disagree
+defp row_key(row), do: to_string(row.id)
 
 def handle_event("table", params, socket) do
   state = State.handle_op(socket.assigns.table, params, fields: [:customer, :status, :amount])

--- a/rules.md
+++ b/rules.md
@@ -197,6 +197,48 @@ If the MCP is unavailable, the source of truth is https://hexdocs.pm/petal_compo
 </.table>
 ```
 
+### Data table (sortable, paged, filtered - the full surface)
+
+For anything beyond a static table, reach for `<.data_table>` instead of hand-wiring `<.table>` + pagination + inputs. One `DataTable.State` struct drives the whole surface; `Engine.List` runs it over an in-memory list (or run the state against your own query layer).
+
+```heex
+<.data_table
+  id="orders"
+  rows={@rows}
+  state={@table}
+  on_change="table"
+  searchable
+  selectable
+  selected={@selected}
+  column_toggle
+  hidden_columns={@hidden}
+  page_size_options={[10, 25, 50]}
+>
+  <:col :let={o} field={:customer} sortable filterable="text">{o.customer}</:col>
+  <:col :let={o} field={:status} filterable="select" options={["paid", "pending", "refunded"]}>
+    <.badge size="sm" variant="soft" label={o.status} />
+  </:col>
+  <:col :let={o} field={:amount} sortable align="right" filterable="number">${o.amount}</:col>
+  <:bulk_action :let={ids}>
+    <.button size="sm" variant="soft" color="danger" phx-click="archive" phx-value-ids={Enum.join(ids, ",")}>
+      Archive {length(ids)}
+    </.button>
+  </:bulk_action>
+</.data_table>
+```
+
+The event-mode backend is two calls - `State.handle_op/3` speaks every query op (sort/page/search/page_size/filter/clear_filters):
+
+```elixir
+def handle_event("table", params, socket) do
+  state = State.handle_op(socket.assigns.table, params, fields: [:customer, :status, :amount])
+  {rows, state} = Engine.List.run(all_orders(), state)
+  {:noreply, assign(socket, rows: rows, table: state)}
+end
+```
+
+Selection and column visibility are UI state (ops `select`/`select_all`/`clear_selection`/`toggle_column` on the same event, or a separate `on_ui`) - keep them in assigns, never in URLs. For URL-driven tables pass `path` instead of `on_change`: every interaction becomes a patch URL and `State.from_params/2` in `handle_params` is the whole backend. `row_id` must uniquely identify records across all pages.
+
 ### Alert / inline feedback
 
 ```heex


### PR DESCRIPTION
The wrap milestone for the 4.13 data table: the teaching surface.

- **Three new showcase registry examples** (all inert - static renders with live-looking state): the full toolbar rendered mid-search + mid-filter so predicate buttons, Reset and the per-page select all show; row selection mid-pick with the morphed toolbar, tri-state header and a `:bulk_action`; columns visibility with a column hidden. These power the playground page (registry loop picks them up with zero changes) and the upcoming petal.build docs page.
- **rules.md** gains the data table pattern for AI assistants: reach for `<.data_table>` over hand-wired table+pagination, the two-call event-mode backend (`State.handle_op/3` + engine run), UI-state-vs-URL-state doctrine for selection/columns, link mode as `handle_params` + `from_params`, and the `row_id` cross-page identity contract. This is source of truth #1 in the three-way rules sync; the MCP and petal.build copies ride the release cascade.

845 Elixir / 112 JS green (registry test pins the new examples' registration).

Remaining before release: version bump to 4.13.0 (separate PR), Nic's hex publish, then the marketing docs + MCP schema sync ride the published release.