### PR TITLE
chore: release v4.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-### Unreleased
+### 4.13.0 - 2026-08-08
 
 #### Added
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PetalComponents.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/petalframework/petal_components"
-  @version "4.12.0"
+  @version "4.13.0"
 
   def project do
     [


### PR DESCRIPTION
Version bump + changelog header for the data table release (DT-M1 through M4, PRs #555/#563/#565/#566/#568/#569/#570/#571). After merge: Nic runs mix hex.publish, then the marketing docs + MCP schema sync cascade rides the published release.