### PR TITLE
fix: nil filter values match no rows; pin gate round-2 contract findings

### DIFF
--- a/lib/petal_components/data_table/engine/list.ex
+++ b/lib/petal_components/data_table/engine/list.ex
@@ -39,7 +39,11 @@ defmodule PetalComponents.DataTable.Engine.List do
 
     * `:search_fields` - the fields the quick-search term matches
       against (case-insensitive contains). Defaults to every field of
-      the first row whose value is a string.
+      the FIRST row whose value is a string - which means the default
+      set depends on that row's data: a text column that is nil in row
+      one is silently excluded, and a loaded UUID column is silently
+      included. Fine for a demo; pass `:search_fields` explicitly in
+      anything real.
   """
   def run(rows, state, opts \\ [])
 
@@ -357,6 +361,16 @@ defmodule PetalComponents.DataTable.Engine.List do
   # Filter values come straight from params and can be ANY shape (a list,
   # a map, whatever the query string carried) - a text op against a
   # non-scalar is a no-match, never a to_string crash.
+  #
+  # nil FIRST: nil is an atom, and the atom clause would read it as ""
+  # - turning "filter by nothing" into "match empty strings" for :eq
+  # and "match every non-nil row" for :contains/:starts_with and the
+  # comparators, while the negations (guarded by text_value?/1, which
+  # rejects nil) matched nothing. One rejection here lines all ten text
+  # ops up: a nil value on a value-carrying op matches NO rows.
+  # from_params/2 never emits one; :is_empty is how you ask for empties.
+  defp with_text(nil, _fun), do: false
+
   defp with_text(value, fun) when is_binary(value), do: fun.(String.downcase(value))
 
   defp with_text(value, fun) when is_number(value) or is_atom(value),

--- a/lib/petal_components/data_table/state.ex
+++ b/lib/petal_components/data_table/state.ex
@@ -60,11 +60,21 @@ defmodule PetalComponents.DataTable.State do
       only for date-typed cells (`Date`, `DateTime`, `NaiveDateTime`) -
       a text column holding an ISO string does not match, because no
       SQL engine would cast every row to find out.
+    * a `nil` value on a value-carrying op is unsatisfiable - it
+      matches NO rows. `from_params/2` never emits one (a blank input
+      drops the filter instead), so this only concerns hand-built
+      states. Asking for empty cells is what `:is_empty` is for.
+    * map-shaped cells are filter-only. Erlang orders maps by size,
+      then keys, then values; jsonb has its own type-ordering rules,
+      and no SQL expression reconciles the two - so a map column has
+      NO defined sort order across engines. Don't mark one sortable.
     * an empty `order_by`, and ties within one, have NO defined row
       order across engines: this engine preserves input order, SQL
       without ORDER BY promises nothing. For stable paging, append a
-      unique tiebreaker (the primary key) to every sort - adapters
-      should do the same.
+      unique tiebreaker (the primary key) to every sort. That is the
+      APPLICATION's job, at the point the state is built - an adapter
+      must reproduce `order_by` exactly as given and never append one
+      silently, or the same state would order differently per engine.
 
   Engines may support a subset. `ops/0` returns the recognised set and
   `valueless_op?/1` identifies the ops that carry no value.
@@ -89,6 +99,18 @@ defmodule PetalComponents.DataTable.State do
   case-insensitive and index-backed - wrapping it in `lower()` defeats
   the index (measured ~28x slower). An adapter that knows a column is
   citext should emit plain `=` there.
+
+  Reproduce `order_by` exactly - do not append a tiebreaker on the
+  application's behalf (see the tie rule above), and do not reorder or
+  drop entries. If the state's sort is unstable, that is the caller's
+  bug to fix where the state is built.
+
+  Text-shaped ops against float columns compare the TEXT FORM of the
+  float, and Elixir and SQL format extremes differently:
+  `to_string(1.0e20)` is `"1.0e20"` while Postgres renders `1e+20` -
+  so `:contains`/`:in` against exponent-range floats can diverge
+  between engines. Integral floats (`10.0`) agree. Money belongs in a
+  decimal column, which has no such gap.
 
   ## Security
 

--- a/test/petal/data_table/engine_list_test.exs
+++ b/test/petal/data_table/engine_list_test.exs
@@ -262,6 +262,39 @@ defmodule PetalComponents.DataTable.Engine.ListTest do
       assert money(%{field: :price, op: :in, value: ["010.50"]}) == []
     end
 
+    test "a nil value on any value-carrying op matches no rows (round 2: nil.*)" do
+      # Round two of the gate caught the engine self-inconsistent here:
+      # with_text/2 read nil as "" (nil is an atom), so `:eq nil`
+      # matched empty-string rows and `:contains`/`:gt`-family nil
+      # matched every non-nil row - a filter silently widening to the
+      # table - while the negations matched nothing. All ten line up
+      # now: nil is unsatisfiable, and :is_empty is the empties op.
+      rows = [
+        %{id: 1, name: "amy"},
+        %{id: 2, name: ""},
+        %{id: 3, name: nil}
+      ]
+
+      pick = fn op ->
+        {out, _} =
+          Engine.run(rows, struct!(State, filters: [%{field: :name, op: op, value: nil}]))
+
+        Enum.map(out, & &1.id)
+      end
+
+      for op <- [:contains, :not_contains, :eq, :neq, :starts_with, :gt, :gte, :lt, :lte],
+          do: assert(pick.(op) == [], "expected #{op} with nil value to match no rows")
+
+      assert pick.(:in) == []
+      assert pick.(:not_in) == []
+
+      # the sanctioned way to ask for empties still works
+      {out, _} =
+        Engine.run(rows, struct!(State, filters: [%{field: :name, op: :is_empty, value: true}]))
+
+      assert Enum.map(out, & &1.id) == [2, 3]
+    end
+
     test "comparators and between treat text cells as text, even ISO-looking ones" do
       rows = [
         %{id: 1, stamp: "2026-01-05T09:00"},


### PR DESCRIPTION
## What

Closes out the escalations from round two of the differential gate (the same `%State{}` run through `Engine.List` and a Flop/Postgres bridge over identical rows, 984 cases).

### Engine fix
`with_text/2` accepted `nil` through its `is_atom` guard and read it as `""` - so `:eq nil` matched empty-string rows, and `:contains`/`:starts_with`/comparators with `nil` matched every non-nil row (a filter silently widening to the whole table), while the negations matched nothing. One nil-rejecting clause lines all ten text ops up: a nil value on a value-carrying op matches no rows. Unreachable via `from_params/2` (blank inputs drop the filter); only hand-built states could hit it. Pinned by the gate as the `nil.*` cases.

### Contract pins (moduledoc)
- **nil values**: unsatisfiable on value-carrying ops; `:is_empty` is how you ask for empties
- **:map columns are filter-only**: Erlang orders maps by size/keys/values, jsonb by its own type rules - no SQL expression reconciles them, so no cross-engine sort order exists
- **Tiebreaker ownership decided (gate G6)**: the application appends the unique tiebreaker when building the state; adapters must reproduce `order_by` exactly and never silently append
- **Float text-form caveat (gate G9)**: `to_string(1.0e20)` vs `1e+20` from `float8::text` - exponent-range floats can diverge on text-shaped ops; money belongs in decimal
- **`:search_fields` default caveat (gate G3)**: derived from the FIRST row's binary fields, so it excludes nil text columns and includes loaded UUIDs - documented as demo-only, pass explicitly in real apps

## Tests
874 Elixir tests, 0 failures. New regression pins all twelve value-carrying ops symmetric on nil (match nothing) with `:is_empty` still working.