### PR TITLE
fix(radius): radio cards join the tall-element clamp - no more pills at full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 #### Fixed
 
+- **Radio cards no longer inflate into pills at `radius="full"`.** The
+  card surface (`.pc-radio-card__fake-input`) joins the tall-element
+  clamp (1rem ceiling) the other multi-line controls already use. The
+  4.10.0 sweep capped the six controls that grow past one line but
+  missed this one - a radio card does too the moment it carries a
+  description, and at the full stop the resulting ellipse crowded the
+  `end` and `corner` indicator dots. Every stop below full is
+  unchanged.
 - **`combo_box` has an accessible name, and `<.field type="combobox">`
   no longer warns at compile time.** The role=combobox input carried no
   label mechanism at all - `{@rest}` lands on the wrapper, so

--- a/assets/default.css
+++ b/assets/default.css
@@ -4962,6 +4962,7 @@
   select.pc-text-input[multiple],
   .pc-input-group:has(.pc-input-group__block),
   .pc-alert-base-classes,
+  .pc-radio-card__fake-input,
   .pc-chat__composer-input,
   .pc-tooltip__content {
     border-radius: min(var(--pc-radius, 0.625rem), 1rem);


### PR DESCRIPTION
## What

Radio cards at `radius="full"` (`--pc-radius: 9999px`) inflated into pill/ellipse shapes, crowding the `end` and `corner` indicator dots. The card surface now clamps the radius token at the same 1rem ceiling every other tall element uses.

## Why

The 4.10.0 tall-element sweep (091ba82) capped the six controls that can grow past one line, but `.pc-radio-card__fake-input` slipped through - a radio card is multi-line the moment it carries a description. Its raw `border-radius: var(--pc-radius, 0.625rem)` meant the full stop rendered a capsule instead of a card.

## How

One selector added to THE TALL-ELEMENT CLAMP list in `assets/default.css` - same mechanism as the original sweep (the late clamp rule overrides the earlier raw declaration at equal specificity within `@layer components`). No component/HEEx changes.

Note: the report suggested a ~14px cap may have been the intent, but 0.875rem appears nowhere in the file or its history - the established ceiling is 1rem, and consistency with the existing clamp list wins. (The playground dial's "14" stop is a token value, not a cap.) The other unclamped rules flagged nearby (`.pc-dropdown__trigger-button--*`) are one-line controls that keep the pill option deliberately, per the clamp doctrine comment.

## Verification

- `mix test`: 891 tests, 0 failures (exit 0); `mix format` clean
- Playground sweep on `/c/radio` with radio cards + indicator dots (end and corner), computed `border-radius` of the card surface at every dial stop:

| dial stop | before | after |
|---|---|---|
| 0 | 0px | 0px |
| 6 | 6px | 6px |
| 10 | 10px | 10px |
| 14 | 14px | 14px |
| full (9999px) | 9999px (pill) | **16px** |

Zero change below full; the clamp only bites at the full stop.