### PR TITLE
fix(popover+data_table): follow the visual viewport; centre field text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 
 #### Fixed
 
+- **Top-layer popovers follow the visual viewport.** Opening a mobile
+  keyboard shrinks and offsets the visual viewport without firing
+  window `scroll` or `resize`, so a panel anchored on layout-viewport
+  numbers was left behind - off-screen while typing, then adrift on
+  the next scroll. `PetalPopover` now subscribes to `visualViewport`
+  events and measures space and clamps against that box, so an open
+  editor stays put and stays visible above the keyboard.
+- **Fields with an explicit height no longer sit their text low.** The
+  data table's search input and filter operator/value controls set
+  `h-9` while inheriting the base `py-2`; at 16px (coarse pointers)
+  the line box overflowed the content box and pushed the text down.
+  They now zero the vertical padding, like the per-page select
+  already did.
 - **Top-layer popovers no longer flash at the top-left corner.** The
   panel's `margin: 0` (which defeats the browser's centring) meant an
   unpositioned panel sat at 0,0, and `toggle` fires late enough for a

--- a/assets/default.css
+++ b/assets/default.css
@@ -2645,7 +2645,7 @@
     @apply w-4! h-4!;
   }
   .pc-data-table__search-input.pc-data-table__search-input {
-    @apply h-9 w-56 max-w-full pl-8 text-sm;
+    @apply h-9 w-56 max-w-full py-0 pl-8 text-sm;
   }
   .pc-data-table__reset {
     @apply ml-auto;
@@ -2672,9 +2672,12 @@
   .pc-data-table__filter-form--select {
     @apply w-48;
   }
+  /* py-0: these carry an explicit height, so the base py-2 would push a
+     16px line box (coarse pointers) past the content box and sit the
+     text low - same normalization the page-size select already had */
   .pc-data-table__filter-op.pc-data-table__filter-op,
   .pc-data-table__filter-value.pc-data-table__filter-value {
-    @apply h-9 text-sm;
+    @apply h-9 py-0 text-sm;
   }
   .pc-data-table__filter-value2 {
     @apply hidden;

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -1439,6 +1439,10 @@ export const PetalInputOTP = {
 // The browser handles open/close and light-dismiss via the popover attribute;
 // this hook only computes fixed coordinates, flipping to the opposite side
 // and clamping to the viewport when space runs out.
+// min wins when the panel is taller/wider than the space it has: better
+// to overflow the far edge than to push the anchored edge off-screen
+const clamp = (value, min, max) => Math.max(min, Math.min(value, max));
+
 export const PetalPopover = {
   mounted() {
     this.open = false;
@@ -1460,12 +1464,10 @@ export const PetalPopover = {
       if (this.open) {
         this.position();
         this.el.style.opacity = "";
-        window.addEventListener("scroll", this.reposition, true);
-        window.addEventListener("resize", this.reposition);
+        this.listen("addEventListener");
       } else {
         this.el.style.opacity = "";
-        window.removeEventListener("scroll", this.reposition, true);
-        window.removeEventListener("resize", this.reposition);
+        this.listen("removeEventListener");
       }
     };
 
@@ -1485,8 +1487,41 @@ export const PetalPopover = {
   destroyed() {
     this.el.removeEventListener("beforetoggle", this.onBeforeToggle);
     this.el.removeEventListener("toggle", this.onToggle);
-    window.removeEventListener("scroll", this.reposition, true);
-    window.removeEventListener("resize", this.reposition);
+    this.listen("removeEventListener");
+  },
+
+  // The visual viewport is its own thing on mobile: opening the
+  // keyboard shrinks and offsets it WITHOUT firing window scroll or
+  // resize, so a panel anchored on layout-viewport numbers is left
+  // behind (off-screen, then adrift once the page does scroll).
+  listen(method) {
+    window[method]("scroll", this.reposition, true);
+    window[method]("resize", this.reposition);
+    if (window.visualViewport) {
+      window.visualViewport[method]("resize", this.reposition);
+      window.visualViewport[method]("scroll", this.reposition);
+    }
+  },
+
+  // The box the panel must stay inside, in client coordinates: the
+  // visible region when a keyboard or pinch-zoom has shrunk it,
+  // otherwise the window.
+  viewport() {
+    const vv = window.visualViewport;
+
+    return vv
+      ? {
+          top: vv.offsetTop,
+          left: vv.offsetLeft,
+          width: vv.width,
+          height: vv.height,
+        }
+      : {
+          top: 0,
+          left: 0,
+          width: window.innerWidth,
+          height: window.innerHeight,
+        };
   },
   position() {
     const trigger = document.querySelector(
@@ -1499,12 +1534,13 @@ export const PetalPopover = {
     const t = trigger.getBoundingClientRect();
     const p = this.el.getBoundingClientRect();
     const [side, align] = (this.el.dataset.placement || "bottom").split("-");
+    const vp = this.viewport();
 
     const space = {
-      top: t.top,
-      bottom: window.innerHeight - t.bottom,
-      left: t.left,
-      right: window.innerWidth - t.right,
+      top: t.top - vp.top,
+      bottom: vp.top + vp.height - t.bottom,
+      left: t.left - vp.left,
+      right: vp.left + vp.width - t.right,
     };
 
     let s = side;
@@ -1546,8 +1582,8 @@ export const PetalPopover = {
       else top = t.top + t.height / 2 - p.height / 2;
     }
 
-    left = Math.max(pad, Math.min(left, window.innerWidth - p.width - pad));
-    top = Math.max(pad, Math.min(top, window.innerHeight - p.height - pad));
+    left = clamp(left, vp.left + pad, vp.left + vp.width - p.width - pad);
+    top = clamp(top, vp.top + pad, vp.top + vp.height - p.height - pad);
 
     this.el.style.top = `${top}px`;
     this.el.style.left = `${left}px`;

--- a/dev.exs
+++ b/dev.exs
@@ -750,6 +750,7 @@ defmodule Dev.PlaygroundLive do
        dt: PetalComponents.DataTable.State |> struct(page_size: 5) |> run_dt(),
        dt_selected: [],
        dt_hidden: [],
+       dt_refunded: [],
        radio: %{
          style: "cards",
          variant: "outline",
@@ -1450,7 +1451,8 @@ defmodule Dev.PlaygroundLive do
     state = State.handle_op(state, params, fields: [:name, :email, :status, :amount])
 
     # selection is UI state, outside State - a MapSet and three clauses
-    selected = socket.assigns.dt_selected
+    was_selected = socket.assigns.dt_selected
+    selected = was_selected
 
     selected =
       case params do
@@ -1468,8 +1470,18 @@ defmodule Dev.PlaygroundLive do
         %{"op" => "clear_selection"} ->
           []
 
+        # a bulk action consumes the selection: act, then clear
+        %{"op" => "refund"} ->
+          []
+
         _ ->
           selected
+      end
+
+    refunded =
+      case params do
+        %{"op" => "refund"} -> Enum.uniq(socket.assigns.dt_refunded ++ was_selected)
+        _ -> socket.assigns.dt_refunded
       end
 
     hidden =
@@ -1484,17 +1496,19 @@ defmodule Dev.PlaygroundLive do
 
     {:noreply,
      socket
-     |> assign(:dt, run_dt(state))
+     |> assign(:dt, run_dt(state, refunded))
      |> assign(:dt_selected, selected)
-     |> assign(:dt_hidden, hidden)}
+     |> assign(:dt_hidden, hidden)
+     |> assign(:dt_refunded, refunded)}
   end
 
-  defp run_dt(state) do
-    {rows, state} =
-      PetalComponents.DataTable.Engine.List.run(
-        PetalComponents.Showcase.DataTable.sample_rows(),
-        state
-      )
+  defp run_dt(state, refunded \\ []) do
+    rows =
+      Enum.map(PetalComponents.Showcase.DataTable.sample_rows(), fn row ->
+        if to_string(row.id) in refunded, do: %{row | status: "refunded"}, else: row
+      end)
+
+    {rows, state} = PetalComponents.DataTable.Engine.List.run(rows, state)
 
     {state, rows}
   end
@@ -7396,7 +7410,7 @@ defmodule Dev.PlaygroundLive do
               variant="soft"
               color="danger"
               phx-click="pg_table"
-              phx-value-op="clear_selection"
+              phx-value-op="refund"
             >
               Refund {length(ids)}
             </.button>

--- a/test/js/popover.test.js
+++ b/test/js/popover.test.js
@@ -77,6 +77,53 @@ describe("PetalPopover", () => {
     expect(el.style.left).toBe(positioned.left);
   });
 
+  it("keeps the panel inside the visual viewport when a keyboard shrinks it", () => {
+    const vv = {
+      offsetTop: 120,
+      offsetLeft: 0,
+      width: 375,
+      height: 300,
+      addEventListener: () => listeners.push("add"),
+      removeEventListener: () => listeners.push("remove"),
+    };
+    const listeners = [];
+    Object.defineProperty(window, "visualViewport", {
+      value: vv,
+      configurable: true,
+    });
+
+    const { el, wrap } = mount();
+    // a trigger sitting below the keyboard-shrunk region
+    wrap.querySelector("button").getBoundingClientRect = () => ({
+      top: 700,
+      bottom: 730,
+      left: 20,
+      right: 120,
+      width: 100,
+      height: 30,
+    });
+    el.getBoundingClientRect = () => ({
+      top: 0,
+      bottom: 200,
+      left: 0,
+      right: 220,
+      width: 220,
+      height: 200,
+    });
+
+    fire(el, "beforetoggle", "open");
+    fire(el, "toggle", "open");
+
+    const top = parseFloat(el.style.top);
+    // clamped into [vv.offsetTop + 8, vv.offsetTop + vv.height - 200 - 8]
+    expect(top).toBeGreaterThanOrEqual(128);
+    expect(top).toBeLessThanOrEqual(212);
+    // and it subscribed to the visual viewport, not just window
+    expect(listeners).toContain("add");
+
+    delete window.visualViewport;
+  });
+
   it("does not reposition a closed panel", () => {
     const { hook, el } = mount();
     fire(el, "beforetoggle", "open");

--- a/test/js/popover.test.js
+++ b/test/js/popover.test.js
@@ -124,6 +124,45 @@ describe("PetalPopover", () => {
     delete window.visualViewport;
   });
 
+  it("unsubscribes from the visual viewport on close and on destroy", () => {
+    const calls = [];
+    const vv = {
+      offsetTop: 0,
+      offsetLeft: 0,
+      width: 375,
+      height: 812,
+      addEventListener: (type) => calls.push(`add:${type}`),
+      removeEventListener: (type) => calls.push(`remove:${type}`),
+    };
+    Object.defineProperty(window, "visualViewport", {
+      value: vv,
+      configurable: true,
+    });
+
+    const { hook, el, wrap } = mount();
+
+    fire(el, "beforetoggle", "open");
+    fire(el, "toggle", "open");
+    expect(calls).toEqual(["add:resize", "add:scroll"]);
+
+    // closing detaches them - a hook that mounts per filter popover
+    // must not accumulate viewport listeners
+    fire(el, "toggle", "closed");
+    expect(calls).toContain("remove:resize");
+    expect(calls).toContain("remove:scroll");
+
+    calls.length = 0;
+    hook.destroyed();
+    expect(calls).toEqual(["remove:resize", "remove:scroll"]);
+
+    mounted.splice(
+      mounted.findIndex((m) => m.hook === hook),
+      1,
+    );
+    wrap.remove();
+    delete window.visualViewport;
+  });
+
   it("does not reposition a closed panel", () => {
     const { hook, el } = mount();
     fire(el, "beforetoggle", "open");


### PR DESCRIPTION
Nic's second iOS pass. Two component fixes and one demo-honesty fix.

### 1. Panel goes adrift when the keyboard opens
Focusing a filter input opens the keyboard, which shrinks and offsets the **visual** viewport - and does so *without* firing window `scroll` or `resize`. The hook was anchored on layout-viewport numbers, so it never repositioned: the panel stayed where it was (now above the visible region) and then jumped somewhere unrelated on the next real scroll.

`PetalPopover` now subscribes to `visualViewport` `resize`/`scroll`, and both the space calculation and the final clamps measure against that box (`offsetTop`/`offsetLeft` + `width`/`height`) rather than `window.innerWidth/Height`. An open editor stays anchored to its trigger and stays inside the region the keyboard leaves visible.

### 2. Field text sitting low
`.pc-data-table__search-input` and the filter operator/value controls set `h-9` while inheriting `.pc-select`/`.pc-text-input`'s `py-2`. At 16px (the coarse-pointer size we added last round) the 24px line box overflowed an 18px content box, so the text rendered low - exactly what Nic's screenshot shows. They now zero the vertical padding, the same normalization `.pc-data-table__page-size-select` already had. Measured after: padding 0, 34px content box around a 24px line box.

### 3. The demo's Refund button (playground only, no component change)
It was wired to `clear_selection`, so tapping it looked like the table reset itself for no reason - Nic reasonably read that as a bug. It now posts a real `refund` op that marks the selected rows refunded (applied *before* the engine runs, so filters and sorts see the new status) and then clears the selection, which is what a bulk action should actually look like.

### Verified
- 117 JS / 845 Elixir. New spec shrinks and offsets a fake `visualViewport` and asserts the panel clamps into that box and subscribes to its events.
- Live at 375px: both controls compute `padding: 0` with a 34px content box; Refund turns Amy from pending to refunded, clears the selection and restores the toolbar.
- **Not verifiable from here:** the real keyboard interaction needs an actual device - the mechanism and the clamp math are covered, but Nic's re-check is the proof.