### PR TITLE
chore: date 4.13.0 for release (2026-08-11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-### Unreleased
+### 4.13.0 - 2026-08-11
 
 #### Fixed
 
@@ -252,11 +252,6 @@
   16px on coarse pointers, keeping their `h-9` box.
 - **`::backdrop` is transparent for top-layer panels**, so no UA can
   paint a dimming layer behind an anchored popover.
-
-### 4.13.0 - 2026-08-08
-
-#### Added
-
 - **Five operators the vocabulary was missing**: `:not_contains`,
   `:gte`, `:lte`, `:not_in`, and the null-ness pair `:is_empty` /
   `:is_not_empty`. Measured against Flop, Ash, Ecto, TanStack, AG Grid,


### PR DESCRIPTION
## What

Changelog-only. Folds `### Unreleased` into `### 4.13.0` and dates it today: the 2026-08-08 header was release prep for a version that never shipped to Hex, so the whole hardening campaign since - differential-gate engine fixes, contract pins, reorder, option filter, link mode, combobox hardening - is one 4.13.0. Single `#### Fixed` / `#### Added` per the convention the combobox audit pinned. `mix.exs` was already `4.13.0`; no code changes.

After merge the release is one command away (Nic's gate): `mix hex.publish`.