### PR TITLE
fix(data_table): dismiss menus on a tap outside, not a press outside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 #### Fixed
 
+- **A drag on the page no longer dismisses an open `data_table` menu.**
+  Dismissal was firing on pointer*down* outside, so the ordinary way
+  anyone scrolls a phone - press the page and drag - killed the menu
+  before it moved. It now takes a *tap*: press and release must both
+  land outside, within a small movement slop, and a gesture the browser
+  hands to the scroller (which cancels rather than releases) leaves the
+  menu alone. This mirrors the native popover's own light-dismiss.
 - **`data_table` filter and column menus live in the page, not the
   browser's top layer.** A top-layer panel is positioned against the
   viewport while its trigger sits in the page, so JavaScript had to

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4818,12 +4818,18 @@ export const PetalDataTable = {
     // Per pointer, because fingers come in twos: a pinch or two-finger
     // scroll would otherwise have one finger overwrite the other's press
     // record, or one finger's cancel disarm the other's tap.
+    // `active` is EVERY pointer currently down, `presses` only the ones
+    // that started outside. Tracking both matters: a finger resting
+    // inside the panel is invisible to `presses`, and without it a
+    // second finger tapping outside would look like a lone clean tap.
+    this.active = new Set();
     this.presses = new Map();
     this.multiTouch = false;
 
     this.onPressStart = (e) => {
       if (!this.openMenu) return;
-      if (this.presses.size > 0) this.multiTouch = true;
+      this.active.add(e.pointerId);
+      if (this.active.size > 1) this.multiTouch = true;
       if (this.isOutsideMenu(e.target)) {
         this.presses.set(e.pointerId, { x: e.clientX, y: e.clientY });
       }
@@ -4832,9 +4838,10 @@ export const PetalDataTable = {
     this.onPressEnd = (e) => {
       const press = this.presses.get(e.pointerId);
       this.presses.delete(e.pointerId);
+      this.active.delete(e.pointerId);
 
       const gesture = this.multiTouch;
-      if (this.presses.size === 0) this.multiTouch = false;
+      if (this.active.size === 0) this.multiTouch = false;
       if (!press || gesture || !this.openMenu) return;
 
       // a release far from the press is a drag, not a tap - iOS uses a
@@ -4845,7 +4852,8 @@ export const PetalDataTable = {
 
     this.onPressCancel = (e) => {
       this.presses.delete(e.pointerId);
-      if (this.presses.size === 0) this.multiTouch = false;
+      this.active.delete(e.pointerId);
+      if (this.active.size === 0) this.multiTouch = false;
     };
 
     this.onMenuKeydown = (e) => {
@@ -5026,6 +5034,7 @@ export const PetalDataTable = {
     document.removeEventListener("pointercancel", this.onPressCancel, true);
     window.removeEventListener("resize", this.onWindowResize);
     this.presses?.clear();
+    this.active?.clear();
   },
 
   committedFilters() {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4809,12 +4809,32 @@ export const PetalDataTable = {
       this.toggleMenu(trigger.getAttribute("data-pc-menu-trigger"));
     };
 
-    this.onOutside = (e) => {
-      if (!this.openMenu) return;
-      const panel = this.menuPanel();
-      const trigger = this.menuTrigger();
-      if (panel?.contains(e.target) || trigger?.contains(e.target)) return;
-      this.closeMenu();
+    // Dismiss on a TAP outside, not a press outside. Closing on
+    // pointerdown means a drag that starts on the page - the ordinary
+    // way anyone scrolls a phone - kills the menu before it moves. The
+    // native popover's light dismiss has the same shape: press and
+    // release must both land outside, and a gesture that turns into a
+    // scroll never releases (it cancels).
+    this.onPressStart = (e) => {
+      this.press =
+        this.openMenu && this.isOutsideMenu(e.target)
+          ? { x: e.clientX, y: e.clientY }
+          : null;
+    };
+
+    this.onPressEnd = (e) => {
+      const press = this.press;
+      this.press = null;
+      if (!press || !this.openMenu) return;
+
+      // a release far from the press is a drag, not a tap - iOS uses a
+      // comparable slop before it commits to "this was a tap"
+      const dragged = Math.hypot(e.clientX - press.x, e.clientY - press.y) > 10;
+      if (!dragged && this.isOutsideMenu(e.target)) this.closeMenu();
+    };
+
+    this.onPressCancel = () => {
+      this.press = null;
     };
 
     this.onMenuKeydown = (e) => {
@@ -4830,7 +4850,9 @@ export const PetalDataTable = {
 
     this.el.addEventListener("click", this.onMenuClick);
     this.el.addEventListener("keydown", this.onMenuKeydown);
-    document.addEventListener("pointerdown", this.onOutside, true);
+    document.addEventListener("pointerdown", this.onPressStart, true);
+    document.addEventListener("pointerup", this.onPressEnd, true);
+    document.addEventListener("pointercancel", this.onPressCancel, true);
     window.addEventListener("resize", this.onWindowResize);
 
     this.el.addEventListener("input", this.onInput);
@@ -4842,6 +4864,13 @@ export const PetalDataTable = {
   // id lookups without CSS.escape: ids here come from a developer's
   // table id and field names, and escaping is one more thing to get
   // wrong (it is also absent in jsdom, so specs would diverge)
+  isOutsideMenu(target) {
+    const panel = this.menuPanel();
+    const trigger = this.menuTrigger();
+
+    return !panel?.contains(target) && !trigger?.contains(target);
+  },
+
   menuPanel() {
     return this.openMenu ? document.getElementById(this.openMenu) : null;
   },
@@ -4981,7 +5010,9 @@ export const PetalDataTable = {
     this.el.removeEventListener("submit", this.onSubmit);
     this.el.removeEventListener("click", this.onMenuClick);
     this.el.removeEventListener("keydown", this.onMenuKeydown);
-    document.removeEventListener("pointerdown", this.onOutside, true);
+    document.removeEventListener("pointerdown", this.onPressStart, true);
+    document.removeEventListener("pointerup", this.onPressEnd, true);
+    document.removeEventListener("pointercancel", this.onPressCancel, true);
     window.removeEventListener("resize", this.onWindowResize);
   },
 

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4815,17 +4815,27 @@ export const PetalDataTable = {
     // native popover's light dismiss has the same shape: press and
     // release must both land outside, and a gesture that turns into a
     // scroll never releases (it cancels).
+    // Per pointer, because fingers come in twos: a pinch or two-finger
+    // scroll would otherwise have one finger overwrite the other's press
+    // record, or one finger's cancel disarm the other's tap.
+    this.presses = new Map();
+    this.multiTouch = false;
+
     this.onPressStart = (e) => {
-      this.press =
-        this.openMenu && this.isOutsideMenu(e.target)
-          ? { x: e.clientX, y: e.clientY }
-          : null;
+      if (!this.openMenu) return;
+      if (this.presses.size > 0) this.multiTouch = true;
+      if (this.isOutsideMenu(e.target)) {
+        this.presses.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      }
     };
 
     this.onPressEnd = (e) => {
-      const press = this.press;
-      this.press = null;
-      if (!press || !this.openMenu) return;
+      const press = this.presses.get(e.pointerId);
+      this.presses.delete(e.pointerId);
+
+      const gesture = this.multiTouch;
+      if (this.presses.size === 0) this.multiTouch = false;
+      if (!press || gesture || !this.openMenu) return;
 
       // a release far from the press is a drag, not a tap - iOS uses a
       // comparable slop before it commits to "this was a tap"
@@ -4833,8 +4843,9 @@ export const PetalDataTable = {
       if (!dragged && this.isOutsideMenu(e.target)) this.closeMenu();
     };
 
-    this.onPressCancel = () => {
-      this.press = null;
+    this.onPressCancel = (e) => {
+      this.presses.delete(e.pointerId);
+      if (this.presses.size === 0) this.multiTouch = false;
     };
 
     this.onMenuKeydown = (e) => {
@@ -5014,6 +5025,7 @@ export const PetalDataTable = {
     document.removeEventListener("pointerup", this.onPressEnd, true);
     document.removeEventListener("pointercancel", this.onPressCancel, true);
     window.removeEventListener("resize", this.onWindowResize);
+    this.presses?.clear();
   },
 
   committedFilters() {

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -348,6 +348,29 @@ describe("PetalDataTable", () => {
     expect(hook.openMenu).toBe(null);
   });
 
+  it("does not dismiss while a finger is still resting inside the panel", () => {
+    const { hook, panel, trigger } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `<form class="pc-data-table__filter-form"></form>`,
+    });
+
+    trigger.click();
+
+    // one finger held inside the panel, a second taps the page
+    pointer("pointerdown", panel, 150, 500, 1);
+    pointer("pointerdown", document.body, 40, 40, 2);
+    pointer("pointerup", document.body, 40, 40, 2);
+    expect(hook.openMenu).toBe("pop");
+
+    pointer("pointerup", panel, 150, 500, 1);
+    expect(hook.openMenu).toBe("pop");
+
+    // with every finger lifted, a plain tap dismisses again
+    tapOutside(40, 40);
+    expect(hook.openMenu).toBe(null);
+  });
+
   it("does not dismiss when a press outside releases inside the panel", () => {
     const { hook, panel, trigger } = mountWithFilter({
       navTemplate: "/orders?:filters",

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -68,10 +68,11 @@ function mountWithFilter({ navTemplate, filters, formHtml }) {
 
 // pointer gestures: jsdom has no PointerEvent, but a MouseEvent named
 // "pointerdown"/"pointerup" carries the clientX/Y the hook reads
-function pointer(type, target, x = 0, y = 0) {
-  target.dispatchEvent(
-    new MouseEvent(type, { bubbles: true, clientX: x, clientY: y }),
-  );
+function pointer(type, target, x = 0, y = 0, pointerId = 1) {
+  const event = new MouseEvent(type, { bubbles: true, clientX: x, clientY: y });
+  // jsdom's MouseEvent has no pointerId, and the hook keys presses by it
+  Object.defineProperty(event, "pointerId", { value: pointerId });
+  target.dispatchEvent(event);
 }
 
 function tapOutside(x = 5, y = 5) {
@@ -320,6 +321,29 @@ describe("PetalDataTable", () => {
     expect(hook.openMenu).toBe("pop");
 
     // and a real tap still dismisses
+    tapOutside(100, 400);
+    expect(hook.openMenu).toBe(null);
+  });
+
+  it("ignores multi-finger gestures outside the panel", () => {
+    const { hook, trigger } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `<form class="pc-data-table__filter-form"></form>`,
+    });
+
+    trigger.click();
+
+    // a pinch: two fingers land, both lift roughly where they started
+    pointer("pointerdown", document.body, 100, 400, 1);
+    pointer("pointerdown", document.body, 200, 400, 2);
+    pointer("pointerup", document.body, 100, 401, 1);
+    pointer("pointerup", document.body, 200, 401, 2);
+    expect(hook.openMenu).toBe("pop");
+
+    // one finger cancelling must not disarm a later single-finger tap
+    pointer("pointerdown", document.body, 100, 400, 3);
+    pointer("pointercancel", document.body, 100, 400, 3);
     tapOutside(100, 400);
     expect(hook.openMenu).toBe(null);
   });

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -66,6 +66,19 @@ function mountWithFilter({ navTemplate, filters, formHtml }) {
   };
 }
 
+// pointer gestures: jsdom has no PointerEvent, but a MouseEvent named
+// "pointerdown"/"pointerup" carries the clientX/Y the hook reads
+function pointer(type, target, x = 0, y = 0) {
+  target.dispatchEvent(
+    new MouseEvent(type, { bubbles: true, clientX: x, clientY: y }),
+  );
+}
+
+function tapOutside(x = 5, y = 5) {
+  pointer("pointerdown", document.body, x, y);
+  pointer("pointerup", document.body, x, y);
+}
+
 function submit(form) {
   form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
 }
@@ -254,7 +267,7 @@ describe("PetalDataTable", () => {
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
 
     trigger.click();
-    document.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    tapOutside();
     expect(hook.openMenu).toBe(null);
 
     trigger.click();
@@ -284,6 +297,43 @@ describe("PetalDataTable", () => {
 
     expect(panel.hidden).toBe(false);
     expect(panel.hasAttribute("data-pc-open")).toBe(true);
+    expect(hook.openMenu).toBe("pop");
+  });
+
+  it("survives a drag on the page - only a tap outside dismisses", () => {
+    const { hook, trigger } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `<form class="pc-data-table__filter-form"></form>`,
+    });
+
+    // dragging the page to scroll it: press outside, move, release far away
+    trigger.click();
+    pointer("pointerdown", document.body, 100, 400);
+    pointer("pointerup", document.body, 100, 180);
+    expect(hook.openMenu).toBe("pop");
+
+    // a gesture the browser hands to the scroller never releases at all
+    pointer("pointerdown", document.body, 100, 400);
+    pointer("pointercancel", document.body, 100, 400);
+    pointer("pointerup", document.body, 100, 120);
+    expect(hook.openMenu).toBe("pop");
+
+    // and a real tap still dismisses
+    tapOutside(100, 400);
+    expect(hook.openMenu).toBe(null);
+  });
+
+  it("does not dismiss when a press outside releases inside the panel", () => {
+    const { hook, panel, trigger } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `<form class="pc-data-table__filter-form"></form>`,
+    });
+
+    trigger.click();
+    pointer("pointerdown", document.body, 10, 10);
+    pointer("pointerup", panel, 10, 10);
     expect(hook.openMenu).toBe("pop");
   });
 


### PR DESCRIPTION
Nic on iOS: with a filter menu open, touching the page to drag-scroll closes it instantly — so you can't move the page while keeping the menu open.

**Cause:** dismissal fired on pointer**down** outside, and a scroll gesture starts with exactly that.

**Fix:** require a *tap*, which is what the browser's own native light-dismiss does — the press and the release must both land outside before it counts. Concretely:

- `pointerdown` outside records the press position.
- `pointerup` outside dismisses only if the pointer barely moved (10px, comparable to the platform's own tap slop).
- `pointercancel` abandons the sequence — and a gesture the browser hands to the scroller cancels rather than releases, so scrolling never dismisses.
- Pressing outside and releasing *inside* the panel doesn't dismiss either.

**Verified** — 130 JS / 845 Elixir, with three new specs (drag, cancelled gesture, release-inside). In a real browser with genuine `PointerEvent`s: a 300px drag leaves the menu open, a cancelled gesture leaves it open, a tap closes it.