### PR TITLE
fix(table): sticky_header was dead; column_toggle rendered a dead button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 
 #### Fixed
 
+- **`sticky_header` never worked.** `.pc-table--basic` and `--ghost`
+  used `overflow: hidden`, which makes the table a scroll container and
+  traps `position: sticky` - so the header scrolled away in every
+  configuration. They now use `overflow: clip`, which clips identically
+  (rounded corners intact) without creating a scrollport.
+- **`column_toggle` on its own rendered a dead button.** The Columns
+  trigger is driven by the `PetalDataTable` hook, but `column_toggle`
+  was missing from the condition that mounts it, so a table using only
+  column visibility rendered a button that did nothing.
+
+#### Added
+
+- **`data_table` gains `max_height`**, which caps the body and makes it
+  scroll under a pinned header. This is what `sticky_header` needs
+  inside a data table: the capped region becomes the scrollport the
+  header sticks to, because a wrapper that scrolls only sideways cannot
+  pin anything - a CSS constraint rather than something a property can
+  undo.
+
 - **Comparators now work on every column type.** `:neq` was guarded on
   numbers, so "is not" against any text column matched nothing - and
   matched nothing *silently*, since an unhandled combination falls

--- a/assets/default.css
+++ b/assets/default.css
@@ -2623,6 +2623,14 @@
   .pc-data-table__scroll {
     @apply overflow-x-auto;
   }
+  /* A capped scroll region is what makes sticky_header work inside a
+     data table: the wrapper becomes the scrollport the header sticks to.
+     Without a cap the wrapper scrolls only sideways, and a horizontally
+     scrolling ancestor traps page-level stickiness - a CSS constraint,
+     not something a property can undo. */
+  .pc-data-table__scroll--capped {
+    @apply overflow-auto;
+  }
   .pc-data-table__footer {
     @apply mt-3 flex flex-wrap items-center justify-between gap-3;
   }
@@ -3147,12 +3155,16 @@
 
   /* Table */
 
+  /* overflow-clip, not overflow-hidden: `hidden` makes the table a scroll
+     container, which traps position:sticky and silently killed
+     sticky_header. `clip` clips identically (the rounded corners still
+     work) without creating a scrollport. */
   .pc-table--basic {
-    @apply min-w-full overflow-hidden shadow-sm table-auto ring-1 ring-gray-200 dark:ring-gray-400/17;
+    @apply min-w-full overflow-clip shadow-sm table-auto ring-1 ring-gray-200 dark:ring-gray-400/17;
     border-radius: min(var(--pc-radius, 0.625rem), 1rem);
   }
   .pc-table--ghost {
-    @apply min-w-full overflow-hidden table-auto;
+    @apply min-w-full overflow-clip table-auto;
   }
   .pc-table__th {
     @apply px-6 py-3 text-sm font-semibold text-left text-gray-900 bg-gray-50 dark:bg-gray-400/8 dark:text-white;

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -78,7 +78,19 @@ defmodule PetalComponents.DataTable do
   attr :loading, :boolean, default: false, doc: "render skeleton rows instead of data"
   attr :density, :string, default: "comfortable", values: ["comfortable", "compact"]
   attr :striped, :boolean, default: false
-  attr :sticky_header, :boolean, default: false
+
+  attr :sticky_header, :boolean,
+    default: false,
+    doc: """
+    pin the header row. Inside a data table this needs `max_height` too:
+    the scroll region is what the header sticks to, and a wrapper that
+    scrolls only sideways cannot pin anything.
+    """
+
+  attr :max_height, :string,
+    default: nil,
+    doc: "caps the table body's height (any CSS length), making it scroll under a pinned header"
+
   attr :variant, :string, default: "basic", values: ["ghost", "basic"]
   attr :of_label, :string, default: "of", doc: "the range summary's connective, localizable"
   attr :page_label, :string, default: "Page", doc: "cursor mode's page word, localizable"
@@ -231,7 +243,7 @@ defmodule PetalComponents.DataTable do
     # property, which markup alone cannot express.
     hooked? =
       (link_mode? and (assigns.searchable or assigns.page_size_options != [])) or
-        filter_cols != [] or assigns.selectable
+        filter_cols != [] or assigns.selectable or assigns.column_toggle
 
     assigns =
       assigns
@@ -398,7 +410,10 @@ defmodule PetalComponents.DataTable do
         <% end %>
       </div>
 
-      <div class="pc-data-table__scroll">
+      <div
+        class={["pc-data-table__scroll", @max_height && "pc-data-table__scroll--capped"]}
+        style={@max_height && "max-height: #{@max_height}"}
+      >
         <.table
           id={"#{@id}-table"}
           rows={if @loading, do: @skeleton_rows, else: @rows}

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -383,6 +383,45 @@ defmodule PetalComponents.DataTableTest do
     assert length(String.split(html, "<em>Nome</em>")) - 1 == 2
   end
 
+  test "column_toggle alone mounts the hook - its trigger is useless without it" do
+    assigns = base(%{})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path} on_ui="ui" column_toggle>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    # the Columns button renders regardless; without the hook nothing
+    # listens for the click and the menu never opens
+    assert html =~ "data-pc-menu-trigger"
+    assert html =~ ~s(phx-hook="PetalDataTable")
+  end
+
+  test "max_height caps the scroll region so a sticky header has something to stick to" do
+    assigns = base(%{})
+
+    plain =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path} sticky_header>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    refute plain =~ "pc-data-table__scroll--capped"
+
+    capped =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path} sticky_header max_height="24rem">
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert capped =~ "pc-data-table__scroll--capped"
+    assert capped =~ ~s(style="max-height: 24rem")
+  end
+
   test "a map-shaped between range renders instead of crashing" do
     assigns =
       base(%{


### PR DESCRIPTION
Two advertised features that did nothing. Both measured in a real browser rather than reasoned about.

## `sticky_header` never worked

`.pc-table--basic` and `--ghost` apply `overflow: hidden`, which makes the table a scroll container and **traps `position: sticky`**. Measured: the header scrolls away in every configuration, including the one the showcase copy advertises.

`overflow: clip` clips identically — rounded corners intact — without creating a scrollport. Measured: header sticks.

## Inside a data table there's a second, deeper constraint

The body sits in a horizontally scrolling wrapper, and *a horizontally scrolling ancestor traps page-level stickiness*. No property fixes that — I measured `overflow-y: clip` on the wrapper as well, and it doesn't rescue it.

The real answer is what every serious data table does: cap the body so it becomes its own scrollport. Hence **`max_height`**, which makes `sticky_header` work inside a data table and is a useful feature in its own right (the classic scrollable-body table). Measured: rows scroll under a header pinned to the capped region.

| configuration | header sticks |
|---|---|
| table `overflow: hidden` (today) | ✗ |
| table `overflow: clip` | ✓ |
| inside `overflow-x: auto` wrapper | ✗ |
| wrapper `overflow: auto` + `max-height` | ✓ |

## `column_toggle` rendered a dead button

The Columns trigger is driven by the `PetalDataTable` hook, but `column_toggle` was missing from the condition that mounts it. A link-mode table using *only* column visibility rendered a button nothing listened to. One term added to `hooked?`, plus a test asserting the hook mounts.

855 tests.