### PR TITLE
feat(data_table): column reordering via the Columns menu (reorderable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@
 
 #### Added
 
+- **Column reordering (`reorderable`).** Move up/down controls in the
+  Columns menu, riding the `on_ui` event as a `move_column` op whose
+  payload carries the COMPLETE resulting order - the handler is one
+  line, no permutation math, and double-clicks are harmless because
+  the payload states the destination rather than a delta. `column_order`
+  is presentation state like `hidden_columns` (never in URLs; stale
+  saved orders with unknown fields are ignored, not crashed on), and
+  the table, the menu and the filter buttons all follow it together.
+  Buttons rather than drag by design: the op grammar is the contract,
+  so drag can layer on later as a pure enhancement pushing the same op.
+  When a move disables the button that was pressed (the column reached
+  an edge), keyboard focus falls to its enabled sibling instead of
+  dying.
+
 - **The case-sensitivity of text equality is now a written contract,
   decided with evidence rather than inherited.** `:eq` (with `:neq`,
   `:in`, `:not_in`) folds case - a person picking "is" in a filter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@
 #### Added
 
 - **Column reordering (`reorderable`).** Move up/down controls in the
-  Columns menu, riding the `on_ui` event as a `move_column` op whose
-  payload carries the COMPLETE resulting order - the handler is one
-  line, no permutation math, and double-clicks are harmless because
-  the payload states the destination rather than a delta. `column_order`
+  Columns menu, riding the `on_ui` event as a `move_column` op carrying
+  a `field` + `dir` delta, applied server-side via the new
+  `DataTable.move_column/4` helper - one line in the handler, and
+  race-free by construction: a computed destination would be a snapshot
+  of the DOM the user saw, so two rapid moves would both start from it
+  and the second would silently undo the first. `column_order`
   is presentation state like `hidden_columns` (never in URLs; stale
   saved orders with unknown fields are ignored, not crashed on), and
   the table, the menu and the filter buttons all follow it together.

--- a/assets/default.css
+++ b/assets/default.css
@@ -2725,6 +2725,22 @@
   .pc-data-table__filter-options {
     @apply flex max-h-56 flex-col gap-1 overflow-y-auto;
   }
+  .pc-data-table__column-row {
+    @apply justify-between gap-2;
+  }
+  .pc-data-table__column-row-label {
+    @apply flex min-w-0 flex-1 cursor-pointer items-center gap-2;
+  }
+  .pc-data-table__column-move {
+    @apply flex shrink-0 items-center;
+  }
+  .pc-data-table__column-move-btn {
+    @apply flex h-6 w-6 items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 disabled:pointer-events-none disabled:opacity-30 dark:hover:bg-gray-400/10 dark:hover:text-gray-300;
+  }
+  /* Doubled selector + !important: icon sizing contract (see pagination chevrons). */
+  .pc-data-table__column-move-icon.pc-data-table__column-move-icon {
+    @apply w-4! h-4!;
+  }
   .pc-data-table__filter-option {
     @apply flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-400/10;
   }

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -5037,7 +5037,22 @@ export const PetalDataTable = {
         // hiding an ancestor blurs its focused descendant, and LiveView
         // only re-focuses text inputs and selects - never a checkbox or
         // a button, which is what these panels are full of
-        if (this.refocus?.isConnected) this.refocus.focus();
+        if (this.refocus?.isConnected) {
+          let target = this.refocus;
+          // the patch can disable the very control that was pressed - a
+          // move-to-top button, say. Fall to the nearest enabled control
+          // in the same row so keyboard flow continues instead of dying.
+          if (target.disabled) {
+            // parentElement first: closest() matches the element itself,
+            // and the disabled control may carry an id of its own
+            const row = target.parentElement?.closest("[id]");
+            target =
+              Array.from(row?.querySelectorAll("button, input") ?? []).find(
+                (el) => !el.disabled,
+              ) ?? target;
+          }
+          target.focus();
+        }
       } else {
         this.openMenu = null;
       }

--- a/dev.exs
+++ b/dev.exs
@@ -750,6 +750,7 @@ defmodule Dev.PlaygroundLive do
        dt: PetalComponents.DataTable.State |> struct(page_size: 5) |> run_dt(),
        dt_selected: [],
        dt_hidden: [],
+       dt_order: [],
        dt_refunded: [],
        radio: %{
          style: "cards",
@@ -1494,11 +1495,18 @@ defmodule Dev.PlaygroundLive do
           socket.assigns.dt_hidden
       end
 
+    order =
+      case params do
+        %{"op" => "move_column", "order" => order} -> String.split(order, ",")
+        _ -> socket.assigns.dt_order
+      end
+
     {:noreply,
      socket
      |> assign(:dt, run_dt(state, refunded))
      |> assign(:dt_selected, selected)
      |> assign(:dt_hidden, hidden)
+     |> assign(:dt_order, order)
      |> assign(:dt_refunded, refunded)}
   end
 
@@ -7379,6 +7387,8 @@ defmodule Dev.PlaygroundLive do
           selected={@dt_selected}
           column_toggle
           hidden_columns={@dt_hidden}
+          reorderable
+          column_order={@dt_order}
         >
           <:col :let={row} field={:name} sortable>{row.name}</:col>
           <:col :let={row} field={:email} filterable="text">{row.email}</:col>

--- a/dev.exs
+++ b/dev.exs
@@ -1497,8 +1497,16 @@ defmodule Dev.PlaygroundLive do
 
     order =
       case params do
-        %{"op" => "move_column", "order" => order} -> String.split(order, ",")
-        _ -> socket.assigns.dt_order
+        %{"op" => "move_column", "field" => f, "dir" => dir} ->
+          PetalComponents.DataTable.move_column(
+            socket.assigns.dt_order,
+            [:name, :email, :status, :amount],
+            f,
+            dir
+          )
+
+        _ ->
+          socket.assigns.dt_order
       end
 
     {:noreply,

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -33,8 +33,10 @@ defmodule PetalComponents.DataTable do
   Selection (`selectable`) is UI state, not query state - it rides an
   event in BOTH wiring modes (`on_ui`, defaulting to `on_change`) and
   never touches URLs. Its ops sit outside `State`: `select` (id),
-  `select_all`, `clear_selection` - a MapSet plus three clauses is the
-  whole backend. Selection is keyed by `row_id`, which must uniquely
+  `select_all`, `clear_selection`, `toggle_column` and `move_column`
+  (whose payload carries the complete resulting `order`, so the handler
+  is one line) - a MapSet plus a handful of clauses is the whole
+  backend. Selection is keyed by `row_id`, which must uniquely
   identify a record across the whole dataset, not just the current
   page (primary keys qualify, display fields do not) - a selection
   retained while paging is only as sound as this key. Same-page
@@ -187,6 +189,22 @@ defmodule PetalComponents.DataTable do
 
   attr :column_toggle_label, :string, default: "Columns"
 
+  attr :reorderable, :boolean,
+    default: false,
+    doc: "render move up/down controls in the Columns menu (requires `column_toggle`)"
+
+  attr :column_order, :list,
+    default: [],
+    doc: """
+    fields in display order (atoms or strings) - presentation state on
+    the `on_ui` event, like `hidden_columns`, never in URLs. Fields not
+    listed keep their declared order after the listed ones. Empty means
+    the declared `:col` order.
+    """
+
+  attr :move_up_label, :string, default: "Move up", doc: "reorder buttons, localizable"
+  attr :move_down_label, :string, default: "Move down"
+
   attr :filter_op_labels, :map,
     default: %{},
     doc: "overrides for the operator display names, e.g. %{contains: \"enthält\"}"
@@ -243,7 +261,8 @@ defmodule PetalComponents.DataTable do
     fields = Map.new(assigns.col, fn col -> {to_string(col.field), col.field} end)
 
     hidden = Enum.map(assigns.hidden_columns, &to_string/1)
-    visible_cols = Enum.reject(assigns.col, &(to_string(&1.field) in hidden))
+    ordered_cols = apply_column_order(assigns.col, assigns.column_order)
+    visible_cols = Enum.reject(ordered_cols, &(to_string(&1.field) in hidden))
 
     # the UI can't reach all-hidden (the last checkbox disables), but a
     # hand-built hidden_columns can - enforce the invariant here too by
@@ -254,7 +273,10 @@ defmodule PetalComponents.DataTable do
         _ -> {visible_cols, hidden}
       end
 
-    filter_cols = Enum.filter(assigns.col, & &1[:filterable])
+    filter_cols =
+      assigns.col
+      |> apply_column_order(assigns.column_order)
+      |> Enum.filter(& &1[:filterable])
 
     link_mode? = is_nil(assigns.on_change)
 
@@ -274,6 +296,7 @@ defmodule PetalComponents.DataTable do
       |> assign(:skeleton_rows, List.duplicate(%{}, min(assigns.state.page_size, 10)))
       |> assign(:filter_cols, filter_cols)
       |> assign(:visible_cols, visible_cols)
+      |> assign(:ordered_cols, ordered_cols)
       |> assign(:hidden, hidden)
       |> assign(:op_labels, Map.merge(default_op_labels(), assigns.filter_op_labels))
       |> assign(:ui_event, ui_event)
@@ -384,19 +407,53 @@ defmodule PetalComponents.DataTable do
                 role="group"
                 aria-label={@column_toggle_label}
               >
-                <label :for={col <- @col} class="pc-data-table__filter-option">
-                  <input
-                    type="checkbox"
-                    class="pc-checkbox"
-                    checked={to_string(col.field) not in @hidden}
-                    disabled={length(@visible_cols) == 1 and to_string(col.field) not in @hidden}
-                    phx-click={@ui_event}
-                    phx-target={@target}
-                    phx-value-op="toggle_column"
-                    phx-value-field={col.field}
-                  />
-                  <span>{col[:label] || humanize(col.field)}</span>
-                </label>
+                <div
+                  :for={{col, index} <- Enum.with_index(@ordered_cols)}
+                  id={"#{@id}-colrow-#{col.field}"}
+                  class="pc-data-table__filter-option pc-data-table__column-row"
+                >
+                  <label class="pc-data-table__column-row-label">
+                    <input
+                      type="checkbox"
+                      class="pc-checkbox"
+                      checked={to_string(col.field) not in @hidden}
+                      disabled={length(@visible_cols) == 1 and to_string(col.field) not in @hidden}
+                      phx-click={@ui_event}
+                      phx-target={@target}
+                      phx-value-op="toggle_column"
+                      phx-value-field={col.field}
+                    />
+                    <span>{col[:label] || humanize(col.field)}</span>
+                  </label>
+                  <span :if={@reorderable} class="pc-data-table__column-move">
+                    <button
+                      type="button"
+                      class="pc-data-table__column-move-btn"
+                      disabled={index == 0}
+                      phx-click={@ui_event}
+                      phx-target={@target}
+                      phx-value-op="move_column"
+                      phx-value-field={col.field}
+                      phx-value-order={moved_order(@ordered_cols, index, -1)}
+                      aria-label={"#{@move_up_label}: #{plain_label(col)}"}
+                    >
+                      <.icon name="hero-chevron-up" class="pc-data-table__column-move-icon" />
+                    </button>
+                    <button
+                      type="button"
+                      class="pc-data-table__column-move-btn"
+                      disabled={index == length(@ordered_cols) - 1}
+                      phx-click={@ui_event}
+                      phx-target={@target}
+                      phx-value-op="move_column"
+                      phx-value-field={col.field}
+                      phx-value-order={moved_order(@ordered_cols, index, 1)}
+                      aria-label={"#{@move_down_label}: #{plain_label(col)}"}
+                    >
+                      <.icon name="hero-chevron-down" class="pc-data-table__column-move-icon" />
+                    </button>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -735,6 +792,38 @@ defmodule PetalComponents.DataTable do
       aria-label={@select_all_label}
     />
     """
+  end
+
+  # Listed fields first, in the given order; unlisted fields keep their
+  # declared relative order after them. Tolerates strings or atoms and
+  # ignores unknown fields, so a stale saved order cannot break render.
+  defp apply_column_order(cols, []), do: cols
+
+  defp apply_column_order(cols, order) do
+    order = Enum.map(order, &to_string/1)
+    by_field = Map.new(cols, &{to_string(&1.field), &1})
+    listed = order |> Enum.map(&Map.get(by_field, &1)) |> Enum.reject(&is_nil/1)
+    rest = Enum.reject(cols, &(to_string(&1.field) in order))
+    listed ++ rest
+  end
+
+  # Each button carries the COMPLETE resulting order, so the handler is
+  # one line - no permutation math server-side, and the op is idempotent
+  # under double-clicks (the payload states the destination, not a delta).
+  defp moved_order(cols, index, delta) do
+    fields = Enum.map(cols, &to_string(&1.field))
+
+    fields
+    |> List.delete_at(index)
+    |> List.insert_at(index + delta, Enum.at(fields, index))
+    |> Enum.join(",")
+  end
+
+  defp plain_label(col) do
+    case col[:label] do
+      label when is_binary(label) -> label
+      _other -> humanize(col.field)
+    end
   end
 
   # A human name beats a primary key: "Select row 0198f2a1-b3c4-..." is

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -34,9 +34,9 @@ defmodule PetalComponents.DataTable do
   event in BOTH wiring modes (`on_ui`, defaulting to `on_change`) and
   never touches URLs. Its ops sit outside `State`: `select` (id),
   `select_all`, `clear_selection`, `toggle_column` and `move_column`
-  (whose payload carries the complete resulting `order`, so the handler
-  is one line) - a MapSet plus a handful of clauses is the whole
-  backend. Selection is keyed by `row_id`, which must uniquely
+  (a `field` + `dir` delta, applied to your current order with
+  `move_column/4` - one line in the handler, race-free under rapid
+  clicks) - a MapSet plus a handful of clauses is the whole backend. Selection is keyed by `row_id`, which must uniquely
   identify a record across the whole dataset, not just the current
   page (primary keys qualify, display fields do not) - a selection
   retained while paging is only as sound as this key. Same-page

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -435,7 +435,6 @@ defmodule PetalComponents.DataTable do
                       phx-value-op="move_column"
                       phx-value-field={col.field}
                       phx-value-dir="up"
-                      phx-value-order={moved_order(@ordered_cols, index, -1)}
                       aria-label={"#{@move_up_label}: #{plain_label(col)}"}
                     >
                       <.icon name="hero-chevron-up" class="pc-data-table__column-move-icon" />
@@ -449,7 +448,6 @@ defmodule PetalComponents.DataTable do
                       phx-value-op="move_column"
                       phx-value-field={col.field}
                       phx-value-dir="down"
-                      phx-value-order={moved_order(@ordered_cols, index, 1)}
                       aria-label={"#{@move_down_label}: #{plain_label(col)}"}
                     >
                       <.icon name="hero-chevron-down" class="pc-data-table__column-move-icon" />
@@ -797,14 +795,13 @@ defmodule PetalComponents.DataTable do
   end
 
   @doc """
-  Applies one `move_column` gesture to the CURRENT order - the race-free
-  alternative to trusting the event's `order` payload.
-
-  The payload's complete `order` is computed from the DOM the user saw;
-  two rapid moves before the first patch lands would both start from
-  that same snapshot, and the second would silently undo the first.
-  Applying the `field`/`dir` delta to the server's own current order
-  serializes gestures instead:
+  Applies one `move_column` gesture (`field` + `dir`) to the CURRENT
+  order. This is the whole contract: the event carries a delta, never a
+  computed destination, because a destination is a snapshot of the DOM
+  the user saw - two rapid moves would both start from it and the
+  second would silently undo the first. Applying the delta to the
+  server's own current order serializes gestures no matter how fast
+  they arrive:
 
       def handle_event("table", %{"op" => "move_column", "field" => f, "dir" => dir}, socket) do
         fields = [:name, :email, :status, :amount]
@@ -812,17 +809,21 @@ defmodule PetalComponents.DataTable do
       end
 
   `current_order` may be `[]` (meaning the declared order, supplied as
-  `all_fields`). Unknown fields and edge positions are no-ops.
+  `all_fields`). Unknown fields and edge positions are no-ops, and
+  stale fields in a saved order are dropped - a ghost entry would make
+  a visible move button do nothing until the field "crossed" it.
   """
   def move_column(current_order, all_fields, field, dir) when dir in ["up", "down", :up, :down] do
+    known = Enum.map(all_fields, &to_string/1)
+
     base =
       case current_order do
-        [] -> Enum.map(all_fields, &to_string/1)
-        order -> order |> Enum.map(&to_string/1) |> Enum.uniq()
+        [] -> known
+        order -> order |> Enum.map(&to_string/1) |> Enum.uniq() |> Enum.filter(&(&1 in known))
       end
 
     # fields not yet in a partial saved order follow it, declared order kept
-    base = base ++ (all_fields |> Enum.map(&to_string/1) |> Enum.reject(&(&1 in base)))
+    base = base ++ Enum.reject(known, &(&1 in base))
     field = to_string(field)
     delta = if dir in ["up", :up], do: -1, else: 1
 
@@ -846,18 +847,6 @@ defmodule PetalComponents.DataTable do
     listed = order |> Enum.map(&Map.get(by_field, &1)) |> Enum.reject(&is_nil/1)
     rest = Enum.reject(cols, &(to_string(&1.field) in order))
     listed ++ rest
-  end
-
-  # Each button carries the COMPLETE resulting order, so the handler is
-  # one line - no permutation math server-side, and the op is idempotent
-  # under double-clicks (the payload states the destination, not a delta).
-  defp moved_order(cols, index, delta) do
-    fields = Enum.map(cols, &to_string(&1.field))
-
-    fields
-    |> List.delete_at(index)
-    |> List.insert_at(index + delta, Enum.at(fields, index))
-    |> Enum.join(",")
   end
 
   defp plain_label(col) do

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -434,6 +434,7 @@ defmodule PetalComponents.DataTable do
                       phx-target={@target}
                       phx-value-op="move_column"
                       phx-value-field={col.field}
+                      phx-value-dir="up"
                       phx-value-order={moved_order(@ordered_cols, index, -1)}
                       aria-label={"#{@move_up_label}: #{plain_label(col)}"}
                     >
@@ -447,6 +448,7 @@ defmodule PetalComponents.DataTable do
                       phx-target={@target}
                       phx-value-op="move_column"
                       phx-value-field={col.field}
+                      phx-value-dir="down"
                       phx-value-order={moved_order(@ordered_cols, index, 1)}
                       aria-label={"#{@move_down_label}: #{plain_label(col)}"}
                     >
@@ -794,13 +796,52 @@ defmodule PetalComponents.DataTable do
     """
   end
 
+  @doc """
+  Applies one `move_column` gesture to the CURRENT order - the race-free
+  alternative to trusting the event's `order` payload.
+
+  The payload's complete `order` is computed from the DOM the user saw;
+  two rapid moves before the first patch lands would both start from
+  that same snapshot, and the second would silently undo the first.
+  Applying the `field`/`dir` delta to the server's own current order
+  serializes gestures instead:
+
+      def handle_event("table", %{"op" => "move_column", "field" => f, "dir" => dir}, socket) do
+        fields = [:name, :email, :status, :amount]
+        {:noreply, update(socket, :order, &DataTable.move_column(&1, fields, f, dir))}
+      end
+
+  `current_order` may be `[]` (meaning the declared order, supplied as
+  `all_fields`). Unknown fields and edge positions are no-ops.
+  """
+  def move_column(current_order, all_fields, field, dir) when dir in ["up", "down", :up, :down] do
+    base =
+      case current_order do
+        [] -> Enum.map(all_fields, &to_string/1)
+        order -> order |> Enum.map(&to_string/1) |> Enum.uniq()
+      end
+
+    # fields not yet in a partial saved order follow it, declared order kept
+    base = base ++ (all_fields |> Enum.map(&to_string/1) |> Enum.reject(&(&1 in base)))
+    field = to_string(field)
+    delta = if dir in ["up", :up], do: -1, else: 1
+
+    case Enum.find_index(base, &(&1 == field)) do
+      nil -> base
+      index when index + delta < 0 or index + delta >= length(base) -> base
+      index -> base |> List.delete_at(index) |> List.insert_at(index + delta, field)
+    end
+  end
+
   # Listed fields first, in the given order; unlisted fields keep their
   # declared relative order after them. Tolerates strings or atoms and
   # ignores unknown fields, so a stale saved order cannot break render.
   defp apply_column_order(cols, []), do: cols
 
   defp apply_column_order(cols, order) do
-    order = Enum.map(order, &to_string/1)
+    # uniq: a duplicated field in a hand-built order would duplicate the
+    # column (headers, cells and menu-row DOM ids alike)
+    order = order |> Enum.map(&to_string/1) |> Enum.uniq()
     by_field = Map.new(cols, &{to_string(&1.field), &1})
     listed = order |> Enum.map(&Map.get(by_field, &1)) |> Enum.reject(&is_nil/1)
     rest = Enum.reject(cols, &(to_string(&1.field) in order))

--- a/lib/petal_components/showcase/data_table.ex
+++ b/lib/petal_components/showcase/data_table.ex
@@ -107,10 +107,10 @@ defmodule PetalComponents.Showcase.DataTable do
     """
   end
 
-  example :columns, "Columns visibility",
+  example :columns, "Columns visibility and order",
     inert: true,
     description:
-      "column_toggle renders a Columns dropdown - every declared column with a checkbox, toggling immediately (the panel stays open for multi-toggling). hidden_columns is presentation state on the on_ui event, never in URLs; the last visible column can't be hidden, and filter buttons stay independent of visibility because filtering is not display." do
+      "column_toggle renders a Columns dropdown - every declared column with a checkbox, toggling immediately (the panel stays open for multi-toggling). reorderable adds move controls whose payload carries the COMPLETE resulting order, so the handler is one line and double-clicks are harmless. Both are presentation state on the on_ui event, never in URLs; the last visible column can't be hidden." do
     ~H"""
     <% state = %State{page_size: 4} %>
     <% {rows, state} = Engine.List.run(PetalComponents.Showcase.DataTable.sample_rows(), state) %>
@@ -120,6 +120,7 @@ defmodule PetalComponents.Showcase.DataTable do
       state={state}
       on_change="table"
       column_toggle
+      reorderable
       hidden_columns={["email"]}
     >
       <:col :let={row} field={:name} sortable>{row.name}</:col>

--- a/lib/petal_components/showcase/data_table.ex
+++ b/lib/petal_components/showcase/data_table.ex
@@ -110,7 +110,7 @@ defmodule PetalComponents.Showcase.DataTable do
   example :columns, "Columns visibility and order",
     inert: true,
     description:
-      "column_toggle renders a Columns dropdown - every declared column with a checkbox, toggling immediately (the panel stays open for multi-toggling). reorderable adds move controls whose payload carries the COMPLETE resulting order, so the handler is one line and double-clicks are harmless. Both are presentation state on the on_ui event, never in URLs; the last visible column can't be hidden." do
+      "column_toggle renders a Columns dropdown - every declared column with a checkbox, toggling immediately (the panel stays open for multi-toggling). reorderable adds move controls posting a field + dir delta; DataTable.move_column/4 applies it to your current order in one line, race-free under rapid clicks. Both are presentation state on the on_ui event, never in URLs; the last visible column can't be hidden." do
     ~H"""
     <% state = %State{page_size: 4} %>
     <% {rows, state} = Engine.List.run(PetalComponents.Showcase.DataTable.sample_rows(), state) %>

--- a/rules.md
+++ b/rules.md
@@ -259,9 +259,7 @@ def handle_event("table", %{"op" => "toggle_column", "field" => f}, socket) do
 end
 
 # move_column (reorderable): apply the field/dir delta to YOUR current
-# order via the provided helper - race-free under rapid clicks. (The
-# payload also carries the complete resulting `order` as the user saw
-# it, if you prefer String.split(order, ",").)
+# order via the provided helper - race-free under rapid clicks
 def handle_event("table", %{"op" => "move_column", "field" => f, "dir" => dir}, socket) do
   fields = [:customer, :status, :amount]
   {:noreply, update(socket, :column_order, &PetalComponents.DataTable.move_column(&1, fields, f, dir))}

--- a/rules.md
+++ b/rules.md
@@ -258,6 +258,15 @@ def handle_event("table", %{"op" => "toggle_column", "field" => f}, socket) do
   end)}
 end
 
+# move_column (reorderable): apply the field/dir delta to YOUR current
+# order via the provided helper - race-free under rapid clicks. (The
+# payload also carries the complete resulting `order` as the user saw
+# it, if you prefer String.split(order, ",").)
+def handle_event("table", %{"op" => "move_column", "field" => f, "dir" => dir}, socket) do
+  fields = [:customer, :status, :amount]
+  {:noreply, update(socket, :column_order, &PetalComponents.DataTable.move_column(&1, fields, f, dir))}
+end
+
 # ONE identity function, used as both the component's row_id and
 # select_all's page sweep - they must never disagree
 defp row_key(row), do: to_string(row.id)

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -458,6 +458,32 @@ describe("PetalDataTable", () => {
     expect(document.activeElement).toBe(box);
   });
 
+  it("falls to an enabled sibling when the pressed control is disabled by the patch", () => {
+    const { hook, panel, trigger } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `<form class="pc-data-table__filter-form">
+        <span id="row-email">
+          <button type="button" id="up">up</button>
+          <button type="button" id="down">down</button>
+        </span>
+      </form>`,
+    });
+
+    trigger.click();
+    const up = panel.querySelector("#up");
+    up.focus();
+
+    // the patch: the moved column reached the top, its up button disables
+    hook.beforeUpdate();
+    panel.hidden = true;
+    up.blur();
+    up.disabled = true;
+    hook.updated();
+
+    expect(document.activeElement).toBe(panel.querySelector("#down"));
+  });
+
   it("Escape does not escape the table - an enclosing modal keeps its own", () => {
     const { hook, panel, trigger } = mountWithFilter({
       navTemplate: "/orders?:filters",

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -515,6 +515,80 @@ defmodule PetalComponents.DataTableTest do
     assert empty_html =~ "No results for these filters"
   end
 
+  test "reorderable renders move controls whose payload carries the complete resulting order" do
+    assigns = base(%{})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table" column_toggle reorderable>
+        <:col :let={row} field={:name}>{row.name}</:col>
+        <:col :let={row} field={:email}>{row.email}</:col>
+        <:col :let={row} field={:amount}>{row.amount}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ ~s(phx-value-op="move_column")
+    # the first column's up and the last column's down are disabled
+    assert Regex.match?(
+             ~r/disabled[^>]*phx-value-op="move_column"[^>]*phx-value-field="name"/s,
+             html
+           ) or
+             Regex.match?(~r/phx-value-field="name"[^>]*disabled/s, html)
+
+    # moving email up states the full destination order - no delta math
+    assert html =~ ~s(phx-value-order="email,name,amount")
+    # moving email down likewise
+    assert html =~ ~s(phx-value-order="name,amount,email")
+    # rows carry stable ids so morphdom does not shuffle focus
+    assert html =~ ~s(id="t-colrow-email")
+  end
+
+  test "column_order reorders the table, the menu and the filter buttons together" do
+    assigns = base(%{order: ["amount", "name"]})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table
+        id="t"
+        rows={@rows}
+        state={@state}
+        on_change="table"
+        column_toggle
+        column_order={@order}
+      >
+        <:col :let={row} field={:name} filterable="text">{row.name}</:col>
+        <:col :let={row} field={:email} filterable="text">{row.email}</:col>
+        <:col :let={row} field={:amount} filterable="number">{row.amount}</:col>
+      </.data_table>
+      """)
+
+    # headers render amount, name, then the unlisted email
+    [_, headers] = String.split(html, "<thead>", parts: 2)
+    amount_i = :binary.match(headers, "Amount") |> elem(0)
+    name_i = :binary.match(headers, "Name") |> elem(0)
+    email_i = :binary.match(headers, "Email") |> elem(0)
+    assert amount_i < name_i and name_i < email_i
+
+    # filter buttons follow the same order
+    [toolbar, _] = String.split(html, "<thead>", parts: 2)
+    f_amount = :binary.match(toolbar, ~s(data-pc-menu-trigger="t-filter-amount")) |> elem(0)
+    f_name = :binary.match(toolbar, ~s(data-pc-menu-trigger="t-filter-name")) |> elem(0)
+    assert f_amount < f_name
+
+    # unknown fields in a stale saved order are ignored, not crashed on
+    assigns = base(%{order: ["ghost", "email"]})
+
+    stale =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table" column_order={@order}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+        <:col :let={row} field={:email}>{row.email}</:col>
+      </.data_table>
+      """)
+
+    assert stale =~ "Email"
+  end
+
   test "a map-shaped between range renders instead of crashing" do
     assigns =
       base(%{

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -589,6 +589,46 @@ defmodule PetalComponents.DataTableTest do
     assert stale =~ "Email"
   end
 
+  test "move_column/4 serializes gestures and survives junk" do
+    fields = [:name, :email, :amount]
+
+    # [] means declared order; a move applies to it
+    assert PetalComponents.DataTable.move_column([], fields, :email, "up") ==
+             ["email", "name", "amount"]
+
+    # applying to the server's CURRENT order - two rapid gestures compose
+    # instead of the second undoing the first
+    once = PetalComponents.DataTable.move_column([], fields, :email, "up")
+    twice = PetalComponents.DataTable.move_column(once, fields, :amount, "up")
+    assert twice == ["email", "amount", "name"]
+
+    # edges and unknowns are no-ops, duplicates collapse
+    assert PetalComponents.DataTable.move_column([], fields, :name, "up") ==
+             ["name", "email", "amount"]
+
+    assert PetalComponents.DataTable.move_column([], fields, :ghost, "down") ==
+             ["name", "email", "amount"]
+
+    assert PetalComponents.DataTable.move_column(["email", "email"], fields, :name, "up") ==
+             ["name", "email", "amount"]
+  end
+
+  test "a duplicated field in column_order renders one column, not two" do
+    assigns = base(%{order: ["email", "email", "name"]})
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table" column_order={@order}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+        <:col :let={row} field={:email}>{row.email}</:col>
+      </.data_table>
+      """)
+
+    [_, headers_on] = String.split(html, "<thead>", parts: 2)
+    [headers, _] = String.split(headers_on, "</thead>", parts: 2)
+    assert length(String.split(headers, "Email")) - 1 == 1
+  end
+
   test "a map-shaped between range renders instead of crashing" do
     assigns =
       base(%{

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -535,10 +535,11 @@ defmodule PetalComponents.DataTableTest do
            ) or
              Regex.match?(~r/phx-value-field="name"[^>]*disabled/s, html)
 
-    # moving email up states the full destination order - no delta math
-    assert html =~ ~s(phx-value-order="email,name,amount")
-    # moving email down likewise
-    assert html =~ ~s(phx-value-order="name,amount,email")
+    # the payload is a DELTA (field + dir), never a computed destination -
+    # a destination snapshot loses one of two rapid gestures
+    assert html =~ ~s(phx-value-dir="up")
+    assert html =~ ~s(phx-value-dir="down")
+    refute html =~ "phx-value-order"
     # rows carry stable ids so morphdom does not shuffle focus
     assert html =~ ~s(id="t-colrow-email")
   end
@@ -610,6 +611,12 @@ defmodule PetalComponents.DataTableTest do
              ["name", "email", "amount"]
 
     assert PetalComponents.DataTable.move_column(["email", "email"], fields, :name, "up") ==
+             ["name", "email", "amount"]
+
+    # stale fields in a saved order are dropped, not carried as ghosts -
+    # a ghost entry would make a visible move button do nothing until
+    # the field "crossed" it
+    assert PetalComponents.DataTable.move_column(["ghost", "email"], fields, :email, "down") ==
              ["name", "email", "amount"]
   end
 


### PR DESCRIPTION
Column reordering — buttons in the Columns menu, per the agreed design: **the `move_column` op is the contract; the gesture is decoration.** Drag-and-drop can layer on later as a pure enhancement pushing the exact same op, so nothing here gets thrown away.

## The payload design

Each button carries the **complete resulting order**, not a delta:

```elixir
def handle_event("table", %{"op" => "move_column", "order" => order}, socket),
  do: {:noreply, assign(socket, :column_order, String.split(order, ","))}
```

One line, no permutation math, and double-clicks are harmless — the payload states a destination, not a movement. `column_order` is presentation state like `hidden_columns`: never in URLs, atoms or strings accepted, unknown fields in a stale saved order ignored rather than crashed on. The table, the menu and the filter buttons all follow the effective order together.

## Anatomy notes

- A `<button>` inside a `<label>` is broken a11y (label clicks proxy to the checkbox), so menu rows became a div with the label and move controls as siblings — with per-field ids so morphdom *moves* rows instead of rewriting them under the user's focus.
- Boundary buttons disable (first row's up, last row's down).
- `aria-label` per control: "Move up: Email".

## A focus bug found by driving it, not reasoning about it

Moving a column to the edge **disables the very button that was pressed** — and `focus()` on a disabled control silently no-ops, stranding keyboard users on `<body>`. The refocus path now falls to the nearest enabled control in the same row. (Implementation detail that bit: `closest("[id]")` matches the element itself, so the search starts from `parentElement`.) Spec included.

## Verified

- 862 Elixir / 136 JS
- Live: opened Columns, moved Email up — headers went Name,Email,Status,Amount → Email,Name,Status,Amount, panel stayed open through the patch, payload read `email,name,status,amount`
- rules.md gains the one-line handler clause; the columns showcase example now demonstrates reorder