### PR TITLE
fix(popover): kill the top-left flash and the patch-snap; guard iOS zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,28 @@
 # Changelog
+### Unreleased
+
+#### Fixed
+
+- **Top-layer popovers no longer flash at the top-left corner.** The
+  panel's `margin: 0` (which defeats the browser's centring) meant an
+  unpositioned panel sat at 0,0, and `toggle` fires late enough for a
+  frame to paint there. `PetalPopover` now gates opacity in
+  `beforetoggle` - which runs synchronously *before* the panel is
+  shown - so the first painted frame is already the positioned one.
+- **Top-layer popovers survive LiveView patches.** A patch merges
+  server attributes onto the panel, dropping the inline `top`/`left`
+  the hook owns and snapping an open panel to 0,0 (hit by the data
+  table's Columns dropdown, where every toggle patches). The hook now
+  re-asserts position in `updated()`, tracking open state on the hook
+  instance rather than a DOM attribute the same merge would strip.
+- **`data_table` filter controls no longer trigger iOS zoom.** Safari
+  zooms the viewport when a focused field's text is under 16px, which
+  scrolled popover editors out of view. The search input, filter
+  operator selects, filter values and the per-page select scale to
+  16px on coarse pointers, keeping their `h-9` box.
+- **`::backdrop` is transparent for top-layer panels**, so no UA can
+  paint a dimming layer behind an anchored popover.
+
 ### 4.13.0 - 2026-08-08
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -2471,6 +2471,12 @@
       opacity: 0;
     }
   }
+  /* the top layer is ours alone - never let a UA paint a dimming
+     backdrop behind an anchored panel (iOS Safari tints the toolbar
+     strip otherwise) */
+  .pc-popover__panel--top-layer::backdrop {
+    background: transparent;
+  }
 
   /* Loading */
 
@@ -2696,6 +2702,17 @@
   }
   .pc-data-table__select-col {
     @apply w-px pr-0;
+  }
+  /* iOS Safari zooms the viewport when a focused field's text is under
+     16px, which on a popover editor scrolls the field out of view. The
+     controls keep their h-9 box; only the type scales up on touch. */
+  @media (hover: none) and (pointer: coarse) {
+    .pc-data-table__search-input.pc-data-table__search-input,
+    .pc-data-table__filter-op.pc-data-table__filter-op,
+    .pc-data-table__filter-value.pc-data-table__filter-value,
+    .pc-data-table__page-size-select.pc-data-table__page-size-select {
+      @apply text-base;
+    }
   }
   .pc-data-table__selection-count {
     @apply text-sm font-medium text-gray-700 dark:text-gray-200;

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -1441,20 +1441,49 @@ export const PetalInputOTP = {
 // and clamping to the viewport when space runs out.
 export const PetalPopover = {
   mounted() {
+    this.open = false;
     this.reposition = () => this.position();
+
+    // An unpositioned top-layer panel sits at 0,0 (the CSS zeroes the
+    // margin that would otherwise centre it), and `toggle` fires as a
+    // queued task - late enough for the browser to paint that corner
+    // first. `beforetoggle` runs synchronously BEFORE the panel is
+    // shown, so hiding it here means the first painted frame is
+    // already the positioned one.
+    this.onBeforeToggle = (e) => {
+      if (e.newState === "open") this.el.style.opacity = "0";
+    };
+
     this.onToggle = (e) => {
-      if (e.newState === "open") {
+      this.open = e.newState === "open";
+
+      if (this.open) {
         this.position();
+        this.el.style.opacity = "";
         window.addEventListener("scroll", this.reposition, true);
         window.addEventListener("resize", this.reposition);
       } else {
+        this.el.style.opacity = "";
         window.removeEventListener("scroll", this.reposition, true);
         window.removeEventListener("resize", this.reposition);
       }
     };
+
+    this.el.addEventListener("beforetoggle", this.onBeforeToggle);
     this.el.addEventListener("toggle", this.onToggle);
   },
+
+  // A patch merges server attributes onto the panel, which drops the
+  // inline top/left this hook owns (the server never renders them) -
+  // an open panel would snap to 0,0. Re-assert before the next paint.
+  // Open state lives on the hook instance, not the DOM, for the same
+  // reason: an attribute stamp would be stripped by that same merge.
+  updated() {
+    if (this.open) this.position();
+  },
+
   destroyed() {
+    this.el.removeEventListener("beforetoggle", this.onBeforeToggle);
     this.el.removeEventListener("toggle", this.onToggle);
     window.removeEventListener("scroll", this.reposition, true);
     window.removeEventListener("resize", this.reposition);

--- a/test/js/popover.test.js
+++ b/test/js/popover.test.js
@@ -1,0 +1,99 @@
+// PetalPopover hook: top-layer panel positioning.
+//
+// The panel's CSS zeroes the margin that would otherwise centre a
+// popover, so an unpositioned panel sits at 0,0 - every spec here is
+// ultimately about never letting a frame paint from that corner.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import hooks from "../../assets/js/petal_components.js";
+
+const mounted = [];
+
+// jsdom has no CSS.escape; the hook uses it to find the trigger
+beforeEach(() => {
+  if (typeof globalThis.CSS === "undefined") globalThis.CSS = {};
+  if (!globalThis.CSS.escape) globalThis.CSS.escape = (s) => s;
+});
+
+function mount({ placement = "bottom-start" } = {}) {
+  const wrap = document.createElement("div");
+  wrap.innerHTML = `
+    <button type="button" popovertarget="pop">Filter</button>
+    <div id="pop" class="pc-popover__panel pc-popover__panel--top-layer" data-placement="${placement}"></div>
+  `;
+  document.body.appendChild(wrap);
+
+  const el = wrap.querySelector("#pop");
+  const hook = Object.create(hooks.PetalPopover);
+  hook.el = el;
+  hook.mounted();
+  mounted.push({ hook, wrap });
+
+  return { hook, el, wrap };
+}
+
+function fire(el, type, newState) {
+  const e = new Event(type);
+  e.newState = newState;
+  el.dispatchEvent(e);
+}
+
+describe("PetalPopover", () => {
+  afterEach(() => {
+    mounted.splice(0).forEach(({ hook, wrap }) => {
+      hook.destroyed();
+      wrap.remove();
+    });
+  });
+
+  it("hides the panel before it is shown, then reveals it positioned", () => {
+    const { el } = mount();
+
+    // beforetoggle runs before the browser paints the open panel
+    fire(el, "beforetoggle", "open");
+    expect(el.style.opacity).toBe("0");
+    expect(el.style.top).toBe("");
+
+    // toggle positions it, then hands opacity back to the CSS fade
+    fire(el, "toggle", "open");
+    expect(el.style.opacity).toBe("");
+    expect(el.style.top).not.toBe("");
+    expect(el.style.left).not.toBe("");
+  });
+
+  it("re-asserts position after a patch strips the inline styles", () => {
+    const { hook, el } = mount();
+    fire(el, "beforetoggle", "open");
+    fire(el, "toggle", "open");
+
+    const positioned = { top: el.style.top, left: el.style.left };
+
+    // what LiveView's attribute merge does to styles the server never rendered
+    el.removeAttribute("style");
+    expect(el.style.top).toBe("");
+
+    hook.updated();
+    expect(el.style.top).toBe(positioned.top);
+    expect(el.style.left).toBe(positioned.left);
+  });
+
+  it("does not reposition a closed panel", () => {
+    const { hook, el } = mount();
+    fire(el, "beforetoggle", "open");
+    fire(el, "toggle", "open");
+    fire(el, "toggle", "closed");
+
+    el.removeAttribute("style");
+    hook.updated();
+    expect(el.style.top).toBe("");
+  });
+
+  it("clears the opacity gate when a panel closes without opening cleanly", () => {
+    const { el } = mount();
+    fire(el, "beforetoggle", "open");
+    expect(el.style.opacity).toBe("0");
+
+    fire(el, "toggle", "closed");
+    expect(el.style.opacity).toBe("");
+  });
+});


### PR DESCRIPTION
Nic's iOS eye-test round. Three reported bugs, one shared root cause.

**Root:** `.pc-popover__panel--top-layer` applies `margin: 0`, which defeats the browser's default centring for popovers. So any panel without a computed `top`/`left` renders at **0,0** - the "flicker in the top-left corner" and the "jumps to the top left" are the same pixel.

### 1. Flash on open
`toggle` fires as a queued task - late enough for the browser to paint the unpositioned panel first. Positioning now happens behind an opacity gate set in `beforetoggle`, which runs **synchronously before** the panel is shown, so the first painted frame is already positioned. The existing `@starting-style` fade takes over from there.

### 2. Snap to 0,0 on patch
A LiveView patch merges server attributes onto the panel and drops the inline `top`/`left` this hook owns (the server never renders them). Every Columns checkbox patches, hence "tap any column and the panel jumps to the top left". The hook now re-asserts position in `updated()`. Open state lives on the hook instance, not a DOM attribute - the same attribute merge would strip a stamp.

### 3. iOS zoom on filter inputs
Safari zooms the viewport when a focused field's text is under 16px, scrolling the popover editor out of view. The search input, filter operator selects, filter value inputs and the per-page select scale to `text-base` under `(hover: none) and (pointer: coarse)`, keeping their `h-9` box. (Android Chrome doesn't zoom on focus with a proper viewport meta, so this is iOS-shaped.)

Also: `::backdrop` is now explicitly transparent for top-layer panels, so no UA can paint a dimming layer behind an anchored popover.

### Verified
- 4 new `PetalPopover` specs (116 JS, 845 Elixir): the gate hides before show and releases after positioning, `updated()` restores position after a style-stripping patch, a closed panel is never repositioned.
- Live at 375px with coarse pointer emulation: `beforetoggle` observes `opacity: 0`; the panel settles at top 483 against a trigger bottom of 475 (8px gap, in-viewport); a Columns toggle holds `top: 525px; left: 142.312px` **through** the patch while the column disappears; all four controls compute `16px`.