### PR TITLE
fix(engine): the differential gate's findings - Decimal, between, and four more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 
 #### Fixed
 
+- **Decimal columns now filter and sort.** `%Decimal{}` - what every
+  Ecto money column holds - was readable by no operator (every filter
+  silently matched zero rows) and sorted by struct internals, so
+  -10.00 ordered as the largest value. Found by the differential gate:
+  the same `State` run through the in-memory engine and through a
+  Flop/Postgres bridge over identical rows, where 31 of 39
+  disagreements traced to this one defect. Decimals now compare
+  numerically everywhere - equality, comparators, `:between`, sorting -
+  and read as text for `:in` and the pattern ops, like every scalar.
+- **`:between` now works on any ordered column.** It was guarded to
+  numbers, so a date range - the most common data-table filter there
+  is - matched nothing while `:gte`/`:lte` on the same column worked.
+  It is now defined as `:gte` AND `:lte`, one ladder, so ranges behave
+  identically to the comparators they decompose into.
+- **`:in` and the pattern operators work on date and Decimal columns**
+  via their text form - a select filter on a date column used to match
+  nothing at all.
+- **Default quick-search fields survive Ecto structs.** The sweep used
+  `for {k, v} <- row`, which raises on structs - exactly the rows a
+  database engine produces.
+- **A JSON-null filter value is dropped** for value-carrying operators
+  instead of quietly reading as `""` and matching empty-string rows.
+
 - **`sticky_header` never worked.** `.pc-table--basic` and `--ghost`
   used `overflow: hidden`, which makes the table a scroll container and
   traps `position: sticky` - so the header scrolled away in every
@@ -14,6 +37,13 @@
   column visibility rendered a button that did nothing.
 
 #### Added
+
+- **Two more pinned contract rules**, both cross-engine findings:
+  date operators are defined only for date-typed cells (a text column
+  holding an ISO string does not match - no SQL engine would cast
+  every row to find out), and an empty `order_by` or a tie within one
+  has no defined cross-engine row order - append a unique tiebreaker
+  for stable paging.
 
 - **Column reordering (`reorderable`).** Move up/down controls in the
   Columns menu, riding the `on_ui` event as a `move_column` op carrying

--- a/lib/petal_components/data_table/engine/list.ex
+++ b/lib/petal_components/data_table/engine/list.ex
@@ -71,9 +71,7 @@ defmodule PetalComponents.DataTable.Engine.List do
   defp apply_search([], _term, _fields), do: []
 
   defp apply_search([first | _] = rows, term, fields) do
-    fields =
-      fields ||
-        for {k, v} <- first, is_binary(v), do: k
+    fields = fields || default_search_fields(first)
 
     needle = String.downcase(term)
 
@@ -85,6 +83,20 @@ defmodule PetalComponents.DataTable.Engine.List do
         end
       end)
     end)
+  end
+
+  # Ecto structs are not Enumerable - `for {k, v} <- row` raises on
+  # exactly the rows a database produces. Strip the struct plumbing and
+  # sweep the string fields, same as for a plain map.
+  defp default_search_fields(%_{} = row) do
+    row
+    |> Map.from_struct()
+    |> Map.drop([:__meta__])
+    |> Enum.flat_map(fn {k, v} -> if is_binary(v), do: [k], else: [] end)
+  end
+
+  defp default_search_fields(row) when is_map(row) do
+    for {k, v} <- row, is_binary(v), do: k
   end
 
   # -- sorting ---------------------------------------------------------------
@@ -125,6 +137,12 @@ defmodule PetalComponents.DataTable.Engine.List do
     end
   end
 
+  # Decimal first: it is a struct too, but Erlang term order over its
+  # fields (coef/exp/sign) sorted -10.00 as the LARGEST value
+  defp cmp(%Decimal{} = a, %Decimal{} = b), do: Decimal.compare(a, b)
+  defp cmp(%Decimal{} = a, b) when is_number(b), do: Decimal.compare(a, to_decimal(b))
+  defp cmp(a, %Decimal{} = b) when is_number(a), do: Decimal.compare(to_decimal(a), b)
+
   defp cmp(%m{} = a, %m{} = b) when m in [Date, DateTime, NaiveDateTime, Time],
     do: m.compare(a, b)
 
@@ -164,6 +182,16 @@ defmodule PetalComponents.DataTable.Engine.List do
 
   defp matches?(nil, _op, _value), do: false
 
+  # Struct scalars read as their text form for the text-shaped ops: a
+  # select filter on a date column posts "2026-01-15" and must match
+  # ~D[2026-01-15]; :in is a text-form comparison on every column type
+  # ("010" does not match 10). Comparators and date ops keep their own
+  # typed clauses below.
+  defp matches?(%mod{} = field_value, op, value)
+       when mod in [Decimal, Date, DateTime, NaiveDateTime, Time] and
+              op in [:contains, :not_contains, :starts_with, :in, :not_in],
+       do: matches?(to_string(field_value), op, value)
+
   defp matches?(field_value, :contains, value) when is_scalar(field_value),
     do: with_text(value, &String.contains?(downcase(field_value), &1))
 
@@ -175,6 +203,13 @@ defmodule PetalComponents.DataTable.Engine.List do
 
   defp matches?(field_value, :eq, value) when is_number(field_value),
     do: with_number(value, &(field_value == &1))
+
+  # Money columns are %Decimal{} structs in every Ecto app - neither
+  # is_number/1 nor is_scalar/1, so before this clause every operator
+  # silently matched zero rows against them (found by the differential
+  # gate, not by any of 860 unit tests)
+  defp matches?(%Decimal{} = field_value, :eq, value),
+    do: with_decimal(value, &(Decimal.compare(field_value, &1) == :eq))
 
   # Atoms and booleans compare as their text form - the same treatment
   # :in (values_equal?/2) and :contains already give them. Without this
@@ -203,11 +238,11 @@ defmodule PetalComponents.DataTable.Engine.List do
   defp matches?(field_value, :lt, value), do: compare(field_value, value, [:lt])
   defp matches?(field_value, :lte, value), do: compare(field_value, value, [:lt, :eq])
 
-  defp matches?(field_value, :between, [min, max]) when is_number(field_value) do
-    with_number(min, fn lo ->
-      with_number(max, fn hi -> field_value >= lo and field_value <= hi end)
-    end)
-  end
+  # between IS gte and lte - one definition, so a date range behaves
+  # exactly like the two comparators it decomposes into (the gate found
+  # the old number-only guard made a date range match nothing, silently)
+  defp matches?(field_value, :between, [min, max]),
+    do: matches?(field_value, :gte, min) and matches?(field_value, :lte, max)
 
   defp matches?(field_value, :between, %{"min" => min, "max" => max}),
     do: matches?(field_value, :between, [min, max])
@@ -230,7 +265,12 @@ defmodule PetalComponents.DataTable.Engine.List do
        when is_scalar(field_value) and is_list(values) and values != [],
        do: not matches?(field_value, :in, values)
 
-  defp matches?(field_value, op, value) when op in [:before, :on, :after] do
+  # Date ops are defined only for date-typed cells. The old clause
+  # coerced binary cells too, so a :string column holding "2026-01-05"
+  # matched :on filters here while no SQL engine would cast every row -
+  # a cross-engine divergence waiting for pathological data.
+  defp matches?(%mod{} = field_value, op, value)
+       when mod in [Date, DateTime, NaiveDateTime] and op in [:before, :on, :after] do
     with {:ok, field_date} <- to_date(field_value),
          {:ok, value_date} <- to_date(value) do
       case {op, Date.compare(field_date, value_date)} do
@@ -254,6 +294,9 @@ defmodule PetalComponents.DataTable.Engine.List do
       is_number(field_value) ->
         with_number(value, &(cmp(field_value, &1) in wanted))
 
+      is_struct(field_value, Decimal) ->
+        with_decimal(value, &(Decimal.compare(field_value, &1) in wanted))
+
       match?({:ok, _}, to_date(field_value)) ->
         with {{:ok, a}, {:ok, b}} <- {to_date(field_value), to_date(value)} do
           Date.compare(a, b) in wanted
@@ -273,6 +316,8 @@ defmodule PetalComponents.DataTable.Engine.List do
   # field of this shape? Mirrors the coercion the :eq clauses perform.
   defp evaluable?(field_value, value) when is_binary(field_value), do: text_value?(value)
   defp evaluable?(field_value, value) when is_number(field_value), do: number_value?(value)
+
+  defp evaluable?(%Decimal{}, value), do: match?({:ok, _}, decimal(value))
 
   defp evaluable?(field_value, value) do
     case to_date(field_value) do
@@ -315,6 +360,29 @@ defmodule PetalComponents.DataTable.Engine.List do
     do: fun.(value |> to_string() |> String.downcase())
 
   defp with_text(_other, _fun), do: false
+
+  defp with_decimal(value, fun) do
+    case decimal(value) do
+      {:ok, d} -> fun.(d)
+      :error -> false
+    end
+  end
+
+  defp decimal(%Decimal{} = d), do: {:ok, d}
+  defp decimal(value) when is_integer(value), do: {:ok, Decimal.new(value)}
+  defp decimal(value) when is_float(value), do: {:ok, Decimal.from_float(value)}
+
+  defp decimal(value) when is_binary(value) do
+    case Decimal.parse(value) do
+      {d, ""} -> {:ok, d}
+      _ -> :error
+    end
+  end
+
+  defp decimal(_other), do: :error
+
+  defp to_decimal(n) when is_integer(n), do: Decimal.new(n)
+  defp to_decimal(n) when is_float(n), do: Decimal.from_float(n)
 
   defp number(value) when is_number(value), do: {:ok, value}
 

--- a/lib/petal_components/data_table/engine/list.ex
+++ b/lib/petal_components/data_table/engine/list.ex
@@ -297,7 +297,12 @@ defmodule PetalComponents.DataTable.Engine.List do
       is_struct(field_value, Decimal) ->
         with_decimal(value, &(Decimal.compare(field_value, &1) in wanted))
 
-      match?({:ok, _}, to_date(field_value)) ->
+      # date comparison only for date-TYPED cells - a text cell that
+      # happens to parse as a date stays text, per the pinned rule (and
+      # ISO strings order correctly as text anyway, which is exactly
+      # what a SQL engine does with a text column)
+      is_struct(field_value, Date) or is_struct(field_value, DateTime) or
+          is_struct(field_value, NaiveDateTime) ->
         with {{:ok, a}, {:ok, b}} <- {to_date(field_value), to_date(value)} do
           Date.compare(a, b) in wanted
         else
@@ -319,14 +324,12 @@ defmodule PetalComponents.DataTable.Engine.List do
 
   defp evaluable?(%Decimal{}, value), do: match?({:ok, _}, decimal(value))
 
-  defp evaluable?(field_value, value) do
-    case to_date(field_value) do
-      {:ok, _} -> match?({:ok, _}, to_date(value))
-      # a field the positive op cannot read is unevaluable regardless of
-      # how good the value is - both sides have to be readable
-      :error -> is_scalar(field_value) and text_value?(value)
-    end
-  end
+  defp evaluable?(%mod{}, value) when mod in [Date, DateTime, NaiveDateTime],
+    do: match?({:ok, _}, to_date(value))
+
+  # a field the positive op cannot read is unevaluable regardless of
+  # how good the value is - both sides have to be readable
+  defp evaluable?(field_value, value), do: is_scalar(field_value) and text_value?(value)
 
   defp text_value?(value) when is_binary(value) or is_number(value), do: true
   defp text_value?(value) when is_atom(value), do: not is_nil(value)

--- a/lib/petal_components/data_table/state.ex
+++ b/lib/petal_components/data_table/state.ex
@@ -56,7 +56,15 @@ defmodule PetalComponents.DataTable.State do
       text all compare with the same op.
     * `:before`/`:on`/`:after` are date-shaped aliases of `:lt`/`:eq`/
       `:gt`; they exist so a date filter reads as a date filter, and an
-      adapter may map them to the same primitives.
+      adapter may map them to the same primitives. They are defined
+      only for date-typed cells (`Date`, `DateTime`, `NaiveDateTime`) -
+      a text column holding an ISO string does not match, because no
+      SQL engine would cast every row to find out.
+    * an empty `order_by`, and ties within one, have NO defined row
+      order across engines: this engine preserves input order, SQL
+      without ORDER BY promises nothing. For stable paging, append a
+      unique tiebreaker (the primary key) to every sort - adapters
+      should do the same.
 
   Engines may support a subset. `ops/0` returns the recognised set and
   `valueless_op?/1` identifies the ops that carry no value.
@@ -367,10 +375,13 @@ defmodule PetalComponents.DataTable.State do
     Enum.flat_map(list, fn
       %{"field" => f, "op" => op, "value" => value} ->
         with {:ok, field} <- Map.fetch(fields, f),
-             {:ok, op} <- Map.fetch(@op_strings, op) do
+             {:ok, op} <- Map.fetch(@op_strings, op),
+             # a JSON null value is nonsense for a value-carrying op -
+             # it would read as "" and quietly match empty-string rows
+             false <- is_nil(value) and op not in @valueless_ops do
           [%{field: field, op: op, value: value}]
         else
-          :error -> []
+          _skip -> []
         end
 
       _other ->

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -281,8 +281,15 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
       assert pick.(%{field: :stamp, op: :between, value: ["2026-01-05T00:00", "2026-01-05T12:00"]}) ==
                [1, 3]
 
-      # a real Date cell still compares as a date
-      assert pick.(%{field: :stamp, op: :gte, value: "2026-01-05"}) == [3]
+      # gte behaves per-cell-type in a mixed column: the text cells match
+      # lexicographically ("2026-01-05T..." >= "2026-01-05" as strings),
+      # and the Date cell matches as a date - all three, each for its
+      # own reason, which is exactly the per-type contract
+      assert pick.(%{field: :stamp, op: :gte, value: "2026-01-05"}) == [1, 2, 3]
+      # eq isolates the Date cell: the text cells are not the exact
+      # string "2026-01-05", while the Date cell equals it at date
+      # granularity
+      assert pick.(%{field: :stamp, op: :eq, value: "2026-01-05"}) == [3]
     end
 
     test "date ops are defined only for date-typed cells (G5)" do

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -1,3 +1,10 @@
+defmodule TestSupport.SearchRow do
+  @moduledoc false
+  # stands in for an Ecto schema struct: not Enumerable, carries a
+  # __meta__-like field the search sweep must skip
+  defstruct [:id, :name, :email, __meta__: :stub]
+end
+
 defmodule PetalComponents.DataTable.Engine.ListTest do
   use ExUnit.Case, async: true
 
@@ -201,6 +208,79 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
         Engine.run(rows, struct!(State, filters: [%{field: :name, op: :eq, value: "café"}]))
 
       assert Enum.map(hit, & &1.id) == [1, 2]
+    end
+  end
+
+  describe "differential-gate findings" do
+    # Every case here was found by running the same State through this
+    # engine AND through a Flop/Postgres bridge over identical rows -
+    # the two-implementation test that unit tests cannot perform.
+
+    @money [
+      %{id: 1, name: "Amy", price: Decimal.new("10.50"), joined: ~D[2026-01-15]},
+      %{id: 2, name: "Bea", price: Decimal.new("-10.00"), joined: ~D[2026-03-10]},
+      %{id: 3, name: "Cal", price: Decimal.new("99.99"), joined: ~D[2026-06-01]},
+      %{id: 4, name: "Dee", price: nil, joined: nil}
+    ]
+
+    defp money(filter) do
+      {rows, _} = Engine.run(@money, struct!(State, filters: [filter]))
+      Enum.map(rows, & &1.id)
+    end
+
+    test "Decimal columns filter like numbers (E1: every op matched zero rows)" do
+      assert money(%{field: :price, op: :eq, value: "10.50"}) == [1]
+      assert money(%{field: :price, op: :neq, value: "10.50"}) == [2, 3]
+      assert money(%{field: :price, op: :gt, value: "0"}) == [1, 3]
+      assert money(%{field: :price, op: :lte, value: "10.50"}) == [1, 2]
+      assert money(%{field: :price, op: :between, value: ["0", "50"]}) == [1]
+      assert money(%{field: :price, op: :is_empty, value: true}) == [4]
+    end
+
+    test "Decimal columns sort by value, not by struct internals (E1: -10.00 sorted largest)" do
+      {rows, _} = Engine.run(@money, struct!(State, order_by: [price: :asc]))
+      # nils last, then numeric order - negative first
+      assert Enum.map(rows, & &1.id) == [2, 1, 3, 4]
+
+      {rows, _} = Engine.run(@money, struct!(State, order_by: [price: :desc]))
+      assert Enum.map(rows, & &1.id) == [3, 1, 2, 4]
+    end
+
+    test "between works on dates, exactly like the comparators it decomposes into (E2)" do
+      assert money(%{field: :joined, op: :between, value: ["2026-02-01", "2026-06-01"]}) ==
+               [2, 3]
+
+      # inclusive both bounds, matching the pinned semantics
+      assert money(%{field: :joined, op: :between, value: ["2026-01-15", "2026-03-10"]}) ==
+               [1, 2]
+    end
+
+    test ":in works on date and Decimal columns via text form (G4: select filters matched nothing)" do
+      assert money(%{field: :joined, op: :in, value: ["2026-01-15", "2026-06-01"]}) == [1, 3]
+      assert money(%{field: :price, op: :in, value: ["10.50"]}) == [1]
+      # text-form comparison: a padded "010.50" is not the same text
+      assert money(%{field: :price, op: :in, value: ["010.50"]}) == []
+    end
+
+    test "date ops are defined only for date-typed cells (G5)" do
+      rows = [%{id: 1, when: "2026-01-05"}, %{id: 2, when: ~D[2026-01-05]}]
+
+      {hit, _} =
+        Engine.run(rows, struct!(State, filters: [%{field: :when, op: :on, value: "2026-01-05"}]))
+
+      # the text cell holding an ISO string does NOT match - no SQL
+      # engine would cast every row to find out
+      assert Enum.map(hit, & &1.id) == [2]
+    end
+
+    test "default quick-search fields survive Ecto-style structs (G3)" do
+      rows = [
+        struct(TestSupport.SearchRow, id: 1, name: "Amy", email: "amy@x.com"),
+        struct(TestSupport.SearchRow, id: 2, name: "Bea", email: "bea@x.com")
+      ]
+
+      {hit, _} = Engine.run(rows, struct!(State, search: "amy"))
+      assert Enum.map(hit, & &1.id) == [1]
     end
   end
 

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -262,6 +262,29 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
       assert money(%{field: :price, op: :in, value: ["010.50"]}) == []
     end
 
+    test "comparators and between treat text cells as text, even ISO-looking ones" do
+      rows = [
+        %{id: 1, stamp: "2026-01-05T09:00"},
+        %{id: 2, stamp: "2026-01-05T23:00"},
+        %{id: 3, stamp: ~D[2026-01-05]}
+      ]
+
+      pick = fn filter ->
+        {out, _} = Engine.run(rows, struct!(State, filters: [filter]))
+        Enum.map(out, & &1.id)
+      end
+
+      # text between is lexicographic - the 23:00 STRING is outside a
+      # range ending at 12:00 (date-coercion would have flattened it to
+      # the day and wrongly included it), while the true Date cell
+      # rightly matches a range within its own day
+      assert pick.(%{field: :stamp, op: :between, value: ["2026-01-05T00:00", "2026-01-05T12:00"]}) ==
+               [1, 3]
+
+      # a real Date cell still compares as a date
+      assert pick.(%{field: :stamp, op: :gte, value: "2026-01-05"}) == [3]
+    end
+
     test "date ops are defined only for date-typed cells (G5)" do
       rows = [%{id: 1, when: "2026-01-05"}, %{id: 2, when: ~D[2026-01-05]}]
 

--- a/test/petal/data_table/state_test.exs
+++ b/test/petal/data_table/state_test.exs
@@ -242,6 +242,21 @@ defmodule PetalComponents.DataTable.StateTest do
     end
   end
 
+  describe "nil filter values" do
+    test "a JSON-null value drops a value-carrying filter, keeps a valueless one" do
+      params = %{
+        "filters" => [
+          %{"field" => "name", "op" => "eq", "value" => nil},
+          %{"field" => "name", "op" => "is_empty", "value" => nil}
+        ]
+      }
+
+      state = State.from_params(params, fields: [:name])
+      # eq nil would read as "" and quietly match empty-string rows
+      assert [%{op: :is_empty}] = state.filters
+    end
+  end
+
   describe "toggle_sort/2" do
     test "cycles asc -> desc -> removed and resets the page" do
       state = %State{page: 7}


### PR DESCRIPTION
The differential gate ran the same `State` through this engine **and** through a State→Flop bridge against real Postgres — 478 cases over identical rows. 439 agreed. All 39 disagreements traced to exactly **two defects in this engine**, invisible to 860+ unit tests because a single implementation cannot disagree with itself.

## E1 — Decimal columns were dead

`%Decimal{}` — what every Ecto money column holds — passes neither `is_number/1` nor `is_scalar/1`. Consequences: **every operator except `is_empty` silently matched zero rows**, and sorting fell to Erlang term order over the struct's fields, ranking **-10.00 as the largest value**. 31 of the 39 disagreements.

Decimals now compare numerically through equality, the comparator ladder, `:between` and sorting (with mixed decimal/number coercion), and read as text for `:in` and the pattern ops like every other scalar.

## E2 — `:between` was number-only

A **date range** — the most common data-table filter there is — matched nothing, while `:gte`/`:lte` on the same column worked. `:between` is now literally `:gte AND :lte`: one ladder, one definition, ranges identical to the comparators they decompose into.

## The smaller findings, all from the gate or its audit

- `:in` and pattern ops on date/Decimal cells read as their text form — a select filter on a date column used to match *nothing*. `:in` stays a text comparison everywhere (`"010.50"` does not match `10.50`).
- Default quick-search fields survive Ecto structs — the sweep comprehended over the row, which **raises** on structs, i.e. exactly the rows a database engine produces.
- Date ops are defined only for date-typed cells, now pinned: a text column holding an ISO string must not behave differently per engine.
- A JSON-null filter value is dropped for value-carrying ops rather than reading as `""` and quietly matching empty-string rows.
- Pinned: an empty `order_by`, or a tie within one, has **no defined cross-engine row order** — append a unique tiebreaker for stable paging. (The gate's audit verified single-key sorts diverge without one.)

## Tests

871 total, including a `differential-gate findings` block whose cases are lifted directly from the gate's disagreement list — Decimal filtering/sorting (including the -10.00 case), date ranges, date `:in`, struct search, the ISO-string text column, and the JSON-null filter.