### PR TITLE
polish(playground): surface the DT-M4 showcase examples

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -7409,7 +7409,7 @@ defmodule Dev.PlaygroundLive do
           ex <-
             examples_for(
               PetalComponents.Showcase.DataTable,
-              ~w(basic loading empty)a
+              ~w(basic toolbar selection columns loading empty)a
             )
         }
         class="mt-10"


### PR DESCRIPTION
One-liner: the data-table page pins showcase example ids explicitly, so the three DT-M4 registry examples (toolbar, selection, columns) never rendered - added to the list.