### PR TITLE
fix: combobox pre-release hardening (a11y, forms, chips)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,51 @@
 
 #### Fixed
 
+- **`combo_box` has an accessible name, and `<.field type="combobox">`
+  no longer warns at compile time.** The role=combobox input carried no
+  label mechanism at all - `{@rest}` lands on the wrapper, so
+  `aria-label` named a roleless div and the placeholder was the only
+  name a screen reader had. There is a `label` attr now, rendered onto
+  the element that carries the role, and `<.field>` points its `for=` at
+  the control that actually renders (the input, or the trigger button)
+  and passes the label down. Separately, `combobox` was never added to
+  field's declared `:type` values, so every call site warned - fatal in
+  projects building with `--warnings-as-errors`.
+- **A `required` combo_box no longer deadlocks the form.** `required`
+  sits on the hidden select, which is `inert` and `sr-only` - so the
+  browser could neither draw its validation bubble nor move focus to it,
+  and submit was blocked with nothing visible, nothing announced, and
+  focus on `<body>`. The hook takes the report over: the browser's own
+  message goes into a `role="alert"` region on the control,
+  `aria-required` and `aria-invalid` reach the a11y tree, and focus
+  lands somewhere the user can act.
+- **`max_items` is a real stop instead of a visual one.** The cap was
+  enforced in CSS alone, so the keyboard still walked onto capped
+  options, `aria-activedescendant` still pointed at them, and Enter was
+  refused in silence. Capped options are `aria-disabled` now, the
+  keyboard skips them, the cap is announced, and the placeholder says
+  the same thing on screen as in the live region rather than being
+  blanked to transparent.
+- **A disabled combo_box no longer ships a working clear button.** The
+  input variant's clear stayed focusable and clickable, and because a
+  disabled select posts nothing, clearing it desynced client from
+  server.
+- **Backspace removes the chip you can see.** It read the hidden
+  select's DOM order while chips render in pick order, so picking out of
+  option order made Backspace delete a chip from the middle of the row.
+- **The trigger variant's clear leaves a coherent state.** It used to
+  leave the panel open with focus parked on the trigger - outside the
+  panel - so arrows and typing were dead and Escape leaked to the
+  enclosing modal instead of closing the panel. It closes the panel and
+  returns focus to the trigger.
+- **`combo_box` group headings reach assistive tech**, the empty row
+  moved out of `role="listbox"` (which may only contain options and
+  groups), a stranded pointerdown no longer disarms outside-tap
+  dismissal for the rest of an open session, `updated()` re-reads
+  `multiple` / the chips container / the clear button so
+  `clearable={@editing}` behaves like the server state it is,
+  `destroyed()` no longer throws on half-mounted markup, and a focusable
+  control in a `:header` / `:footer` slot can take a pointer press.
 - **Decimal columns now filter and sort.** `%Decimal{}` - what every
   Ecto money column holds - was readable by no operator (every filter
   silently matched zero rows) and sorted by struct internals, so
@@ -289,8 +334,6 @@
   cleanly. Rich slots (`:option`, `:selected`, `:chip`,
   `:header`/`:footer`) stay on the bare component by design.
 
-#### Added
-
 - **`combo_box` M3b - the modes: `free_text`, `create`, remote search.**
   The last of the Tom Select parity surface, on the new architecture:
   - `free_text`: Enter at the empty stop commits the typed text as a
@@ -308,8 +351,6 @@
     mode - one writer per region). Designed loading row
     (`loading_label`), stale replies dropped by sequence, chosen
     results inserted into the select.
-
-#### Added
 
 - **`combo_box` M3a - the slot family completes: `:header`, `:footer`,
   `:selected`, `:chip`.** All four speak the `:option` slot's grammar
@@ -339,8 +380,6 @@
   playground get a working table with zero setup. The `<.data_table>`
   component builds on this next.
 
-#### Added
-
 - **`combo_box` trigger variant supports `clearable`.** A chosen
   single-select trigger had no road back to the empty state (Nic's
   find - the input variant had the X, the trigger silently ignored the
@@ -351,63 +390,6 @@
   placeholder label, keeps the panel closed and returns focus to the
   trigger. Multiple mode stays clear-less by design on both variants -
   chips and panel toggles are its road back.
-
-#### Fixed
-
-- **`combo_box`: iOS taps on control chrome and the trigger button
-  reliably toggle the panel.** iOS Safari fires `focusout` with
-  `relatedTarget: null` even when focus moves WITHIN the component, so
-  a chevron or trigger tap closed the panel mid-press and the tap's own
-  click instantly reopened it - an invisible flash that read as a dead
-  chevron zone (input variant) and a picker that never closes (trigger
-  variant). Device-log verified. The focusout close now defers one tick
-  and verifies where focus actually landed instead of trusting
-  `relatedTarget`; genuine Tab-away and click-away close exactly as
-  before.
-
-- **`combo_box`: a touch-scroll no longer dismisses the panel.** The
-  outside dismiss closed on `pointerdown`, so starting a scroll gesture
-  anywhere outside the panel killed it the instant the finger landed
-  (Nic's iOS find). The dismiss is now a completed press - `pointerdown`
-  arms it, `pointerup` in (roughly) the same spot closes; a scroll ends
-  in `pointercancel` or a far-away release and leaves the panel open,
-  matching shadcn/Base UI and the old Tom Select behavior. A clean tap
-  outside still closes, and the desktop focusout path is unchanged.
-
-#### Fixed
-
-- **`combo_box`: chevron press reliably toggles the panel closed on
-  every platform.** Two interacting bugs: on desktop, pressing the
-  (non-focusable) chevron blurred the input, focusout closed the panel
-  mid-press, and the click then saw a closed panel and REOPENED it -
-  the toggle flashed instead of closing. On iOS no blur fires, but tap-
-  target correction rewrites the synthesized click's target and
-  coordinates onto the nearby text field, so the tap read as caret work
-  and nothing closed. Fix: chrome-vs-caret is decided at `pointerdown`
-  (which hit-tests the real touch point and is never rewritten), the
-  click consumes that record, and chrome presses are preventDefaulted
-  so the input never blurs mid-press. Input presses keep caret
-  behavior and never discard the active query.
-
-#### Fixed
-
-- **`combo_box` multiple: the highlight stays on the item just picked.**
-  Choosing used to reset the filter and re-home the highlight on the
-  first option - a disorienting jump when picking from the middle of the
-  list (Nic's on-device find). Now arrowing resumes from the item you
-  just toggled (Base UI/downshift grammar); the trigger variant's
-  multiple mode gets the same fix through the shared path.
-
-#### Changed
-
-- **`combo_box` multiple: the placeholder stays visible with chips
-  present** ("Add members…" style - the reui/Mantine TagsInput
-  convention) instead of vanishing after the first pick, and it rests
-  while `max_items` is reached (pure CSS on `data-max-reached` - the
-  attribute itself stays server truth, so live placeholder changes
-  always win). Single-select behavior unchanged.
-
-#### Added
 
 - **`combo_box` `:option` slot - rich options.** Render anything inside
   each panel option (avatars, flags, secondary text); `:let` receives
@@ -470,6 +452,57 @@
   `total` is unknown. `previous_label`/`next_label` attrs make the copy
   localizable; link and event modes work unchanged. The numbered layout is
   untouched and stays the default (`variant="numbered"`).
+
+#### Changed
+
+- **`combo_box` multiple: the placeholder stays visible with chips
+  present** ("Add members…" style - the reui/Mantine TagsInput
+  convention) instead of vanishing after the first pick, and it rests
+  while `max_items` is reached (pure CSS on `data-max-reached` - the
+  attribute itself stays server truth, so live placeholder changes
+  always win). Single-select behavior unchanged.
+
+#### Fixed
+
+- **`combo_box`: iOS taps on control chrome and the trigger button
+  reliably toggle the panel.** iOS Safari fires `focusout` with
+  `relatedTarget: null` even when focus moves WITHIN the component, so
+  a chevron or trigger tap closed the panel mid-press and the tap's own
+  click instantly reopened it - an invisible flash that read as a dead
+  chevron zone (input variant) and a picker that never closes (trigger
+  variant). Device-log verified. The focusout close now defers one tick
+  and verifies where focus actually landed instead of trusting
+  `relatedTarget`; genuine Tab-away and click-away close exactly as
+  before.
+
+- **`combo_box`: a touch-scroll no longer dismisses the panel.** The
+  outside dismiss closed on `pointerdown`, so starting a scroll gesture
+  anywhere outside the panel killed it the instant the finger landed
+  (Nic's iOS find). The dismiss is now a completed press - `pointerdown`
+  arms it, `pointerup` in (roughly) the same spot closes; a scroll ends
+  in `pointercancel` or a far-away release and leaves the panel open,
+  matching shadcn/Base UI and the old Tom Select behavior. A clean tap
+  outside still closes, and the desktop focusout path is unchanged.
+
+- **`combo_box`: chevron press reliably toggles the panel closed on
+  every platform.** Two interacting bugs: on desktop, pressing the
+  (non-focusable) chevron blurred the input, focusout closed the panel
+  mid-press, and the click then saw a closed panel and REOPENED it -
+  the toggle flashed instead of closing. On iOS no blur fires, but tap-
+  target correction rewrites the synthesized click's target and
+  coordinates onto the nearby text field, so the tap read as caret work
+  and nothing closed. Fix: chrome-vs-caret is decided at `pointerdown`
+  (which hit-tests the real touch point and is never rewritten), the
+  click consumes that record, and chrome presses are preventDefaulted
+  so the input never blurs mid-press. Input presses keep caret
+  behavior and never discard the active query.
+
+- **`combo_box` multiple: the highlight stays on the item just picked.**
+  Choosing used to reset the filter and re-home the highlight on the
+  first option - a disorienting jump when picking from the middle of the
+  list (Nic's on-device find). Now arrowing resumes from the item you
+  just toggled (Base UI/downshift grammar); the trigger variant's
+  multiple mode gets the same fix through the shared path.
 
 ### 4.11.3 - 2026-08-05
 

--- a/assets/default.css
+++ b/assets/default.css
@@ -2352,14 +2352,24 @@
   .pc-combo-box__clear-icon.pc-combo-box__clear-icon {
     @apply w-4! h-4!;
   }
-  /* at max_items, unchosen options rest until something is removed */
+  /* a disabled combobox has no live chrome: the button carries the disabled
+     attribute (so it leaves the tab order and swallows clicks) and this
+     keeps a stray pointer from reaching it either - both anatomies alike */
+  .pc-combo-box__clear:disabled,
+  .pc-combo-box__trigger-clear:disabled {
+    @apply pointer-events-none;
+  }
+  /* at max_items, unchosen options rest until something is removed. The
+     hook stamps aria-disabled to match, so the keyboard and the a11y tree
+     agree with what this rule shows - CSS alone made the cap a silent
+     dead end for anyone not using a mouse. */
   .pc-combo-box[data-max-reached] .pc-combo-box__option:not([aria-selected="true"]) {
     @apply pointer-events-none opacity-50;
   }
-  /* inviting more picks while the cap dims every option reads wrong -
-     the placeholder rests at the cap; the attribute stays server truth */
-  .pc-combo-box[data-max-reached] .pc-combo-box__input::placeholder {
-    @apply text-transparent;
+  /* the hook's constraint-validation message: the field-error look, since
+     that is what it is - the report the inert hidden select cannot make */
+  .pc-combo-box__error {
+    @apply mt-1.5 text-sm text-danger-600 dark:text-danger-400;
   }
   .pc-combo-box__live {
     @apply sr-only;

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -3693,6 +3693,11 @@ function sameValueMultiset(a, b) {
   return true;
 }
 
+// Slot content the panel must let the pointer focus - everything else in
+// there is chrome whose press has to keep focus in the search input.
+// [tabindex] covers hand-rolled widgets; the option rows have none.
+const FOCUSABLE_IN_PANEL = "input, select, textarea, button, [tabindex]";
+
 export const PetalComboBox = {
   mounted() {
     this.select = this.el.querySelector(".pc-combo-box__select");
@@ -3719,7 +3724,7 @@ export const PetalComboBox = {
       );
     }
     this.live = this.el.querySelector("[data-pc-combo-live]");
-    this.clearBtn = this.el.querySelector("[data-pc-combo-clear]");
+    this.errorEl = this.el.querySelector("[data-pc-combo-error]");
     this.query = "";
 
     this.onInput = (e) => {
@@ -3764,7 +3769,14 @@ export const PetalComboBox = {
     // focusout close would swallow the click before it lands; the search
     // input (trigger variant) must stay clickable for caret work
     this.onPanelPointerDown = (e) => {
-      if (e.target !== this.input) e.preventDefault();
+      if (e.target === this.input) return;
+      // ...but a focusable control in a :header / :footer slot needs the
+      // press to do its normal job: preventDefault here is what made a
+      // text field or select in a slot impossible to focus by pointer.
+      // The panel survives the focus move because onFocusOut only closes
+      // when focus lands OUTSIDE the component.
+      if (e.target.closest && e.target.closest(FOCUSABLE_IN_PANEL)) return;
+      e.preventDefault();
     };
     // Chrome-vs-caret is decided at POINTERDOWN, not click: pointer events
     // hit-test the real touch point, while iOS tap-target correction
@@ -3856,9 +3868,34 @@ export const PetalComboBox = {
     // clear from reading as a control/trigger toggle.
     this.onClearClick = (e) => {
       e.stopPropagation();
+      // the select carries the disabled state in both anatomies, so it is
+      // the one honest check - a disabled widget must not ship a working
+      // control, and a cleared-but-disabled select posts nothing, which
+      // would desync the server from what the user sees
+      if (this.select.disabled) return;
       this.select.value = "";
       this.dispatchChange();
       this.syncFromSelect();
+      if (this.trigger) {
+        // the trigger variant's search input lives INSIDE the panel, so
+        // clearing with it open parked focus on the trigger - outside the
+        // panel, with nothing driving it: arrows dead, and Escape read as
+        // "panel already closed" and leaked to the enclosing modal. Close
+        // it; focus belongs on the trigger either way.
+        this.closePanel();
+        this.trigger.focus();
+      } else {
+        this.input.focus();
+      }
+    };
+    // The hidden select is the form control, but it is inert and off
+    // screen: the browser can neither draw its validation bubble nor move
+    // focus to it, so a failed submit was silent - blocked, unexplained,
+    // focus on <body>. Take the report over. preventDefault only drops the
+    // (undrawable) native UI; the submit stays blocked, as required means.
+    this.onSelectInvalid = (e) => {
+      e.preventDefault();
+      this.showError(this.select.validationMessage);
       (this.trigger || this.input).focus();
     };
     this.onFocusOut = (e) => {
@@ -3869,7 +3906,8 @@ export const PetalComboBox = {
       // focus actually landed once it settles; closing a tick later is
       // imperceptible on the genuine Tab-away/click-away paths.
       if (this.el.contains(e.relatedTarget)) return;
-      setTimeout(() => {
+      clearTimeout(this.focusOutTimer);
+      this.focusOutTimer = setTimeout(() => {
         if (!this.el.contains(document.activeElement)) this.closePanel();
       }, 0);
     };
@@ -3907,7 +3945,17 @@ export const PetalComboBox = {
     // landing mid-press disarms it - multi-touch is a gesture (pinch,
     // two-finger scroll), never a deliberate dismiss tap.
     this.onOutsidePointerDown = (e) => {
-      this.activePointers.add(e.pointerId);
+      // A press that never gets its pointerup or pointercancel - a
+      // right-click handing the release to the context menu, a pointer
+      // lost to a system gesture - would sit in here forever and read as
+      // "a second finger is down" on every later press, disarming
+      // outside-tap dismissal for the rest of the open session. Age
+      // leftovers out at press time, the way the press verdicts do.
+      const now = performance.now();
+      for (const [id, at] of this.activePointers) {
+        if (now - at > 1000) this.activePointers.delete(id);
+      }
+      this.activePointers.set(e.pointerId, now);
       if (this.activePointers.size > 1) {
         this.outsidePress = null;
         return;
@@ -3931,7 +3979,13 @@ export const PetalComboBox = {
       }
     };
     // form.reset() resets the select; nothing else would re-sync the chrome
-    this.onFormReset = () => setTimeout(() => this.syncFromSelect(), 0);
+    this.onFormReset = () => {
+      clearTimeout(this.resetTimer);
+      this.resetTimer = setTimeout(() => {
+        this.clearError();
+        this.syncFromSelect();
+      }, 0);
+    };
     this.onReposition = () => this.positionPanel();
 
     this.input.addEventListener("input", this.onInput);
@@ -3939,10 +3993,9 @@ export const PetalComboBox = {
     this.list.addEventListener("pointerover", this.onPointerOver);
     this.list.addEventListener("click", this.onListClick);
     this.panel.addEventListener("pointerdown", this.onPanelPointerDown);
-    this.clearButton = this.el.querySelector("[data-pc-combo-clear]");
-    if (this.clearButton) {
-      this.clearButton.addEventListener("click", this.onClearClick);
-    }
+    this.clearButton = null;
+    this.bindClearButton();
+    this.select.addEventListener("invalid", this.onSelectInvalid);
     this.pressVerdicts = new Map();
     this.suppressOpenAt = -Infinity;
     if (this.control) {
@@ -3961,6 +4014,8 @@ export const PetalComboBox = {
     this.form = this.select.form;
     if (this.form) this.form.addEventListener("reset", this.onFormReset);
     this.syncFromSelect();
+    // everything from here is a real state CHANGE, so it can be announced
+    this.announceReady = true;
   },
 
   updated() {
@@ -3971,6 +4026,14 @@ export const PetalComboBox = {
     const prevEvent = this.remoteEvent;
     const prevTarget = this.remoteTarget;
     this.freeText = this.el.hasAttribute("data-free-text");
+    this.multiple = this.select.multiple;
+    this.chips = this.el.querySelector("[data-pc-combo-chips]");
+    this.errorEl = this.el.querySelector("[data-pc-combo-error]");
+    // clearable={@editing} / multiple={@mode == :many} are ordinary server
+    // state: a clear button that appeared on this patch has no listener
+    // until we bind it, and a chips container we never re-read stays null
+    // so no chip ever renders
+    this.bindClearButton();
     this.remoteEvent = this.el.dataset.remoteEvent || null;
     this.remoteTarget = this.el.dataset.remoteTarget || null;
     if (this.remoteEvent !== prevEvent || this.remoteTarget !== prevTarget) {
@@ -4015,13 +4078,32 @@ export const PetalComboBox = {
     }
   },
 
+  // the clear button is conditionally rendered, so binding is not a
+  // one-shot: rebind whenever the node identity changes (a patch that
+  // added, removed or replaced it), never twice on the same node
+  bindClearButton() {
+    const next = this.el.querySelector("[data-pc-combo-clear]");
+    if (next === this.clearButton) return;
+    if (this.clearButton) {
+      this.clearButton.removeEventListener("click", this.onClearClick);
+    }
+    this.clearButton = next;
+    if (this.clearButton) {
+      this.clearButton.addEventListener("click", this.onClearClick);
+    }
+  },
+
   destroyed() {
-    if (!this.input) return;
+    // mounted() bails on half-mounted markup without binding anything, so
+    // teardown bails on exactly the same shape - dereferencing this.list
+    // here threw, and the throw left the document listeners attached
+    if (!this.select || !this.input || !this.panel || !this.list) return;
     this.input.removeEventListener("input", this.onInput);
     this.input.removeEventListener("keydown", this.onKeydown);
     this.list.removeEventListener("pointerover", this.onPointerOver);
     this.list.removeEventListener("click", this.onListClick);
     this.panel.removeEventListener("pointerdown", this.onPanelPointerDown);
+    this.select.removeEventListener("invalid", this.onSelectInvalid);
     if (this.control) {
       this.control.removeEventListener(
         "pointerdown",
@@ -4038,6 +4120,11 @@ export const PetalComboBox = {
     this.el.removeEventListener("focusout", this.onFocusOut);
     clearTimeout(this.labelPatchTimer);
     clearTimeout(this.remoteTimer);
+    // the deferred close and the post-reset re-sync both reach into the
+    // tree they were queued against - torn down in the same tick as a
+    // focusout or a reset, they would run against a detached one
+    clearTimeout(this.focusOutTimer);
+    clearTimeout(this.resetTimer);
     if (this.clearButton) {
       this.clearButton.removeEventListener("click", this.onClearClick);
     }
@@ -4087,7 +4174,8 @@ export const PetalComboBox = {
     this.input.setAttribute("aria-expanded", "true");
     if (this.trigger) this.trigger.setAttribute("aria-expanded", "true");
     this.outsidePress = null;
-    this.activePointers = new Set();
+    // pointerId -> the time it went down, so a stranded press can age out
+    this.activePointers = new Map();
     document.addEventListener("pointerdown", this.onOutsidePointerDown, true);
     document.addEventListener("pointerup", this.onOutsidePointerUp, true);
     document.addEventListener(
@@ -4183,10 +4271,42 @@ export const PetalComboBox = {
     return this.multiple && !isNaN(max) && this.selectedValues().length >= max;
   },
 
+  // At the cap the unchosen options stop being choosable, and CSS alone
+  // only made them LOOK that way: visibleItems()/navItems() read
+  // data-disabled, screen readers read aria-disabled, so without both the
+  // keyboard walked onto an option that Enter then silently refused.
+  // data-max-blocked keeps OUR capping separable from a server-rendered
+  // per-option `disabled: true`, which must survive the cap lifting.
+  applyCap(capped) {
+    for (const item of this.items()) {
+      const blocked = capped && item.getAttribute("aria-selected") !== "true";
+      if (blocked && !item.hasAttribute("data-disabled")) {
+        item.setAttribute("data-max-blocked", "");
+        item.setAttribute("data-disabled", "true");
+        item.setAttribute("aria-disabled", "true");
+      } else if (!blocked && item.hasAttribute("data-max-blocked")) {
+        item.removeAttribute("data-max-blocked");
+        item.removeAttribute("data-disabled");
+        item.removeAttribute("aria-disabled");
+      }
+    }
+  },
+
   chosenItem() {
     const value = this.select.value;
     if (!value) return null;
     return this.items().find((i) => i.dataset.value === value) || null;
+  },
+
+  // the chip row is the visual order of record; the select is only the
+  // fallback for a multiple combobox rendered without a chips container
+  lastChipValue() {
+    if (this.chips) {
+      const chips = this.chips.querySelectorAll("[data-pc-combo-chip]");
+      return chips.length ? chips[chips.length - 1].dataset.value : null;
+    }
+    const values = this.selectedValues();
+    return values.length ? values[values.length - 1] : null;
   },
 
   restoreDisplay() {
@@ -4337,6 +4457,11 @@ export const PetalComboBox = {
 
   syncFromSelect() {
     const values = this.selectedValues();
+    // a satisfied constraint retires the message the hook drew for it -
+    // .validity is the reading that does NOT re-fire the invalid event
+    if (this.errorEl && !this.errorEl.hidden && this.select.validity.valid) {
+      this.clearError();
+    }
     for (const i of this.items()) {
       i.setAttribute(
         "aria-selected",
@@ -4347,10 +4472,26 @@ export const PetalComboBox = {
     if (this.multiple) {
       this.syncChips();
       const capped = this.maxReached();
+      // the transition is tracked in hook state, not read back off the
+      // attribute: a patch can rewrite the root element's attributes, and
+      // that must not read as "the cap was just reached" all over again
+      const wasCapped = this.capped === true;
+      this.capped = capped;
       this.el.toggleAttribute("data-max-reached", capped);
-      // the placeholder rests at the cap via CSS on [data-max-reached] -
-      // the hook never touches the attribute, so a server-rendered
-      // placeholder (including live changes to it) is always the truth
+      this.applyCap(capped);
+      // "invites more picks while every option is dimmed" was the reason
+      // the placeholder used to be blanked to transparent at the cap - but
+      // that left the field looking empty while a screen reader still read
+      // the placeholder aloud. Say the same thing both ways instead. The
+      // server's placeholder rides in data-placeholder-text, so it stays
+      // the truth to return to (a patch updates it even while capped).
+      const base = this.input.dataset.placeholderText;
+      const maxText = this.live && this.live.dataset.maxItemsText;
+      if (base != null) this.input.placeholder = (capped && maxText) || base;
+      // reaching the cap is a state change worth hearing once - but a
+      // combobox that MOUNTS at its cap has not just changed, and a page
+      // full of them announcing on load would be noise
+      if (capped && !wasCapped && this.announceReady) this.announceMax();
     }
     // :selected slot content is server-rendered; the label carries the
     // values it was rendered for. When they match the selection (the
@@ -4441,7 +4582,13 @@ export const PetalComboBox = {
     this.ensureOption(value, item.dataset.label || value);
     if (this.multiple) {
       const selected = this.selectedValues().includes(value);
-      if (!selected && this.maxReached()) return;
+      if (!selected && this.maxReached()) {
+        // capped options are aria-disabled so the keyboard should never
+        // land here - a pointer or assistive tech still can, and refusing
+        // in silence was the whole complaint
+        this.announceMax();
+        return;
+      }
       this.setSelected(value, !selected);
       // the panel stays open for more picks; the query resets so the next
       // keystrokes start a fresh search. The highlight stays on the item
@@ -4493,10 +4640,13 @@ export const PetalComboBox = {
     )) {
       stale.remove();
     }
+    // rows go before the create row when there is one, otherwise at the
+    // end of the listbox - the empty row is panel chrome and lives
+    // outside the list, so it is not an anchor insertBefore can use
     const anchor =
-      (this.createRow && this.createRow.parentElement === this.list
+      this.createRow && this.createRow.parentElement === this.list
         ? this.createRow
-        : null) || this.el.querySelector("[data-pc-combo-empty]");
+        : null;
     for (const result of results) {
       const row = document.createElement("div");
       row.className = "pc-combo-box__option";
@@ -4532,7 +4682,10 @@ export const PetalComboBox = {
       this.choose(existing);
       return;
     }
-    if (this.multiple && this.maxReached()) return;
+    if (this.multiple && this.maxReached()) {
+      this.announceMax();
+      return;
+    }
     const option = this.ensureOption(raw, raw);
     if (this.multiple) {
       option.selected = true;
@@ -4555,7 +4708,40 @@ export const PetalComboBox = {
     if (!this.live) return;
     const label = this.live.dataset.resultsLabel || "results";
     const empty = this.live.dataset.noResultsText || "No results found";
-    this.live.textContent = count === 0 ? empty : `${count} ${label}`;
+    const base = count === 0 ? empty : `${count} ${label}`;
+    // filter() runs after every pick, so a cap message written on its own
+    // would be overwritten a tick later by the result count. While the cap
+    // is on, the two belong together anyway: a bare count invites picks
+    // that are then refused.
+    const max = this.capped && this.live.dataset.maxItemsText;
+    this.live.textContent = max ? `${max}. ${base}` : base;
+  },
+
+  // A blocked pick used to be pure silence: choose() returned early and
+  // nothing spoke. A live region only speaks on a CHANGE, though, and a
+  // second blocked press carries the identical string - so alternate an
+  // invisible zero-width space to guarantee every press is heard.
+  announceMax() {
+    const text = this.live && this.live.dataset.maxItemsText;
+    if (!text) return;
+    this.live.textContent =
+      this.live.textContent === text ? `${text}\u200b` : text;
+  },
+
+  // The browser writes validationMessage in the user's own locale - the
+  // right message to show, and nothing new to translate.
+  showError(message) {
+    (this.trigger || this.input).setAttribute("aria-invalid", "true");
+    if (!this.errorEl) return;
+    this.errorEl.textContent = message;
+    this.errorEl.hidden = false;
+  },
+
+  clearError() {
+    (this.trigger || this.input).removeAttribute("aria-invalid");
+    if (!this.errorEl) return;
+    this.errorEl.textContent = "";
+    this.errorEl.hidden = true;
   },
 
   filter() {
@@ -4704,8 +4890,12 @@ export const PetalComboBox = {
         break;
       case "Backspace": {
         if (!this.multiple || this.input.value !== "") return;
-        const values = this.selectedValues();
-        if (values.length) this.setSelected(values[values.length - 1], false);
+        // Backspace removes the chip the user sees LAST. selectedValues()
+        // is the select's DOM order, which diverges from the chip row the
+        // moment someone picks out of option order (chips follow pick
+        // order by design) - reading it deleted a chip from the middle.
+        const value = this.lastChipValue();
+        if (value != null) this.setSelected(value, false);
         break;
       }
       case "Enter": {

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -96,7 +96,8 @@ defmodule PetalComponents.ComboBox do
 
   attr :max_items, :integer,
     default: nil,
-    doc: "multiple only: cap on chosen options; at the cap, unchosen options render inert"
+    doc:
+      "multiple only: cap on chosen options; at the cap, unchosen options go genuinely inert - aria-disabled and skipped by the keyboard - until something is removed"
 
   attr :clearable, :boolean,
     default: false,
@@ -154,19 +155,47 @@ defmodule PetalComponents.ComboBox do
     values: ["sm", "md", "lg"],
     doc: "control density - follows the field-size family"
 
-  attr :placeholder, :string, default: "Select an option…"
-  attr :disabled, :boolean, default: false
+  attr :label, :string,
+    default: nil,
+    doc: """
+    the control's accessible name, rendered as aria-label on the visible
+    combobox (the input, or the trigger button). `<.field type="combobox">`
+    supplies this from its own label - pass it here when you use the
+    component standalone, or the placeholder ends up being the only name
+    a screen reader has.
+    """
+
+  attr :placeholder, :string,
+    default: "Select an option…",
+    doc: "empty-state text in the control - a hint, never the accessible name (see label)"
+
+  attr :disabled, :boolean, default: false, doc: "disables the control and all of its chrome"
 
   attr :required, :boolean,
     default: false,
-    doc: "renders on the hidden select, so native required validation guards the real control"
+    doc: """
+    marks the control required: `aria-required` on the visible combobox and
+    `required` on the hidden select, so native constraint validation guards
+    the real control. The select is inert and off-screen, so the hook takes
+    the browser's failed-validation report over - it shows the browser's own
+    message on the visible control and puts focus there.
+    """
 
   attr :form_id, :string,
     default: nil,
     doc: "the form this control belongs to when rendered outside it (the select's form attribute)"
 
-  attr :no_results_text, :string, default: "No results found"
+  attr :no_results_text, :string,
+    default: "No results found",
+    doc: "the empty-state row's text, also announced in the live region"
+
   attr :results_label, :string, default: "results", doc: "the live-region word after the count"
+
+  attr :max_items_text, :string,
+    default: "Maximum selections reached",
+    doc:
+      "multiple with max_items: announced (and shown in place of the placeholder) once the cap blocks further picks"
+
   attr :clear_label, :string, default: "Clear selection", doc: "aria-label for the clear button"
 
   attr :remove_label, :string,
@@ -175,7 +204,10 @@ defmodule PetalComponents.ComboBox do
 
   attr :listbox_label, :string, default: "Options", doc: "accessible name for the listbox"
   attr :class, :any, default: nil, doc: "extra classes for the wrapper"
-  attr :rest, :global
+
+  attr :rest, :global,
+    doc:
+      "arbitrary HTML attributes for the wrapper element (phx-* bindings, data-*). Use label for the accessible name - aria-* on a wrapper div names nothing"
 
   slot :option,
     doc: """
@@ -196,8 +228,10 @@ defmodule PetalComponents.ComboBox do
   slot :footer,
     doc: """
     panel chrome rendered below the option list - counts, "manage"
-    links. Lives OUTSIDE the listbox; pointer-interactive content works,
-    keyboard focus stays with the options.
+    links. Lives OUTSIDE the listbox. Pointer-interactive content works,
+    and a focusable control here (input, select, button) takes focus on
+    click without closing the panel; the arrow-key highlight stays with
+    the options either way.
     """
 
   slot :selected,
@@ -303,6 +337,9 @@ defmodule PetalComponents.ComboBox do
         aria-haspopup="listbox"
         aria-expanded="false"
         aria-controls={"#{@id}-listbox"}
+        aria-label={@label}
+        aria-required={@required && "true"}
+        aria-describedby={@required && "#{@id}-error"}
         data-pc-combo-trigger
         data-placeholder={@current_values == [] && "true"}
         disabled={@disabled}
@@ -386,10 +423,14 @@ defmodule PetalComponents.ComboBox do
             aria-expanded="false"
             aria-autocomplete="list"
             aria-controls={"#{@id}-listbox"}
+            aria-label={@label}
+            aria-required={@required && "true"}
+            aria-describedby={@required && "#{@id}-error"}
             autocomplete="off"
             autocorrect="off"
             spellcheck="false"
             placeholder={@placeholder}
+            data-placeholder-text={@placeholder}
             value={@selected_label}
             disabled={@disabled}
           />
@@ -400,6 +441,7 @@ defmodule PetalComponents.ComboBox do
           class="pc-combo-box__clear"
           data-pc-combo-clear
           aria-label={@clear_label}
+          disabled={@disabled}
         >
           <.icon name="hero-x-mark-mini" class="pc-combo-box__clear-icon" />
         </button>
@@ -421,10 +463,12 @@ defmodule PetalComponents.ComboBox do
             aria-expanded="false"
             aria-autocomplete="list"
             aria-controls={"#{@id}-listbox"}
+            aria-label={@search_placeholder}
             autocomplete="off"
             autocorrect="off"
             spellcheck="false"
             placeholder={@search_placeholder}
+            data-placeholder-text={@search_placeholder}
           />
         </div>
         <div :if={@header != []} class="pc-combo-box__header">
@@ -451,8 +495,17 @@ defmodule PetalComponents.ComboBox do
         >
           <%= for group <- @groups do %>
             <%= if group.label do %>
-              <div class="pc-combo-box__group" role="group" data-pc-combo-group>
-                <div class="pc-combo-box__group-heading" aria-hidden="true">{group.label}</div>
+              <%!-- the group carries its heading as its accessible name (the
+              data table's convention): aria-hidden on the heading hid the
+              sectioning from assistive tech entirely, so a screen reader
+              heard one flat list where sighted users see sections --%>
+              <div
+                class="pc-combo-box__group"
+                role="group"
+                aria-label={group.label}
+                data-pc-combo-group
+              >
+                <div class="pc-combo-box__group-heading">{group.label}</div>
                 <.option_items
                   options={group.options}
                   current_values={@current_values}
@@ -478,8 +531,11 @@ defmodule PetalComponents.ComboBox do
             <.icon name="hero-plus-mini" class="pc-combo-box__create-icon" />
             <span>{@create_label} "<span data-pc-combo-create-query></span>"</span>
           </div>
-          <div class="pc-combo-box__empty" data-pc-combo-empty hidden>{@no_results_text}</div>
         </div>
+        <%!-- a listbox may only contain options and groups - the empty row is
+        panel chrome, so it lives OUTSIDE with the other chrome regions
+        (__loading, __header, __footer). The live region announces it. --%>
+        <div class="pc-combo-box__empty" data-pc-combo-empty hidden>{@no_results_text}</div>
         <div :if={@footer != []} class="pc-combo-box__footer">
           {render_slot(@footer)}
         </div>
@@ -494,11 +550,27 @@ defmodule PetalComponents.ComboBox do
         data-value={opt.value}
       >{render_slot(@chip, opt)}</template>
 
+      <%!-- required lives on the inert, off-screen select, so the browser can
+      neither draw its validation bubble nor focus it - a submit would fail
+      in silence. The hook takes the report over and writes the browser's
+      own (already localized) message here: visible, role=alert so it is
+      announced, and aria-describedby from the control. --%>
+      <div
+        :if={@required}
+        id={"#{@id}-error"}
+        class="pc-combo-box__error"
+        data-pc-combo-error
+        role="alert"
+        hidden
+      >
+      </div>
+
       <div
         class="pc-combo-box__live"
         data-pc-combo-live
         data-results-label={@results_label}
         data-no-results-text={@no_results_text}
+        data-max-items-text={@max_items_text}
         aria-live="polite"
       >
       </div>

--- a/lib/petal_components/combo_box.ex
+++ b/lib/petal_components/combo_box.ex
@@ -691,7 +691,10 @@ defmodule PetalComponents.ComboBox do
   defp resolve_id(%{id: id}) when is_binary(id), do: id
   defp resolve_id(%{field: %{id: id}}) when is_binary(id), do: "#{id}_combo_box"
 
-  defp resolve_id(%{name: name}) when is_binary(name) do
+  # an empty name is no identity: deriving from it mints the same
+  # "combo_box_" id for every such instance on the page, so it falls
+  # through to the raise with the others
+  defp resolve_id(%{name: name}) when is_binary(name) and name != "" do
     "combo_box_" <> String.replace(name, ~r/[^A-Za-z0-9_]/, "_")
   end
 

--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -265,14 +265,23 @@ defmodule PetalComponents.Field do
       # combo_box derives its own id from the name when none is passed, and
       # the label's for= has to name a control that actually exists - so
       # resolve the id HERE and pass it down. One id, no way to drift.
+      # No identity at all (no id, no field, nil/empty name) resolves to
+      # nil so the call flows into combo_box's own ArgumentError - a loud
+      # programming error beats minting the same constant id for every
+      # instance on the page.
       |> then(fn a ->
-        id = a.id || "combo_box_" <> String.replace(a.name || "", ~r/[^A-Za-z0-9_]/, "_")
+        id =
+          a.id ||
+            case a.name do
+              name when name in [nil, ""] -> nil
+              name -> "combo_box_" <> String.replace(name, ~r/[^A-Za-z0-9_]/, "_")
+            end
 
         a
         |> assign(:combo_id, id)
         |> assign(
           :combo_label_for,
-          if(a.combo_variant == "trigger", do: "#{id}-trigger", else: "#{id}-input")
+          id && if(a.combo_variant == "trigger", do: "#{id}-trigger", else: "#{id}-input")
         )
       end)
       # the combobox appends [] itself for multiple; the hidden empty

--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -32,7 +32,7 @@ defmodule PetalComponents.Field do
   attr :type, :string,
     default: "text",
     values:
-      ~w(checkbox checkbox-group color date datetime-local email file hidden month number password
+      ~w(checkbox checkbox-group color combobox date datetime-local email file hidden month number password
                range range-dual radio-group radio-card search select switch tel text textarea time url week),
     doc: "the type of input"
 
@@ -262,6 +262,19 @@ defmodule PetalComponents.Field do
       # :variant belongs to radio-card here - the combobox anatomy rides
       # combo_variant ("input" | "trigger")
       |> assign_new(:combo_variant, fn -> "input" end)
+      # combo_box derives its own id from the name when none is passed, and
+      # the label's for= has to name a control that actually exists - so
+      # resolve the id HERE and pass it down. One id, no way to drift.
+      |> then(fn a ->
+        id = a.id || "combo_box_" <> String.replace(a.name || "", ~r/[^A-Za-z0-9_]/, "_")
+
+        a
+        |> assign(:combo_id, id)
+        |> assign(
+          :combo_label_for,
+          if(a.combo_variant == "trigger", do: "#{id}-trigger", else: "#{id}-input")
+        )
+      end)
       # the combobox appends [] itself for multiple; the hidden empty
       # input must post the SAME name or a bare-name field submits a
       # mixed shape (the FormField path appends [] upstream already)
@@ -278,13 +291,19 @@ defmodule PetalComponents.Field do
 
     ~H"""
     <.field_wrapper errors={@errors} name={@name} class={@wrapper_class} no_margin={@no_margin}>
-      <.field_label required={@required} for={@id} class={@label_class}>
+      <%!-- @id lands on the combobox WRAPPER (a roleless div), so for= has to
+      name the focusable control inside it: the input, or the trigger button
+      in the trigger anatomy. Both are labelable elements, so clicking the
+      label focuses the real control. The label also rides down as the
+      combobox's accessible name. --%>
+      <.field_label required={@required} for={@combo_label_for} class={@label_class}>
         {@label}
       </.field_label>
       <input :if={@multiple} type="hidden" name={@hidden_name} value="" />
       <PetalComponents.ComboBox.combo_box
-        id={@id}
+        id={@combo_id}
         name={@name}
+        label={@label}
         value={@selected || @value}
         options={@options}
         multiple={@multiple}

--- a/rules.md
+++ b/rules.md
@@ -59,7 +59,7 @@ end
 
 ### 5. Register the JS hooks
 
-petal_components v4 ships a bundled JS hook set - toasts, the command palette and its trigger, the colour-scheme switch, carousel, charts, local time, sliders, OTP input, the chat family, popover, the navigation menu's hover mode, the effects, and the enhanced inputs (everything else is CSS + LiveView.JS only). You never register hooks individually - spread the whole set once. Open `assets/js/app.js`, import the hooks, and merge them into your `LiveSocket`:
+petal_components v4 ships a bundled JS hook set - toasts, the command palette and its trigger, the colour-scheme switch, carousel, charts, local time, sliders, OTP input, the chat family, popover, the combobox, the data table, the navigation menu's hover mode, the effects, and the enhanced inputs (everything else is CSS + LiveView.JS only). You never register hooks individually - spread the whole set once. Open `assets/js/app.js`, import the hooks, and merge them into your `LiveSocket`:
 
 ```js
 import PetalComponents from "../../deps/petal_components/assets/js/petal_components"
@@ -124,7 +124,7 @@ One deliberate choice to know about: the `gray` role ships Tailwind's **zinc** v
 2. **Do not invent Tailwind soup for things petal_components already does.** No hand-rolled modal divs, no manual dropdown JS, no DIY form labels. There is almost certainly an existing component for it.
 3. **Look up the schema before guessing attrs.** Do not assume attr names from memory. Call `list_components` and `get_component` (see below) to get the real attr/slot signature before writing HEEx.
 4. **Call components as plain HEEx tags after `use PetalComponents`.** `<.button>`, `<.modal>`, `<.table>`, `<.card>`, etc. If you have not imported, qualify with the module: `<PetalComponents.Button.button />`. Note: the `pc-*` prefix you see in source is the CSS class prefix for styling, not part of the function name.
-5. **Components work in both live and dead views.** Interactivity is Phoenix.LiveView.JS only (no Alpine.js as of v4). Many components (toasts, command palette, colour scheme, carousel, charts, chat, enhanced inputs and more) use bundled JS hooks — register the whole set once in your LiveSocket: `import PetalComponents from "../../deps/petal_components/assets/js/petal_components"` then `hooks: { ...PetalComponents }`.
+5. **Components work in both live and dead views.** Interactivity is Phoenix.LiveView.JS only (no Alpine.js as of v4). Many components (toasts, command palette, colour scheme, carousel, charts, chat, combobox, data table, enhanced inputs and more) use bundled JS hooks — register the whole set once in your LiveSocket: `import PetalComponents from "../../deps/petal_components/assets/js/petal_components"` then `hooks: { ...PetalComponents }`.
 6. **Form inputs come in two layers, pick deliberately.** Use `<.field type="..." />` when you want label + input + error + help text bundled (the common case in form contexts). Use the standalone primitives (`<.text_input>`, `<.select>`, `<.checkbox>`, etc.) when composing your own field layout.
 
 ## Discovering components
@@ -277,6 +277,80 @@ end
 ```
 
 Selection and column visibility are UI state (the clauses above; move them to a separate `on_ui` event if you prefer) - keep them in assigns, never in URLs. For URL-driven tables pass `path` instead of `on_change`: every interaction becomes a patch URL and `State.from_params/2` in `handle_params` is the whole backend. `row_id` must uniquely identify records across all pages.
+
+### Combobox (searchable select, chips, remote search)
+
+Reach for `<.combo_box>` whenever a `<.select>` has more options than someone wants to scroll. It is form-native: the real control is a hidden `<select>` the `PetalComboBox` hook keeps in sync, so changesets, `phx-change` and LiveView form recovery behave exactly as they do for a plain select. Filtering is client-side and dependency-free.
+
+```heex
+<.combo_box
+  id="country"
+  name="country"
+  label="Country"
+  options={["Australia", "Japan", "Portugal"]}
+/>
+```
+
+Always pass `label` (or go through `<.field>`, below). It is the control's accessible name - without it the placeholder is all a screen reader has.
+
+Options take the shapes `select` users expect, and groups are `{heading, options}`:
+
+```heex
+<.combo_box
+  id="city"
+  name="city"
+  label="City"
+  value="syd"
+  options={[
+    {"Oceania", [{"Sydney", "syd"}, {"Melbourne", "mel", disabled: true}]},
+    {"Europe", [{"Lisbon", "lis"}, {"Stockholm", "sto"}]}
+  ]}
+/>
+```
+
+`multiple` turns the control into a chip row - each choice is a removable token, the panel stays open while picking, and Backspace in an empty input removes the last chip. `max_items` caps it; at the cap the unchosen options go inert. The hidden select becomes a `<select multiple>` and the name gains `[]`, so every choice survives the post.
+
+```heex
+<.combo_box
+  id="tags"
+  name="tags"
+  label="Tags"
+  multiple
+  max_items={5}
+  value={@tags}
+  options={["elixir", "phoenix", "liveview", "ecto"]}
+/>
+```
+
+For a remote data source, name an event with `remote_options_event_name` (add `remote_options_target={@myself}` from a LiveComponent). Typing pushes the raw search term, debounced, and the reply becomes the option list:
+
+```elixir
+def handle_event("search_users", term, socket) do
+  results = MyApp.Accounts.search(term) |> Enum.map(&%{text: &1.name, value: &1.id})
+  {:reply, %{results: results}, socket}
+end
+```
+
+In a form, use `<.field type="combobox">` - it brings the label, changeset errors and help text, and forwards every combobox attr:
+
+```heex
+<.form :let={f} for={@changeset} phx-change="validate" phx-submit="save">
+  <.field
+    type="combobox"
+    field={f[:country]}
+    label="Country"
+    help_text="Where the account is billed"
+    options={@countries}
+    clearable
+  />
+</.form>
+```
+
+One gotcha through `<.field>`: the anatomy attr is `combo_variant`, NOT `variant` (`:variant` already belongs to radio-card there). `combo_variant="trigger"` gives the select-like button whose panel carries the search input - the picker shape, and what the data table's filter editor uses. On the bare `<.combo_box>` the attr is just `variant`.
+
+```heex
+<.field type="combobox" field={f[:owner]} label="Owner" combo_variant="trigger" options={@people} />
+```
 
 ### Alert / inline feedback
 

--- a/test/js/combo_box.test.js
+++ b/test/js/combo_box.test.js
@@ -42,6 +42,9 @@ function mountCombo({
   freeText = false,
   create = false,
   remote = false,
+  required = false,
+  disabled = false,
+  footer = "",
 } = {}) {
   const selectOptions = [...options, ...groups.flatMap((g) => g.options)]
     .map(
@@ -55,8 +58,8 @@ function mountCombo({
     groups
       .map(
         (g) => `
-        <div class="pc-combo-box__group" role="group" data-pc-combo-group>
-          <div class="pc-combo-box__group-heading" aria-hidden="true">${g.label}</div>
+        <div class="pc-combo-box__group" role="group" aria-label="${g.label}" data-pc-combo-group>
+          <div class="pc-combo-box__group-heading">${g.label}</div>
           ${g.options.map(optionHtml).join("")}
         </div>`,
       )
@@ -71,26 +74,33 @@ function mountCombo({
   if (remote) el.setAttribute("data-remote-event", "search");
   const inputHtml = `<input type="text" id="${id}-input" class="pc-combo-box__input" role="combobox"
           aria-expanded="false" aria-autocomplete="list" aria-controls="${id}-listbox"
-          autocomplete="off" placeholder="Pick..." />`;
+          ${required ? `aria-required="true" aria-describedby="${id}-error"` : ""}
+          ${disabled ? "disabled" : ""}
+          autocomplete="off" placeholder="Pick..." data-placeholder-text="Pick..." />`;
+
+  const clearHtml = (cls) =>
+    `<button type="button" class="${cls}" data-pc-combo-clear aria-label="Clear selection" ${disabled ? "disabled" : ""}><span class="hero-x-mark-mini pc-combo-box__clear-icon"></span></button>`;
 
   const bodyHtml = trigger
     ? `<button type="button" id="${id}-trigger" class="pc-combo-box__trigger" role="combobox"
         aria-haspopup="listbox" aria-expanded="false" aria-controls="${id}-listbox"
+        ${required ? `aria-required="true" aria-describedby="${id}-error"` : ""}
+        ${disabled ? "disabled" : ""}
         data-pc-combo-trigger data-placeholder="true">
         <span class="pc-combo-box__trigger-label" data-pc-combo-trigger-label
           data-placeholder-text="Pick..." data-count-label="selected">Pick...</span>
-      </button>${clearable ? '<button type="button" class="pc-combo-box__trigger-clear" data-pc-combo-clear aria-label="Clear selection"><span class="hero-x-mark-mini pc-combo-box__clear-icon"></span></button>' : ""}`
+      </button>${clearable ? clearHtml("pc-combo-box__trigger-clear") : ""}`
     : `<div class="pc-combo-box__control">
       <div class="pc-combo-box__content">
         ${multiple ? '<div class="pc-combo-box__chips" data-pc-combo-chips data-remove-label="Remove"></div>' : ""}
         ${inputHtml}
       </div>
-      ${clearable ? '<button type="button" class="pc-combo-box__clear" data-pc-combo-clear aria-label="Clear selection"><span class="hero-x-mark-mini pc-combo-box__clear-icon"></span></button>' : ""}
+      ${clearable ? clearHtml("pc-combo-box__clear") : ""}
       ${multiple ? "" : '<span class="hero-chevron-down-mini pc-combo-box__chevron"></span>'}
     </div>`;
 
   el.innerHTML = `
-    <select id="${id}-select" name="city${multiple ? "[]" : ""}" class="pc-combo-box__select" tabindex="-1" aria-hidden="true" inert ${multiple ? "multiple" : ""}>
+    <select id="${id}-select" name="city${multiple ? "[]" : ""}" class="pc-combo-box__select" tabindex="-1" aria-hidden="true" inert ${multiple ? "multiple" : ""} ${required ? "required" : ""} ${disabled ? "disabled" : ""}>
       ${multiple ? "" : '<option value=""></option>'}
       ${selectOptions}
     </select>
@@ -101,10 +111,12 @@ function mountCombo({
       <div role="listbox" id="${id}-listbox" class="pc-combo-box__list" aria-label="Options">
         ${listHtml}
         ${create ? '<div class="pc-combo-box__create" data-pc-combo-create role="option" aria-selected="false" hidden><span>Create "<span data-pc-combo-create-query></span>"</span></div>' : ""}
-        <div class="pc-combo-box__empty" data-pc-combo-empty hidden>No results found</div>
       </div>
+      <div class="pc-combo-box__empty" data-pc-combo-empty hidden>No results found</div>
+      ${footer ? `<div class="pc-combo-box__footer">${footer}</div>` : ""}
     </div>
-    <div class="pc-combo-box__live" data-pc-combo-live data-results-label="results" data-no-results-text="No results found" aria-live="polite"></div>`;
+    ${required ? `<div id="${id}-error" class="pc-combo-box__error" data-pc-combo-error role="alert" hidden></div>` : ""}
+    <div class="pc-combo-box__live" data-pc-combo-live data-results-label="results" data-no-results-text="No results found" data-max-items-text="Maximum selections reached" aria-live="polite"></div>`;
   document.body.appendChild(el);
 
   const hook = Object.create(hooks.PetalComboBox);
@@ -127,7 +139,13 @@ function mountCombo({
     highlighted: () => el.querySelector("[data-highlighted]"),
     empty: () => el.querySelector("[data-pc-combo-empty]"),
     chips: () => [...el.querySelectorAll("[data-pc-combo-chip]")],
+    chipValues: () =>
+      [...el.querySelectorAll("[data-pc-combo-chip]")].map(
+        (chip) => chip.dataset.value,
+      ),
     live: () => el.querySelector("[data-pc-combo-live]"),
+    error: () => el.querySelector("[data-pc-combo-error]"),
+    clear: () => el.querySelector("[data-pc-combo-clear]"),
     trigger: el.querySelector("[data-pc-combo-trigger]"),
     triggerLabel: () => el.querySelector("[data-pc-combo-trigger-label]"),
   };
@@ -964,20 +982,24 @@ describe("multiple with chips", () => {
     expect(c.items().filter((i) => !i.hidden).length).toBeGreaterThan(1);
   });
 
-  it("the placeholder attribute is server truth - the hook never rewrites it", () => {
-    // the cap-rest is pure CSS on [data-max-reached]; the attribute must
-    // survive every selection transition so live server changes always win
+  it("the cap says the same thing on screen as in the live region, and the server's placeholder is what it restores", () => {
+    // the cap used to blank the placeholder to transparent in CSS, so the
+    // field LOOKED empty while a screen reader still read the placeholder
+    // aloud. The hook swaps the text instead - and data-placeholder-text
+    // keeps the server's own placeholder the truth to come back to.
     const c = mountCombo({ options: CITIES, multiple: true, maxItems: 2 });
     c.control.click();
     c.items()[0].click();
     expect(c.input.getAttribute("placeholder")).toBe("Pick...");
     c.items()[1].click();
     expect(c.el.hasAttribute("data-max-reached")).toBe(true);
-    expect(c.input.getAttribute("placeholder")).toBe("Pick...");
-    // server changes it while capped - updated() must not revert it
-    c.input.setAttribute("placeholder", "Añadir…");
+    expect(c.input.getAttribute("placeholder")).toBe("Maximum selections reached");
+    expect(c.live().textContent).toContain("Maximum selections reached");
+    // server changes the placeholder while capped: the cap text still
+    // shows, and the NEW server value is what uncapping restores
+    c.input.dataset.placeholderText = "Añadir…";
     c.hook.updated();
-    expect(c.input.getAttribute("placeholder")).toBe("Añadir…");
+    expect(c.input.getAttribute("placeholder")).toBe("Maximum selections reached");
     c.chips()[0].querySelector("[data-pc-combo-chip-remove]").click();
     expect(c.el.hasAttribute("data-max-reached")).toBe(false);
     expect(c.input.getAttribute("placeholder")).toBe("Añadir…");
@@ -1583,5 +1605,342 @@ describe("server ownership", () => {
     expect(formInputs).toBe(0);
     key(c.input, "Enter");
     expect(formInputs).toBe(1);
+  });
+});
+
+// The pre-release a11y/behaviour sweep. Each spec here pins a finding that
+// was reproducible on the live demo page - the repro is in the comment.
+describe("chips: Backspace targets what the user sees", () => {
+  it("removes the LAST CHIP, not the last option in the select's DOM order", () => {
+    // audit repro: preselect Sydney + Tokyo, then pick Stockholm and
+    // Lisbon in that order. Chips read [syd, tyo, sto, lis]; the select's
+    // DOM order is [syd, tyo, lis, sto], so reading the select deleted
+    // Stockholm - a chip from the MIDDLE of the row.
+    const c = mountCombo({ options: CITIES, multiple: true });
+    c.select.querySelector('option[value="syd"]').selected = true;
+    c.select.querySelector('option[value="tyo"]').selected = true;
+    c.hook.updated();
+    c.control.click();
+    c.items().find((i) => i.dataset.value === "sto").click();
+    c.items().find((i) => i.dataset.value === "lis").click();
+    expect(c.chipValues()).toEqual(["syd", "tyo", "sto", "lis"]);
+    expect(c.hook.selectedValues()).toEqual(["syd", "tyo", "lis", "sto"]);
+
+    c.input.value = "";
+    key(c.input, "Backspace");
+    expect(c.chipValues()).toEqual(["syd", "tyo", "sto"]);
+    expect(c.select.querySelector('option[value="lis"]').selected).toBe(false);
+    expect(c.select.querySelector('option[value="sto"]').selected).toBe(true);
+  });
+
+  it("keeps walking backwards through the row, one chip per press", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    c.control.click();
+    c.items().find((i) => i.dataset.value === "sto").click();
+    c.items().find((i) => i.dataset.value === "syd").click();
+    expect(c.chipValues()).toEqual(["sto", "syd"]);
+    c.input.value = "";
+    key(c.input, "Backspace");
+    expect(c.chipValues()).toEqual(["sto"]);
+    key(c.input, "Backspace");
+    expect(c.chipValues()).toEqual([]);
+    // nothing left to remove is a no-op, never a throw
+    key(c.input, "Backspace");
+    expect(c.chipValues()).toEqual([]);
+  });
+
+  it("a typed query still owns Backspace", () => {
+    const c = mountCombo({ options: CITIES, multiple: true });
+    c.control.click();
+    c.items()[0].click();
+    type(c.input, "sto");
+    key(c.input, "Backspace");
+    expect(c.chipValues()).toEqual(["syd"]);
+  });
+});
+
+describe("trigger variant: clearing leaves a coherent state", () => {
+  it("closes the panel and puts focus on the trigger", () => {
+    // before: the panel stayed open with focus parked on the trigger -
+    // outside the panel - so arrows and typing were dead and Escape read
+    // as "already closed" and leaked to the enclosing modal
+    const c = mountCombo({ options: CITIES, trigger: true, clearable: true });
+    c.trigger.click();
+    c.items()[0].click();
+    expect(c.select.value).toBe("syd");
+    c.trigger.click();
+    expect(c.panel.hidden).toBe(false);
+
+    c.clear().click();
+    expect(c.select.value).toBe("");
+    expect(c.panel.hidden).toBe(true);
+    expect(document.activeElement).toBe(c.trigger);
+    expect(c.trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("Escape after a clear is handled by the page again, not swallowed", () => {
+    const c = mountCombo({ options: CITIES, trigger: true, clearable: true });
+    c.trigger.click();
+    c.items()[0].click();
+    c.trigger.click();
+    c.clear().click();
+    // the panel is shut, so Escape belongs to whatever encloses us (a
+    // modal); the combobox only stops it while it owns an open panel
+    const ev = key(c.input, "Escape");
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it("a still-open panel keeps stopping Escape", () => {
+    const c = mountCombo({ options: CITIES, trigger: true, clearable: true });
+    c.trigger.click();
+    const ev = key(c.input, "Escape");
+    expect(ev.defaultPrevented).toBe(true);
+    expect(c.panel.hidden).toBe(true);
+  });
+});
+
+describe("disabled", () => {
+  it("the clear button does nothing - no value change, no event", () => {
+    // reproduced live in three clicks: pick a value, flip disabled, and
+    // the X was still focusable and still cleared - and because a
+    // disabled select posts nothing, it desynced client from server
+    const c = mountCombo({
+      options: CITIES,
+      clearable: true,
+      disabled: true,
+    });
+    c.select.value = "syd";
+    c.hook.updated();
+    let changes = 0;
+    c.select.addEventListener("change", () => changes++);
+    c.clear().click();
+    expect(c.select.value).toBe("syd");
+    expect(changes).toBe(0);
+    expect(c.clear().disabled).toBe(true);
+  });
+});
+
+describe("max_items is a real stop, not a visual one", () => {
+  it("stamps aria-disabled on unchosen options and takes them out of the keyboard path", () => {
+    const c = mountCombo({ options: CITIES, multiple: true, maxItems: 2 });
+    c.control.click();
+    c.items()[0].click();
+    c.items()[1].click();
+    const capped = c.items().filter((i) => i.dataset.value === "lis")[0];
+    expect(capped.getAttribute("aria-disabled")).toBe("true");
+    // chosen options stay live - removing is the way back
+    expect(c.items()[0].hasAttribute("aria-disabled")).toBe(false);
+    expect(c.hook.navItems().map((i) => i.dataset.value)).toEqual([
+      "syd",
+      "tyo",
+    ]);
+
+    // lifting the cap restores them
+    c.chips()[0].querySelector("[data-pc-combo-chip-remove]").click();
+    expect(capped.hasAttribute("aria-disabled")).toBe(false);
+    expect(capped.hasAttribute("data-disabled")).toBe(false);
+  });
+
+  it("never un-disables an option the server disabled", () => {
+    const c = mountCombo({
+      options: [...CITIES, option("mel", "Melbourne", true)],
+      multiple: true,
+      maxItems: 2,
+    });
+    const melbourne = c.items().find((i) => i.dataset.value === "mel");
+    c.control.click();
+    c.items()[0].click();
+    c.items()[1].click();
+    c.chips()[0].querySelector("[data-pc-combo-chip-remove]").click();
+    expect(c.el.hasAttribute("data-max-reached")).toBe(false);
+    expect(melbourne.getAttribute("aria-disabled")).toBe("true");
+    expect(melbourne.hasAttribute("data-disabled")).toBe(true);
+  });
+
+  it("announces the cap, and announces again on a blocked pick", () => {
+    const c = mountCombo({ options: CITIES, multiple: true, maxItems: 2 });
+    c.control.click();
+    c.items()[0].click();
+    c.items()[1].click();
+    expect(c.live().textContent).toContain("Maximum selections reached");
+
+    // a live region only speaks on a CHANGE, so a second blocked press
+    // with the identical string would be silence - the text must differ
+    const first = c.live().textContent;
+    c.hook.choose(c.items().find((i) => i.dataset.value === "lis"));
+    expect(c.live().textContent).not.toBe(first);
+    expect(c.live().textContent).toContain("Maximum selections reached");
+    expect(c.chipValues()).toEqual(["syd", "tyo"]);
+  });
+
+  it("mounting at the cap is not a state change - nothing is announced", () => {
+    const c = mountCombo({ options: CITIES, multiple: true, maxItems: 1 });
+    c.select.querySelector('option[value="syd"]').selected = true;
+    const fresh = Object.create(hooks.PetalComboBox);
+    fresh.el = c.el;
+    fresh.mounted();
+    mounted.push(fresh);
+    expect(fresh.el.hasAttribute("data-max-reached")).toBe(true);
+    expect(c.live().textContent).toBe("");
+  });
+});
+
+describe("required: the form never fails in silence", () => {
+  it("takes the report over - visible message, focus on the control, aria-invalid", () => {
+    // the hidden select is inert and sr-only, so the browser could
+    // neither draw its bubble nor focus it: submit was blocked with
+    // nothing shown, nothing announced, and focus on <body>
+    const c = mountCombo({ options: CITIES, required: true });
+    expect(c.select.checkValidity()).toBe(false);
+    expect(c.error().hidden).toBe(false);
+    expect(c.error().textContent).toBe(c.select.validationMessage);
+    expect(c.error().getAttribute("role")).toBe("alert");
+    expect(document.activeElement).toBe(c.input);
+    expect(c.input.getAttribute("aria-invalid")).toBe("true");
+  });
+
+  it("choosing a value retires the message", () => {
+    const c = mountCombo({ options: CITIES, required: true });
+    c.select.checkValidity();
+    expect(c.error().hidden).toBe(false);
+    c.control.click();
+    c.items()[0].click();
+    expect(c.error().hidden).toBe(true);
+    expect(c.error().textContent).toBe("");
+    expect(c.input.hasAttribute("aria-invalid")).toBe(false);
+  });
+
+  it("the trigger anatomy reports on the trigger", () => {
+    const c = mountCombo({ options: CITIES, required: true, trigger: true });
+    c.select.checkValidity();
+    expect(document.activeElement).toBe(c.trigger);
+    expect(c.trigger.getAttribute("aria-invalid")).toBe("true");
+  });
+
+  it("a combobox with no constraint has nothing to report", () => {
+    const c = mountCombo({ options: CITIES });
+    expect(c.error()).toBeNull();
+    expect(c.select.checkValidity()).toBe(true);
+  });
+});
+
+describe("panel slots", () => {
+  it("lets a focusable control in a footer take the press", () => {
+    // preventDefault on every panel press is what kept focus in the search
+    // input - and made a text field in a :header / :footer slot impossible
+    // to focus by pointer
+    const c = mountCombo({
+      options: CITIES,
+      footer: '<input type="text" id="footer-field" /><span id="footer-text">x</span>',
+    });
+    c.control.click();
+    const field = document.getElementById("footer-field");
+    const press = pointerEvent("pointerdown", "mouse", { cancelable: true });
+    field.dispatchEvent(press);
+    expect(press.defaultPrevented).toBe(false);
+
+    // ordinary chrome still keeps focus where it is
+    const chromePress = pointerEvent("pointerdown", "mouse", {
+      cancelable: true,
+    });
+    document.getElementById("footer-text").dispatchEvent(chromePress);
+    expect(chromePress.defaultPrevented).toBe(true);
+  });
+});
+
+describe("lifecycle hardening", () => {
+  it("a stranded pointerdown does not disarm outside-tap dismissal forever", () => {
+    // a press that never gets its pointerup (a right-click handing the
+    // release to the context menu) used to sit in the active set for the
+    // rest of the open session, so every later tap read as multi-touch
+    const clock = vi.spyOn(performance, "now").mockReturnValue(1_000);
+    const c = mountCombo({ options: CITIES });
+    c.control.click();
+    document.body.dispatchEvent(
+      pointerEvent("pointerdown", "mouse", { pointerId: 7 }),
+    );
+    // ...no pointerup for 7 ever arrives
+    clock.mockReturnValue(5_000);
+    document.body.dispatchEvent(
+      pointerEvent("pointerdown", "mouse", { pointerId: 8, clientX: 5, clientY: 5 }),
+    );
+    document.body.dispatchEvent(
+      pointerEvent("pointerup", "mouse", { pointerId: 8, clientX: 5, clientY: 5 }),
+    );
+    expect(c.panel.hidden).toBe(true);
+    clock.mockRestore();
+  });
+
+  it("updated() re-reads the conditionally rendered chrome", () => {
+    // clearable={@editing} and multiple={@mode == :many} are ordinary
+    // server state: a clear button that arrives on a patch needs binding,
+    // and a chips container we never re-read stays null so no chip renders
+    const c = mountCombo({ options: CITIES });
+    expect(c.hook.multiple).toBe(false);
+    expect(c.hook.clearButton).toBeNull();
+
+    c.select.multiple = true;
+    const chips = document.createElement("div");
+    chips.className = "pc-combo-box__chips";
+    chips.setAttribute("data-pc-combo-chips", "");
+    chips.dataset.removeLabel = "Remove";
+    c.el.querySelector(".pc-combo-box__content").prepend(chips);
+    const clear = document.createElement("button");
+    clear.type = "button";
+    clear.setAttribute("data-pc-combo-clear", "");
+    c.control.appendChild(clear);
+
+    c.hook.updated();
+    expect(c.hook.multiple).toBe(true);
+    expect(c.hook.chips).toBe(chips);
+    expect(c.hook.clearButton).toBe(clear);
+
+    c.control.click();
+    c.items()[0].click();
+    expect(c.chipValues()).toEqual(["syd"]);
+    clear.click();
+    expect(c.select.value).toBe("");
+
+    // a second patch must not double-bind the same node
+    c.hook.updated();
+    let changes = 0;
+    c.select.addEventListener("change", () => changes++);
+    c.control.click();
+    c.items()[1].click();
+    clear.click();
+    expect(changes).toBe(2);
+  });
+
+  it("destroyed() on half-mounted markup neither throws nor strands listeners", () => {
+    const el = document.createElement("div");
+    el.id = "half";
+    // an input but no listbox: mounted() bails, so teardown must too
+    el.innerHTML = `<select class="pc-combo-box__select"></select>
+      <div class="pc-combo-box__control">
+        <input type="text" class="pc-combo-box__input" />
+      </div>`;
+    document.body.appendChild(el);
+    const hook = Object.create(hooks.PetalComboBox);
+    hook.el = el;
+    hook.mounted();
+    expect(() => hook.destroyed()).not.toThrow();
+  });
+
+  it("destroyed() clears the deferred close and the post-reset re-sync", () => {
+    vi.useFakeTimers();
+    const form = document.createElement("form");
+    document.body.appendChild(form);
+    const c = mountCombo({ options: CITIES });
+    form.appendChild(c.el);
+    // rebind to the form the way a server-rendered one would be
+    const hook = Object.create(hooks.PetalComboBox);
+    hook.el = c.el;
+    hook.mounted();
+    hook.el.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    form.dispatchEvent(new Event("reset"));
+    hook.destroyed();
+    expect(() => vi.runAllTimers()).not.toThrow();
+    expect(vi.getTimerCount()).toBe(0);
+    vi.useRealTimers();
   });
 });

--- a/test/petal/combo_box_test.exs
+++ b/test/petal/combo_box_test.exs
@@ -599,6 +599,185 @@ defmodule PetalComponents.ComboBoxTest do
     end
   end
 
+  describe "accessible name" do
+    test "label names the visible input, not the wrapper" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="c" name="country" label="Country" options={["Australia"]} />
+        """)
+
+      # the name has to sit on the role=combobox element itself - the
+      # wrapper is a roleless div and naming it names nothing
+      assert html =~ ~r/<input[^>]*id="c-input"[^>]*aria-label="Country"/s
+      refute html =~ ~r/<div[^>]*id="c"[^>]*aria-label=/s
+    end
+
+    test "the trigger anatomy names the button and the panel's search input" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box
+          id="t"
+          name="country"
+          variant="trigger"
+          label="Country"
+          search_placeholder="Find a country…"
+          options={["Australia"]}
+        />
+        """)
+
+      assert html =~ ~r/<button[^>]*aria-label="Country"[^>]*data-pc-combo-trigger/s
+
+      assert html =~ ~r/<input[^>]*id="t-input"[^>]*aria-label="Find a country…"/s
+    end
+
+    test "no label leaves no empty aria-label behind" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="c" name="country" options={["Australia"]} />
+        """)
+
+      refute html =~ "aria-label=\"\""
+    end
+  end
+
+  describe "required" do
+    test "renders aria-required on the visible combobox and an error region to report into" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="c" name="country" label="Country" required options={["Australia"]} />
+        """)
+
+      # the state has to reach the a11y tree: the select carrying it is
+      # aria-hidden, so aria-required on the visible control is the only cue
+      assert html =~ ~r/<input[^>]*id="c-input"[^>]*aria-required="true"/s
+      assert html =~ ~r/<input[^>]*id="c-input"[^>]*aria-describedby="c-error"/s
+      assert html =~ ~r/<div[^>]*id="c-error"[^>]*role="alert"[^>]*hidden/s
+      assert html =~ "data-pc-combo-error"
+      # still the real constraint - the hook only takes over the reporting
+      assert html =~ ~r/<select[^>]*required/s
+    end
+
+    test "the trigger anatomy carries the same state" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="t" name="country" variant="trigger" required options={["Australia"]} />
+        """)
+
+      assert html =~ ~r/<button[^>]*aria-required="true"[^>]*data-pc-combo-trigger/s
+      assert html =~ ~s|aria-describedby="t-error"|
+    end
+
+    test "without required there is no error region and no dangling description" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.combo_box id="c" name="country" options={["Australia"]} />
+        """)
+
+      refute html =~ "data-pc-combo-error"
+      refute html =~ "aria-describedby"
+      refute html =~ "aria-required"
+    end
+  end
+
+  test "a disabled combobox ships no live clear button" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box id="c" name="city" clearable disabled value="syd" options={[{"Sydney", "syd"}]} />
+      """)
+
+    # the clear used to stay tabbable and clickable inside a disabled
+    # widget, and clearing it desynced the server (a disabled select posts
+    # nothing) - both anatomies disable it now
+    assert html =~ ~r/<button[^>]*pc-combo-box__clear[^>]*disabled/s
+
+    trigger =
+      rendered_to_string(~H"""
+      <.combo_box
+        id="t"
+        name="city"
+        variant="trigger"
+        clearable
+        disabled
+        value="syd"
+        options={[{"Sydney", "syd"}]}
+      />
+      """)
+
+    assert trigger =~ ~r/<button[^>]*pc-combo-box__trigger-clear[^>]*disabled/s
+  end
+
+  test "groups expose their heading instead of hiding it" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box
+        id="c"
+        name="city"
+        options={[{"Oceania", [{"Sydney", "syd"}]}, {"Europe", [{"Lisbon", "lis"}]}]}
+      />
+      """)
+
+    assert html =~ ~r/role="group"[^>]*aria-label="Oceania"/s
+    assert html =~ ~r/role="group"[^>]*aria-label="Europe"/s
+    # the heading used to be aria-hidden, so the sections vanished entirely
+    refute html =~ ~r/pc-combo-box__group-heading[^>]*aria-hidden/s
+  end
+
+  test "the empty row is panel chrome, not a listbox child" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box id="c" name="city" no_results_text="Nothing here" options={[{"Sydney", "syd"}]} />
+      """)
+
+    assert html =~ "Nothing here"
+    # a listbox may only contain options and groups; every other chrome
+    # region (loading, header, footer) already lives outside it
+    [_, after_list] = String.split(html, ~s|role="listbox"|, parts: 2)
+    [inside_list, outside_list] = String.split(after_list, "</div>\n", parts: 2)
+    refute inside_list =~ "pc-combo-box__empty"
+    assert outside_list =~ "pc-combo-box__empty"
+  end
+
+  test "max_items carries the cap announcement and the placeholder to restore" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.combo_box
+        id="c"
+        name="tags"
+        multiple
+        max_items={2}
+        placeholder="Build your stack…"
+        max_items_text="That's the lot"
+        options={["a", "b", "c"]}
+      />
+      """)
+
+    assert html =~ ~s|data-max-items="2"|
+    assert html =~ ~s|data-max-items-text="That&#39;s the lot"|
+    # the hook swaps the placeholder at the cap and restores from here, so
+    # a server-rendered placeholder stays the truth
+    assert html =~ ~s|data-placeholder-text="Build your stack…"|
+  end
+
   test "raises without any id source" do
     assigns = %{}
 

--- a/test/petal/field_test.exs
+++ b/test/petal/field_test.exs
@@ -1498,5 +1498,24 @@ defmodule PetalComponents.FieldTest do
       # the probe itself has to be able to fail
       assert warn.("not-a-real-type") =~ "must be one of"
     end
+
+    test "a nil or empty name raises combo_box's own identity error, never a constant id" do
+      # the old fallback minted the same "combo_box_" id for EVERY
+      # identityless instance - two on a page meant duplicate ids and
+      # ambiguous label targets. With the fallback gone, the identityless
+      # call flows into resolve_id/1's deliberate ArgumentError: a form
+      # control with no identity is a programming error and says so,
+      # loudly, instead of silently colliding. (A field with the :name
+      # key MISSING entirely is a pre-existing KeyError for every type.)
+      for name <- [nil, ""] do
+        assigns = %{name: name}
+
+        assert_raise ArgumentError, ~r/needs an :id, a :field or a :name/, fn ->
+          rendered_to_string(~H"""
+          <.field type="combobox" name={@name} value={nil} label="City" options={[{"Sydney", "syd"}]} />
+          """)
+        end
+      end
+    end
   end
 end

--- a/test/petal/field_test.exs
+++ b/test/petal/field_test.exs
@@ -1417,5 +1417,86 @@ defmodule PetalComponents.FieldTest do
       assert html =~ "pc-combo-box--sm"
       assert html =~ "pc-combo-box__trigger"
     end
+
+    test "the label names the focusable control, not the wrapper div" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.field type="combobox" name="city" value={nil} label="City" options={[{"Sydney", "syd"}]} />
+        """)
+
+      # for= used to point at @id, which lands on the combobox WRAPPER -
+      # a roleless div, so clicking the label focused nothing
+      assert html =~ ~s|for="combo_box_city-input"|
+      assert html =~ ~r/<input[^>]*id="combo_box_city-input"[^>]*aria-label="City"/s
+    end
+
+    test "the trigger anatomy's label points at the trigger button" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.field
+          type="combobox"
+          name="city"
+          value={nil}
+          label="City"
+          combo_variant="trigger"
+          options={[{"Sydney", "syd"}]}
+        />
+        """)
+
+      # a button is a labelable element, so this is a real association -
+      # and it is the control that is focusable while the panel is shut
+      assert html =~ ~s|for="combo_box_city-trigger"|
+      assert html =~ ~s|id="combo_box_city-trigger"|
+    end
+
+    test "an explicit id still owns the association" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.field
+          type="combobox"
+          id="picker"
+          name="city"
+          value={nil}
+          label="City"
+          options={[{"Sydney", "syd"}]}
+        />
+        """)
+
+      assert html =~ ~s|for="picker-input"|
+      assert html =~ ~s|id="picker-input"|
+    end
+
+    test ~s|type="combobox" compiles without an attr warning| do
+      # ComponentCase only IMPORTS Phoenix.Component, so attr validation
+      # never runs in this suite - it runs in the consumer's module. Compile
+      # a caller the way a consumer project does and read stderr, or the
+      # missing values: entry goes unnoticed again (it shipped once).
+      warn = fn type ->
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Code.compile_string("""
+          defmodule FieldTypeProbe#{:erlang.unique_integer([:positive])} do
+            use Phoenix.Component
+            import PetalComponents.Field
+
+            def render(assigns) do
+              ~H\"\"\"
+              <.field type="#{type}" name="city" value={nil} label="City" options={[]} />
+              \"\"\"
+            end
+          end
+          """)
+        end)
+      end
+
+      refute warn.("combobox") =~ "must be one of"
+      # the probe itself has to be able to fail
+      assert warn.("not-a-real-type") =~ "must be one of"
+    end
   end
 end


### PR DESCRIPTION
Audit-driven: a three-lens QA sweep (a11y, docs accuracy, behaviour) over the 4.12 combobox, held to the bar the data table passed. Every finding below was reproduced on the live demo page before it was fixed; every blocker fix has a regression test.

## Accessibility (LENS 0)

**Blockers**

- **No accessible name, and no way to supply one.** `{@rest}` lands on the wrapper, so `<.combo_box aria-label="Country">` named a roleless div while the input stayed anonymous - its only name was the placeholder. There is a `label` attr now, rendered onto whichever element carries `role="combobox"` (the input, or the trigger button); the trigger variant's panel search input is named from `search_placeholder`. `<.field type="combobox">` pointed `for=` at `@id`, which is the wrapper - it now points at `-input` (or `-trigger` in the trigger anatomy; a button is a labelable element, so clicking the label focuses the control) and passes the label down. The id is resolved in `field.ex` and passed to `combo_box`, so the label target and the rendered control cannot drift.
- **`required` deadlocked the form invisibly.** `required` sits on the hidden select, which is `aria-hidden` + `inert` + `sr-only` - `inert` does not exempt it from constraint validation, so submit was blocked with no bubble drawn, nothing announced, and focus on `<body>`. The hook now listens for `invalid`, preventDefaults the (undrawable) native report, writes the browser's own localized `validationMessage` into a visible `role="alert"` region, sets `aria-invalid`, and focuses the visible control. `aria-required="true"` renders on the visible combobox, and a satisfied constraint retires all of it. The doc string that claimed this already worked has been rewritten to describe what actually happens.
- **A disabled combobox shipped a tabbable, working clear button.** Added `disabled={@disabled}` to the input variant's clear (the trigger variant had it), a `this.select.disabled` guard in `onClearClick` (the select is the honest carrier of the state in both anatomies), and `pointer-events: none` on both disabled clears. Clearing while disabled also desynced client from server, since a disabled select posts nothing.
- **`max_items` was a silent keyboard dead end.** The cap was CSS-only, so `visibleItems()` still returned capped options, `aria-activedescendant` still pointed at them, and Enter was refused with zero feedback. Capped-but-unchosen options now get `data-disabled` + `aria-disabled="true"` - reusing the per-option disabled path, so `navItems()`/`visibleItems()` skip them - marked `data-max-blocked` so a server-rendered `disabled: true` survives the cap lifting. The cap is announced on the transition and again on any blocked pick (alternating a zero-width space, since a live region is silent when the string is unchanged). The `text-transparent` placeholder blanking is gone: the hook swaps the placeholder for the cap text so the field says the same thing on screen as it does to a screen reader, with the server's placeholder riding in `data-placeholder-text` as the value to restore.

**Polish**

- Group headings are exposed instead of `aria-hidden`, with `aria-label` on the `role="group"` - the data table's convention. Sections were entirely absent from the a11y tree.
- The "No results found" row moved out of `role="listbox"` to sit with the other chrome regions (`__loading`, `__header`, `__footer`). A listbox may only contain options and groups.

## Docs (LENS 1)

- `combobox` added to `field.ex`'s declared `:type` values - it fired a warning at every call site, and hard-failed projects on `--warnings-as-errors`. **Pinned by a test that compiles a caller with `use Phoenix.Component`**, since this suite's `ComponentCase` only `import`s it and structurally cannot catch attr drift. The test also asserts a bogus type still warns, so the probe can fail.
- `doc:` strings for `disabled`, `no_results_text`, `placeholder` and `rest` - the four blank Description cells in the published Properties table.
- CHANGELOG 4.12.0: `#### Added` (x4) and `#### Fixed` (x3) merged into one each, house Added/Changed/Fixed order, all 15 entries preserved (verified by count). The 4.13.0/4.12.0 same-date situation is untouched.
- rules.md (repo copy only - the MCP and petal.build cascade happens at release): the combobox added to both hook-enumeration passages, plus a "### Combobox" patterns section at the data table's depth - basic usage, `{label, value}` + groups, multiple/chips/max_items, the remote handler shape, `<.field type="combobox">`, and the `combo_variant` gotcha. Every example in it was rendered before commit.

## Behaviour (LENS 2)

**Blockers**

- **Backspace removed the wrong chip.** It read `select.selectedOptions` (DOM order) while chips render in pick order, so picking out of option order deleted a chip from the middle of the row. It reads the chip row now. The regression test is the audit's exact repro: preselect two, pick two out of order, assert the most recently picked one goes.
- **Trigger + clearable left an incoherent state.** Clearing left the panel open with focus on the trigger - outside the panel - so arrows and typing were dead and Escape read as "already closed" and leaked to the enclosing modal. Clearing now closes the panel and returns focus to the trigger; tests cover both the end state and that Escape is handled by the page again afterwards (and that an open panel still stops it).

**Polish - all applied**

- Stranded pointerIds age out on a fresh press, mirroring the `pressVerdicts` pattern, so a release lost to a context menu no longer disarms outside-tap dismissal for the rest of the open session.
- `updated()` re-reads `multiple`, the chips container and the clear button; the clear button rebinds only when the node identity changes, so a patch cannot double-bind it.
- `destroyed()` bails on the same half-mounted shape `mounted()` does - it dereferenced `this.list` and the throw stranded the document listeners.
- The `onFocusOut` and `onFormReset` timers are tracked and cleared on teardown.
- `onPanelPointerDown` skips `preventDefault` when the pressed target (or an ancestor) is itself focusable, so form controls in `:header`/`:footer` slots are usable by pointer. `onFocusOut` already ignores focus that stays inside the component, so the panel survives. The `:footer` doc was narrowed to match.

## Deliberately not done

- **Nothing was skipped from the brief.** All 17 scope items are in.
- Out-of-scope audit polish left for a follow-up: the two `role="combobox"` elements per trigger-variant widget, chip remove buttons not being keyboard-reachable, `aria-selected="false"` noise in single-select, remote mode not announcing its loading state, `listbox_label` defaulting to "Options", the live region not using `role="status"`, and the two missing migration-table rows. None are blockers and each is a design call worth making on its own.
- The hosted rules.md being 88 lines behind petal.build is a `petal_marketing` deploy, not a change to this repo.

## Notes on the audit

- One claim did not hold as written: the audit says the `:footer` slot's "Manage list" button works today because "preventDefault on pointerdown does not cancel click". True for buttons, but the finding's framing implied only text inputs were affected - in fact any focusable slot control lost its focus, buttons included (they just still fired their click handler). Fixed for all of them rather than only inputs.
- Everything else reproduced exactly as described.

## Tests

- Elixir: **892 tests, 0 failures** (1 skipped) - up 18. `mix format` clean.
- JS: **157 tests, 0 failures** - up 20, all in `test/js/combo_box.test.js` (88 -> 108).
- One pre-existing spec was rewritten rather than deleted: "the placeholder attribute is server truth - the hook never rewrites it" pinned the CSS-blanking doctrine this PR replaces. It now pins the new contract - the cap text shows while capped, and the server's `data-placeholder-text` is what uncapping restores.
