### PR TITLE
fix(css): drop the dead radio-card "checked" rules with broken escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 
 #### Fixed
 
+- **The radio-card "checked" rules that tripped strict CSS parsers are
+  gone.** Three selectors in `default.css` escaped their colons with
+  `\\:` instead of `\:`, so Tailwind v4's `--minify` optimizer
+  (Lightning CSS) warned "not recognized as a valid pseudo-class" four
+  times on every consumer asset build. They were also dead selectors:
+  nothing the field component renders carries those literal
+  `peer-checked:*` class names - the checked state has lived on
+  `.pc-radio-card__input:checked ~ .pc-radio-card__fake-input` since
+  the card got its fake-input anatomy. Deleted, and a guard test now
+  fails the suite if a Tailwind utility name ever leaks into a shipped
+  selector again. (#582)
 - **Decimal columns now filter and sort.** `%Decimal{}` - what every
   Ecto money column holds - was readable by no operator (every filter
   silently matched zero rows) and sorted by struct internals, so

--- a/assets/default.css
+++ b/assets/default.css
@@ -1953,19 +1953,6 @@
     @apply dark:text-gray-400;
   }
 
-  /* Apply styles when input is checked using peer-checked variants */
-  .pc-radio-card.peer-checked\\:border-primary-500 {
-    @apply border-primary-500;
-  }
-
-  .pc-radio-card.peer-checked\\:bg-primary-50 {
-    @apply bg-primary-50;
-  }
-
-  .pc-radio-card.dark\\:peer-checked\\:bg-primary-700 {
-    @apply dark:bg-primary-700;
-  }
-
   /* Dropdown */
 
   .pc-dropdown {

--- a/test/petal/css_assets_test.exs
+++ b/test/petal/css_assets_test.exs
@@ -1,0 +1,26 @@
+defmodule PetalComponents.CssAssetsTest do
+  use ExUnit.Case, async: true
+
+  # The shipped stylesheets are consumed by strict downstream parsers
+  # (Lightning CSS via Tailwind v4's --minify). These guards keep selector
+  # mistakes that plain `mix test` can't see from reaching users' builds.
+
+  @app_root Path.expand("../..", __DIR__)
+  @css_assets ["assets/default.css", "assets/tailwind-gray.css"]
+
+  for path <- @css_assets do
+    test "#{path} contains no escaped-colon class selectors" do
+      css = File.read!(Path.join(@app_root, unquote(path)))
+
+      # pc-* semantic classes never contain colons, so a backslash-escaped
+      # colon in this file means a Tailwind utility name (peer-checked:*,
+      # dark:*, ...) leaked in as a selector. Those never match anything the
+      # components render, and the double-backslash form (`\\:`) additionally
+      # trips Lightning CSS with "not a valid pseudo-class" warnings on every
+      # consumer asset build (issue #582).
+      refute css =~ ~r/\\+:/,
+             "#{unquote(path)} contains a backslash-escaped colon selector: " <>
+               inspect(Regex.run(~r/^.*\\+:.*$/m, css))
+    end
+  end
+end


### PR DESCRIPTION
Fixes #582 — the report is correct on both counts, and both were reproduced before touching anything.

## The two defects, verified

**1. Broken escaping.** The three radio-card "checked" rules escaped their colons as `\\:` — an escaped literal backslash followed by a *bare* colon. Lightning CSS (Tailwind v4's `--minify` optimizer) parses what follows as an unknown pseudo-class. Reproduced on CLI v4.3.3: exactly **4 warnings** per build — one each from the first two selectors, two from `dark\\:peer-checked\\:bg-primary-700`. The v4.0.9 CLI stays silent, which is how this survived. Worse, the optimizer re-serializes the third selector into a literal invalid pseudo-class (`…peer-checked:bg-primary-700`) in shipped minified output.

**2. Dead either way.** No element the field component renders ever carries a literal `peer-checked:*` class name (`grep -rn "peer-checked" lib/` is empty — checked in the working tree, HEAD, and every commit on every branch via `git log --all -S`). There's no class passthrough onto the `.pc-radio-card` element either, so no consumer could have been relying on them. They're leftovers from the original radio-card WIP, before the card got its fake-input anatomy: the real checked state lives on `.pc-radio-card__input:checked ~ .pc-radio-card__fake-input`, which stays untouched.

## Proof the deletion is inert

Hermetic compile of just the stylesheet (`@import "tailwindcss" source(none)`, v4.3.3, `--minify`), before vs after:

- warnings: **4 → 0**
- compiled output diff: **exactly the three dead rules** — nothing else changes, so no rendered visual state can change

## The guard

`test/petal/css_assets_test.exs`: `pc-*` semantic classes never contain colons, so a backslash-escaped colon in a shipped stylesheet always means a Tailwind utility name leaked in as a selector. The test fails the suite (with the offending line in the message) if that ever happens again — verified red on the pre-fix file, green after. The only legitimate escapes in the file are the skeleton `\.` dot-escapes, which it correctly ignores.

875 tests, 0 failures.

A sweep for siblings found five more dead selectors of the same family (no parser warnings, no visual impact) — kept out of this PR to stay surgical; they're queued as a separate cleanup.
