### PR TITLE
fix(border_plasma): halo geometry, glow=both near halo, a11y guards, live pause hook

### DIFF
--- a/assets/default.css
+++ b/assets/default.css
@@ -5467,6 +5467,7 @@
 
   .pc-border-plasma__stroke,
   .pc-border-plasma__core,
+  .pc-border-plasma__aura,
   .pc-border-plasma__bloom,
   .pc-border-plasma__sheen {
     @apply pointer-events-none absolute;
@@ -5479,7 +5480,8 @@
      where they never animate and the whole pulse freezes (shipped that
      bug twice; never again). */
   .pc-border-plasma__stroke,
-  .pc-border-plasma__core {
+  .pc-border-plasma__core,
+  .pc-border-plasma__aura {
     /* Every layer shares one field: eight long, THIN ellipses hugging the
        edges (80x19, 74x11...), ported stop-for-stop from the reference's
        runtime CSS. You never see an ellipse outline - only its intersection
@@ -5520,38 +5522,71 @@
 
   /* THE CORE GLOW (halo variant): the same field hung BEHIND the panel,
      10px proud of it, softly blurred and squashed so it hugs the shape.
-     z-index -1 paints it under the content but over the page. */
-  .pc-border-plasma__core {
-    inset: calc(-10px - 12px);
-    padding: 12px;
+     z-index -1 paints it under the content but over the page. In
+     glow="both" the core is busy being the inner wash, so a dedicated
+     twin (__aura) carries this exact recipe instead. The TRANSPARENT
+     BORDER is blur headroom: Safari clips filter output near the element
+     box, so the box is oversized while background-origin: padding-box
+     keeps the gradients sized to the original geometry (a padding would
+     NOT do this - with zero border, padding-box equals border-box and the
+     art drifts outward with the box; that bug shipped once as ghost-blob
+     reflections). no-repeat is load-bearing: without it the padding-box-
+     sized image tiles into the headroom. */
+  .pc-border-plasma__core,
+  .pc-border-plasma--glow-both > .pc-border-plasma__aura {
+    display: block;
+    /* COUPLED PAIR: the 33px headroom is 3x the blur radius below (the
+       filter's spread). Bump the blur and this border moves with it, or
+       Safari starts amputating the halo edge again. */
+    inset: calc(-10px - 33px);
+    border: 33px solid transparent;
     background-origin: padding-box;
+    background-repeat: no-repeat;
     z-index: -1;
-    border-radius: calc(var(--pc-plasma-radius, min(calc(var(--pc-radius, 0.625rem) * 1.2), 1.25rem)) + 22px);
+    border-radius: calc(var(--pc-plasma-radius, min(calc(var(--pc-radius, 0.625rem) * 1.2), 1.25rem)) + 43px);
     background-image: var(--pc-plasma-field);
     transform: scale(0.95, 0.9);
     opacity: calc(0.44 * var(--pc-plasma-strength, 1));
-    filter: blur(6px) hue-rotate(var(--pc-plasma-hue, 0deg)) brightness(1.9) saturate(1.2);
+    filter: blur(11px) hue-rotate(var(--pc-plasma-hue, 0deg)) brightness(1.9) saturate(1.2);
+  }
+
+  /* The aura exists only for glow="both"; everywhere else it stays dark.
+     Rotate keeps all light inside the silhouette, so it wins over the
+     glow-both rule above (same specificity, later in source). */
+  .pc-border-plasma__aura {
+    display: none;
+  }
+
+  .pc-border-plasma--rotate > .pc-border-plasma__aura {
+    display: none;
   }
 
   /* THE OUTER HALO (halo variant): the wide bloom, 30px proud, heavily
-     blurred - the spectacular glow that spills onto the page. */
+     blurred - the spectacular glow that spills onto the page. The
+     reference site drives this layer harder than its own base numbers
+     (~38px bloom blur at our panel sizes), and each ellipse gets eased
+     mid-stops instead of a linear two-stop fade, so the light dies away
+     gradually with no perceptible perimeter. Same transparent-border
+     headroom contract as the core above. */
   .pc-border-plasma__bloom {
-    inset: calc(-30px - 68px);
-    padding: 68px;
+    /* COUPLED PAIR: 86px headroom ~ 3x the 28px blur below (see core). */
+    inset: calc(-30px - 86px);
+    border: 86px solid transparent;
     background-origin: padding-box;
+    background-repeat: no-repeat;
     z-index: -1;
-    border-radius: calc(var(--pc-plasma-radius, min(calc(var(--pc-radius, 0.625rem) * 1.2), 1.25rem)) + 98px);
+    border-radius: calc(var(--pc-plasma-radius, min(calc(var(--pc-radius, 0.625rem) * 1.2), 1.25rem)) + 116px);
     background-image:
-      radial-gradient(ellipse calc(110px * var(--pc-plasma-scale, 1)) calc(30px * var(--pc-plasma-scale, 1)) at 27% 3%, color-mix(in srgb, var(--pc-plasma-c1) 77%, transparent), transparent),
-      radial-gradient(ellipse calc(100px * var(--pc-plasma-scale, 1)) calc(20px * var(--pc-plasma-scale, 1)) at 73% 1%, color-mix(in srgb, var(--pc-plasma-c2) 77%, transparent), transparent),
-      radial-gradient(ellipse calc(26px * var(--pc-plasma-scale, 1)) calc(62px * var(--pc-plasma-scale, 1)) at 100% 33%, color-mix(in srgb, var(--pc-plasma-c3) 77%, transparent), transparent),
-      radial-gradient(ellipse calc(30px * var(--pc-plasma-scale, 1)) calc(56px * var(--pc-plasma-scale, 1)) at 101% 72%, color-mix(in srgb, var(--pc-plasma-c4) 77%, transparent), transparent),
-      radial-gradient(ellipse calc(120px * var(--pc-plasma-scale, 1)) calc(22px * var(--pc-plasma-scale, 1)) at 67% 99%, color-mix(in srgb, var(--pc-plasma-c5) 77%, transparent), transparent),
-      radial-gradient(ellipse calc(88px * var(--pc-plasma-scale, 1)) calc(32px * var(--pc-plasma-scale, 1)) at 24% 99%, color-mix(in srgb, var(--pc-plasma-c6) 77%, transparent), transparent),
-      radial-gradient(ellipse calc(28px * var(--pc-plasma-scale, 1)) calc(58px * var(--pc-plasma-scale, 1)) at 0% 60%, color-mix(in srgb, var(--pc-plasma-c7) 77%, transparent), transparent);
+      radial-gradient(ellipse calc(110px * var(--pc-plasma-scale, 1)) calc(30px * var(--pc-plasma-scale, 1)) at 27% 3%, color-mix(in srgb, var(--pc-plasma-c1) 77%, transparent), color-mix(in srgb, var(--pc-plasma-c1) 42%, transparent) 38%, color-mix(in srgb, var(--pc-plasma-c1) 16%, transparent) 67%, transparent),
+      radial-gradient(ellipse calc(100px * var(--pc-plasma-scale, 1)) calc(20px * var(--pc-plasma-scale, 1)) at 73% 1%, color-mix(in srgb, var(--pc-plasma-c2) 77%, transparent), color-mix(in srgb, var(--pc-plasma-c2) 42%, transparent) 38%, color-mix(in srgb, var(--pc-plasma-c2) 16%, transparent) 67%, transparent),
+      radial-gradient(ellipse calc(26px * var(--pc-plasma-scale, 1)) calc(62px * var(--pc-plasma-scale, 1)) at 100% 33%, color-mix(in srgb, var(--pc-plasma-c3) 77%, transparent), color-mix(in srgb, var(--pc-plasma-c3) 42%, transparent) 38%, color-mix(in srgb, var(--pc-plasma-c3) 16%, transparent) 67%, transparent),
+      radial-gradient(ellipse calc(30px * var(--pc-plasma-scale, 1)) calc(56px * var(--pc-plasma-scale, 1)) at 101% 72%, color-mix(in srgb, var(--pc-plasma-c4) 77%, transparent), color-mix(in srgb, var(--pc-plasma-c4) 42%, transparent) 38%, color-mix(in srgb, var(--pc-plasma-c4) 16%, transparent) 67%, transparent),
+      radial-gradient(ellipse calc(120px * var(--pc-plasma-scale, 1)) calc(22px * var(--pc-plasma-scale, 1)) at 67% 99%, color-mix(in srgb, var(--pc-plasma-c5) 77%, transparent), color-mix(in srgb, var(--pc-plasma-c5) 42%, transparent) 38%, color-mix(in srgb, var(--pc-plasma-c5) 16%, transparent) 67%, transparent),
+      radial-gradient(ellipse calc(88px * var(--pc-plasma-scale, 1)) calc(32px * var(--pc-plasma-scale, 1)) at 24% 99%, color-mix(in srgb, var(--pc-plasma-c6) 77%, transparent), color-mix(in srgb, var(--pc-plasma-c6) 42%, transparent) 38%, color-mix(in srgb, var(--pc-plasma-c6) 16%, transparent) 67%, transparent),
+      radial-gradient(ellipse calc(28px * var(--pc-plasma-scale, 1)) calc(58px * var(--pc-plasma-scale, 1)) at 0% 60%, color-mix(in srgb, var(--pc-plasma-c7) 77%, transparent), color-mix(in srgb, var(--pc-plasma-c7) 42%, transparent) 38%, color-mix(in srgb, var(--pc-plasma-c7) 16%, transparent) 67%, transparent);
     transform: scale(0.95, 0.9);
-    opacity: calc(0.36 * var(--pc-plasma-strength, 1));
-    filter: blur(22.5px) hue-rotate(var(--pc-plasma-hue, 0deg)) brightness(1.9) saturate(1.2);
+    opacity: calc(0.34 * var(--pc-plasma-strength, 1));
+    filter: blur(28px) hue-rotate(var(--pc-plasma-hue, 0deg)) brightness(1.9) saturate(1.2);
   }
 
   /* CLIP VARIANT: nothing leaves the silhouette. The stroke dims to the
@@ -5567,6 +5602,12 @@
   .pc-border-plasma--glow-both > .pc-border-plasma__core {
     z-index: 1;
     inset: 0;
+    /* The halo recipe's headroom border must not leak into the inner
+       wash: an inherited 33px transparent border shrinks the padding box
+       the gradients size to, dragging the whole field inward. */
+    border: 0;
+    padding: 0;
+    background-origin: border-box;
     border-radius: inherit;
     clip-path: inset(0 round var(--pc-plasma-radius, min(calc(var(--pc-radius, 0.625rem) * 1.2), 1.25rem)));
     transform: none;
@@ -5591,6 +5632,9 @@
   .pc-border-plasma--glow-inside > .pc-border-plasma__bloom {
     z-index: 2;
     inset: calc(-1 * var(--pc-plasma-border-width, 1px));
+    /* Ring geometry: the halo's headroom border would corrupt the
+       content-box mask, so it resets here. */
+    border: 0;
     border-radius: inherit;
     clip-path: inset(0 round var(--pc-plasma-radius, min(calc(var(--pc-radius, 0.625rem) * 1.2), 1.25rem)));
     transform: none;
@@ -5601,6 +5645,117 @@
     mask-composite: exclude;
     opacity: calc(0.66 * var(--pc-plasma-strength, 1));
     filter: blur(8px) hue-rotate(var(--pc-plasma-hue, 0deg)) brightness(0.75) saturate(1.2);
+  }
+
+  /* ROTATE'S GEOMETRY LIVES OUTSIDE THE MOTION MEDIA BLOCK deliberately:
+     only the sweep animation is motion-gated below. With these rules
+     inside the block, reduced-motion users fell through to the base halo
+     recipe and rotate leaked a static outside glow - violating "rotate
+     keeps its light inside the silhouette". Statically the conic masks
+     rest at var(--pc-plasma-angle, 0deg): a frozen window, fully clipped.
+     Source order matters: these sit AFTER the glow-inside/glow-both
+     rules so rotate wins their equal-specificity fights. */
+
+  /* The wash follows the beam: same colours, held to the edge band AND
+     the window, with the reference's inset white sheen. */
+  .pc-border-plasma--rotate > .pc-border-plasma__core {
+    z-index: 1;
+    background-image: var(--pc-plasma-field);
+    box-shadow: inset 0 0 9px 1px rgb(255 255 255 / 0.27);
+    transform: none;
+    inset: 0;
+    /* Same leak guard as the inner wash: no halo headroom here. */
+    border: 0;
+    padding: 0;
+    background-origin: border-box;
+    border-radius: inherit;
+    filter: blur(9px) hue-rotate(var(--pc-plasma-hue, 0deg)) saturate(1.2);
+    opacity: calc(0.45 * var(--pc-plasma-strength, 1));
+    -webkit-mask-image:
+      conic-gradient(
+      from var(--pc-plasma-angle, 0deg),
+      transparent 0%,
+      transparent 30%,
+      rgb(255 255 255 / 0.1) 36%,
+      rgb(255 255 255 / 0.35) 44%,
+      #fff 52%,
+      #fff 80%,
+      rgb(255 255 255 / 0.35) 86%,
+      rgb(255 255 255 / 0.1) 92%,
+      transparent 95%,
+      transparent 100%
+    ),
+      linear-gradient(white, transparent 28px, transparent calc(100% - 28px), white),
+      linear-gradient(to right, white, transparent 28px, transparent calc(100% - 28px), white);
+    -webkit-mask-composite: source-in, source-over;
+    mask-image:
+      conic-gradient(
+      from var(--pc-plasma-angle, 0deg),
+      transparent 0%,
+      transparent 30%,
+      rgb(255 255 255 / 0.1) 36%,
+      rgb(255 255 255 / 0.35) 44%,
+      #fff 52%,
+      #fff 80%,
+      rgb(255 255 255 / 0.35) 86%,
+      rgb(255 255 255 / 0.1) 92%,
+      transparent 95%,
+      transparent 100%
+    ),
+      linear-gradient(white, transparent 28px, transparent calc(100% - 28px), white),
+      linear-gradient(to right, white, transparent 28px, transparent calc(100% - 28px), white);
+    mask-composite: intersect, add;
+  }
+
+  /* The halo sweeps too: the bloom keeps its variant geometry and gains
+     the window, so the outer glow travels with the beam. */
+  .pc-border-plasma--rotate > .pc-border-plasma__bloom {
+    inset: calc(-1 * var(--pc-plasma-border-width, 1px));
+    z-index: 2;
+    /* Ring geometry: reset the halo's headroom border (see glow-inside). */
+    border: 0;
+    border-radius: inherit;
+    clip-path: inset(0 round var(--pc-plasma-radius, min(calc(var(--pc-radius, 0.625rem) * 1.2), 1.25rem)));
+    transform: none;
+    padding: var(--pc-plasma-border-width, 1px);
+    opacity: calc(0.66 * var(--pc-plasma-strength, 1));
+    filter: blur(8px) hue-rotate(var(--pc-plasma-hue, 0deg)) brightness(0.9) saturate(1.2);
+    -webkit-mask:
+      conic-gradient(
+        from var(--pc-plasma-angle, 0deg),
+        transparent 0%,
+        transparent 30%,
+        rgb(255 255 255 / 0.1) 36%,
+        rgb(255 255 255 / 0.35) 44%,
+        #fff 52%,
+        #fff 80%,
+        rgb(255 255 255 / 0.35) 86%,
+        rgb(255 255 255 / 0.1) 92%,
+        transparent 95%,
+        transparent 100%
+      ),
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: source-in, xor;
+    mask:
+      conic-gradient(
+        from var(--pc-plasma-angle, 0deg),
+        transparent 0%,
+        transparent 30%,
+        rgb(255 255 255 / 0.1) 36%,
+        rgb(255 255 255 / 0.35) 44%,
+        #fff 52%,
+        #fff 80%,
+        rgb(255 255 255 / 0.35) 86%,
+        rgb(255 255 255 / 0.1) 92%,
+        transparent 95%,
+        transparent 100%
+      ),
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    mask-composite: intersect, exclude;
+    background-image: var(--pc-plasma-field);
+    background-origin: border-box;
   }
 
   /* Rotate's neutral sweeping light (unchanged from the arc port). */
@@ -5641,6 +5796,7 @@
   @media (prefers-reduced-motion: no-preference) {
     .pc-border-plasma--pulse > .pc-border-plasma__stroke,
     .pc-border-plasma--pulse > .pc-border-plasma__core,
+    .pc-border-plasma--pulse > .pc-border-plasma__aura,
     .pc-border-plasma--pulse > .pc-border-plasma__bloom {
       animation:
         pc-plasma-bw1 calc(var(--pc-plasma-duration, 4s) * 2.5) ease-in-out infinite,
@@ -5658,6 +5814,11 @@
         pc-plasma-q-bl calc(var(--pc-plasma-duration, 4s) * 0.84) ease-in-out calc(var(--pc-plasma-duration, 4s) * -0.55) infinite,
         pc-plasma-q-br calc(var(--pc-plasma-duration, 4s) * 1.58) ease-in-out calc(var(--pc-plasma-duration, 4s) * -0.83) infinite,
         pc-plasma-hue-cycle var(--pc-plasma-hue-period, 14s) linear infinite;
+      /* MUST follow the shorthand: `animation:` resets play-state to
+         running at this rule's higher specificity, silently killing the
+         base rule's pause hook (that shipped: the viewport observer's
+         pause was a no-op until this line). */
+      animation-play-state: var(--pc-plasma-play, running);
     }
 
     /* Rotate, ported from the reference's runtime CSS: the rim is DARK
@@ -5719,104 +5880,30 @@
         linear-gradient(#fff 0 0);
       mask-composite: intersect, exclude;
       animation: pc-plasma-rotate var(--pc-plasma-duration, 2s) linear infinite;
+      animation-play-state: var(--pc-plasma-play, running);
     }
 
-    /* The wash follows the beam: same colours, held to the edge band AND
-       the window, with the reference's inset white sheen. */
-    .pc-border-plasma--rotate > .pc-border-plasma__core {
-      z-index: 1;
-      background-image: var(--pc-plasma-field);
-      box-shadow: inset 0 0 9px 1px rgb(255 255 255 / 0.27);
-      transform: none;
-      inset: 0;
-      border-radius: inherit;
-      filter: blur(9px) hue-rotate(var(--pc-plasma-hue, 0deg)) saturate(1.2);
-      opacity: calc(0.45 * var(--pc-plasma-strength, 1));
-      -webkit-mask-image:
-        conic-gradient(
-        from var(--pc-plasma-angle, 0deg),
-        transparent 0%,
-        transparent 30%,
-        rgb(255 255 255 / 0.1) 36%,
-        rgb(255 255 255 / 0.35) 44%,
-        #fff 52%,
-        #fff 80%,
-        rgb(255 255 255 / 0.35) 86%,
-        rgb(255 255 255 / 0.1) 92%,
-        transparent 95%,
-        transparent 100%
-      ),
-        linear-gradient(white, transparent 28px, transparent calc(100% - 28px), white),
-        linear-gradient(to right, white, transparent 28px, transparent calc(100% - 28px), white);
-      -webkit-mask-composite: source-in, source-over;
-      mask-image:
-        conic-gradient(
-        from var(--pc-plasma-angle, 0deg),
-        transparent 0%,
-        transparent 30%,
-        rgb(255 255 255 / 0.1) 36%,
-        rgb(255 255 255 / 0.35) 44%,
-        #fff 52%,
-        #fff 80%,
-        rgb(255 255 255 / 0.35) 86%,
-        rgb(255 255 255 / 0.1) 92%,
-        transparent 95%,
-        transparent 100%
-      ),
-        linear-gradient(white, transparent 28px, transparent calc(100% - 28px), white),
-        linear-gradient(to right, white, transparent 28px, transparent calc(100% - 28px), white);
-      mask-composite: intersect, add;
-      animation: pc-plasma-rotate var(--pc-plasma-duration, 2s) linear infinite;
-    }
-
-    /* The halo sweeps too: the bloom keeps its variant geometry and gains
-       the window, so the outer glow travels with the beam. */
+    /* Rotate's geometry is static (hoisted above the media block); only
+       the lap itself is motion. */
+    .pc-border-plasma--rotate > .pc-border-plasma__core,
     .pc-border-plasma--rotate > .pc-border-plasma__bloom {
-      inset: calc(-1 * var(--pc-plasma-border-width, 1px));
-      z-index: 2;
-      border-radius: inherit;
-      clip-path: inset(0 round var(--pc-plasma-radius, min(calc(var(--pc-radius, 0.625rem) * 1.2), 1.25rem)));
-      transform: none;
-      padding: var(--pc-plasma-border-width, 1px);
-      opacity: calc(0.66 * var(--pc-plasma-strength, 1));
-      filter: blur(8px) hue-rotate(var(--pc-plasma-hue, 0deg)) brightness(0.9) saturate(1.2);
-      -webkit-mask:
-        conic-gradient(
-          from var(--pc-plasma-angle, 0deg),
-          transparent 0%,
-          transparent 30%,
-          rgb(255 255 255 / 0.1) 36%,
-          rgb(255 255 255 / 0.35) 44%,
-          #fff 52%,
-          #fff 80%,
-          rgb(255 255 255 / 0.35) 86%,
-          rgb(255 255 255 / 0.1) 92%,
-          transparent 95%,
-          transparent 100%
-        ),
-        linear-gradient(#fff 0 0) content-box,
-        linear-gradient(#fff 0 0);
-      -webkit-mask-composite: source-in, xor;
-      mask:
-        conic-gradient(
-          from var(--pc-plasma-angle, 0deg),
-          transparent 0%,
-          transparent 30%,
-          rgb(255 255 255 / 0.1) 36%,
-          rgb(255 255 255 / 0.35) 44%,
-          #fff 52%,
-          #fff 80%,
-          rgb(255 255 255 / 0.35) 86%,
-          rgb(255 255 255 / 0.1) 92%,
-          transparent 95%,
-          transparent 100%
-        ),
-        linear-gradient(#fff 0 0) content-box,
-        linear-gradient(#fff 0 0);
-      mask-composite: intersect, exclude;
-      background-image: var(--pc-plasma-field);
-      background-origin: border-box;
       animation: pc-plasma-rotate var(--pc-plasma-duration, 2s) linear infinite;
+      animation-play-state: var(--pc-plasma-play, running);
+    }
+  }
+
+  /* Windows High Contrast repaints transparent borders in an opaque
+     system colour (the same mechanism the WHCM focus-outline trick uses)
+     while forcing gradient backgrounds to none - the headroom borders
+     above would render as giant blurred frames around every panel. The
+     glow is aria-hidden decoration; drop it entirely. The aura selector
+     must be the two-class form: a bare __aura (0,1,0) loses to the
+     glow-both display:block at (0,2,0). */
+  @media (forced-colors: active) {
+    .pc-border-plasma__core,
+    .pc-border-plasma__bloom,
+    .pc-border-plasma--glow-both > .pc-border-plasma__aura {
+      display: none;
     }
   }
 

--- a/lib/petal_components/border_plasma.ex
+++ b/lib/petal_components/border_plasma.ex
@@ -5,8 +5,8 @@ defmodule PetalComponents.BorderPlasma do
   by default a soft halo spills past the border onto the page. Set
   `glow="inside"` to keep every layer inside a crisp silhouette, or
   `glow="both"` for the halo and the inner wash together. Pure CSS (registered custom properties driving one shared
-  gradient field through three differently-masked layers) — no JavaScript
-  required.
+  gradient field through a stack of differently-masked layers) — no
+  JavaScript required.
 
   The sibling of `border_beam`: the beam sends one travelling light around
   the edge; plasma keeps a field of light alive on it. `mode="pulse"`
@@ -20,10 +20,14 @@ defmodule PetalComponents.BorderPlasma do
   This is the most paint-expensive effect in the library and it should be
   spent like it: one hero panel or one CTA per view, not a border on every
   card. Animated custom properties repaint on the main thread, so each
-  instance re-rasterises its gradient layers (two of them blurred) at up
-  to the display's refresh rate. A page full of simultaneous instances -
-  like the playground demo - is a worst case no real app should ship.
-  Reduced-motion users pay nothing: the field rests lit and still.
+  instance re-rasterises its gradient layers (two of them blurred; three
+  with `glow="both"`, which restores the near halo via a dedicated aura
+  layer and is the most expensive configuration) at up to the display's
+  refresh rate. A page full of simultaneous instances - like the
+  playground demo - is a worst case no real app should ship. The glow's
+  invisible paint boxes extend ~120px past the panel, so give it that
+  much clearance inside `overflow: auto` containers or the scroll range
+  grows. Reduced-motion users pay nothing: the field rests lit and still.
   """
   use Phoenix.Component
 
@@ -65,7 +69,7 @@ defmodule PetalComponents.BorderPlasma do
     default: "outside",
     values: ["outside", "inside", "both"],
     doc:
-      "where PULSE's light lives: a halo spilling past the border onto the page (outside, the default), a wash hugging the edges inside a crisp silhouette (inside), or the two together (both). Rotate always keeps its light inside the silhouette, as the reference effect does"
+      "where PULSE's light lives: a halo spilling past the border onto the page (outside, the default), a wash hugging the edges inside a crisp silhouette (inside), or the two together (both - the most paint-expensive option; prefer outside or inside when several instances share a view). Rotate always keeps its light inside the silhouette, as the reference effect does"
 
   attr :border_width, :string,
     default: "1px",
@@ -136,10 +140,13 @@ defmodule PetalComponents.BorderPlasma do
       {@rest}
     >
       <%!-- Halo layers sit at z-index -1: painted over the page but under the
-      panel's content. In clip mode the same two become the inner wash and
-      the blurred ring. The stroke and sheen paint after the content - the
-      hairline rides the rim, never over the middle. --%>
+      panel's content. In clip mode the bloom and core become the inner wash
+      and the blurred ring; in glow="both" the aura (hidden otherwise) takes
+      over the near halo so the core is free to be the inner wash. The stroke
+      and sheen paint after the content - the hairline rides the rim, never
+      over the middle. --%>
       <div class="pc-border-plasma__bloom" aria-hidden="true"></div>
+      <div class="pc-border-plasma__aura" aria-hidden="true"></div>
       <div class="pc-border-plasma__core" aria-hidden="true"></div>
       <div class="pc-border-plasma__content">{render_slot(@inner_block)}</div>
       <div class="pc-border-plasma__stroke" aria-hidden="true"></div>

--- a/test/petal/border_plasma_test.exs
+++ b/test/petal/border_plasma_test.exs
@@ -25,7 +25,7 @@ defmodule PetalComponents.BorderPlasmaTest do
       assert html =~ ~s(aria-hidden="true")
     end
 
-    test "all four decorative layers are hidden from assistive tech" do
+    test "all five decorative layers are hidden from assistive tech" do
       assigns = %{}
 
       html =
@@ -33,8 +33,10 @@ defmodule PetalComponents.BorderPlasmaTest do
         <.border_plasma>Content</.border_plasma>
         """)
 
-      # bloom + core + stroke + sheen: light is decoration, every layer of it
-      assert count_substring(html, ~s(aria-hidden="true")) == 4
+      # bloom + aura + core + stroke + sheen: light is decoration, every
+      # layer of it (the aura renders always and lights up in glow="both")
+      assert count_substring(html, ~s(aria-hidden="true")) == 5
+      assert html =~ "pc-border-plasma__aura"
 
       inside =
         rendered_to_string(~H"""

--- a/test/petal/css_assets_test.exs
+++ b/test/petal/css_assets_test.exs
@@ -23,4 +23,128 @@ defmodule PetalComponents.CssAssetsTest do
                inspect(Regex.run(~r/^.*\\+:.*$/m, css))
     end
   end
+
+  describe "border_plasma cross-rule invariants" do
+    # This CSS section has shipped three cross-rule interaction bugs
+    # (custom-property var scoping twice, headroom geometry drift once).
+    # These guards pin the invariants a refactor could silently break.
+
+    setup do
+      %{css: File.read!(Path.join(@app_root, "assets/default.css"))}
+    end
+
+    defp rule_body(css, selector) do
+      case Regex.run(~r/#{Regex.escape(selector)}\s*\{([^}]*)\}/s, css) do
+        [_, body] -> body
+        nil -> flunk("selector not found in default.css: #{selector}")
+      end
+    end
+
+    test "rotate's aura hide outranks glow-both's show by source order", %{css: css} do
+      # Both selectors are specificity (0,2,0): ONLY source order keeps the
+      # aura dark for mode="rotate" glow="both" (a legal attr combination).
+      # If the rotate rule moves above the glow-both rule, rotate grows a
+      # static unmasked halo outside its silhouette.
+      show = :binary.match(css, ".pc-border-plasma--glow-both > .pc-border-plasma__aura")
+      hide = :binary.match(css, ".pc-border-plasma--rotate > .pc-border-plasma__aura")
+      assert {show_pos, _} = show
+      assert {hide_pos, _} = hide
+      assert hide_pos > show_pos
+    end
+
+    test "the aura is dark by default", %{css: css} do
+      # The bare one-class rule specifically - not the aura's appearances
+      # at the tail of selector lists (hence the no-preceding-comma guard).
+      assert [_, body] =
+               Regex.run(~r/(?<!,)\n  \.pc-border-plasma__aura \{([^}]*)\}/, css),
+             "bare .pc-border-plasma__aura rule not found"
+
+      assert body =~ "display: none"
+    end
+
+    test "every ring/wash override resets the halo headroom border", %{css: css} do
+      # The base halo rules put 33px/86px transparent borders on core and
+      # bloom. Every rule that repurposes those layers with content-box
+      # mask or inset-0 geometry must reset the border, or the headroom
+      # drags its geometry out from under it.
+      for selector <- [
+            ".pc-border-plasma--glow-inside > .pc-border-plasma__core,\n  .pc-border-plasma--glow-both > .pc-border-plasma__core",
+            ".pc-border-plasma--glow-inside > .pc-border-plasma__bloom",
+            ".pc-border-plasma--rotate > .pc-border-plasma__core",
+            ".pc-border-plasma--rotate > .pc-border-plasma__bloom"
+          ] do
+        assert rule_body(css, selector) =~ "border: 0",
+               "#{selector} must reset the halo headroom border"
+      end
+    end
+
+    test "the halo recipes keep their headroom contract", %{css: css} do
+      core =
+        rule_body(
+          css,
+          ".pc-border-plasma__core,\n  .pc-border-plasma--glow-both > .pc-border-plasma__aura"
+        )
+
+      bloom = rule_body(css, ".pc-border-plasma__bloom")
+
+      # Transparent border = Safari blur headroom (sized ~3x blur radius);
+      # origin padding-box keeps the art at the original geometry; no-repeat
+      # stops the padding-box-sized image tiling ghost blobs into the band.
+      assert core =~ "border: 33px solid transparent"
+      assert bloom =~ "border: 86px solid transparent"
+
+      for {name, body} <- [core: core, bloom: bloom] do
+        assert body =~ "background-origin: padding-box", "#{name} lost background-origin"
+        assert body =~ "background-repeat: no-repeat", "#{name} lost background-repeat"
+      end
+    end
+
+    test "rotate's geometry is not motion-gated (reduced-motion silhouette contract)", %{css: css} do
+      # The full rotate core/bloom recipes must live OUTSIDE the plasma
+      # oscillator media block, or reduce users fall through to the base
+      # halo and rotate leaks a static outside glow. The oscillator
+      # animation list ("pc-plasma-bw1 calc") anchors that block; the
+      # first occurrence of each rotate selector is the hoisted geometry
+      # rule and must come before it, carrying the full recipe.
+      {media_pos, _} = :binary.match(css, "pc-plasma-bw1 calc")
+
+      for selector <- [
+            ".pc-border-plasma--rotate > .pc-border-plasma__core",
+            ".pc-border-plasma--rotate > .pc-border-plasma__bloom"
+          ] do
+        {pos, _} = :binary.match(css, selector)
+        assert pos < media_pos, "#{selector} geometry is motion-gated"
+        body = rule_body(css, selector)
+        assert body =~ "mask", "#{selector} hoisted rule lost its mask recipe"
+        refute body =~ ~r/animation:/, "#{selector} geometry rule must not carry the animation"
+      end
+    end
+
+    test "animation shorthands re-declare the pause hook", %{css: css} do
+      # `animation:` resets animation-play-state at its own specificity,
+      # which silently kills the viewport observer's pause (that shipped).
+      # Every plasma rule using the shorthand must re-declare the longhand.
+      plasma_shorthand_rules =
+        Regex.scan(~r/\.pc-border-plasma[^{]*\{[^}]*animation:\s*pc-plasma[^}]*\}/s, css)
+
+      assert plasma_shorthand_rules != []
+
+      for [rule] <- plasma_shorthand_rules do
+        assert rule =~ "animation-play-state: var(--pc-plasma-play, running)",
+               "a plasma animation shorthand lost its play-state re-declaration:\n" <>
+                 String.slice(rule, 0, 200)
+      end
+    end
+
+    test "forced-colors drops the transparent-border halo layers", %{css: css} do
+      # WHCM repaints transparent borders in an opaque system colour, so
+      # the headroom borders would render as giant blurred frames.
+      [_, after_media] = String.split(css, "@media (forced-colors: active)", parts: 2)
+      [guard_block | _] = String.split(after_media, "\n  }\n", parts: 2)
+      assert guard_block =~ ".pc-border-plasma__core"
+      assert guard_block =~ ".pc-border-plasma__bloom"
+      assert guard_block =~ ".pc-border-plasma--glow-both > .pc-border-plasma__aura"
+      assert guard_block =~ "display: none"
+    end
+  end
 end


### PR DESCRIPTION
Closes out Nic's second iPhone eye-test round on the plasma border. Four user-visible fixes plus what an adversarial audit and the guard work surfaced.

## The ghost-reflection / remaining-iOS-clip root cause

#597's blur headroom used padding + \`background-origin: padding-box\` — but with zero border, **padding-box equals border-box**, so the gradients silently sized to the enlarged box. The bloom's blobs drifted ~68px outward (the "faint halo/reflection of each blob beyond a dark gap"), and their edges reached the new box so Safari kept amputating further out. The correct mechanism is a **transparent border** (genuinely insets the padding box) + \`background-repeat: no-repeat\` (load-bearing: the padding-box-sized image otherwise tiles into the band). Art verified back at its exact -10px/-30px geometry in-browser.

## The wispier, perimeter-free falloff

The reference site drives its own component harder than the base numbers we ported: measured live, core blur ~20px / bloom ~38px with 1.71x opacity boosts. Ours: core 6→11px, bloom 22.5→28px, eased mid-stops on the bloom ellipses, opacity 0.36→0.34, headroom sized ~3× blur with coupled-pair comments.

## glow="both" near halo restored

The outside glow "apart from the halo" was structural: core gets repurposed as the inner wash in both-mode, so nothing painted the near halo. A dedicated \`__aura\` twin (hidden everywhere else, re-hidden by rotate via source order) now carries the exact near-halo recipe.

## From the adversarial audit (3 lenses, per-finding verification)

- **Rotate + reduced-motion leaked a static outside halo** (geometry was motion-gated; falls back to the base halo recipe). Rotate's core/bloom geometry is hoisted out of the media block; only the lap animation stays gated. Frozen window at 0deg = silhouette contract holds for reduce users.
- **Windows High Contrast** repaints transparent borders in an opaque system color — the headroom borders would render as giant blurred frames. \`forced-colors: active\` guard drops the aria-hidden halo layers.
- **Moduledoc cost copy** updated: glow="both" now runs three blurred layers and is named as the ceiling; ~120px scroll-container clearance note added.
- **Seven CSS guard tests** pin the cross-rule invariants (aura source-order, border resets in all four override sites, headroom contract, motion-gating, forced-colors, pause-hook re-declaration) — this section has shipped three cross-rule bugs; now they're regression-locked.

## Bonus: the viewport pause hook was dead CSS

\`animation:\` shorthands reset \`animation-play-state\` at their own (higher) specificity, so the IntersectionObserver's \`--pc-plasma-play: paused\` never paused anything — offscreen instances have been animating since the perf pass shipped. The longhand is re-declared after every shorthand; verified live (computed style flips to paused now).

## Verification

- Art geometry numerically confirmed (padding box back at -10/-30px pre-transform)
- Full mode x glow matrix computed-style checked, incl. rotate+both hiding the aura
- Eye pass on flagship (medium + strong), three-jobs examples, inside, rotate
- 911 Elixir tests (7 new guards) + 157 JS, both exit 0
- The iOS re-test is Nic's, on the deployed playground

🤖 Generated with [Claude Code](https://claude.com/claude-code)