### PR TITLE
fix(popover): anchor, don't clamp - the main-axis clamp was the bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 
 #### Fixed
 
+- **Top-layer popovers stay anchored to their trigger.** They were
+  clamped into the viewport on *both* axes, so a panel with no room
+  below was shunted up until it detached from its trigger - pinned to
+  the top of the screen, over the header, over the button that opened
+  it. Clamping now applies to the cross axis only (keeping a panel on
+  screen sideways never detaches it); the main axis is handled by
+  flipping sides, and a panel with more content than room is capped
+  with `max-height` and scrolls. A panel whose trigger scrolls out of
+  view hides with it rather than stranding itself against an edge.
+- **Repositioning is throttled to one pass per animation frame**, so
+  a panel tracks a scrolling page smoothly instead of juddering
+  behind a burst of scroll events, and writes whole-pixel offsets.
+- **An unpositioned top-layer panel centres instead of landing in the
+  corner.** A native `popovertarget` works from first paint, so a fast
+  tap can open a panel before the hook mounts; it now reads as a
+  centred sheet, and the hook anchors it as soon as it mounts.
 - **Top-layer popovers follow the visual viewport.** Opening a mobile
   keyboard shrinks and offsets the visual viewport without firing
   window `scroll` or `resize`, so a panel anchored on layout-viewport

--- a/assets/default.css
+++ b/assets/default.css
@@ -2462,8 +2462,14 @@
   }
   /* Top-layer mode: the PetalPopover hook positions with fixed inline styles;
      [popover] UA defaults handle visibility. Fade in via @starting-style where supported. */
+  /* m-auto, not m-0: with the UA's `inset: 0` an auto margin centres an
+     unpositioned panel, which is what a tap lands on in the moment
+     before the hook mounts - a centred sheet reads as intentional, the
+     0,0 corner reads as broken. (Tailwind's preflight zeroes margins,
+     so the UA's own `margin: auto` never survives to do this for us.)
+     The hook sets margin:0 inline the instant it anchors. */
   .pc-popover__panel--top-layer {
-    @apply fixed m-0 transition-opacity duration-100;
+    @apply fixed m-auto transition-opacity duration-100;
   }
   .pc-popover__panel--top-layer:popover-open {
     opacity: 1;

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -1446,7 +1446,18 @@ const clamp = (value, min, max) => Math.max(min, Math.min(value, max));
 export const PetalPopover = {
   mounted() {
     this.open = false;
-    this.reposition = () => this.position();
+    this.frame = null;
+
+    // Scroll fires far faster than the screen refreshes, and each pass
+    // reads layout then writes it. Coalescing to one pass per frame is
+    // what stops the panel juddering behind the scroll.
+    this.reposition = () => {
+      if (this.frame) return;
+      this.frame = requestAnimationFrame(() => {
+        this.frame = null;
+        this.position();
+      });
+    };
 
     // An unpositioned top-layer panel sits at 0,0 (the CSS zeroes the
     // margin that would otherwise centre it), and `toggle` fires as a
@@ -1473,6 +1484,23 @@ export const PetalPopover = {
 
     this.el.addEventListener("beforetoggle", this.onBeforeToggle);
     this.el.addEventListener("toggle", this.onToggle);
+
+    // A native popovertarget works from first paint, so a fast tap can
+    // open a panel before this hook exists - it opens centred (the UA
+    // default) and lands here already open. Anchor it now.
+    if (this.isOpen()) {
+      this.open = true;
+      this.position();
+      this.listen("addEventListener");
+    }
+  },
+
+  isOpen() {
+    try {
+      return this.el.matches(":popover-open");
+    } catch {
+      return false;
+    }
   },
 
   // A patch merges server attributes onto the panel, which drops the
@@ -1485,6 +1513,7 @@ export const PetalPopover = {
   },
 
   destroyed() {
+    if (this.frame) cancelAnimationFrame(this.frame);
     this.el.removeEventListener("beforetoggle", this.onBeforeToggle);
     this.el.removeEventListener("toggle", this.onToggle);
     this.listen("removeEventListener");
@@ -1531,10 +1560,19 @@ export const PetalPopover = {
 
     const gap = 8;
     const pad = 8;
+    const floor = 96;
+
+    // margin:0 anchors the panel to our top/left - without it the UA's
+    // `inset: 0; margin: auto` centres it, which is the sane look for
+    // the split second before this hook mounts
+    this.el.style.margin = "0";
+    // measure unconstrained: a previous pass may have capped the height
+    this.el.style.maxHeight = "";
+
     const t = trigger.getBoundingClientRect();
     const p = this.el.getBoundingClientRect();
-    const [side, align] = (this.el.dataset.placement || "bottom").split("-");
     const vp = this.viewport();
+    const [side, align] = (this.el.dataset.placement || "bottom").split("-");
 
     const space = {
       top: t.top - vp.top,
@@ -1542,6 +1580,12 @@ export const PetalPopover = {
       left: t.left - vp.left,
       right: vp.left + vp.width - t.right,
     };
+
+    // Anchored means anchored: a trigger scrolled out of the visible
+    // region takes its panel with it rather than stranding it against
+    // an edge, on top of whatever chrome lives there.
+    this.el.style.visibility =
+      t.bottom < vp.top || t.top > vp.top + vp.height ? "hidden" : "";
 
     let s = side;
     if (
@@ -1569,24 +1613,45 @@ export const PetalPopover = {
     )
       s = "right";
 
-    let top, left;
+    let top, left, maxHeight;
+
     if (s === "top" || s === "bottom") {
-      top = s === "top" ? t.top - p.height - gap : t.bottom + gap;
+      // Cap the panel to the room on its chosen side and let it scroll.
+      // Clamping the MAIN axis instead is what tore the panel off its
+      // trigger - pinning it to the top of the screen, over the header,
+      // over the button that opened it.
+      maxHeight = Math.max(
+        (s === "top" ? space.top : space.bottom) - gap - pad,
+        floor,
+      );
+      const height = Math.min(p.height, maxHeight);
+
+      top = s === "top" ? t.top - height - gap : t.bottom + gap;
+
       if (align === "start") left = t.left;
       else if (align === "end") left = t.right - p.width;
       else left = t.left + t.width / 2 - p.width / 2;
+
+      // cross axis only - keeping it on screen sideways never detaches it
+      left = clamp(left, vp.left + pad, vp.left + vp.width - p.width - pad);
     } else {
+      maxHeight = Math.max(vp.height - 2 * pad, floor);
+      const height = Math.min(p.height, maxHeight);
+
       left = s === "left" ? t.left - p.width - gap : t.right + gap;
+
       if (align === "start") top = t.top;
-      else if (align === "end") top = t.bottom - p.height;
-      else top = t.top + t.height / 2 - p.height / 2;
+      else if (align === "end") top = t.bottom - height;
+      else top = t.top + t.height / 2 - height / 2;
+
+      top = clamp(top, vp.top + pad, vp.top + vp.height - height - pad);
     }
 
-    left = clamp(left, vp.left + pad, vp.left + vp.width - p.width - pad);
-    top = clamp(top, vp.top + pad, vp.top + vp.height - p.height - pad);
-
-    this.el.style.top = `${top}px`;
-    this.el.style.left = `${left}px`;
+    this.el.style.maxHeight = `${Math.round(maxHeight)}px`;
+    this.el.style.overflowY = "auto";
+    // whole pixels: sub-pixel writes shimmer against a scrolling page
+    this.el.style.top = `${Math.round(top)}px`;
+    this.el.style.left = `${Math.round(left)}px`;
   },
 };
 

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -1560,7 +1560,6 @@ export const PetalPopover = {
 
     const gap = 8;
     const pad = 8;
-    const floor = 96;
 
     // margin:0 anchors the panel to our top/left - without it the UA's
     // `inset: 0; margin: auto` centres it, which is the sane look for
@@ -1584,8 +1583,13 @@ export const PetalPopover = {
     // Anchored means anchored: a trigger scrolled out of the visible
     // region takes its panel with it rather than stranding it against
     // an edge, on top of whatever chrome lives there.
-    this.el.style.visibility =
-      t.bottom < vp.top || t.top > vp.top + vp.height ? "hidden" : "";
+    const offscreen =
+      t.bottom < vp.top ||
+      t.top > vp.top + vp.height ||
+      t.right < vp.left ||
+      t.left > vp.left + vp.width;
+
+    this.el.style.visibility = offscreen ? "hidden" : "";
 
     let s = side;
     if (
@@ -1620,9 +1624,12 @@ export const PetalPopover = {
       // Clamping the MAIN axis instead is what tore the panel off its
       // trigger - pinning it to the top of the screen, over the header,
       // over the button that opened it.
+      // No minimum, the same call the combobox listbox already makes: a
+      // floor taller than the actual room pushes the panel back out of
+      // the viewport, which is the thing this cap exists to prevent.
       maxHeight = Math.max(
         (s === "top" ? space.top : space.bottom) - gap - pad,
-        floor,
+        0,
       );
       const height = Math.min(p.height, maxHeight);
 
@@ -1635,7 +1642,7 @@ export const PetalPopover = {
       // cross axis only - keeping it on screen sideways never detaches it
       left = clamp(left, vp.left + pad, vp.left + vp.width - p.width - pad);
     } else {
-      maxHeight = Math.max(vp.height - 2 * pad, floor);
+      maxHeight = Math.max(vp.height - 2 * pad, 0);
       const height = Math.min(p.height, maxHeight);
 
       left = s === "left" ? t.left - p.width - gap : t.right + gap;

--- a/test/js/popover.test.js
+++ b/test/js/popover.test.js
@@ -219,6 +219,49 @@ describe("PetalPopover", () => {
     expect(el.style.overflowY).toBe("auto");
   });
 
+  it("never caps taller than the room it has, even in a sliver of viewport", () => {
+    // a viewport strip barely taller than the trigger: neither side has
+    // room for a comfortable panel, and the cap must still contain it
+    stubViewport({ offsetTop: 0, height: 140 });
+    const { el, wrap } = mount();
+    stubRects(wrap, el, {
+      trigger: { top: 60, left: 20, width: 100, height: 30 },
+      panel: { width: 220, height: 400 },
+    });
+
+    open(el);
+
+    const top = parseFloat(el.style.top);
+    const maxHeight = parseFloat(el.style.maxHeight);
+    // it takes the roomier side - 60px above the trigger beats 50 below -
+    // and caps to exactly that room, less gap and pad
+    expect(maxHeight).toBe(44);
+    // the whole box stays inside the 140px strip, above the trigger
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(top + maxHeight).toBeLessThanOrEqual(60);
+  });
+
+  it("hides when its trigger leaves sideways, not just vertically", () => {
+    stubViewport({ offsetLeft: 0, width: 375 });
+    const { hook, el, wrap } = mount();
+    stubRects(wrap, el, {
+      trigger: { top: 100, left: 40, width: 100, height: 30 },
+      panel: { width: 220, height: 150 },
+    });
+
+    open(el);
+    expect(el.style.visibility).toBe("");
+
+    // a horizontally scrolling container carries the trigger off-screen
+    // while it stays vertically in view
+    stubRects(wrap, el, {
+      trigger: { top: 100, left: -300, width: 100, height: 30 },
+      panel: { width: 220, height: 150 },
+    });
+    hook.position();
+    expect(el.style.visibility).toBe("hidden");
+  });
+
   it("hides itself when its trigger scrolls out of the visible region", () => {
     stubViewport({ offsetTop: 0, height: 400 });
     const { hook, el, wrap } = mount();

--- a/test/js/popover.test.js
+++ b/test/js/popover.test.js
@@ -77,51 +77,208 @@ describe("PetalPopover", () => {
     expect(el.style.left).toBe(positioned.left);
   });
 
-  it("keeps the panel inside the visual viewport when a keyboard shrinks it", () => {
-    const vv = {
-      offsetTop: 120,
-      offsetLeft: 0,
-      width: 375,
-      height: 300,
-      addEventListener: () => listeners.push("add"),
-      removeEventListener: () => listeners.push("remove"),
-    };
-    const listeners = [];
+  // Geometry helpers: the specs below drive real numbers through the
+  // hook the way a phone would - a shrunken visual viewport for the
+  // keyboard, a moved trigger for scrolling.
+  function stubViewport({
+    offsetTop = 0,
+    offsetLeft = 0,
+    width = 375,
+    height = 812,
+  } = {}) {
+    const calls = [];
     Object.defineProperty(window, "visualViewport", {
-      value: vv,
+      value: {
+        offsetTop,
+        offsetLeft,
+        width,
+        height,
+        addEventListener: (type) => calls.push(`add:${type}`),
+        removeEventListener: (type) => calls.push(`remove:${type}`),
+      },
       configurable: true,
     });
+    return calls;
+  }
 
-    const { el, wrap } = mount();
-    // a trigger sitting below the keyboard-shrunk region
+  function stubRects(wrap, el, { trigger, panel }) {
     wrap.querySelector("button").getBoundingClientRect = () => ({
-      top: 700,
-      bottom: 730,
-      left: 20,
-      right: 120,
+      top: trigger.top,
+      bottom: trigger.top + trigger.height,
+      left: trigger.left,
+      right: trigger.left + trigger.width,
+      width: trigger.width,
+      height: trigger.height,
+    });
+    el.getBoundingClientRect = () => ({
+      top: 0,
+      bottom: panel.height,
+      left: 0,
+      right: panel.width,
+      width: panel.width,
+      height: panel.height,
+    });
+  }
+
+  function open(el) {
+    fire(el, "beforetoggle", "open");
+    fire(el, "toggle", "open");
+  }
+
+  it("anchors a panel that was opened before the hook mounted", () => {
+    stubViewport();
+
+    // build the panel WITHOUT mounting the hook, and open it - the
+    // native popovertarget works from first paint
+    const wrap = document.createElement("div");
+    wrap.innerHTML = `
+      <button type="button" popovertarget="pop">Filter</button>
+      <div id="pop" class="pc-popover__panel pc-popover__panel--top-layer" data-placement="bottom-start"></div>
+    `;
+    document.body.appendChild(wrap);
+    const el = wrap.querySelector("#pop");
+    el.matches = (sel) => sel === ":popover-open";
+    wrap.querySelector("button").getBoundingClientRect = () => ({
+      top: 200,
+      bottom: 230,
+      left: 40,
+      right: 140,
       width: 100,
       height: 30,
     });
     el.getBoundingClientRect = () => ({
       top: 0,
-      bottom: 200,
+      bottom: 150,
       left: 0,
       right: 220,
       width: 220,
-      height: 200,
+      height: 150,
     });
 
-    fire(el, "beforetoggle", "open");
-    fire(el, "toggle", "open");
+    expect(el.style.top).toBe("");
+
+    const hook = Object.create(hooks.PetalPopover);
+    hook.el = el;
+    hook.mounted();
+    mounted.push({ hook, wrap });
+
+    // mounting anchors the already-open panel instead of leaving it centred
+    expect(parseFloat(el.style.top)).toBe(230 + 8);
+    expect(parseFloat(el.style.left)).toBe(40);
+  });
+
+  it("stays glued under its trigger - never pinned to the viewport edge", () => {
+    stubViewport();
+    const { el, wrap } = mount();
+    // trigger low on a tall page, panel taller than the room beneath it
+    stubRects(wrap, el, {
+      trigger: { top: 700, left: 20, width: 100, height: 30 },
+      panel: { width: 220, height: 200 },
+    });
+
+    open(el);
+
+    // it flips above rather than shunting up to the top of the screen
+    const top = parseFloat(el.style.top);
+    expect(top).toBe(700 - 200 - 8);
+    expect(top).not.toBe(8);
+  });
+
+  it("flips above the trigger when a keyboard eats the space below, without covering it", () => {
+    stubViewport({ offsetTop: 0, height: 380 }); // keyboard up
+    const { el, wrap } = mount();
+    stubRects(wrap, el, {
+      trigger: { top: 300, left: 20, width: 100, height: 30 },
+      panel: { width: 220, height: 200 },
+    });
+
+    open(el);
 
     const top = parseFloat(el.style.top);
-    // clamped into [vv.offsetTop + 8, vv.offsetTop + vv.height - 200 - 8]
-    expect(top).toBeGreaterThanOrEqual(128);
-    expect(top).toBeLessThanOrEqual(212);
-    // and it subscribed to the visual viewport, not just window
-    expect(listeners).toContain("add");
+    const height = parseFloat(el.style.maxHeight);
+    // sits fully above the trigger: bottom edge clears trigger.top
+    expect(top + Math.min(200, height)).toBeLessThanOrEqual(300 - 8);
+    // and never overlaps the control that opened it
+    expect(top).toBeLessThan(300);
+  });
 
-    delete window.visualViewport;
+  it("caps its height to the room available instead of overflowing", () => {
+    stubViewport({ offsetTop: 0, height: 400 });
+    const { el, wrap } = mount();
+    // trigger high, panel far taller than the 400px visible strip
+    stubRects(wrap, el, {
+      trigger: { top: 100, left: 20, width: 100, height: 30 },
+      panel: { width: 220, height: 900 },
+    });
+
+    open(el);
+
+    const maxHeight = parseFloat(el.style.maxHeight);
+    // room below the trigger inside the visible box, less gap and pad
+    expect(maxHeight).toBe(400 - 130 - 8 - 8);
+    expect(el.style.overflowY).toBe("auto");
+  });
+
+  it("hides itself when its trigger scrolls out of the visible region", () => {
+    stubViewport({ offsetTop: 0, height: 400 });
+    const { hook, el, wrap } = mount();
+    stubRects(wrap, el, {
+      trigger: { top: 100, left: 20, width: 100, height: 30 },
+      panel: { width: 220, height: 150 },
+    });
+
+    open(el);
+    expect(el.style.visibility).toBe("");
+
+    // the page scrolls; the trigger leaves the top of the visible box
+    stubRects(wrap, el, {
+      trigger: { top: -200, left: 20, width: 100, height: 30 },
+      panel: { width: 220, height: 150 },
+    });
+    hook.position();
+    expect(el.style.visibility).toBe("hidden");
+
+    // and comes back when it returns
+    stubRects(wrap, el, {
+      trigger: { top: 150, left: 20, width: 100, height: 30 },
+      panel: { width: 220, height: 150 },
+    });
+    hook.position();
+    expect(el.style.visibility).toBe("");
+  });
+
+  it("tracks the trigger through a scroll, one layout pass per frame", async () => {
+    stubViewport();
+    const { hook, el, wrap } = mount();
+    let scrollY = 0;
+    const triggerAt = () => ({
+      trigger: { top: 400 - scrollY, left: 20, width: 100, height: 30 },
+      panel: { width: 220, height: 150 },
+    });
+    stubRects(wrap, el, triggerAt());
+    open(el);
+
+    let passes = 0;
+    const real = hook.position.bind(hook);
+    hook.position = () => {
+      passes += 1;
+      real();
+    };
+
+    // a burst of scroll events inside one frame
+    for (let i = 1; i <= 10; i += 1) {
+      scrollY = i * 10;
+      stubRects(wrap, el, triggerAt());
+      hook.reposition();
+    }
+    expect(passes).toBe(0); // nothing runs synchronously
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    expect(passes).toBe(1); // coalesced into a single pass
+    // and it landed glued to where the trigger ended up
+    expect(parseFloat(el.style.top)).toBe(400 - 100 + 30 + 8);
   });
 
   it("unsubscribes from the visual viewport on close and on destroy", () => {


### PR DESCRIPTION
Nic asked whether this is even the right approach for a floating panel with options. The approach is right - it's what Floating UI and Radix converged on - but my geometry had one wrong rule, and all four reported symptoms trace back to it.

## The bug
`position()` clamped the panel into the viewport on **both axes**. Clamping the *main* axis is what tears a panel off its trigger: with no room below, the panel gets shunted upward until it's sitting over the header, over the button that opened it, and it "floats" back up every time the page reaches the top.

## The rules now
- **Cross axis only.** Keeping a panel on screen sideways never detaches it. The main axis belongs to the flip, not to a clamp.
- **Flip, don't shove.** A keyboard-shrunk viewport puts the panel *above* its trigger, clearing it by the gap.
- **Size, don't overflow.** More content than room gets a `max-height` for that side and scrolls.
- **Hide with the trigger.** Anchored means anchored: a trigger scrolled out of the visible region takes its panel with it, rather than stranding it against an edge on top of whatever chrome lives there.
- **One layout pass per frame.** Scroll fires far faster than the screen refreshes and each pass read-then-wrote layout - that's the judder. Now rAF-coalesced, whole-pixel writes.

## Mount race (issue 4)
A native `popovertarget` works from first paint, so a tap within a second of load opened an unpositioned panel at 0,0. Unpositioned now means **centred** - `m-auto` in the class (Tailwind's preflight zeroes the UA's own `margin: auto`, so it has to be explicit), with the hook writing `margin: 0` inline the instant it anchors. The hook also anchors an already-open panel when it mounts, so a pre-hook tap self-corrects.

## Simulation (what Nic asked for)
Specs drive real geometry rather than mocking the outcome: shrunken/offset `visualViewport` objects for the keyboard, moved trigger rects for scrolling, a hook mounted onto an already-open panel. 123 JS / 845 Elixir.

Driven in a real browser at 375px:
| check | result |
|---|---|
| gap to trigger across scrollTop 0 → 400 | **8px at every step** (was: pinned to 8px from the top) |
| trigger scrolled out of view | panel `visibility: hidden`, restored on return |
| simulated keyboard (viewport 812 → 380) | flips above trigger: panel 127–283 vs trigger top 291, inside the strip, `max-height: 275px` |
| unpositioned/pre-hook panel | centred (was: 0,0 corner) |
| right-edge Amount trigger | in viewport, 41–299 |
| Columns checkbox patch | position held byte-identical, panel stayed open |