### PR TITLE
fix(data_table): stable ids on the search, page-size and filter forms

### DIFF
--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -353,7 +353,12 @@ defmodule PetalComponents.DataTable do
           <div :if={@searchable} class="pc-data-table__search">
             <.icon name="hero-magnifying-glass" class="pc-data-table__search-icon" />
             <%= if @on_change do %>
-              <form phx-change={@on_change} phx-submit={@on_change} phx-target={@target}>
+              <form
+                id={"#{@id}-search-form"}
+                phx-change={@on_change}
+                phx-submit={@on_change}
+                phx-target={@target}
+              >
                 <input type="hidden" name="op" value="search" />
                 <input
                   type="text"
@@ -594,7 +599,7 @@ defmodule PetalComponents.DataTable do
             {@per_page_label}
           </label>
           <%= if @on_change do %>
-            <form phx-change={@on_change} phx-target={@target}>
+            <form id={"#{@id}-page-size-form"} phx-change={@on_change} phx-target={@target}>
               <input type="hidden" name="op" value="page_size" />
               <select
                 id={"#{@id}-page-size"}
@@ -960,6 +965,7 @@ defmodule PetalComponents.DataTable do
           class="pc-popover__panel pc-popover__panel--bottom-start"
         >
           <form
+            id={"#{@pop_id}-form"}
             class={["pc-data-table__filter-form", "pc-data-table__filter-form--#{@type}"]}
             phx-submit={@submit_js}
             data-pc-dt-filter={is_nil(@on_change) || nil}

--- a/test/petal/data_table_test.exs
+++ b/test/petal/data_table_test.exs
@@ -122,6 +122,33 @@ defmodule PetalComponents.DataTableTest do
     refute html =~ "data-filters="
   end
 
+  test "every form carries a table-scoped id" do
+    # LiveViewTest warns on form[phx-change]:not([id]) - and raises under
+    # missing_form_id: :raise - so a bare form here becomes noise in every
+    # host app's test suite. Ids derive from the table id so two tables
+    # can share a page without colliding.
+    assigns = base()
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table
+        id="t"
+        rows={@rows}
+        state={@state}
+        on_change="table"
+        searchable
+        page_size_options={[10, 20]}
+      >
+        <:col :let={row} field={:name} filterable="text">{row.name}</:col>
+      </.data_table>
+      """)
+
+    assert html =~ ~s(id="t-search-form")
+    assert html =~ ~s(id="t-page-size-form")
+    assert html =~ ~s(id="t-filter-name-form")
+    assert html |> parse_html() |> LazyHTML.query("form:not([id])") |> Enum.count() == 0
+  end
+
   test "filterable link mode: hook + :filters placeholder + JSON stamp + clear URL" do
     assigns =
       base(%{


### PR DESCRIPTION
## What

Gives the data table's three `<form>` elements stable, table-scoped ids:

- search box → `{table_id}-search-form`
- per-page select → `{table_id}-page-size-form`
- each filter popover → `{table_id}-filter-{field}-form`

## Why

Phoenix.LiveViewTest (1.2+) warns on every `form[phx-change]` without an id, so any host app writing a LiveView test that touches a searchable or paginated data table gets a wall of "Detected a form with phx-change but missing id" warnings - a single interaction test on petal.build's data table docs page produced 20+. Apps configured with `missing_form_id: :raise` fail outright. The id also gives LiveView's form recovery an anchor.

The filter form is `phx-submit`-only (no warning today) but gets an id under the same uniqueness contract for consistency.

Ids derive from the table's `id` attr, so multiple tables on one page can't collide. Existing id namespaces (`{id}-page-size` on the select, `{id}-filter-{field}` on the popover panel) are avoided via the `-form` suffix.

## Testing

New test renders a fully-loaded event-mode table and asserts the three ids plus `form:not([id])` matching nothing. Full suite: 892 tests, 0 failures.

Found while shipping the petal.build docs page for 4.13.0 - purely upstream, no host-app changes needed.