### PR TITLE
fix(data_table): accessibility pass - roles, labels, focus, live region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@
 
 #### Added
 
+- **The range summary is now a live region.** Filtering 74 rows down to
+  3 previously announced nothing. It speaks a written-out sentence
+  ("26 to 50 of 74 results") separate from the visible text, because
+  the visible en dash is frequently read as nothing at all, and because
+  the visible string is empty in the zero case - the one that matters
+  most. Localizable via `results_label`.
+- **`data_table` gains `row_label`** for naming rows in the selection
+  checkbox's accessible name, and `actions_label` for the actions
+  column's announced-but-unseen header.
+- **`pagination` gains `aria_label`** to name its navigation landmark.
+
 - **`data_table` gains `max_height`**, which caps the body and makes it
   scroll under a pinned header. This is what `sticky_header` needs
   inside a data table: the capped region becomes the scrollport the

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4777,7 +4777,7 @@ export const PetalDataTable = {
       // event mode: the form pushes its own phx-submit - only the menu
       // close is ours
       if (!form.hasAttribute("data-pc-dt-filter")) {
-        this.closeMenu();
+        this.closeMenu({ restoreFocus: true });
         return;
       }
 
@@ -4789,7 +4789,7 @@ export const PetalDataTable = {
       const next = this.readFilter(form, field);
       if (next) filters.push(next);
 
-      this.closeMenu();
+      this.closeMenu({ restoreFocus: true });
       this.patchTo(this.navUrl(filters));
     };
 
@@ -4858,6 +4858,8 @@ export const PetalDataTable = {
 
     this.onMenuKeydown = (e) => {
       if (e.key !== "Escape" || !this.openMenu) return;
+      // a data table inside a modal would otherwise close both at once
+      e.stopPropagation();
       const trigger = this.menuTrigger();
       this.closeMenu();
       trigger?.focus();
@@ -4867,8 +4869,25 @@ export const PetalDataTable = {
       if (this.openMenu) this.alignMenu();
     };
 
+    // Tab out of the panel closes it. relatedTarget lies on iOS, so this
+    // is the combobox's proven shape: defer a tick, then ask the document
+    // where focus actually landed.
+    this.onMenuFocusOut = () => {
+      if (!this.openMenu) return;
+      setTimeout(() => {
+        if (!this.openMenu) return;
+        const panel = this.menuPanel();
+        const trigger = this.menuTrigger();
+        const active = document.activeElement;
+        if (!active || active === document.body) return;
+        if (panel?.contains(active) || trigger?.contains(active)) return;
+        this.closeMenu();
+      }, 0);
+    };
+
     this.el.addEventListener("click", this.onMenuClick);
     this.el.addEventListener("keydown", this.onMenuKeydown);
+    this.el.addEventListener("focusout", this.onMenuFocusOut);
     document.addEventListener("pointerdown", this.onPressStart, true);
     document.addEventListener("pointerup", this.onPressEnd, true);
     document.addEventListener("pointercancel", this.onPressCancel, true);
@@ -4926,9 +4945,13 @@ export const PetalDataTable = {
     });
   },
 
-  closeMenu() {
+  closeMenu({ restoreFocus = false } = {}) {
     const panel = this.menuPanel();
-    this.menuTrigger()?.setAttribute("aria-expanded", "false");
+    const trigger = this.menuTrigger();
+    trigger?.setAttribute("aria-expanded", "false");
+    // closing hides the panel, which blurs whatever was focused inside
+    // it - without this the user lands on <body>
+    if (restoreFocus) trigger?.focus();
     this.openMenu = null;
     if (!panel) return;
     panel.removeAttribute("data-pc-open");
@@ -4993,6 +5016,12 @@ export const PetalDataTable = {
     panel.style.overflowY = "auto";
   },
 
+  beforeUpdate() {
+    const panel = this.menuPanel();
+    const active = document.activeElement;
+    this.refocus = panel && active && panel.contains(active) ? active : null;
+  },
+
   updated() {
     this.syncIndeterminate();
 
@@ -5005,6 +5034,10 @@ export const PetalDataTable = {
         panel.setAttribute("data-pc-open", "");
         this.menuTrigger()?.setAttribute("aria-expanded", "true");
         this.alignMenu();
+        // hiding an ancestor blurs its focused descendant, and LiveView
+        // only re-focuses text inputs and selects - never a checkbox or
+        // a button, which is what these panels are full of
+        if (this.refocus?.isConnected) this.refocus.focus();
       } else {
         this.openMenu = null;
       }
@@ -5029,6 +5062,7 @@ export const PetalDataTable = {
     this.el.removeEventListener("submit", this.onSubmit);
     this.el.removeEventListener("click", this.onMenuClick);
     this.el.removeEventListener("keydown", this.onMenuKeydown);
+    this.el.removeEventListener("focusout", this.onMenuFocusOut);
     document.removeEventListener("pointerdown", this.onPressStart, true);
     document.removeEventListener("pointerup", this.onPressEnd, true);
     document.removeEventListener("pointercancel", this.onPressCancel, true);

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -103,6 +103,14 @@ defmodule PetalComponents.DataTable do
 
   attr :clear_filters_label, :string, default: "Clear filters"
 
+  attr :results_label, :string,
+    default: "results",
+    doc: "the announced result-count noun, localizable"
+
+  attr :actions_label, :string,
+    default: "Actions",
+    doc: "the actions column's header, announced but not shown"
+
   attr :searchable, :boolean,
     default: false,
     doc: "render the quick-search input in the toolbar (drives `state.search`)"
@@ -130,6 +138,15 @@ defmodule PetalComponents.DataTable do
     default: [],
     doc: "the currently selected row ids (any terms; compared as strings)"
 
+  attr :row_label, :any,
+    default: nil,
+    doc: """
+    a 1-arity function returning a human name for a row, used as the
+    selection checkbox's accessible name. Without it the checkbox
+    announces its position ("Select row 3"), because a primary key -
+    a UUID, say - is not something a screen reader user can act on.
+    """
+
   attr :row_id, :any,
     default: :id,
     doc: """
@@ -151,6 +168,10 @@ defmodule PetalComponents.DataTable do
     doc: "the selection count's word, localizable"
 
   attr :clear_selection_label, :string, default: "Clear selection"
+
+  attr :select_row_label, :string,
+    default: "Select row",
+    doc: "the row checkbox's aria-label prefix, localizable"
 
   attr :select_all_label, :string,
     default: "Select all rows",
@@ -345,7 +366,6 @@ defmodule PetalComponents.DataTable do
               type="button"
               id={"#{@id}-columns-trigger"}
               data-pc-menu-trigger={"#{@id}-columns"}
-              aria-haspopup="dialog"
               aria-expanded="false"
               aria-controls={"#{@id}-columns"}
               class="pc-popover__trigger pc-button pc-button--sm pc-button--gray-outline"
@@ -355,7 +375,6 @@ defmodule PetalComponents.DataTable do
             </button>
             <div
               id={"#{@id}-columns"}
-              role="dialog"
               hidden
               data-pc-menu
               class="pc-popover__panel pc-popover__panel--bottom-end"
@@ -442,7 +461,7 @@ defmodule PetalComponents.DataTable do
               phx-target={@target}
               phx-value-op="select"
               phx-value-id={row_key(row, @row_id)}
-              aria-label={"Select row #{row_key(row, @row_id)}"}
+              aria-label={row_aria_label(row, @row_label, @rows, @select_row_label)}
             />
           </:col>
           <:col
@@ -460,7 +479,12 @@ defmodule PetalComponents.DataTable do
               {render_slot(col, row)}
             <% end %>
           </:col>
-          <:col :let={row} :if={@action != []} label="" class="pc-data-table__actions-th">
+          <:col
+            :let={row}
+            :if={@action != []}
+            label={sr_only_label(@actions_label)}
+            class="pc-data-table__actions-th"
+          >
             <span :if={!@loading} class="pc-data-table__actions">
               {render_slot(@action, row)}
             </span>
@@ -499,7 +523,10 @@ defmodule PetalComponents.DataTable do
       </div>
 
       <div class="pc-data-table__footer">
-        <span class="pc-data-table__range">{range_text(@state, @of_label, @page_label)}</span>
+        <span class="pc-data-table__range" role="status" aria-atomic="true">
+          <span aria-hidden="true">{range_text(@state, @of_label, @page_label)}</span>
+          <span class="sr-only">{range_announcement(assigns)}</span>
+        </span>
         <div :if={@page_size_options != []} class="pc-data-table__page-size">
           <label for={"#{@id}-page-size"} class="pc-data-table__page-size-label">
             {@per_page_label}
@@ -710,6 +737,27 @@ defmodule PetalComponents.DataTable do
     """
   end
 
+  # A human name beats a primary key: "Select row 0198f2a1-b3c4-..." is
+  # what a UUID announces, once per row. Falls back to the row's position
+  # on the page, which is at least sayable.
+  defp row_aria_label(row, fun, _rows, prefix) when is_function(fun, 1),
+    do: "#{prefix} #{fun.(row)}"
+
+  defp row_aria_label(row, _none, rows, prefix) do
+    case Enum.find_index(rows, &(&1 == row)) do
+      nil -> prefix
+      index -> "#{prefix} #{index + 1}"
+    end
+  end
+
+  defp sr_only_label(text) do
+    assigns = %{text: text}
+
+    ~H"""
+    <span class="sr-only">{@text}</span>
+    """
+  end
+
   defp row_key(row, fun) when is_function(fun, 1), do: to_string(fun.(row))
   defp row_key(row, field) when is_atom(field), do: to_string(Map.get(row, field))
 
@@ -770,7 +818,6 @@ defmodule PetalComponents.DataTable do
           type="button"
           id={"#{@pop_id}-trigger"}
           data-pc-menu-trigger={@pop_id}
-          aria-haspopup="dialog"
           aria-expanded="false"
           aria-controls={@pop_id}
           class={[
@@ -784,7 +831,6 @@ defmodule PetalComponents.DataTable do
         </button>
         <div
           id={@pop_id}
-          role="dialog"
           hidden
           data-pc-menu
           class="pc-popover__panel pc-popover__panel--bottom-start"
@@ -873,6 +919,7 @@ defmodule PetalComponents.DataTable do
       step="any"
       name="value"
       value={@value}
+      aria-label={"#{@label} lower bound"}
       class="pc-text-input pc-data-table__filter-value"
     />
     <input
@@ -899,6 +946,7 @@ defmodule PetalComponents.DataTable do
       type="date"
       name="value"
       value={@value}
+      aria-label={"#{@label} value"}
       class="pc-text-input pc-data-table__filter-value"
     />
     """
@@ -917,6 +965,7 @@ defmodule PetalComponents.DataTable do
       type="text"
       name="value"
       value={@value}
+      aria-label={"#{@label} value"}
       class="pc-text-input pc-data-table__filter-value"
     />
     """
@@ -995,6 +1044,29 @@ defmodule PetalComponents.DataTable do
 
   defp display_value(%{value: %{} = value}, _options), do: inspect(value)
   defp display_value(%{value: value}, _options), do: to_string(value)
+
+  # Announced separately from the visible range: the visible string uses
+  # an en dash, which screen readers frequently read as nothing at all
+  # ("1 25 of 500"), and the zero case renders empty - which would make
+  # the region silent in precisely the case that matters most.
+  defp range_announcement(%{state: %State{total: nil} = state} = assigns),
+    do: "#{assigns.page_label} #{state.page}"
+
+  defp range_announcement(%{state: %State{total: 0}} = assigns) do
+    case filtering?(assigns.state) do
+      true -> assigns.no_filtered_results_text
+      false -> assigns.no_results_text
+    end
+  end
+
+  defp range_announcement(%{state: %State{} = state} = assigns) do
+    first = (state.page - 1) * state.page_size + 1
+    last = min(state.page * state.page_size, state.total)
+    "#{first} to #{last} #{assigns.of_label} #{state.total} #{assigns.results_label}"
+  end
+
+  defp filtering?(%State{filters: [], search: nil}), do: false
+  defp filtering?(%State{}), do: true
 
   defp range_text(%State{total: nil} = state, _of_label, page_label),
     do: "#{page_label} #{state.page}"

--- a/lib/petal_components/pagination.ex
+++ b/lib/petal_components/pagination.ex
@@ -20,9 +20,16 @@ defmodule PetalComponents.Pagination do
 
   attr :previous_label, :string,
     default: "Previous",
-    doc: "simple variant: label for the previous button"
+    doc:
+      "the previous button's label - visible in the simple variant, announced in the numbered one"
 
-  attr :next_label, :string, default: "Next", doc: "simple variant: label for the next button"
+  attr :next_label, :string,
+    default: "Next",
+    doc: "the next button's label - visible in the simple variant, announced in the numbered one"
+
+  attr :aria_label, :string,
+    default: "Pagination",
+    doc: "names the navigation landmark, localizable"
 
   attr :link_type, :string,
     default: "a",
@@ -119,30 +126,11 @@ defmodule PetalComponents.Pagination do
 
     ~H"""
     <div {@rest} class={["pc-pagination", @class]}>
-      <ul class="pc-pagination__inner">
-        <%= for item <- get_pagination_items(@total_pages, @current_page, @sibling_count, @boundary_count) do %>
-          <%= if item.type == "prev" and (item.enabled? or @show_boundary_chevrons) do %>
-            <li>
-              <Link.a
-                phx-click={event_name(@event)}
-                {phx_values(@event_values)}
-                phx-target={if @event?, do: @target}
-                phx-value-page={item.number}
-                link_type={if @event?, do: "button", else: @link_type}
-                to={if not @event?, do: get_path(@path, item.number, @current_page)}
-                class="pc-pagination__item__previous"
-                disabled={!item.enabled?}
-              >
-                <.icon name="hero-chevron-left-solid" class="pc-pagination__item__previous__chevron" />
-              </Link.a>
-            </li>
-          <% end %>
-
-          <%= if item.type == "page" do %>
-            <li>
-              <%= if item.current? do %>
-                <span class={get_box_class(item)}>{item.number}</span>
-              <% else %>
+      <nav aria-label={@aria_label}>
+        <ul class="pc-pagination__inner">
+          <%= for item <- get_pagination_items(@total_pages, @current_page, @sibling_count, @boundary_count) do %>
+            <%= if item.type == "prev" and (item.enabled? or @show_boundary_chevrons) do %>
+              <li>
                 <Link.a
                   phx-click={event_name(@event)}
                   {phx_values(@event_values)}
@@ -150,40 +138,66 @@ defmodule PetalComponents.Pagination do
                   phx-value-page={item.number}
                   link_type={if @event?, do: "button", else: @link_type}
                   to={if not @event?, do: get_path(@path, item.number, @current_page)}
-                  class={get_box_class(item)}
+                  class="pc-pagination__item__previous"
+                  disabled={!item.enabled?}
                 >
-                  {item.number}
+                  <.icon
+                    name="hero-chevron-left-solid"
+                    class="pc-pagination__item__previous__chevron"
+                  />
+                  <span class="sr-only">{@previous_label}</span>
                 </Link.a>
-              <% end %>
-            </li>
-          <% end %>
+              </li>
+            <% end %>
 
-          <%= if item.type == "..." do %>
-            <li>
-              <span class="pc-pagination__item__ellipsis">
-                ...
-              </span>
-            </li>
-          <% end %>
+            <%= if item.type == "page" do %>
+              <li>
+                <%= if item.current? do %>
+                  <span class={get_box_class(item)} aria-current="page">{item.number}</span>
+                <% else %>
+                  <Link.a
+                    phx-click={event_name(@event)}
+                    {phx_values(@event_values)}
+                    phx-target={if @event?, do: @target}
+                    phx-value-page={item.number}
+                    link_type={if @event?, do: "button", else: @link_type}
+                    to={if not @event?, do: get_path(@path, item.number, @current_page)}
+                    class={get_box_class(item)}
+                  >
+                    {item.number}
+                  </Link.a>
+                <% end %>
+              </li>
+            <% end %>
 
-          <%= if item.type == "next" and (item.enabled? or @show_boundary_chevrons) do %>
-            <li>
-              <Link.a
-                phx-click={event_name(@event)}
-                {phx_values(@event_values)}
-                phx-target={if @event?, do: @target}
-                phx-value-page={item.number}
-                link_type={if @event?, do: "button", else: @link_type}
-                to={if not @event?, do: get_path(@path, item.number, @current_page)}
-                class="pc-pagination__item__next"
-                disabled={!item.enabled?}
-              >
-                <.icon name="hero-chevron-right-solid" class="pc-pagination__item__next__chevron" />
-              </Link.a>
-            </li>
+            <%= if item.type == "..." do %>
+              <li>
+                <span class="pc-pagination__item__ellipsis">
+                  ...
+                </span>
+              </li>
+            <% end %>
+
+            <%= if item.type == "next" and (item.enabled? or @show_boundary_chevrons) do %>
+              <li>
+                <Link.a
+                  phx-click={event_name(@event)}
+                  {phx_values(@event_values)}
+                  phx-target={if @event?, do: @target}
+                  phx-value-page={item.number}
+                  link_type={if @event?, do: "button", else: @link_type}
+                  to={if not @event?, do: get_path(@path, item.number, @current_page)}
+                  class="pc-pagination__item__next"
+                  disabled={!item.enabled?}
+                >
+                  <.icon name="hero-chevron-right-solid" class="pc-pagination__item__next__chevron" />
+                  <span class="sr-only">{@next_label}</span>
+                </Link.a>
+              </li>
+            <% end %>
           <% end %>
-        <% end %>
-      </ul>
+        </ul>
+      </nav>
     </div>
     """
   end

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -416,6 +416,70 @@ describe("PetalDataTable", () => {
     expect(document.getElementById("pop2").hidden).toBe(false);
   });
 
+  it("returns focus to the trigger when a menu closes by Apply", () => {
+    const { hook, trigger, form } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `<form class="pc-data-table__filter-form" data-pc-dt-filter data-field="email">
+        <input name="value" value="amy" />
+      </form>`,
+    });
+
+    trigger.click();
+    form.querySelector("input").focus();
+    submit(form);
+
+    // closing hides the panel, which blurs whatever was inside it -
+    // without restoring focus the user is dumped on <body>
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("re-focuses the control a patch blurred inside an open menu", () => {
+    const { hook, panel, trigger } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `<form class="pc-data-table__filter-form">
+        <input type="checkbox" id="col-email" />
+      </form>`,
+    });
+
+    trigger.click();
+    const box = panel.querySelector("#col-email");
+    box.focus();
+    expect(document.activeElement).toBe(box);
+
+    // a patch re-applies the server's `hidden`, blurring the checkbox;
+    // LiveView only restores text inputs and selects, never checkboxes
+    hook.beforeUpdate();
+    panel.hidden = true;
+    box.blur();
+    hook.updated();
+
+    expect(document.activeElement).toBe(box);
+  });
+
+  it("Escape does not escape the table - an enclosing modal keeps its own", () => {
+    const { hook, panel, trigger } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `<form class="pc-data-table__filter-form"></form>`,
+    });
+
+    trigger.click();
+
+    let reachedOuter = false;
+    const outer = () => (reachedOuter = true);
+    document.addEventListener("keydown", outer);
+
+    panel.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+
+    document.removeEventListener("keydown", outer);
+    expect(hook.openMenu).toBe(null);
+    expect(reachedOuter).toBe(false);
+  });
+
   it("never repositions on scroll - the page carries the panel", () => {
     const { hook, trigger } = mountWithFilter({
       navTemplate: "/orders?:filters",

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -422,6 +422,99 @@ defmodule PetalComponents.DataTableTest do
     assert capped =~ ~s(style="max-height: 24rem")
   end
 
+  test "the filter panels are disclosures, not dialogs" do
+    assigns = base(%{})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table" column_toggle>
+        <:col :let={row} field={:email} filterable="text">{row.email}</:col>
+      </.data_table>
+      """)
+
+    # role="dialog" promises focus management these panels deliberately
+    # do not do, and an unnamed dialog is an automated-scan failure
+    refute html =~ ~s(role="dialog")
+    refute html =~ ~s(aria-haspopup="dialog")
+    assert html =~ ~s(aria-expanded="false")
+    assert html =~ "aria-controls"
+    # the field you actually type in has a name
+    assert html =~ ~s(aria-label="Email value")
+  end
+
+  test "selection checkboxes announce something a person can act on" do
+    assigns =
+      base(%{
+        rows: [%{id: "0198f2a1-b3c4-7d5e", name: "Amy"}, %{id: "0198f2a1-ffff", name: "Bea"}],
+        namer: fn row -> row.name end
+      })
+
+    # without a row_label, a UUID primary key would be read out in full
+    positional =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table" selectable selected={[]}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert positional =~ ~s(aria-label="Select row 1")
+    assert positional =~ ~s(aria-label="Select row 2")
+    refute positional =~ "Select row 0198f2a1"
+
+    named =
+      rendered_to_string(~H"""
+      <.data_table
+        id="t"
+        rows={@rows}
+        state={@state}
+        on_change="table"
+        selectable
+        selected={[]}
+        row_label={@namer}
+      >
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert named =~ ~s(aria-label="Select row Amy")
+  end
+
+  test "the range summary is a live region that speaks the zero case" do
+    assigns = base(%{state: %State{total: 74, page: 2, page_size: 25}})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ ~s(role="status")
+    assert html =~ ~s(aria-atomic="true")
+    # the visible en dash is hidden from the region and spoken as words
+    assert html =~ ~s(<span aria-hidden="true">26–50 of 74</span>)
+    assert html =~ "26 to 50 of 74 results"
+
+    empty =
+      base(%{
+        rows: [],
+        state: %State{total: 0, filters: [%{field: :name, op: :contains, value: "zz"}]}
+      })
+
+    assigns = empty
+
+    empty_html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} path={@path}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    # range_text renders nothing at zero - the region would be silent in
+    # exactly the case that matters most without its own sentence
+    assert empty_html =~ "No results for these filters"
+  end
+
   test "a map-shaped between range renders instead of crashing" do
     assigns =
       base(%{


### PR DESCRIPTION
The gaps an auditor finds in the first ten seconds, and the ones a keyboard user finds in the first ten.

## The pattern, decided rather than assumed

These panels are **Disclosures** — not menus, not dialogs.

A `role="menu"` requires `menuitem` children; ours are *forms* with selects and text inputs, which screen readers handle badly inside a menu. A `role="dialog"` promises focus management we deliberately don't do, because auto-focusing raises the iOS keyboard on every filter tap.

So the fix is mostly **subtraction**: `role="dialog"` and `aria-haspopup="dialog"` are gone; `aria-expanded` + `aria-controls` stay.

**Arrow keys and focus traps are deliberately not added.** The panel is its trigger's next DOM sibling, so DOM order *is* tab order — for free. That's only true because these are in-page rather than portaled, which is worth remembering before anyone moves them back to the top layer.

## Automated-scan failures fixed

- unnamed `role="dialog"` panels (removed the role entirely)
- filter **value** inputs with no label — the operator select was labelled, the field you type in wasn't
- selection checkboxes announcing UUID primary keys: *"Select row 0198f2a1-b3c4-7d5e…"*, once per row. Now positional, or a human name via the new `row_label`
- icon-only pagination prev/next with no accessible name, no `<nav>` landmark, no `aria-current` on the current page
- an empty actions `<th>`

## Focus bugs, all confirmed

- **A patch while a menu is open dropped focus to `<body>`.** Hiding an ancestor blurs its descendant, and LiveView's focus restoration only covers text inputs and selects — never checkboxes or buttons, which is what these panels are full of. Now captured in `beforeUpdate` and restored in `updated`.
- **Apply closed a menu without returning focus** to its trigger, unlike Escape.
- **Tabbing past the last control** left the panel open, overlaying the table.
- **Escape propagated** — one keypress closed both a filter menu and an enclosing modal.

## Live region

The range summary becomes `role="status"`. The announced sentence is separate from the visible text for two reasons: the visible string uses an en dash that screen readers frequently drop entirely (*"1 25 of 500"*), and it renders **empty** at zero results — which would leave the region silent in exactly the case that matters most. The zero case now announces the empty-state text instead.

Pagination changes land in the shared component, so every consumer benefits, not just the data table.

858 Elixir / 135 JS.