### PR TITLE
feat(data_table): option-filter box for long select editors

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -2722,6 +2722,9 @@
     .pc-data-table__filter-value2 {
     @apply block;
   }
+  .pc-data-table__option-filter.pc-data-table__option-filter {
+    @apply mb-1 h-8 text-sm;
+  }
   .pc-data-table__filter-options {
     @apply flex max-h-56 flex-col gap-1 overflow-y-auto;
   }

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4751,6 +4751,14 @@ export const PetalDataTable = {
     this.searchTimer = null;
 
     this.onInput = (e) => {
+      // the select editor's option-filter box: purely visual narrowing
+      // of the checkbox list, never submitted, never navigates
+      const optionFilter = e.target.closest("[data-pc-dt-option-filter]");
+      if (optionFilter) {
+        this.filterOptions(optionFilter);
+        return;
+      }
+
       if (!e.target.closest("[data-pc-dt-search]")) return;
       clearTimeout(this.searchTimer);
       const wait = parseInt(this.el.dataset.debounce || "300", 10);
@@ -5024,6 +5032,7 @@ export const PetalDataTable = {
 
   updated() {
     this.syncIndeterminate();
+    this.syncOptionFilters();
 
     // a patch re-renders panels from the server: `hidden` comes back and
     // the inline offsets this hook owns are dropped
@@ -5057,6 +5066,30 @@ export const PetalDataTable = {
         this.openMenu = null;
       }
     }
+  },
+
+  // Hide checkbox rows whose label does not contain the typed term.
+  // Checked rows stay visible regardless - hiding an active selection
+  // behind a filter box reads as losing it.
+  filterOptions(input) {
+    const list = input.nextElementSibling;
+    if (!list) return;
+    const term = input.value.trim().toLowerCase();
+
+    list.querySelectorAll(".pc-data-table__filter-option").forEach((row) => {
+      const matches =
+        term === "" || (row.textContent || "").toLowerCase().includes(term);
+      const checked = row.querySelector("input:checked");
+      row.hidden = !matches && !checked;
+    });
+  },
+
+  // a patch re-renders the option rows all-visible while the focused
+  // input keeps its value - reapply the narrowing
+  syncOptionFilters() {
+    this.el
+      .querySelectorAll("[data-pc-dt-option-filter]")
+      .forEach((input) => input.value && this.filterOptions(input));
   },
 
   // indeterminate is a DOM property, not an attribute - mirror the

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4766,6 +4766,17 @@ export const PetalDataTable = {
     };
 
     this.onChange = (e) => {
+      // unchecking a kept-visible-because-checked option row must rerun
+      // the narrowing, or the stale row lingers until the term changes
+      const optionRow = e.target.closest(".pc-data-table__filter-option");
+      if (optionRow) {
+        const box = optionRow
+          .closest(".pc-data-table__filter-form")
+          ?.querySelector("[data-pc-dt-option-filter]");
+        if (box?.value) this.filterOptions(box);
+        return;
+      }
+
       if (!e.target.closest("[data-pc-dt-page-size]")) return;
       // the nav URL reads the live search input too, so the pending
       // debounced patch is redundant - and letting it fire later would

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -134,6 +134,10 @@ defmodule PetalComponents.DataTable do
     default: "Apply",
     doc: "the filter editors' submit label, localizable"
 
+  attr :filter_options_placeholder, :string,
+    default: "Filter options\u2026",
+    doc: "the select editor's option-filter placeholder (shown from 8 options up), localizable"
+
   attr :selectable, :boolean, default: false, doc: "render a leading checkbox column"
 
   attr :selected, :list,
@@ -382,6 +386,7 @@ defmodule PetalComponents.DataTable do
             target={@target}
             op_labels={@op_labels}
             apply_label={@apply_label}
+            filter_options_placeholder={@filter_options_placeholder}
           />
           {render_slot(@toolbar)}
           <div :if={@column_toggle} class="pc-popover pc-data-table__columns">
@@ -968,6 +973,7 @@ defmodule PetalComponents.DataTable do
               options={@options}
               op_labels={@op_labels}
               label={@label}
+              filter_options_placeholder={@filter_options_placeholder}
             />
             <.button size="sm" type="submit" class="pc-data-table__filter-apply">
               {@apply_label}
@@ -1001,11 +1007,28 @@ defmodule PetalComponents.DataTable do
     """
   end
 
+  # eight or more options get a client-side filter box - a checkbox wall
+  # with no way to narrow it is where long lists go to die
+  @option_filter_threshold 8
+
   defp filter_editor(%{type: "select"} = assigns) do
     current = assigns.filter |> current_values() |> Enum.map(&to_string/1)
-    assigns = assign(assigns, :current, current)
+
+    assigns =
+      assigns
+      |> assign(:current, current)
+      |> assign(:show_option_filter, length(assigns.options) >= @option_filter_threshold)
 
     ~H"""
+    <input
+      :if={@show_option_filter}
+      type="text"
+      data-pc-dt-option-filter
+      autocomplete="off"
+      placeholder={@filter_options_placeholder}
+      aria-label={"#{@label} option filter"}
+      class="pc-text-input pc-data-table__filter-value pc-data-table__option-filter"
+    />
     <div class="pc-data-table__filter-options" role="group" aria-label={"#{@label} options"}>
       <label :for={{label, value} <- @options} class="pc-data-table__filter-option">
         <input

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -506,6 +506,49 @@ describe("PetalDataTable", () => {
     expect(reachedOuter).toBe(false);
   });
 
+  it("the option-filter box narrows the checkbox list, keeps checked rows, survives patches", () => {
+    const { hook, panel, trigger } = mountWithFilter({
+      navTemplate: "/orders?:filters",
+      filters: [],
+      formHtml: `<form class="pc-data-table__filter-form">
+        <input type="text" data-pc-dt-option-filter />
+        <div class="pc-data-table__filter-options">
+          <label class="pc-data-table__filter-option"><input type="checkbox" value="alpha" checked /><span>Alpha</span></label>
+          <label class="pc-data-table__filter-option"><input type="checkbox" value="beta" /><span>Beta</span></label>
+          <label class="pc-data-table__filter-option"><input type="checkbox" value="gamma" /><span>Gamma</span></label>
+        </div>
+      </form>`,
+    });
+
+    trigger.click();
+    const box = panel.querySelector("[data-pc-dt-option-filter]");
+    const rows = () =>
+      [...panel.querySelectorAll(".pc-data-table__filter-option")].map(
+        (r) => r.hidden,
+      );
+
+    box.value = "bet";
+    box.dispatchEvent(new Event("input", { bubbles: true }));
+    // Alpha stays visible despite not matching - it is CHECKED, and
+    // hiding an active selection reads as losing it
+    expect(rows()).toEqual([false, false, true]);
+
+    // typing in the option filter must never trigger navigation
+    vi.advanceTimersByTime(1000);
+    expect(hook.openMenu).toBe("pop");
+
+    // a patch re-renders rows all-visible; the sync reapplies the term
+    panel
+      .querySelectorAll(".pc-data-table__filter-option")
+      .forEach((r) => (r.hidden = false));
+    hook.updated();
+    expect(rows()).toEqual([false, false, true]);
+
+    box.value = "";
+    box.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(rows()).toEqual([false, false, false]);
+  });
+
   it("never repositions on scroll - the page carries the panel", () => {
     const { hook, trigger } = mountWithFilter({
       navTemplate: "/orders?:filters",

--- a/test/js/data_table.test.js
+++ b/test/js/data_table.test.js
@@ -544,6 +544,15 @@ describe("PetalDataTable", () => {
     hook.updated();
     expect(rows()).toEqual([false, false, true]);
 
+    // unchecking the kept-visible row re-runs the narrowing - the stale
+    // row must not linger
+    box.value = "bet";
+    box.dispatchEvent(new Event("input", { bubbles: true }));
+    const alpha = panel.querySelector('input[value="alpha"]');
+    alpha.checked = false;
+    alpha.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(rows()).toEqual([true, false, true]);
+
     box.value = "";
     box.dispatchEvent(new Event("input", { bubbles: true }));
     expect(rows()).toEqual([false, false, false]);

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -636,6 +636,34 @@ defmodule PetalComponents.DataTableTest do
     assert length(String.split(headers, "Email")) - 1 == 1
   end
 
+  test "select editors gain an option-filter box from 8 options up" do
+    seven = Enum.map(1..7, &"opt#{&1}")
+    eight = Enum.map(1..8, &"opt#{&1}")
+    assigns = base(%{seven: seven, eight: eight})
+
+    small =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table">
+        <:col :let={row} field={:name} filterable="select" options={@seven}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    refute small =~ "data-pc-dt-option-filter"
+
+    large =
+      rendered_to_string(~H"""
+      <.data_table id="t" rows={@rows} state={@state} on_change="table">
+        <:col :let={row} field={:name} filterable="select" options={@eight}>{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert large =~ "data-pc-dt-option-filter"
+    assert large =~ ~s(aria-label="Name option filter")
+    # never submitted: no name attribute on the filter box
+    assert Regex.match?(~r/<input[^>]*data-pc-dt-option-filter[^>]*>/, large)
+    refute Regex.match?(~r/<input[^>]*data-pc-dt-option-filter[^>]*name=/, large)
+  end
+
   test "a map-shaped between range renders instead of crashing" do
     assigns =
       base(%{


### PR DESCRIPTION
A select filter with dozens of options was an unsearchable checkbox wall — the audit's original example was a 50-option column.

From **8 options up**, the select editor gains a client-side filter box:

- **Purely visual narrowing** — no `name` attribute so it never submits, and the hook routes it away from the nav debounce (typing in it can never navigate; the spec pins that with a fake-timer advance).
- **Checked rows stay visible** regardless of the term — hiding an active selection behind a filter box reads as losing it.
- **Survives patches** — a LiveView patch re-renders rows all-visible while the focused input keeps its value; `updated()` reapplies the term.

This is the deliberate alternative to embedding the combobox inside the menu, which earlier research showed would clip its listbox against the panel's `overflow-y: auto`. One input, ~25 lines of hook, zero new contract surface. Localizable via `filter_options_placeholder`.

873 Elixir / 137 JS.