### PR TITLE
fix(css): sweep out five dead selectors; carousel honours reduced motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 
 #### Fixed
 
+- **The carousel honours `prefers-reduced-motion` when sliding.** The
+  hook always requested `scrollTo({behavior: "smooth"})`, and the
+  stylesheet's reduced-motion override targeted a `smooth-scroll` class
+  nothing ever applies - an explicit scrollTo behavior beats the CSS
+  property anyway, so the animation never turned off. Every slide
+  scroll (`goto()` and the two loop-wrap paths) now funnels through one
+  `scrollSlidesTo()` that checks the media query and jumps instantly,
+  the same path the loop teleports already use.
+- **The radio group's empty message uses its own class.** The
+  `options={[]}` branch emitted `pc-checkbox-group--empty-message`
+  (copy-pasted from the checkbox group), leaving
+  `pc-radio-group--empty-message` in the stylesheet matching nothing.
+  The radio-card group's empty message also picks up the same `text-sm`
+  styling as its siblings - it previously had no rule at all.
+- **Four more dead selectors swept out of `default.css`**, found by the
+  same audit that resolved #582: `.select-wrapper select` (its markup
+  was renamed to `pc-time-select`/`pc-datetime-select`/`pc-date-select`
+  in early 2023), the two carousel `.smooth-scroll` rules above,
+  `.pc-pagination__item--current` (pagination emits `--is-current`),
+  and `.pc-carousel__icon`. None ever matched rendered markup, so
+  nothing changes visually.
 - **The radio-card "checked" rules that tripped strict CSS parsers are
   gone.** Three selectors in `default.css` escaped their colons with
   `\\:` instead of `\:`, so Tailwind v4's `--minify` optimizer

--- a/assets/default.css
+++ b/assets/default.css
@@ -1768,7 +1768,8 @@
     @apply inline-flex items-center gap-3 cursor-pointer;
   }
   .pc-checkbox-group--empty-message,
-  .pc-radio-group--empty-message {
+  .pc-radio-group--empty-message,
+  .pc-radio-card-group--empty-message {
     @apply text-sm;
   }
 
@@ -2924,10 +2925,6 @@
   }
   .pc-pagination__item--is-not-current {
     @apply text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-400/17 dark:hover:text-gray-200;
-  }
-  .pc-pagination__item--current {
-    @apply inline-flex h-9 min-w-9 items-center justify-center px-2;
-    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.125rem), 0px);
   }
   .pc-pagination__item__previous {
     @apply mr-1 inline-flex h-9 min-w-9 items-center justify-center px-2 text-gray-600 enabled:hover:bg-gray-100 enabled:hover:text-gray-900 disabled:opacity-40 dark:text-gray-400 enabled:dark:hover:bg-gray-400/17 enabled:dark:hover:text-gray-200 transition-colors duration-150;
@@ -4527,11 +4524,6 @@
   }
 
   /* Other */
-
-  /* This is for selects inside of a group of selects. Phoenix doesn't provide a way to add a class to these. */
-  .select-wrapper select {
-    @apply text-sm border-gray-300 rounded-md shadow-xs cursor-pointer disabled:bg-gray-100 disabled:cursor-not-allowed focus:border-primary-500 focus:ring-primary-500 dark:border-gray-600 dark:focus:border-primary-500 dark:bg-gray-800 dark:text-gray-300 focus:outline-hidden;
-  }
 
   /* No bangs needed in the has-error family: form.ex puts has-error on the
      same element as the pc class (`has-error pc-text-input`), so
@@ -6205,10 +6197,6 @@
     @apply opacity-40 cursor-default;
   }
 
-  .pc-carousel__icon {
-    @apply text-current;
-  }
-
   .pc-carousel__slides {
     @apply relative w-full h-full;
   }
@@ -6258,10 +6246,6 @@
     scroll-snap-align: center;
     min-width: 100%;
     height: 100%;
-  }
-
-  .pc-carousel[data-transition-type="slide"] .pc-carousel__slides.smooth-scroll {
-    scroll-behavior: smooth;
   }
 
   /* Fade transition specific styles */
@@ -6447,13 +6431,13 @@
     z-index: 20;
   }
 
+  /* Slide-transition scrolling honours reduced motion in the hook itself
+     (goto() swaps smooth scrollTo for an instant jump) - a CSS
+     scroll-behavior override can't reach it, since an explicit
+     scrollTo({behavior}) wins over the property. */
   @media (prefers-reduced-motion: reduce) {
     .pc-carousel__slide {
       transition-duration: 1ms !important;
-    }
-
-    .pc-carousel[data-transition-type="slide"] .pc-carousel__slides.smooth-scroll {
-      scroll-behavior: auto;
     }
   }
 

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -2435,19 +2435,24 @@ export const PetalCarousel = {
     const scrollPosition =
       (this.slideWidth + this.spaceBtwSlides) * (index + this.n_slidesCloned);
 
-    if (smooth) {
-      this.slideWrapper.scrollTo({
-        left: this.isVertical ? 0 : scrollPosition,
-        top: this.isVertical ? scrollPosition : 0,
-        behavior: "smooth",
-      });
-    } else {
-      if (this.isVertical) {
-        this.slideWrapper.scrollTo(0, scrollPosition);
-      } else {
-        this.slideWrapper.scrollTo(scrollPosition, 0);
-      }
+    this.scrollSlidesTo(scrollPosition, smooth);
+  },
+
+  // The single scroll entry point for slide transitions - goto() AND the
+  // loop-wrap paths (which scroll into the clone strip and can't go through
+  // goto) all funnel here, so the reduced-motion gate can't be bypassed.
+  // Instant jumps are already a supported path (loop teleports use them),
+  // so reduced motion just routes every scroll through it.
+  scrollSlidesTo(scrollPosition, smooth = true) {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      smooth = false;
     }
+
+    this.slideWrapper.scrollTo({
+      left: this.isVertical ? 0 : scrollPosition,
+      top: this.isVertical ? scrollPosition : 0,
+      behavior: smooth ? "smooth" : "auto",
+    });
   },
 
   setupInfiniteScrolling() {
@@ -2973,11 +2978,7 @@ export const PetalCarousel = {
         // At first slide with loop enabled, scroll to the cloned slides at the beginning
         const scrollPosition =
           (this.slideWidth + this.spaceBtwSlides) * (this.n_slidesCloned - 1);
-        this.slideWrapper.scrollTo({
-          left: this.isVertical ? 0 : scrollPosition,
-          top: this.isVertical ? scrollPosition : 0,
-          behavior: "smooth",
-        });
+        this.scrollSlidesTo(scrollPosition);
       } else {
         // Normal previous slide
         this.activeIndex = this.activeIndex - 1;
@@ -3021,11 +3022,7 @@ export const PetalCarousel = {
         const scrollPosition =
           (this.slideWidth + this.spaceBtwSlides) *
           (this.n_slides + this.n_slidesCloned);
-        this.slideWrapper.scrollTo({
-          left: this.isVertical ? 0 : scrollPosition,
-          top: this.isVertical ? scrollPosition : 0,
-          behavior: "smooth",
-        });
+        this.scrollSlidesTo(scrollPosition);
       } else {
         // Normal next slide
         this.activeIndex = this.activeIndex + 1;

--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -448,7 +448,7 @@ defmodule PetalComponents.Field do
         <% end %>
 
         <%= if @empty_message && Enum.empty?(@options) do %>
-          <div class="pc-checkbox-group--empty-message">
+          <div class="pc-radio-group--empty-message">
             {@empty_message}
           </div>
         <% end %>

--- a/test/petal/field_test.exs
+++ b/test/petal/field_test.exs
@@ -639,6 +639,7 @@ defmodule PetalComponents.FieldTest do
       """)
 
     assert html =~ "No options"
+    assert html =~ "pc-radio-group--empty-message"
 
     assigns = %{form: to_form(%{}, as: :user)}
 


### PR DESCRIPTION
The sibling findings from the #582 adversarial audit (see #590), each independently re-verified against `lib/` and `assets/js/` before touching anything.

## Five dead selectors removed

| Selector | Why it's dead |
|---|---|
| `.select-wrapper select` | markup renamed to `pc-time-select` / `pc-datetime-select` / `pc-date-select` in 8b037fd (Feb 2023); the rule and its stale comment were left behind |
| `.pc-carousel … .smooth-scroll` (×2) | no markup or JS ever adds `smooth-scroll` — the hook calls `scrollTo({behavior:"smooth"})` directly (`git log --all -S` finds no emitter, ever) |
| `.pc-pagination__item--current` | pagination emits `--is-current` / `--is-not-current` only |
| `.pc-carousel__icon` | never emitted; carousel buttons render `<.icon>` bare |

Hermetic before/after compile (`source(none)`, minified): the output diff is **exactly** the removed rules plus the one comma-group addition below — removal is provably visually inert.

## Two real fixes that fell out of it

**The carousel never honoured `prefers-reduced-motion` while sliding.** The second `.smooth-scroll` rule was the reduced-motion override — targeting a class nothing applies, and powerless anyway, since an explicit `scrollTo` behavior beats the `scroll-behavior` property. The fix has to live in the hook: `goto()` **and** both loop-wrap paths (which scroll into the clone strip and can't route through `goto`) now funnel through a single `scrollSlidesTo()` that swaps smooth scrolling for the instant jump the loop teleports have always used. An adversarial pass over the hook confirmed nothing depends on smooth-scroll timing: the only scroll listener is debounced and position-based, and the transition lock releases on a fixed timeout, so instant jumps have been absorbed since day one.

**The radio group's empty message wore the checkbox group's class.** The `options={[]}` branch emitted `pc-checkbox-group--empty-message` (copy-pasted), leaving `.pc-radio-group--empty-message` in the stylesheet matching nothing. It now emits its own class (compiles to identical declarations — pixel-identical), with a test assertion pinning it. The radio-card group's empty message joins the same `text-sm` comma group; it previously had no rule at all.

876 tests, 0 failures.
