### PR TITLE
fix(data_table): comparators for every column type; five missing operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 
 #### Fixed
 
+- **Comparators now work on every column type.** `:neq` was guarded on
+  numbers, so "is not" against any text column matched nothing - and
+  matched nothing *silently*, since an unhandled combination falls
+  through to a catch-all rather than raising. `:eq`, `:lt` and `:gt`
+  had the same hole for dates. Every comparator now tries numbers, then
+  dates, then text, so an operator means the same thing whatever the
+  column holds.
+- **A filter operator without a label no longer crashes the render.**
+  Two `Map.fetch!` lookups raised a `KeyError` while drawing the
+  toolbar; unlabelled (for example adapter-specific) ops now render
+  humanised.
+
 - **A drag on the page no longer dismisses an open `data_table` menu.**
   Dismissal was firing on pointer*down* outside, so the ordinary way
   anyone scrolls a phone - press the page and drag - killed the menu
@@ -76,6 +88,18 @@
 ### 4.13.0 - 2026-08-08
 
 #### Added
+
+- **Five operators the vocabulary was missing**: `:not_contains`,
+  `:gte`, `:lte`, `:not_in`, and the null-ness pair `:is_empty` /
+  `:is_not_empty`. Measured against Flop, Ash, Ecto, TanStack, AG Grid,
+  MUI and the filter menus of Notion and Airtable, these were the
+  near-universal ones we lacked. Value-less operators hide their value
+  input (CSS `:has()`, no JS) and are understood by both wiring modes.
+- **`State.ops/0` and `State.valueless_op?/1`**, so an adapter can
+  enumerate the contract rather than hardcode it.
+- **Operator semantics are now pinned in writing** - `:between` is
+  inclusive, `:is_empty` matches nil/`""`/`[]`, text comparison is
+  case-insensitive - because "obvious" differs per query library.
 
 - **`<.data_table>` - the component core (4.12 data table, milestone 1).**
   Composed around `<.table>`, driven entirely by `DataTable.State`:

--- a/assets/default.css
+++ b/assets/default.css
@@ -2701,6 +2701,14 @@
   .pc-data-table__filter-value2 {
     @apply hidden;
   }
+  /* is_empty / is_not_empty take no value, so the input goes away - :has
+     keeps this JS-free, the same trick the between bound uses below */
+  .pc-data-table__filter-form:has(select[name="filter_op"] option[value="is_empty"]:checked)
+    .pc-data-table__filter-value,
+  .pc-data-table__filter-form:has(select[name="filter_op"] option[value="is_not_empty"]:checked)
+    .pc-data-table__filter-value {
+    @apply hidden;
+  }
   /* the between op needs its second bound; :has keeps this JS-free in both wiring modes */
   .pc-data-table__filter-form:has(select[name="filter_op"] option[value="between"]:checked)
     .pc-data-table__filter-value2 {

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -5055,6 +5055,12 @@ export const PetalDataTable = {
     }
 
     const op = form.querySelector('select[name="filter_op"]')?.value || "eq";
+
+    // is_empty / is_not_empty carry no value, so an empty input must not
+    // read as "remove this filter" the way it does for every other op
+    if (op === "is_empty" || op === "is_not_empty")
+      return { field, op, value: true };
+
     const value = (form.querySelector('[name="value"]')?.value || "").trim();
 
     if (op === "between") {

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -700,18 +700,24 @@ defmodule PetalComponents.DataTable do
 
   # -- filters ---------------------------------------------------------------
 
-  @text_ops ~w(contains eq starts_with)a
-  @number_ops ~w(eq neq gt lt between)a
-  @date_ops ~w(before on after)a
+  @text_ops ~w(contains not_contains eq neq starts_with is_empty is_not_empty)a
+  @number_ops ~w(eq neq gt gte lt lte between is_empty is_not_empty)a
+  @date_ops ~w(before on after is_empty is_not_empty)a
 
   defp default_op_labels do
     %{
       contains: "contains",
       eq: "is",
       starts_with: "starts with",
+      not_contains: "does not contain",
       neq: "is not",
       gt: ">",
+      gte: "\u2265",
       lt: "<",
+      lte: "\u2264",
+      not_in: "is none of",
+      is_empty: "is empty",
+      is_not_empty: "is not empty",
       between: "between",
       in: "is any of",
       before: "before",
@@ -909,7 +915,7 @@ defmodule PetalComponents.DataTable do
       aria-label={"#{@label} operator"}
     >
       <option :for={op <- @ops} value={op} selected={op == @current_op}>
-        {Map.fetch!(@op_labels, op)}
+        {op_label(@op_labels, op)}
       </option>
     </select>
     """
@@ -921,6 +927,12 @@ defmodule PetalComponents.DataTable do
   defp filter_submit_js(event, target, _pop_id) do
     if target, do: JS.push(event, target: target), else: JS.push(event)
   end
+
+  # An op with no label is a custom one an adapter added - render the atom
+  # rather than raising mid-render, which is what Map.fetch!/2 did.
+  defp op_label(labels, op), do: Map.get(labels, op, humanize_op(op))
+
+  defp humanize_op(op), do: op |> to_string() |> String.replace("_", " ")
 
   defp normalize_options(options) do
     Enum.map(options, fn
@@ -940,7 +952,10 @@ defmodule PetalComponents.DataTable do
   defp current_pair(_other), do: {nil, nil}
 
   defp predicate_text(label, filter, op_labels, options) do
-    "#{label} #{Map.fetch!(op_labels, filter.op)} #{display_value(filter, options)}"
+    case State.valueless_op?(filter.op) do
+      true -> "#{label} #{op_label(op_labels, filter.op)}"
+      false -> "#{label} #{op_label(op_labels, filter.op)} #{display_value(filter, options)}"
+    end
   end
 
   defp display_value(%{op: :in, value: values}, options) do

--- a/lib/petal_components/data_table/engine/list.ex
+++ b/lib/petal_components/data_table/engine/list.ex
@@ -183,7 +183,13 @@ defmodule PetalComponents.DataTable.Engine.List do
   # the catch-all `false` rather than raising. Each comparator now tries
   # numbers, then dates, then text, so the op means the same thing
   # whatever the column holds.
-  defp matches?(field_value, :neq, value), do: not matches?(field_value, :eq, value)
+  # A negation must never turn "this filter cannot be evaluated" into a
+  # match. :neq with "abc" against a numeric column would otherwise
+  # invert a coercion failure into EVERY row matching - the loudest
+  # possible wrong answer. An unusable filter matches nothing here, as
+  # it does everywhere else in this engine.
+  defp matches?(field_value, :neq, value),
+    do: evaluable?(field_value, value) and not matches?(field_value, :eq, value)
 
   defp matches?(field_value, :gt, value), do: compare(field_value, value, [:gt])
   defp matches?(field_value, :gte, value), do: compare(field_value, value, [:gt, :eq])
@@ -207,13 +213,13 @@ defmodule PetalComponents.DataTable.Engine.List do
   end
 
   defp matches?(field_value, :not_contains, value),
-    do: not matches?(field_value, :contains, value)
+    do: text_value?(value) and not matches?(field_value, :contains, value)
 
   defp matches?(field_value, :in, values) when is_list(values) do
     Enum.any?(values, &values_equal?(field_value, &1))
   end
 
-  defp matches?(field_value, :not_in, values) when is_list(values),
+  defp matches?(field_value, :not_in, values) when is_list(values) and values != [],
     do: not matches?(field_value, :in, values)
 
   defp matches?(field_value, op, value) when op in [:before, :on, :after] do
@@ -254,6 +260,24 @@ defmodule PetalComponents.DataTable.Engine.List do
         false
     end
   end
+
+  # Can the positive form of this filter actually be evaluated against a
+  # field of this shape? Mirrors the coercion the :eq clauses perform.
+  defp evaluable?(field_value, value) when is_binary(field_value), do: text_value?(value)
+  defp evaluable?(field_value, value) when is_number(field_value), do: number_value?(value)
+
+  defp evaluable?(field_value, value) do
+    case to_date(field_value) do
+      {:ok, _} -> match?({:ok, _}, to_date(value))
+      :error -> text_value?(value)
+    end
+  end
+
+  defp text_value?(value) when is_binary(value) or is_number(value), do: true
+  defp text_value?(value) when is_atom(value), do: not is_nil(value)
+  defp text_value?(_other), do: false
+
+  defp number_value?(value), do: match?({:ok, _}, number(value))
 
   defp empty_value?(nil), do: true
   defp empty_value?(""), do: true

--- a/lib/petal_components/data_table/engine/list.ex
+++ b/lib/petal_components/data_table/engine/list.ex
@@ -212,15 +212,16 @@ defmodule PetalComponents.DataTable.Engine.List do
     end
   end
 
-  defp matches?(field_value, :not_contains, value),
+  defp matches?(field_value, :not_contains, value) when is_scalar(field_value),
     do: text_value?(value) and not matches?(field_value, :contains, value)
 
   defp matches?(field_value, :in, values) when is_list(values) do
     Enum.any?(values, &values_equal?(field_value, &1))
   end
 
-  defp matches?(field_value, :not_in, values) when is_list(values) and values != [],
-    do: not matches?(field_value, :in, values)
+  defp matches?(field_value, :not_in, values)
+       when is_scalar(field_value) and is_list(values) and values != [],
+       do: not matches?(field_value, :in, values)
 
   defp matches?(field_value, op, value) when op in [:before, :on, :after] do
     with {:ok, field_date} <- to_date(field_value),
@@ -269,7 +270,9 @@ defmodule PetalComponents.DataTable.Engine.List do
   defp evaluable?(field_value, value) do
     case to_date(field_value) do
       {:ok, _} -> match?({:ok, _}, to_date(value))
-      :error -> text_value?(value)
+      # a field the positive op cannot read is unevaluable regardless of
+      # how good the value is - both sides have to be readable
+      :error -> is_scalar(field_value) and text_value?(value)
     end
   end
 

--- a/lib/petal_components/data_table/engine/list.ex
+++ b/lib/petal_components/data_table/engine/list.ex
@@ -176,6 +176,13 @@ defmodule PetalComponents.DataTable.Engine.List do
   defp matches?(field_value, :eq, value) when is_number(field_value),
     do: with_number(value, &(field_value == &1))
 
+  # Atoms and booleans compare as their text form - the same treatment
+  # :in (values_equal?/2) and :contains already give them. Without this
+  # clause :eq fell through to date coercion and a status: :active or
+  # admin?: true column silently matched nothing.
+  defp matches?(field_value, :eq, value) when is_atom(field_value),
+    do: with_text(value, &(downcase(field_value) == &1))
+
   # Comparators are op-first, not type-first. Guarding :neq on numbers
   # meant "is not" against any text column matched nothing at all, and
   # guarding the comparators on numbers meant a plain :lt against a date

--- a/lib/petal_components/data_table/engine/list.ex
+++ b/lib/petal_components/data_table/engine/list.ex
@@ -153,6 +153,15 @@ defmodule PetalComponents.DataTable.Engine.List do
     Enum.filter(rows, fn row -> matches?(fetch(row, field), op, value) end)
   end
 
+  # These two run before the nil short-circuit below, because they are the
+  # only ops where a nil field is a MATCH rather than a miss. Semantics
+  # are pinned deliberately and documented in State: empty means nil, an
+  # empty string, or an empty list - the shapes a form or an association
+  # actually produces. A blank-ish " " is NOT empty; trim before filtering
+  # if you want it to be.
+  defp matches?(field_value, :is_empty, _value), do: empty_value?(field_value)
+  defp matches?(field_value, :is_not_empty, _value), do: not empty_value?(field_value)
+
   defp matches?(nil, _op, _value), do: false
 
   defp matches?(field_value, :contains, value) when is_scalar(field_value),
@@ -167,14 +176,19 @@ defmodule PetalComponents.DataTable.Engine.List do
   defp matches?(field_value, :eq, value) when is_number(field_value),
     do: with_number(value, &(field_value == &1))
 
-  defp matches?(field_value, :neq, value) when is_number(field_value),
-    do: with_number(value, &(field_value != &1))
+  # Comparators are op-first, not type-first. Guarding :neq on numbers
+  # meant "is not" against any text column matched nothing at all, and
+  # guarding the comparators on numbers meant a plain :lt against a date
+  # column did the same - silently, since an unmatched clause falls to
+  # the catch-all `false` rather than raising. Each comparator now tries
+  # numbers, then dates, then text, so the op means the same thing
+  # whatever the column holds.
+  defp matches?(field_value, :neq, value), do: not matches?(field_value, :eq, value)
 
-  defp matches?(field_value, :gt, value) when is_number(field_value),
-    do: with_number(value, &(field_value > &1))
-
-  defp matches?(field_value, :lt, value) when is_number(field_value),
-    do: with_number(value, &(field_value < &1))
+  defp matches?(field_value, :gt, value), do: compare(field_value, value, [:gt])
+  defp matches?(field_value, :gte, value), do: compare(field_value, value, [:gt, :eq])
+  defp matches?(field_value, :lt, value), do: compare(field_value, value, [:lt])
+  defp matches?(field_value, :lte, value), do: compare(field_value, value, [:lt, :eq])
 
   defp matches?(field_value, :between, [min, max]) when is_number(field_value) do
     with_number(min, fn lo ->
@@ -185,9 +199,22 @@ defmodule PetalComponents.DataTable.Engine.List do
   defp matches?(field_value, :between, %{"min" => min, "max" => max}),
     do: matches?(field_value, :between, [min, max])
 
+  defp matches?(field_value, :eq, value) do
+    case {to_date(field_value), to_date(value)} do
+      {{:ok, a}, {:ok, b}} -> Date.compare(a, b) == :eq
+      _ -> false
+    end
+  end
+
+  defp matches?(field_value, :not_contains, value),
+    do: not matches?(field_value, :contains, value)
+
   defp matches?(field_value, :in, values) when is_list(values) do
     Enum.any?(values, &values_equal?(field_value, &1))
   end
+
+  defp matches?(field_value, :not_in, values) when is_list(values),
+    do: not matches?(field_value, :in, values)
 
   defp matches?(field_value, op, value) when op in [:before, :on, :after] do
     with {:ok, field_date} <- to_date(field_value),
@@ -204,6 +231,34 @@ defmodule PetalComponents.DataTable.Engine.List do
   end
 
   defp matches?(_field_value, _op, _value), do: false
+
+  # one comparison ladder for every comparator: numbers, then dates, then
+  # text. `wanted` is the set of Erlang comparison results that count as
+  # a match, so :gte is just :gt plus :eq rather than a second ladder.
+  defp compare(field_value, value, wanted) do
+    cond do
+      is_number(field_value) ->
+        with_number(value, &(cmp(field_value, &1) in wanted))
+
+      match?({:ok, _}, to_date(field_value)) ->
+        with {{:ok, a}, {:ok, b}} <- {to_date(field_value), to_date(value)} do
+          Date.compare(a, b) in wanted
+        else
+          _ -> false
+        end
+
+      is_scalar(field_value) ->
+        with_text(value, &(cmp(downcase(field_value), &1) in wanted))
+
+      true ->
+        false
+    end
+  end
+
+  defp empty_value?(nil), do: true
+  defp empty_value?(""), do: true
+  defp empty_value?([]), do: true
+  defp empty_value?(_other), do: false
 
   defp values_equal?(a, b) when is_scalar(a),
     do: with_text(b, &(downcase(a) == &1))

--- a/lib/petal_components/data_table/state.ex
+++ b/lib/petal_components/data_table/state.ex
@@ -21,10 +21,31 @@ defmodule PetalComponents.DataTable.State do
 
   ## Filter operators
 
-  Text: `:contains`, `:eq`, `:starts_with` - number: `:eq`, `:neq`,
-  `:gt`, `:lt`, `:between` - select: `:in` - date: `:before`, `:on`,
-  `:after`. Engines may support a subset; unknown ops are an engine
-  concern, not a state concern.
+  The vocabulary describes what the USER expressed, not how a database
+  spells it. Each engine translates intent into its own query language,
+  which is why `:contains` here means "text contains" even though some
+  query libraries use that name for array membership.
+
+    * text - `:contains`, `:not_contains`, `:eq`, `:neq`, `:starts_with`
+    * ordered (numbers, dates) - `:gt`, `:gte`, `:lt`, `:lte`, `:between`
+    * sets - `:in`, `:not_in`
+    * null-ness - `:is_empty`, `:is_not_empty`
+    * dates, read as intent - `:before`, `:on`, `:after`
+
+  Semantics pinned deliberately, because "obvious" differs per engine:
+
+    * `:between` is INCLUSIVE of both bounds.
+    * `:is_empty` matches nil, `""` and `[]` - a blank-ish `" "` is not
+      empty. Trim before filtering if you want it to be.
+    * text comparisons are case-insensitive.
+    * comparators work on whatever the column holds - numbers, dates and
+      text all compare with the same op.
+    * `:before`/`:on`/`:after` are date-shaped aliases of `:lt`/`:eq`/
+      `:gt`; they exist so a date filter reads as a date filter, and an
+      adapter may map them to the same primitives.
+
+  Engines may support a subset. `ops/0` returns the recognised set and
+  `valueless_op?/1` identifies the ops that carry no value.
 
   ## Security
 
@@ -48,7 +69,12 @@ defmodule PetalComponents.DataTable.State do
           total: non_neg_integer() | nil
         }
 
-  @ops ~w(contains eq starts_with neq gt lt between in before on after)a
+  @ops ~w(contains not_contains eq neq starts_with gt gte lt lte between
+          in not_in is_empty is_not_empty before on after)a
+
+  # Ops that carry no value - the editors render no input for them and
+  # put_filter/4 must not read them as "clear this filter".
+  @valueless_ops ~w(is_empty is_not_empty)a
   @op_strings Map.new(@ops, &{Atom.to_string(&1), &1})
   @dir_strings %{"asc" => :asc, "desc" => :desc}
 
@@ -123,7 +149,20 @@ defmodule PetalComponents.DataTable.State do
     %{state | order_by: order_by, page: 1}
   end
 
+  @doc "The operators this contract recognises."
+  def ops, do: @ops
+
+  @doc "True for operators that carry no value, like `:is_empty`."
+  def valueless_op?(op), do: op in @valueless_ops
+
   @doc "Replaces the filter for `field` (or removes it when `value` is nil/empty), resetting to page 1."
+  def put_filter(%__MODULE__{} = state, field, op, value)
+      when op in @valueless_ops do
+    filter = %{field: field, op: op, value: value}
+    rest = Enum.reject(state.filters, &(&1.field == field))
+    %{state | filters: rest ++ [filter], page: 1}
+  end
+
   def put_filter(%__MODULE__{} = state, field, _op, value)
       when value in [nil, "", []] do
     %{state | filters: Enum.reject(state.filters, &(&1.field == field)), page: 1}
@@ -201,7 +240,20 @@ defmodule PetalComponents.DataTable.State do
     end
   end
 
-  defp apply_filter_op(state, field, params) do
+  defp apply_filter_op(state, field, %{"filter_op" => op} = params)
+       when is_binary(op) do
+    case Map.fetch(@op_strings, op) do
+      {:ok, valueless} when valueless in @valueless_ops ->
+        put_filter(state, field, valueless, true)
+
+      _ ->
+        do_apply_filter_op(state, field, params)
+    end
+  end
+
+  defp apply_filter_op(state, field, params), do: do_apply_filter_op(state, field, params)
+
+  defp do_apply_filter_op(state, field, params) do
     resolved =
       cond do
         # the select editor's shape - its grammar is always :in, whether

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -109,6 +109,20 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
       assert names(%{field: :name, op: :not_in, value: ["Amy"]}) == ["Bea", "Cal"]
     end
 
+    test "a negation never inverts a coercion failure into matching everything" do
+      # :neq "abc" against a numeric column cannot be evaluated - the
+      # positive form fails to coerce, and a bare `not` would turn that
+      # into every row matching
+      assert names(%{field: :amount, op: :neq, value: "abc"}) == []
+      assert names(%{field: :joined, op: :neq, value: "not-a-date"}) == []
+      assert names(%{field: :name, op: :not_contains, value: nil}) == []
+      assert names(%{field: :name, op: :not_in, value: []}) == []
+
+      # and the usable cases still invert normally
+      assert names(%{field: :amount, op: :neq, value: "40"}) == ["Amy", "Cal"]
+      assert names(%{field: :joined, op: :neq, value: "2026-01-15"}) == ["Bea", "Cal"]
+    end
+
     test "emptiness counts nil, empty string and empty list - and nothing else" do
       # the only ops for which a nil field is a match rather than a miss
       assert names(%{field: :note, op: :is_empty, value: true}) == ["Amy", "Bea"]

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -123,6 +123,25 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
       assert names(%{field: :joined, op: :neq, value: "2026-01-15"}) == ["Bea", "Cal"]
     end
 
+    test "atom and boolean columns compare like any other scalar" do
+      rows = [
+        %{name: "Amy", status: :active, admin?: true},
+        %{name: "Bea", status: :archived, admin?: false}
+      ]
+
+      pick = fn filter ->
+        {out, _} = Engine.run(rows, struct!(State, filters: [filter]))
+        Enum.map(out, & &1.name)
+      end
+
+      # :eq fell through to date coercion for atoms, so an atom column
+      # matched nothing - and :neq then inverted that into everything
+      assert pick.(%{field: :status, op: :eq, value: "active"}) == ["Amy"]
+      assert pick.(%{field: :status, op: :neq, value: "active"}) == ["Bea"]
+      assert pick.(%{field: :admin?, op: :eq, value: "true"}) == ["Amy"]
+      assert pick.(%{field: :admin?, op: :neq, value: "true"}) == ["Bea"]
+    end
+
     test "a negation does not include rows whose field the positive op cannot read" do
       rows = [
         %{name: "Amy", meta: %{nested: 1}},

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -74,6 +74,48 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
     end
   end
 
+  describe "comparators across column types" do
+    @typed [
+      %{id: 1, name: "Amy", amount: 300, joined: ~D[2026-01-15], note: nil},
+      %{id: 2, name: "Bea", amount: 40, joined: ~D[2026-06-01], note: ""},
+      %{id: 3, name: "Cal", amount: 150, joined: ~D[2026-03-10], note: "hi"}
+    ]
+
+    defp names(filter) do
+      {rows, _} = Engine.run(@typed, struct!(State, filters: [filter]))
+      Enum.map(rows, & &1.name)
+    end
+
+    test "neq works on text, not only numbers" do
+      # guarded on is_number before: "is not" against any text column
+      # matched nothing, silently, because the catch-all returns false
+      assert names(%{field: :name, op: :neq, value: "Amy"}) == ["Bea", "Cal"]
+      assert names(%{field: :amount, op: :neq, value: "40"}) == ["Amy", "Cal"]
+    end
+
+    test "eq and the comparators work on dates, not only numbers" do
+      assert names(%{field: :joined, op: :eq, value: "2026-01-15"}) == ["Amy"]
+      assert names(%{field: :joined, op: :lt, value: "2026-06-01"}) == ["Amy", "Cal"]
+      assert names(%{field: :joined, op: :gte, value: "2026-03-10"}) == ["Bea", "Cal"]
+    end
+
+    test "gte and lte include the boundary" do
+      assert names(%{field: :amount, op: :gte, value: "150"}) == ["Amy", "Cal"]
+      assert names(%{field: :amount, op: :lte, value: "150"}) == ["Bea", "Cal"]
+    end
+
+    test "negations mirror their positive op exactly" do
+      assert names(%{field: :name, op: :not_contains, value: "a"}) == []
+      assert names(%{field: :name, op: :not_in, value: ["Amy"]}) == ["Bea", "Cal"]
+    end
+
+    test "emptiness counts nil, empty string and empty list - and nothing else" do
+      # the only ops for which a nil field is a match rather than a miss
+      assert names(%{field: :note, op: :is_empty, value: true}) == ["Amy", "Bea"]
+      assert names(%{field: :note, op: :is_not_empty, value: true}) == ["Cal"]
+    end
+  end
+
   describe "sorting" do
     test "sorts strings case-insensitively" do
       assert ids(run(order_by: [name: :asc], page_size: 10)) == [3, 2, 1, 5, 4]

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -123,6 +123,24 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
       assert names(%{field: :joined, op: :neq, value: "2026-01-15"}) == ["Bea", "Cal"]
     end
 
+    test "a negation does not include rows whose field the positive op cannot read" do
+      rows = [
+        %{name: "Amy", meta: %{nested: 1}},
+        %{name: "Bea", meta: "text"}
+      ]
+
+      pick = fn filter ->
+        {out, _} = Engine.run(rows, struct!(State, filters: [filter]))
+        Enum.map(out, & &1.name)
+      end
+
+      # :contains / :in / :eq cannot read a map field - their negations
+      # must exclude that row rather than invert an unreadable field
+      assert pick.(%{field: :meta, op: :not_contains, value: "zz"}) == ["Bea"]
+      assert pick.(%{field: :meta, op: :not_in, value: ["y"]}) == ["Bea"]
+      assert pick.(%{field: :meta, op: :neq, value: "x"}) == ["Bea"]
+    end
+
     test "emptiness counts nil, empty string and empty list - and nothing else" do
       # the only ops for which a nil field is a match rather than a miss
       assert names(%{field: :note, op: :is_empty, value: true}) == ["Amy", "Bea"]


### PR DESCRIPTION
The contract slab. 4.13.0 is still unpublished (Hex is on 4.12.0), so this is the last moment any of it is free — operators are a public URL format, and after the first publish they can't change without breaking every consumer and adapter.

## Three silent bugs, verified by running the engine

```
neq on a text field  → []     "is not" against any text column matched nothing, ever
eq  on a date field  → []
lt  on a date field  → []
```

Comparators were guarded **type-first** (`when is_number`), and an unmatched clause falls through to a catch-all `false` rather than raising — so the failure was invisible. They're now **op-first**, running one comparison ladder (numbers → dates → text), so an operator means the same thing whatever the column holds.

Latent rather than user-facing today, because the editors don't offer those combinations. They stop being latent the moment the vocabulary grows — which is what this PR also does.

## Two crash-on-render lookups

`Map.fetch!` on the op-label map raised `KeyError` while drawing the toolbar for any op lacking a label — i.e. every op an adapter might add. Now renders humanised.

## Five operators added

`:not_contains`, `:gte`, `:lte`, `:not_in`, `:is_empty`, `:is_not_empty`.

Chosen by measuring our vocabulary against Flop, Ash, Ecto, TanStack, AG Grid, MUI DataGrid, and the filter menus of Notion and Airtable — these were the near-universal ones we lacked. Their absence is also *why* `:between` had to exist as a composite that every adapter must decompose.

Deliberately **not** added: `ends_with` (Flop escapes `%`/`_`, so it can't anchor a LIKE — unimplementable there), and relative dates (a feature, not an operator).

## The null-ness pair needed a real decision

They're the only ops where a nil field is a **match** rather than a miss, so they run before the nil short-circuit. Their semantics differ between libraries — Flop's `:empty` is strictly `IS NULL`, the UI systems count `""` too. Ours is pinned in `State`'s moduledoc: nil, `""`, `[]`; a blank-ish `" "` is not empty.

Same for the rest: `:between` inclusive, text comparison case-insensitive, `:before`/`:on`/`:after` documented as date-shaped aliases of `:lt`/`:eq`/`:gt`. An adapter author shouldn't have to read the in-memory engine to learn which meaning we intend.

## Also

`State.ops/0` and `State.valueless_op?/1` let an adapter enumerate the contract instead of hardcoding it. Value-less ops hide their input via `:has()` (no JS, matching the `between` bound), and the link-mode hook special-cases them so an empty input isn't read as "remove this filter".

854 Elixir / 132 JS, including a new `comparators across column types` block covering each fixed hole and each new operator.