### PR TITLE
docs(data_table): pin the case-folding contract, with the evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@
 
 #### Added
 
+- **The case-sensitivity of text equality is now a written contract,
+  decided with evidence rather than inherited.** `:eq` (with `:neq`,
+  `:in`, `:not_in`) folds case - a person picking "is" in a filter
+  means "this value", not "these bytes". This matches every major grid
+  (TanStack, AG Grid and MUI all default text-equals to
+  case-insensitive), and the case-sensitive camp's own behaviour:
+  Airtable's help tells users to switch to "contains", and Django's
+  admin overrides its own case-sensitive ORM with `iexact`. Accents
+  are NOT folded, and the pin says so. If byte-exact equality is ever
+  needed it will arrive as a new operator (`:eq_sensitive`), never as
+  a change to this one. `State`'s moduledoc gains a "Writing an
+  adapter" section with the measured index guidance - including that
+  on `citext` columns plain `=` must be used, since wrapping it in
+  `lower()` defeats the index (~28x, measured).
+
 - **The range summary is now a live region.** Filtering 74 rows down to
   3 previously announced nothing. It speaks a written-out sentence
   ("26 to 50 of 74 results") separate from the visible text, because

--- a/lib/petal_components/data_table/state.ex
+++ b/lib/petal_components/data_table/state.ex
@@ -37,7 +37,21 @@ defmodule PetalComponents.DataTable.State do
     * `:between` is INCLUSIVE of both bounds.
     * `:is_empty` matches nil, `""` and `[]` - a blank-ish `" "` is not
       empty. Trim before filtering if you want it to be.
-    * text comparisons are case-insensitive.
+    * text comparisons fold CASE, and only case. `:eq`, `:neq`, `:in`,
+      `:not_in`, `:contains`, `:not_contains`, `:starts_with`, the
+      comparators against text columns, and the quick `search` all
+      compare downcased on both sides. Accents are NOT folded: "cafe"
+      does not match "café", while "CAFÉ" does. Folding is whatever
+      `String.downcase/1` does; a SQL `lower()` is collation-dependent,
+      so non-ASCII input can diverge between engines (Turkish dotless i
+      is the classic case). ASCII agrees everywhere.
+    * `:eq` is deliberately NOT SQL `=`. A person picking "is" in a
+      filter means "this value", not "these bytes" - and the same
+      dropdown offers `:contains` and `:starts_with`, which every
+      engine folds, so a byte-exact `:eq` would make case behaviour
+      silently flip as the user moves down the operator list. If a
+      byte-exact equality is ever needed it will arrive as a NEW
+      operator (`:eq_sensitive`), never as a change to this one.
     * comparators work on whatever the column holds - numbers, dates and
       text all compare with the same op.
     * `:before`/`:on`/`:after` are date-shaped aliases of `:lt`/`:eq`/
@@ -46,6 +60,27 @@ defmodule PetalComponents.DataTable.State do
 
   Engines may support a subset. `ops/0` returns the recognised set and
   `valueless_op?/1` identifies the ops that carry no value.
+
+  ## Writing an adapter
+
+  Text equality in this contract folds case, so `lower(col) = lower($1)`
+  is the SQL you want and plain `=` is wrong - for `:eq`, `:neq`, `:in`
+  and `:not_in` alike, since they share one equality primitive. A
+  half-folded implementation is worse than either extreme: "is not
+  alice" leaving a visible "Alice" on screen is the loudest possible
+  wrong answer.
+
+  Plan for the index rather than discovering it: `lower(col)` will not
+  use a plain btree index - add `CREATE INDEX ... ON t (lower(col))`,
+  with the emitted expression matching the index expression exactly.
+  Measured at one million rows (PostgreSQL 14), the functional index
+  makes folded equality as fast as exact (`~0.02ms` either way);
+  without it you get a sequential scan.
+
+  One exception: on a `citext` column, plain `=` is ALREADY
+  case-insensitive and index-backed - wrapping it in `lower()` defeats
+  the index (measured ~28x slower). An adapter that knows a column is
+  citext should emit plain `=` there.
 
   ## Security
 

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -167,6 +167,43 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
     end
   end
 
+  describe "case folding - the published contract" do
+    # These pin the decision, made pre-publish with the evidence in
+    # PR #, that text equality folds case: a person picking "is" in a
+    # filter means "this value", not "these bytes". A byte-exact
+    # equality, if ever needed, arrives as a NEW operator - these
+    # assertions are here to make silently changing this one impossible.
+    @cased [
+      %{id: 1, name: "Alice", status: :Active},
+      %{id: 2, name: "alice", status: :active},
+      %{id: 3, name: "Bob", status: :archived}
+    ]
+
+    defp cased(filter) do
+      {rows, _} = Engine.run(@cased, struct!(State, filters: [filter]))
+      Enum.map(rows, & &1.id)
+    end
+
+    test "eq/neq/in/not_in all fold case, together" do
+      # one equality primitive - a half-folded family would let
+      # "is not alice" leave a visible Alice on screen
+      assert cased(%{field: :name, op: :eq, value: "ALICE"}) == [1, 2]
+      assert cased(%{field: :name, op: :neq, value: "ALICE"}) == [3]
+      assert cased(%{field: :name, op: :in, value: ["ALICE"]}) == [1, 2]
+      assert cased(%{field: :name, op: :not_in, value: ["ALICE"]}) == [3]
+      assert cased(%{field: :status, op: :eq, value: "ACTIVE"}) == [1, 2]
+    end
+
+    test "case folds; accents do not" do
+      rows = [%{id: 1, name: "café"}, %{id: 2, name: "CAFÉ"}, %{id: 3, name: "cafe"}]
+
+      {hit, _} =
+        Engine.run(rows, struct!(State, filters: [%{field: :name, op: :eq, value: "café"}]))
+
+      assert Enum.map(hit, & &1.id) == [1, 2]
+    end
+  end
+
   describe "sorting" do
     test "sorts strings case-insensitively" do
       assert ids(run(order_by: [name: :asc], page_size: 10)) == [3, 2, 1, 5, 4]


### PR DESCRIPTION
The last one-way decision before publish — what does `:eq` mean on text — settled with a four-stream investigation (verified conventions, Pro archaeology, measured Postgres, a live Flop spike) plus an adversarial pass, rather than by instinct.

## Verdict: `:eq` folds case. High confidence.

**The dropdown argument is decisive.** `:eq` doesn't ship alone: one dropdown offers *contains / does not contain / is / is not / starts with*, and `contains`/`starts_with` fold case in every engine (they're ILIKE in SQL). A byte-exact `:eq` would make case behaviour silently flip as the user moves down the list — and *"is not alice"* would leave a row visibly reading **Alice** on screen: an exclusion filter that fails to exclude.

**Conventions, verified against source:** TanStack lowercases both sides of `equalsString` (v8 shipped no sensitive variant at all); AG Grid documents `caseSensitive: false` as the default; MUI compares via `Intl.Collator` sensitivity `"base"` with no case option anywhere in the repo. The sharper signal comes from the case-sensitive camp itself: Airtable's help center tells users to abandon "is" for "contains", and Django's admin overrides its own case-sensitive ORM (`=` → `__iexact`). No surveyed tool exposes case-sensitivity to end users.

**Pro:** zero screens change — every operable `:==` filter today is a fixed-value select or boolean.

**Postgres, measured at 1M rows:** with a functional index on `lower(col)`, folded equality costs the same as exact (~0.02ms both ways). Without it, a seq scan — so the adapter guide says to plan the index, with the numbers.

## What the adversarial pass added (it did not overturn)

- **The citext trap, measured:** on a `citext` column plain `=` is already case-insensitive and index-backed; wrapping it in `lower()` defeats the index (~28x slower). Now in the adapter guidance.
- **Precision in the pin:** case folds and *only* case — accents are not folded ("cafe" ≠ "café", "CAFÉ" = "café"), and SQL `lower()` is collation-dependent, so non-ASCII can diverge per engine. Said out loud rather than discovered.
- **The escape hatch, pre-committed by name:** if byte-exact equality is ever needed it arrives as a new `:eq_sensitive` operator — additive, URL-safe — never as a change to `:eq`.

## Changes

No behaviour change — the engine already folds. This PR makes the behaviour impossible to change *accidentally*: the operator-level pin in `State`'s moduledoc, a **"Writing an adapter"** section carrying the measured guidance, and contract tests asserting the whole equality family (`:eq`/`:neq`/`:in`/`:not_in`) folds together — because a half-folded family is worse than either extreme.

859 tests.