### PR TITLE
fix(data_table): put the menus in the page - stop chasing the viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 
 #### Fixed
 
+- **`data_table` filter and column menus live in the page, not the
+  browser's top layer.** A top-layer panel is positioned against the
+  viewport while its trigger sits in the page, so JavaScript had to
+  re-sync them on every scroll event - and JS runs after the frame is
+  already painted (iOS often doesn't repaint fixed content at all
+  during a momentum flick, then snaps it). No amount of throttling
+  fixes that. The panels are now absolutely positioned next to their
+  triggers, so the browser moves both together at compositor speed:
+  there are no scroll listeners left, and nothing to drift. Geometry
+  (flip above, slide sideways into view, cap height) runs once on open
+  and on resize. The `PetalDataTable` hook owns open state, so a menu
+  survives the patches that a filter or column toggle triggers.
+  `<.popover top_layer>` is unchanged and remains the tool for panels
+  that must escape a clipping container.
 - **Top-layer popovers stay anchored to their trigger.** They were
   clamped into the viewport on *both* axes, so a panel with no room
   below was shunted up until it detached from its trigger - pinned to

--- a/assets/default.css
+++ b/assets/default.css
@@ -2468,6 +2468,19 @@
      0,0 corner reads as broken. (Tailwind's preflight zeroes margins,
      so the UA's own `margin: auto` never survives to do this for us.)
      The hook sets margin:0 inline the instant it anchors. */
+  /* An in-page menu panel: hidden until its hook shows it, faded in, and
+     flippable above its trigger. No top layer, so the page carries it -
+     scroll, momentum flicks and keyboard scrolls move panel and trigger
+     as one, with no JavaScript in the loop. */
+  .pc-popover__panel[data-pc-menu] {
+    @apply opacity-0 transition-opacity duration-100;
+  }
+  .pc-popover__panel[data-pc-menu][data-pc-open] {
+    @apply opacity-100;
+  }
+  .pc-popover__panel[data-pc-flip="top"] {
+    @apply bottom-full top-auto mt-0 mb-2;
+  }
   .pc-popover__panel--top-layer {
     @apply fixed m-auto transition-opacity duration-100;
   }

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4868,6 +4868,8 @@ export const PetalDataTable = {
   revealMenu() {
     const panel = this.menuPanel();
     if (!panel) return;
+    // a pending hide from a previous close would yank it back
+    clearTimeout(panel.pcHideTimer);
     panel.hidden = false;
     this.menuTrigger()?.setAttribute("aria-expanded", "true");
     // a frame later so the fade has a start state to move from
@@ -4882,9 +4884,13 @@ export const PetalDataTable = {
     this.openMenu = null;
     if (!panel) return;
     panel.removeAttribute("data-pc-open");
-    clearTimeout(this.menuHideTimer);
-    this.menuHideTimer = setTimeout(() => {
-      if (!this.openMenu) panel.hidden = true;
+    // Per-panel timer, and the check names THIS panel rather than asking
+    // whether any menu is open: opening a sibling within the fade window
+    // would otherwise leave this one unhidden - invisible, but still
+    // laid out and still swallowing taps.
+    clearTimeout(panel.pcHideTimer);
+    panel.pcHideTimer = setTimeout(() => {
+      if (this.openMenu !== panel.id) panel.hidden = true;
     }, 120);
   },
 
@@ -4967,7 +4973,9 @@ export const PetalDataTable = {
 
   destroyed() {
     clearTimeout(this.searchTimer);
-    clearTimeout(this.menuHideTimer);
+    this.el
+      .querySelectorAll("[data-pc-menu]")
+      .forEach((panel) => clearTimeout(panel.pcHideTimer));
     this.el.removeEventListener("input", this.onInput);
     this.el.removeEventListener("change", this.onChange);
     this.el.removeEventListener("submit", this.onSubmit);

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4774,10 +4774,10 @@ export const PetalDataTable = {
       const form = e.target.closest(".pc-data-table__filter-form");
       if (!form) return;
 
-      // event mode: the form pushes its own phx-submit - only the
-      // popover close is ours
+      // event mode: the form pushes its own phx-submit - only the menu
+      // close is ours
       if (!form.hasAttribute("data-pc-dt-filter")) {
-        this.closePopover(form);
+        this.closeMenu();
         return;
       }
 
@@ -4789,9 +4789,49 @@ export const PetalDataTable = {
       const next = this.readFilter(form, field);
       if (next) filters.push(next);
 
-      this.closePopover(form);
+      this.closeMenu();
       this.patchTo(this.navUrl(filters));
     };
+
+    // -- menus --------------------------------------------------------
+    // The filter and column panels sit NEXT TO their triggers in the
+    // page, not in the browser's top layer. That is the whole trick:
+    // the page moves them together at compositor speed, so scrolling
+    // (including an iOS momentum flick, and the scroll iOS does to
+    // reveal a focused field) can't desync them. There is deliberately
+    // no scroll listener here - nothing to chase, nothing to judder.
+    this.openMenu = null;
+
+    this.onMenuClick = (e) => {
+      const trigger = e.target.closest("[data-pc-menu-trigger]");
+      if (!trigger || !this.el.contains(trigger)) return;
+      e.preventDefault();
+      this.toggleMenu(trigger.getAttribute("data-pc-menu-trigger"));
+    };
+
+    this.onOutside = (e) => {
+      if (!this.openMenu) return;
+      const panel = this.menuPanel();
+      const trigger = this.menuTrigger();
+      if (panel?.contains(e.target) || trigger?.contains(e.target)) return;
+      this.closeMenu();
+    };
+
+    this.onMenuKeydown = (e) => {
+      if (e.key !== "Escape" || !this.openMenu) return;
+      const trigger = this.menuTrigger();
+      this.closeMenu();
+      trigger?.focus();
+    };
+
+    this.onWindowResize = () => {
+      if (this.openMenu) this.alignMenu();
+    };
+
+    this.el.addEventListener("click", this.onMenuClick);
+    this.el.addEventListener("keydown", this.onMenuKeydown);
+    document.addEventListener("pointerdown", this.onOutside, true);
+    window.addEventListener("resize", this.onWindowResize);
 
     this.el.addEventListener("input", this.onInput);
     this.el.addEventListener("change", this.onChange);
@@ -4799,8 +4839,122 @@ export const PetalDataTable = {
     this.syncIndeterminate();
   },
 
+  // id lookups without CSS.escape: ids here come from a developer's
+  // table id and field names, and escaping is one more thing to get
+  // wrong (it is also absent in jsdom, so specs would diverge)
+  menuPanel() {
+    return this.openMenu ? document.getElementById(this.openMenu) : null;
+  },
+
+  menuTrigger() {
+    if (!this.openMenu) return null;
+
+    return (
+      Array.from(this.el.querySelectorAll("[data-pc-menu-trigger]")).find(
+        (button) =>
+          button.getAttribute("data-pc-menu-trigger") === this.openMenu,
+      ) || null
+    );
+  },
+
+  toggleMenu(id) {
+    if (this.openMenu === id) return this.closeMenu();
+    if (this.openMenu) this.closeMenu();
+    this.openMenu = id;
+    this.revealMenu();
+    this.alignMenu();
+  },
+
+  revealMenu() {
+    const panel = this.menuPanel();
+    if (!panel) return;
+    panel.hidden = false;
+    this.menuTrigger()?.setAttribute("aria-expanded", "true");
+    // a frame later so the fade has a start state to move from
+    requestAnimationFrame(() => {
+      if (this.openMenu) this.menuPanel()?.setAttribute("data-pc-open", "");
+    });
+  },
+
+  closeMenu() {
+    const panel = this.menuPanel();
+    this.menuTrigger()?.setAttribute("aria-expanded", "false");
+    this.openMenu = null;
+    if (!panel) return;
+    panel.removeAttribute("data-pc-open");
+    clearTimeout(this.menuHideTimer);
+    this.menuHideTimer = setTimeout(() => {
+      if (!this.openMenu) panel.hidden = true;
+    }, 120);
+  },
+
+  // One-shot geometry, run on open and on resize only. A page-anchored
+  // panel keeps its offset relative to the trigger for free, so this
+  // never needs to run again while the user scrolls.
+  alignMenu() {
+    const panel = this.menuPanel();
+    const trigger = this.menuTrigger();
+    if (!panel || !trigger) return;
+
+    panel.style.transform = "";
+    panel.style.maxHeight = "";
+    panel.removeAttribute("data-pc-flip");
+
+    const vv = window.visualViewport;
+    const view = vv
+      ? {
+          top: vv.offsetTop,
+          left: vv.offsetLeft,
+          width: vv.width,
+          height: vv.height,
+        }
+      : {
+          top: 0,
+          left: 0,
+          width: window.innerWidth,
+          height: window.innerHeight,
+        };
+    const pad = 8;
+
+    const t = trigger.getBoundingClientRect();
+    const below = view.top + view.height - t.bottom;
+    const above = t.top - view.top;
+    let r = panel.getBoundingClientRect();
+
+    if (r.height + pad > below && above > below) {
+      panel.setAttribute("data-pc-flip", "top");
+      r = panel.getBoundingClientRect();
+    }
+
+    // slide sideways into view - true for as long as the panel is open,
+    // because horizontal position relative to the page doesn't change
+    const overRight = r.right - (view.left + view.width - pad);
+    const overLeft = view.left + pad - r.left;
+    const shift = overRight > 0 ? -overRight : overLeft > 0 ? overLeft : 0;
+    if (shift) panel.style.transform = `translateX(${Math.round(shift)}px)`;
+
+    const flipped = panel.getAttribute("data-pc-flip") === "top";
+    const room = (flipped ? above : below) - pad * 2;
+    panel.style.maxHeight = `${Math.max(Math.round(room), 0)}px`;
+    panel.style.overflowY = "auto";
+  },
+
   updated() {
     this.syncIndeterminate();
+
+    // a patch re-renders panels from the server: `hidden` comes back and
+    // the inline offsets this hook owns are dropped
+    if (this.openMenu) {
+      const panel = this.menuPanel();
+      if (panel) {
+        panel.hidden = false;
+        panel.setAttribute("data-pc-open", "");
+        this.menuTrigger()?.setAttribute("aria-expanded", "true");
+        this.alignMenu();
+      } else {
+        this.openMenu = null;
+      }
+    }
   },
 
   // indeterminate is a DOM property, not an attribute - mirror the
@@ -4813,9 +4967,14 @@ export const PetalDataTable = {
 
   destroyed() {
     clearTimeout(this.searchTimer);
+    clearTimeout(this.menuHideTimer);
     this.el.removeEventListener("input", this.onInput);
     this.el.removeEventListener("change", this.onChange);
     this.el.removeEventListener("submit", this.onSubmit);
+    this.el.removeEventListener("click", this.onMenuClick);
+    this.el.removeEventListener("keydown", this.onMenuKeydown);
+    document.removeEventListener("pointerdown", this.onOutside, true);
+    window.removeEventListener("resize", this.onWindowResize);
   },
 
   committedFilters() {
@@ -4849,23 +5008,6 @@ export const PetalDataTable = {
     }
 
     return value === "" ? null : { field, op, value };
-  },
-
-  closePopover(form) {
-    const panel = form.closest(".pc-popover__panel");
-    if (!panel) return;
-    if (
-      panel.hasAttribute("popover") &&
-      typeof panel.hidePopover === "function"
-    ) {
-      // top-layer panels close through the native API, which also
-      // restores focus and light-dismiss state
-      panel.hidePopover();
-      return;
-    }
-    panel.style.display = "none";
-    const trigger = document.getElementById(`${panel.id}-trigger`);
-    if (trigger) trigger.setAttribute("aria-expanded", "false");
   },
 
   // Both placeholders resolve from the live DOM in one pass, so

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -50,7 +50,6 @@ defmodule PetalComponents.DataTable do
   import PetalComponents.Button
   import PetalComponents.Icon
   import PetalComponents.Pagination
-  import PetalComponents.Popover
   import PetalComponents.Skeleton
   import PetalComponents.Table
 
@@ -226,9 +225,10 @@ defmodule PetalComponents.DataTable do
 
     link_mode? = is_nil(assigns.on_change)
 
-    # link mode: URL wiring. Either mode: filter popovers are native
-    # top-layer popovers the hook closes after an Apply, and selection's
-    # tri-state header checkbox needs its indeterminate property set.
+    # link mode: URL wiring. Either mode: the hook drives the filter and
+    # column menus (in-page panels, so the page carries them rather than
+    # JS chasing the scroll) and sets the header checkbox's indeterminate
+    # property, which markup alone cannot express.
     hooked? =
       (link_mode? and (assigns.searchable or assigns.page_size_options != [])) or
         filter_cols != [] or assigns.selectable
@@ -328,34 +328,47 @@ defmodule PetalComponents.DataTable do
             apply_label={@apply_label}
           />
           {render_slot(@toolbar)}
-          <.popover
-            :if={@column_toggle}
-            id={"#{@id}-columns"}
-            top_layer
-            placement="bottom-end"
-            class="pc-data-table__columns"
-            trigger_class="pc-button pc-button--sm pc-button--gray-outline"
-          >
-            <:trigger>
+          <div :if={@column_toggle} class="pc-popover pc-data-table__columns">
+            <button
+              type="button"
+              id={"#{@id}-columns-trigger"}
+              data-pc-menu-trigger={"#{@id}-columns"}
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-controls={"#{@id}-columns"}
+              class="pc-popover__trigger pc-button pc-button--sm pc-button--gray-outline"
+            >
               <.icon name="hero-view-columns" class="pc-data-table__filter-icon" />
               <span>{@column_toggle_label}</span>
-            </:trigger>
-            <div class="pc-data-table__filter-options" role="group" aria-label={@column_toggle_label}>
-              <label :for={col <- @col} class="pc-data-table__filter-option">
-                <input
-                  type="checkbox"
-                  class="pc-checkbox"
-                  checked={to_string(col.field) not in @hidden}
-                  disabled={length(@visible_cols) == 1 and to_string(col.field) not in @hidden}
-                  phx-click={@ui_event}
-                  phx-target={@target}
-                  phx-value-op="toggle_column"
-                  phx-value-field={col.field}
-                />
-                <span>{col[:label] || humanize(col.field)}</span>
-              </label>
+            </button>
+            <div
+              id={"#{@id}-columns"}
+              role="dialog"
+              hidden
+              data-pc-menu
+              class="pc-popover__panel pc-popover__panel--bottom-end"
+            >
+              <div
+                class="pc-data-table__filter-options"
+                role="group"
+                aria-label={@column_toggle_label}
+              >
+                <label :for={col <- @col} class="pc-data-table__filter-option">
+                  <input
+                    type="checkbox"
+                    class="pc-checkbox"
+                    checked={to_string(col.field) not in @hidden}
+                    disabled={length(@visible_cols) == 1 and to_string(col.field) not in @hidden}
+                    phx-click={@ui_event}
+                    phx-target={@target}
+                    phx-value-op="toggle_column"
+                    phx-value-field={col.field}
+                  />
+                  <span>{col[:label] || humanize(col.field)}</span>
+                </label>
+              </div>
             </div>
-          </.popover>
+          </div>
           <%= if @state.filters != [] do %>
             <.button
               :if={@on_change}
@@ -731,41 +744,51 @@ defmodule PetalComponents.DataTable do
 
     ~H"""
     <div class="pc-data-table__filter">
-      <.popover
-        id={@pop_id}
-        top_layer
-        placement="bottom-start"
-        class="pc-data-table__filter-popover"
-        trigger_class={[
-          "pc-button pc-button--sm",
-          (@filter && "pc-button--primary-soft pc-data-table__filter-trigger--active") ||
-            "pc-button--gray-outline"
-        ]}
-      >
-        <:trigger>
+      <div class="pc-popover">
+        <button
+          type="button"
+          id={"#{@pop_id}-trigger"}
+          data-pc-menu-trigger={@pop_id}
+          aria-haspopup="dialog"
+          aria-expanded="false"
+          aria-controls={@pop_id}
+          class={[
+            "pc-popover__trigger pc-button pc-button--sm",
+            (@filter && "pc-button--primary-soft pc-data-table__filter-trigger--active") ||
+              "pc-button--gray-outline"
+          ]}
+        >
           <.icon :if={!@filter} name="hero-funnel" class="pc-data-table__filter-icon" />
           <span>{(@filter && predicate_text(@label, @filter, @op_labels, @options)) || @label}</span>
-        </:trigger>
-        <form
-          class={["pc-data-table__filter-form", "pc-data-table__filter-form--#{@type}"]}
-          phx-submit={@submit_js}
-          data-pc-dt-filter={is_nil(@on_change) || nil}
-          data-field={@field_str}
+        </button>
+        <div
+          id={@pop_id}
+          role="dialog"
+          hidden
+          data-pc-menu
+          class="pc-popover__panel pc-popover__panel--bottom-start"
         >
-          <input :if={@on_change} type="hidden" name="op" value="filter" />
-          <input :if={@on_change} type="hidden" name="field" value={@field_str} />
-          <.filter_editor
-            type={@type}
-            filter={@filter}
-            options={@options}
-            op_labels={@op_labels}
-            label={@label}
-          />
-          <.button size="sm" type="submit" class="pc-data-table__filter-apply">
-            {@apply_label}
-          </.button>
-        </form>
-      </.popover>
+          <form
+            class={["pc-data-table__filter-form", "pc-data-table__filter-form--#{@type}"]}
+            phx-submit={@submit_js}
+            data-pc-dt-filter={is_nil(@on_change) || nil}
+            data-field={@field_str}
+          >
+            <input :if={@on_change} type="hidden" name="op" value="filter" />
+            <input :if={@on_change} type="hidden" name="field" value={@field_str} />
+            <.filter_editor
+              type={@type}
+              filter={@filter}
+              options={@options}
+              op_labels={@op_labels}
+              label={@label}
+            />
+            <.button size="sm" type="submit" class="pc-data-table__filter-apply">
+              {@apply_label}
+            </.button>
+          </form>
+        </div>
+      </div>
       <%= if @filter do %>
         <.link
           :if={@path}
@@ -892,8 +915,7 @@ defmodule PetalComponents.DataTable do
     """
   end
 
-  # event mode pushes the form; the hook closes the native popover on
-  # submit (a top-layer panel needs hidePopover(), not a display toggle)
+  # event mode pushes the form; the hook closes the menu on submit
   defp filter_submit_js(nil, _target, _pop_id), do: nil
 
   defp filter_submit_js(event, target, _pop_id) do

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -287,6 +287,38 @@ describe("PetalDataTable", () => {
     expect(hook.openMenu).toBe("pop");
   });
 
+  it("hides a panel that loses focus to a sibling inside the fade window", () => {
+    const { hook, el, panel, trigger } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `<form class="pc-data-table__filter-form"></form>`,
+    });
+
+    // a second menu in the same table
+    const other = document.createElement("div");
+    other.className = "pc-popover";
+    other.innerHTML = `
+      <button type="button" data-pc-menu-trigger="pop2" aria-expanded="false">Other</button>
+      <div id="pop2" class="pc-popover__panel" data-pc-menu hidden></div>
+    `;
+    el.appendChild(other);
+
+    trigger.click();
+    expect(panel.hidden).toBe(false);
+
+    // switch menus well inside the 120ms fade
+    vi.advanceTimersByTime(40);
+    other.querySelector("button").click();
+    expect(hook.openMenu).toBe("pop2");
+
+    vi.advanceTimersByTime(200);
+
+    // the first panel must be out of the layout, not merely transparent -
+    // an invisible panel still swallows taps
+    expect(panel.hidden).toBe(true);
+    expect(document.getElementById("pop2").hidden).toBe(false);
+  });
+
   it("never repositions on scroll - the page carries the panel", () => {
     const { hook, trigger } = mountWithFilter({
       navTemplate: "/orders?:filters",

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -43,12 +43,27 @@ const mount = mountBase;
 function mountWithFilter({ navTemplate, filters, formHtml }) {
   const { hook, el, patched } = mountBase({ navTemplate });
   if (filters) el.dataset.filters = JSON.stringify(filters);
-  const wrap = document.createElement("div");
-  wrap.className = "pc-popover__panel";
-  wrap.id = "pop";
-  wrap.innerHTML = formHtml;
-  el.appendChild(wrap);
-  return { hook, el, patched, form: wrap.querySelector("form") };
+
+  // the in-page menu anatomy: trigger and panel as siblings under a
+  // relatively positioned wrapper, panel hidden until the hook shows it
+  const anchor = document.createElement("div");
+  anchor.className = "pc-popover";
+  anchor.innerHTML = `
+    <button type="button" data-pc-menu-trigger="pop" aria-expanded="false">Filter</button>
+    <div id="pop" class="pc-popover__panel" data-pc-menu hidden></div>
+  `;
+  el.appendChild(anchor);
+  const panel = anchor.querySelector("#pop");
+  panel.innerHTML = formHtml;
+
+  return {
+    hook,
+    el,
+    patched,
+    panel,
+    trigger: anchor.querySelector("button"),
+    form: panel.querySelector("form"),
+  };
 }
 
 function submit(form) {
@@ -136,7 +151,7 @@ describe("PetalDataTable", () => {
   });
 
   it("filter apply replaces this field's committed entry and closes the popover", () => {
-    const { el, patched, form } = mountWithFilter({
+    const { hook, patched, form } = mountWithFilter({
       navTemplate: "/orders?:filters",
       filters: [
         { field: "email", op: "contains", value: "d" },
@@ -153,6 +168,7 @@ describe("PetalDataTable", () => {
       `,
     });
 
+    hook.toggleMenu("pop");
     submit(form);
 
     expect(patched).toHaveLength(1);
@@ -161,7 +177,7 @@ describe("PetalDataTable", () => {
     expect(url).toContain("filters[1][field]=email");
     expect(url).toContain("filters[1][op]=starts_with");
     expect(url).toContain("filters[1][value]=amy");
-    expect(el.querySelector(".pc-popover__panel").style.display).toBe("none");
+    expect(hook.openMenu).toBe(null);
   });
 
   it("a select editor posts checked values as :in; none checked removes the filter", () => {
@@ -221,47 +237,107 @@ describe("PetalDataTable", () => {
     expect(url).toContain("filters[0][field]=email");
   });
 
-  it("closes a top-layer panel through the native popover API", () => {
-    const { el, patched, form } = mountWithFilter({
+  it("opens and closes a menu from its trigger, and on outside press and Escape", () => {
+    const { hook, panel, trigger } = mountWithFilter({
       navTemplate: "/orders?:filters",
       filters: [],
-      formHtml: `
-        <form class="pc-data-table__filter-form" data-pc-dt-filter data-field="email">
-          <select name="filter_op"><option value="contains" selected>contains</option></select>
-          <input name="value" value="x" />
-        </form>
-      `,
+      formHtml: `<form class="pc-data-table__filter-form"></form>`,
     });
 
-    const panel = el.querySelector(".pc-popover__panel");
-    panel.setAttribute("popover", "auto");
-    const hidden = [];
-    panel.hidePopover = () => hidden.push(true);
+    trigger.click();
+    expect(hook.openMenu).toBe("pop");
+    expect(panel.hidden).toBe(false);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
 
-    submit(form);
-    expect(hidden).toEqual([true]);
-    expect(patched).toHaveLength(1);
+    trigger.click(); // same trigger toggles shut
+    expect(hook.openMenu).toBe(null);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+    trigger.click();
+    document.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    expect(hook.openMenu).toBe(null);
+
+    trigger.click();
+    const escape = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+    });
+    panel.dispatchEvent(escape);
+    expect(hook.openMenu).toBe(null);
+    expect(document.activeElement).toBe(trigger);
   });
 
-  it("event mode: submit only closes the popover - no interception, no navigation", () => {
-    const { el, patched } = mountBase({});
-    delete el.dataset.navTemplate;
-    const wrap = document.createElement("div");
-    wrap.className = "pc-popover__panel";
-    wrap.innerHTML = `
-      <form class="pc-data-table__filter-form" phx-submit="table">
-        <input name="value" value="x" />
-      </form>
-    `;
-    el.appendChild(wrap);
+  it("keeps an open menu open across a patch that restores `hidden`", () => {
+    const { hook, panel, trigger } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `<form class="pc-data-table__filter-form"></form>`,
+    });
 
-    const form = wrap.querySelector("form");
+    trigger.click();
+    expect(panel.hidden).toBe(false);
+
+    // what a LiveView patch does: server markup wins, so `hidden` is back
+    panel.hidden = true;
+    panel.removeAttribute("data-pc-open");
+    hook.updated();
+
+    expect(panel.hidden).toBe(false);
+    expect(panel.hasAttribute("data-pc-open")).toBe(true);
+    expect(hook.openMenu).toBe("pop");
+  });
+
+  it("never repositions on scroll - the page carries the panel", () => {
+    const { hook, trigger } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `<form class="pc-data-table__filter-form"></form>`,
+    });
+
+    trigger.click();
+
+    let aligns = 0;
+    const real = hook.alignMenu.bind(hook);
+    hook.alignMenu = () => {
+      aligns += 1;
+      real();
+    };
+
+    // scroll the world in every way the old implementation listened for
+    window.dispatchEvent(new Event("scroll"));
+    document.dispatchEvent(new Event("scroll", { bubbles: true }));
+    if (window.visualViewport) {
+      window.visualViewport.dispatchEvent?.(new Event("scroll"));
+    }
+
+    // this is the architecture, pinned: nothing recomputes on scroll,
+    // so there is nothing to lag behind the page
+    expect(aligns).toBe(0);
+
+    // a resize is the one thing that does invalidate the geometry
+    window.dispatchEvent(new Event("resize"));
+    expect(aligns).toBe(1);
+  });
+
+  it("event mode: submit closes the menu without intercepting or navigating", () => {
+    const { hook, patched, trigger, form } = mountWithFilter({
+      navTemplate: undefined,
+      filters: [],
+      // no data-pc-dt-filter: event mode posts its own phx-submit
+      formHtml: `<form class="pc-data-table__filter-form" phx-submit="table">
+        <input name="value" value="x" />
+      </form>`,
+    });
+
+    trigger.click();
+    expect(hook.openMenu).toBe("pop");
+
     const e = new Event("submit", { bubbles: true, cancelable: true });
     form.dispatchEvent(e);
 
     expect(e.defaultPrevented).toBe(false);
     expect(patched).toEqual([]);
-    expect(wrap.style.display).toBe("none");
+    expect(hook.openMenu).toBe(null);
   });
 
   it("mirrors the indeterminate stamp onto the DOM property on mount and update", () => {

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -112,7 +112,12 @@ defmodule PetalComponents.DataTableTest do
     # only to close top-layer popovers - no URL wiring
     assert html =~ ~s(name="op" value="filter")
     assert html =~ ~s(phx-hook="PetalDataTable")
-    assert html =~ ~s(popover="auto")
+    # in-page menu anatomy: trigger and panel are siblings under a
+    # relatively positioned wrapper, so the page carries them together
+    assert html =~ ~s(data-pc-menu-trigger="t-filter-email")
+    assert html =~ ~s(<div class="pc-popover">)
+    assert html =~ ~s(hidden data-pc-menu)
+    refute html =~ ~s(popover="auto")
     refute html =~ "data-nav-template"
     refute html =~ "data-filters="
   end


### PR DESCRIPTION
Nic, after a third round of mobile jitter: *"I don't understand why the panel can't be fixed/anchored to the button intelligently?"* He's right, and the top layer is what made it impossible.

## Why it kept failing
A `popover` in the browser's **top layer** is positioned against the **viewport**. Its trigger lives in the **page**. Two coordinate systems, so JS must re-sync them on every scroll event — and JS runs *after* the browser has painted that frame. On iOS it's worse: Safari frequently doesn't repaint fixed/top-layer content during a momentum flick at all, then snaps it at the end. The rAF throttling, `visualViewport` maths and clamping rules were all tuning a fight that can't be won.

## What it does now
The filter and column panels are absolutely positioned **next to their triggers**, inside a relatively positioned wrapper — ordinary page content. The browser moves panel and trigger together at compositor speed, so scrolling, momentum flicks, and the scroll iOS performs to reveal a focused field cannot desync them. **There is no scroll listener left in the data table.**

One-shot geometry remains, on open and resize only: flip above when the room below runs out, slide sideways to stay on screen, cap the height to the room and scroll. None of it re-runs during scrolling because a page-anchored panel keeps its offset for free.

The `PetalDataTable` hook owns menu state — open/close, outside press, Escape with focus return, close on apply — and re-asserts it in `updated()`, because a patch restores the server's `hidden` attribute (the same reason position needed re-asserting before).

`<.popover top_layer>` is untouched and remains the right tool for panels that must escape a clipping container, with the scroll-sync cost that implies.

## Verification
845 Elixir / 127 JS, including a spec that pins the architecture itself: after opening a menu, scroll events must produce **zero** geometry passes (a resize still produces one).

Driven in a real browser at 375px, sampling **synchronously with no frame for the page to catch up** — the measurement that exposes drift:

| scrollTop | 0 | 37 | 91 | 158 | 240 | 333 |
|---|---|---|---|---|---|---|
| gap to trigger | 8 | 8 | 8 | 8 | 8 | 8 |

Also verified: flip-above under a keyboard-sized strip (panel 277–433 above a trigger at 441, entirely inside the strip); the right-edge Amount trigger sliding into view (41–299); the columns menu surviving its own patch with the column disappearing; outside-press, Escape (focus returns to trigger) and apply-closes; and `offsetParent` confirming the panel is page content rather than top layer.