### PR TITLE
feat(empty): empty-state component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **New `empty` component: the empty state, standardised.** The thing a
+  list, table, inbox or search renders when it has nothing to show -
+  media, title, description, an actions row and an optional trailing
+  line, centred in a column. Every app rebuilds this anatomy by hand and
+  ends up with five different versions of it; `<.empty>` makes them one.
+  Four variants: `default` is the bare centred column with page-level
+  air, `compact` tightens the padding and type for a table frame or a
+  list, `card` wraps it in the panel surface (border, radius, the same
+  formula the card uses), and `dashed` is the drop-target look - a
+  visual treatment only, no drag and drop attached. Sizes `sm`/`md`/`lg`
+  scale the media, the type and the spacing together. Without an `:icon`
+  slot a default treatment renders - a muted circle with a dashed ring
+  around a heroicon glyph, marked `aria-hidden` because it is
+  decorative - and the slot replaces it with any icon or illustration
+  you like. Every part is optional, so a title on its own renders fine.
+  The root stays a plain `div` with no landmark and no live region:
+  announcing that a result set changed is the job of whatever changed
+  it, not of static content. It drops straight into `<.data_table>`'s
+  `:empty` slot, so a table's empty state and a page's are the same
+  component. Pure markup and CSS - no JS, no hook.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,123 @@
       transition-duration: 1ms;
     }
   }
+
+  /* Empty state: media, title, description, actions, trailing line */
+
+  .pc-empty {
+    @apply flex w-full flex-col items-center text-center;
+  }
+
+  .pc-empty__media {
+    @apply flex shrink-0 items-center justify-center text-gray-400 dark:text-gray-500;
+  }
+
+  /* the default treatment - a muted circle with a dashed ring */
+  .pc-empty__media--default {
+    @apply rounded-full border border-dashed border-gray-300 bg-gray-50;
+    @apply dark:border-gray-400/25 dark:bg-white/[0.04];
+  }
+
+  .pc-empty__title {
+    @apply font-semibold text-gray-900 dark:text-gray-100;
+  }
+
+  .pc-empty__description {
+    @apply max-w-md text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-empty__actions {
+    @apply flex flex-wrap items-center justify-center;
+  }
+
+  .pc-empty__footer {
+    @apply text-sm text-gray-500 dark:text-gray-400;
+  }
+
+  /* Empty state - variants */
+
+  .pc-empty--default {
+    @apply px-6 py-12;
+  }
+
+  .pc-empty--compact {
+    @apply px-4 py-8;
+  }
+
+  .pc-empty--card {
+    @apply border border-gray-200 bg-white px-6 py-12 shadow-xs dark:border-gray-400/17 dark:bg-gray-900;
+    border-radius: min(calc(var(--pc-radius, 0.625rem) * 1.2), 1.25rem);
+  }
+
+  .pc-empty--dashed {
+    @apply border border-dashed border-gray-300 px-6 py-12 dark:border-gray-400/25;
+    border-radius: min(calc(var(--pc-radius, 0.625rem) * 1.2), 1.25rem);
+  }
+
+  /* Empty state - sizes (media, type and spacing scale together) */
+
+  .pc-empty--sm .pc-empty__media--default {
+    @apply size-10;
+  }
+  .pc-empty--sm .pc-empty__icon {
+    @apply w-5 h-5;
+  }
+  .pc-empty--sm .pc-empty__title {
+    @apply mt-3 text-sm;
+  }
+  .pc-empty--sm .pc-empty__description {
+    @apply mt-1 text-xs;
+  }
+  .pc-empty--sm .pc-empty__actions {
+    @apply mt-3 gap-2;
+  }
+  .pc-empty--sm .pc-empty__footer {
+    @apply mt-2 text-xs;
+  }
+
+  .pc-empty--md .pc-empty__media--default {
+    @apply size-12;
+  }
+  .pc-empty--md .pc-empty__icon {
+    @apply w-6 h-6;
+  }
+  .pc-empty--md .pc-empty__title {
+    @apply mt-4 text-base;
+  }
+  .pc-empty--md .pc-empty__description {
+    @apply mt-1.5 text-sm;
+  }
+  .pc-empty--md .pc-empty__actions {
+    @apply mt-5 gap-2;
+  }
+  .pc-empty--md .pc-empty__footer {
+    @apply mt-3;
+  }
+
+  .pc-empty--lg .pc-empty__media--default {
+    @apply size-16;
+  }
+  .pc-empty--lg .pc-empty__icon {
+    @apply w-8 h-8;
+  }
+  .pc-empty--lg .pc-empty__title {
+    @apply mt-5 text-lg;
+  }
+  .pc-empty--lg .pc-empty__description {
+    @apply mt-2 text-base;
+  }
+  .pc-empty--lg .pc-empty__actions {
+    @apply mt-6 gap-3;
+  }
+  .pc-empty--lg .pc-empty__footer {
+    @apply mt-4;
+  }
+
+  /* compact runs one notch tighter than its size band asks for - it lives
+     inside a table frame or a list, where page-level air reads as a gap */
+  .pc-empty--compact .pc-empty__title {
+    @apply mt-3;
+  }
+  .pc-empty--compact .pc-empty__actions {
+    @apply mt-4;
+  }

--- a/dev.exs
+++ b/dev.exs
@@ -262,6 +262,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "progress", name: "Progress", ready: true},
         %{slug: "rating", name: "Rating", ready: true},
         %{slug: "skeleton", name: "Skeleton", ready: true},
+        %{slug: "empty", name: "Empty state", ready: true},
         %{slug: "loading", name: "Loading", ready: true}
       ]
     },
@@ -762,6 +763,7 @@ defmodule Dev.PlaygroundLive do
          rev: 0
        },
        badge: %{color: "primary", variant: "outline", size: "md", icon: false},
+       empty: %{variant: "default", size: "md", actions: "primary"},
        input: %{type: "text", disabled: false, error: false, help: false},
        checkbox: %{layout: "row", disabled: false, error: false},
        select: %{disabled: false, error: false, help: false},
@@ -1691,6 +1693,17 @@ defmodule Dev.PlaygroundLive do
   def handle_event("ctl_badge", %{"k" => "icon"}, socket),
     do: {:noreply, update(socket, :badge, &%{&1 | icon: !&1.icon})}
 
+  def handle_event("ctl_empty", %{"k" => "variant", "v" => v}, socket)
+      when v in ~w(default compact card dashed),
+      do: {:noreply, update(socket, :empty, &%{&1 | variant: v})}
+
+  def handle_event("ctl_empty", %{"k" => "size", "v" => v}, socket) when v in ~w(sm md lg),
+    do: {:noreply, update(socket, :empty, &%{&1 | size: v})}
+
+  def handle_event("ctl_empty", %{"k" => "actions", "v" => v}, socket)
+      when v in ~w(none primary both),
+      do: {:noreply, update(socket, :empty, &%{&1 | actions: v})}
+
   def handle_event("chat_send", %{"prompt" => prompt}, socket), do: chat_start(socket, prompt)
 
   def handle_event("chat_suggest", %{"prompt" => prompt}, socket), do: chat_start(socket, prompt)
@@ -2292,6 +2305,32 @@ defmodule Dev.PlaygroundLive do
 
     open = Enum.join(["<.alert" | attrs], " ")
     open <> ">Your subscription renews on 12 August.</.alert>"
+  end
+
+  defp empty_snippet(e) do
+    attrs =
+      [
+        e.variant != "default" && ~s(variant="#{e.variant}"),
+        e.size != "md" && ~s(size="#{e.size}"),
+        ~s(title="No projects yet"),
+        ~s(description="Projects hold your environments, deploys and team access.")
+      ]
+      |> Enum.filter(& &1)
+
+    open = Enum.join(["<.empty" | attrs], " ")
+
+    case e.actions do
+      "none" ->
+        open <> " />"
+
+      "primary" ->
+        open <>
+          ">\n  <:actions>\n    <.button size=\"sm\" label=\"Create project\" />\n  </:actions>\n</.empty>"
+
+      "both" ->
+        open <>
+          ">\n  <:actions>\n    <.button size=\"sm\" label=\"Create project\" />\n    <.button size=\"sm\" variant=\"outline\" color=\"gray\" label=\"Import from Git\" />\n  </:actions>\n</.empty>"
+    end
   end
 
   defp badge_snippet(b) do
@@ -5266,6 +5305,116 @@ defmodule Dev.PlaygroundLive do
         registry - the same source petal.build renders, so the playground and the marketing
         docs can't drift.
       </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "empty"} = assigns) do
+    ~H"""
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">Empty state</h1>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        What a list, table, inbox or search renders when it has nothing to show.
+        Media, title, description, actions, a trailing line - every part optional,
+        pure markup and CSS.
+      </p>
+
+      <div class="mt-8 overflow-hidden border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="flex items-center justify-center px-6 py-12">
+          <div class="w-full max-w-xl">
+            <.empty
+              variant={@empty.variant}
+              size={@empty.size}
+              title="No projects yet"
+              description="Projects hold your environments, deploys and team access. Create one to get started."
+            >
+              <:actions :if={@empty.actions != "none"}>
+                <.button size="sm" label="Create project" />
+                <.button
+                  :if={@empty.actions == "both"}
+                  size="sm"
+                  variant="outline"
+                  color="gray"
+                  label="Import from Git"
+                />
+              </:actions>
+            </.empty>
+          </div>
+        </div>
+        <div class="flex flex-wrap items-end gap-x-8 gap-y-4 px-4 sm:px-6 py-4 border-t border-gray-200 dark:border-gray-800">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">variant</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Variant"
+              value={@empty.variant}
+              on_change="ctl_empty"
+            >
+              <:item
+                :for={v <- ~w(default compact card dashed)}
+                value={v}
+                phx-value-k="variant"
+                phx-value-v={v}
+              >
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">size</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Size"
+              value={@empty.size}
+              on_change="ctl_empty"
+            >
+              <:item :for={s <- ~w(sm md lg)} value={s} phx-value-k="size" phx-value-v={s}>
+                {s}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">actions</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Actions"
+              value={@empty.actions}
+              on_change="ctl_empty"
+            >
+              <:item :for={a <- ~w(none primary both)} value={a} phx-value-k="actions" phx-value-v={a}>
+                {a}
+              </:item>
+            </.toggle_group>
+          </div>
+        </div>
+      </div>
+
+      <button
+        phx-click="flip"
+        phx-value-k="show_code"
+        class="mt-3 inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+      >
+        <.icon name="hero-code-bracket" class="w-4 h-4" />
+        {if @show_code, do: "Hide code", else: "View code"}
+      </button>
+      <pre
+        :if={@show_code}
+        class="p-4 mt-2 overflow-x-auto text-sm text-gray-100 bg-gray-900 rounded-xl dark:border dark:border-gray-800"
+      ><code>{empty_snippet(@empty)}</code></pre>
+
+      <div :for={ex <- PetalComponents.Showcase.Empty.examples()} class="mt-10">
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
+      <.showcase_props component={PetalComponents.Empty} function={:empty} />
     </div>
     """
   end

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -37,6 +37,7 @@ defmodule PetalComponents do
         Confetti,
         Container,
         Dropdown,
+        Empty,
         Field,
         Form,
         Icon,

--- a/lib/petal_components/empty.ex
+++ b/lib/petal_components/empty.ex
@@ -79,41 +79,35 @@ defmodule PetalComponents.Empty do
 
   import PetalComponents.Icon
 
-  attr(:title, :string, default: nil, doc: "the headline, e.g. \"No results found\"")
+  attr :title, :string, default: nil, doc: "the headline, e.g. \"No results found\""
 
-  attr(:description, :string,
+  attr :description, :string,
     default: nil,
     doc: "one or two sentences of supporting text under the title"
-  )
 
-  attr(:variant, :string,
+  attr :variant, :string,
     default: "default",
     values: ["default", "compact", "card", "dashed"],
     doc:
       "default: centred with generous vertical padding; compact: tighter, for table/list empties; card: wrapped in the floating-panel surface; dashed: dashed border, drop-target look"
-  )
 
-  attr(:size, :string,
+  attr :size, :string,
     default: "md",
     values: ["sm", "md", "lg"],
     doc: "scales the media, the type and the spacing"
-  )
 
-  attr(:class, :any, default: nil, doc: "CSS class for the outer container")
-  attr(:rest, :global)
+  attr :class, :any, default: nil, doc: "CSS class for the outer container"
+  attr :rest, :global
 
-  slot(:icon,
+  slot :icon,
     doc:
       "custom icon or illustration; without it a default treatment renders - a muted circle with a dashed ring around a heroicon glyph"
-  )
 
-  slot(:actions,
+  slot :actions,
     doc: "primary and secondary actions (buttons or links) rendered under the description"
-  )
 
-  slot(:inner_block,
+  slot :inner_block,
     doc: "an optional trailing line, e.g. a \"Learn more\" link rendered under the actions"
-  )
 
   @doc """
   The empty state: media, title, description, actions, trailing line - every

--- a/lib/petal_components/empty.ex
+++ b/lib/petal_components/empty.ex
@@ -1,0 +1,152 @@
+defmodule PetalComponents.Empty do
+  @moduledoc """
+  The empty state: what a list, table, inbox or search renders when it has
+  nothing to show.
+
+  Every app reinvents this anatomy by hand - a piece of media, a title, a
+  short description, one or two actions. `<.empty>` standardises it so the
+  empty states across a product read as one system:
+
+      <.empty
+        title="No results found"
+        description="No projects match your filters. Try a broader search."
+      >
+        <:actions>
+          <.button size="sm" variant="outline" color="gray">Clear filters</.button>
+        </:actions>
+      </.empty>
+
+  Every part is optional - a title on its own renders fine. Without an
+  `:icon` slot a default treatment renders: a muted circle with a dashed
+  ring around a heroicon glyph, marked `aria-hidden` because it is
+  decorative.
+
+  ## Variants
+
+    * `default` - centred with generous vertical padding, no border. The
+      page-level empty state.
+    * `compact` - tighter padding and type, sized to sit inside a table
+      frame or a list.
+    * `card` - the floating-panel surface (border + radius), for an empty
+      state that has to hold its own on a busy page.
+    * `dashed` - a dashed border on the gray ramp, the drop-target look.
+      Visual only; it ships no drag-and-drop behaviour.
+
+  `size` (`sm`/`md`/`lg`) scales the media, the type and the spacing of
+  every variant.
+
+  ## A first-run state with actions
+
+      <.empty
+        variant="dashed"
+        title="No projects yet"
+        description="Projects hold your environments, deploys and team access."
+      >
+        <:icon><.icon name="hero-folder-plus" class="w-6 h-6 text-gray-400" /></:icon>
+        <:actions>
+          <.button size="sm">Create your first project</.button>
+          <.button size="sm" variant="outline" color="gray">Import from Git</.button>
+        </:actions>
+        <.a to="/docs/projects" class="text-sm">Learn more about projects</.a>
+      </.empty>
+
+  ## Inside a data table
+
+  `<.data_table>` takes an `:empty` slot, so the empty state of a table is
+  the same component as the empty state of a page:
+
+      <.data_table id="orders" rows={@rows} state={@state} path={~p"/orders"}>
+        <:col :let={row} field={:name}>{row.name}</:col>
+        <:empty>
+          <.empty
+            variant="compact"
+            size="sm"
+            title="No orders yet"
+            description="Orders show up here the moment your first customer checks out."
+          />
+        </:empty>
+      </.data_table>
+
+  ## Accessibility
+
+  The root is a plain `<div>` - no landmark, no live region. An empty state
+  is static content; announcing that a result set changed is the job of the
+  thing that changed it. The media is `aria-hidden="true"`, and the title,
+  description and actions sit in DOM order so a screen reader gets a
+  coherent read.
+  """
+  use Phoenix.Component
+
+  import PetalComponents.Icon
+
+  attr(:title, :string, default: nil, doc: "the headline, e.g. \"No results found\"")
+
+  attr(:description, :string,
+    default: nil,
+    doc: "one or two sentences of supporting text under the title"
+  )
+
+  attr(:variant, :string,
+    default: "default",
+    values: ["default", "compact", "card", "dashed"],
+    doc:
+      "default: centred with generous vertical padding; compact: tighter, for table/list empties; card: wrapped in the floating-panel surface; dashed: dashed border, drop-target look"
+  )
+
+  attr(:size, :string,
+    default: "md",
+    values: ["sm", "md", "lg"],
+    doc: "scales the media, the type and the spacing"
+  )
+
+  attr(:class, :any, default: nil, doc: "CSS class for the outer container")
+  attr(:rest, :global)
+
+  slot(:icon,
+    doc:
+      "custom icon or illustration; without it a default treatment renders - a muted circle with a dashed ring around a heroicon glyph"
+  )
+
+  slot(:actions,
+    doc: "primary and secondary actions (buttons or links) rendered under the description"
+  )
+
+  slot(:inner_block,
+    doc: "an optional trailing line, e.g. a \"Learn more\" link rendered under the actions"
+  )
+
+  @doc """
+  The empty state: media, title, description, actions, trailing line - every
+  part optional, centred in a column.
+  """
+  def empty(assigns) do
+    ~H"""
+    <div
+      class={["pc-empty", "pc-empty--#{@variant}", "pc-empty--#{@size}", @class]}
+      {@rest}
+    >
+      <div
+        class={["pc-empty__media", @icon == [] && "pc-empty__media--default"]}
+        aria-hidden="true"
+      >
+        <%= if @icon == [] do %>
+          <.icon name="hero-inbox" class="pc-empty__icon" />
+        <% else %>
+          {render_slot(@icon)}
+        <% end %>
+      </div>
+
+      <p :if={@title} class="pc-empty__title">{@title}</p>
+      <p :if={@description} class="pc-empty__description">{@description}</p>
+
+      <div :if={@actions != []} class="pc-empty__actions">
+        {render_slot(@actions)}
+      </div>
+
+      <div :if={@inner_block != []} class="pc-empty__footer">
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/petal_components/showcase/empty.ex
+++ b/lib/petal_components/showcase/empty.ex
@@ -1,0 +1,82 @@
+defmodule PetalComponents.Showcase.Empty do
+  @moduledoc false
+  use PetalComponents.Showcase,
+    component: PetalComponents.Empty,
+    title: "Empty"
+
+  alias PetalComponents.DataTable.State
+
+  example :search, "No search results",
+    description:
+      "The most common empty state in any product: a search that found nothing. compact keeps it inside the result frame instead of taking over the page, and the secondary action is the way back out - never leave someone staring at a dead end." do
+    ~H"""
+    <.empty
+      variant="compact"
+      title="No results for “quaterly report”"
+      description="Check the spelling, or drop a filter to widen the search."
+    >
+      <:icon><.icon name="hero-magnifying-glass" class="w-6 h-6 text-gray-400" /></:icon>
+      <:actions>
+        <.button size="sm" variant="outline" color="gray" label="Clear filters" />
+      </:actions>
+    </.empty>
+    """
+  end
+
+  example :first_run, "First run, with a way in",
+    description:
+      "The first-run state earns a card: it is the whole page, so give it the panel surface, a primary CTA that creates the missing thing, and a trailing docs line for people who want to read before they click." do
+    ~H"""
+    <.empty
+      variant="card"
+      size="lg"
+      title="No projects yet"
+      description="Projects hold your environments, deploys and team access. Create one to get started."
+    >
+      <:icon>
+        <div class="flex items-center justify-center bg-primary-50 rounded-full size-16 dark:bg-primary-500/10">
+          <.icon name="hero-folder-plus" class="w-8 h-8 text-primary-600 dark:text-primary-400" />
+        </div>
+      </:icon>
+      <:actions>
+        <.button size="sm" label="Create your first project" />
+        <.button size="sm" variant="outline" color="gray" label="Import from Git" />
+      </:actions>
+      <.a to="#" class="text-sm">Learn more about projects</.a>
+    </.empty>
+    """
+  end
+
+  example :variants, "Four treatments",
+    description:
+      "default is the bare centred column, compact tightens it for lists and tables, card wraps it in the panel surface, and dashed is the drop-target look - a visual treatment only, no drag and drop attached." do
+    ~H"""
+    <div class="grid w-full gap-4 sm:grid-cols-2">
+      <.empty variant="default" size="sm" title="default" description="Centred, no border." />
+      <.empty variant="compact" size="sm" title="compact" description="Tighter, for lists." />
+      <.empty variant="card" size="sm" title="card" description="The panel surface." />
+      <.empty variant="dashed" size="sm" title="dashed" description="The drop-target look." />
+    </div>
+    """
+  end
+
+  example :in_table, "Inside a data table",
+    description:
+      "The data table takes an :empty slot, so a table's empty state is the same component as a page's. compact plus sm sits inside the table frame without blowing it open." do
+    ~H"""
+    <% state = %State{total: 0} %>
+    <.data_table id="sx-empty-dt" rows={[]} state={state} path="#">
+      <:col :let={row} field={:name}>{row.name}</:col>
+      <:col :let={row} field={:email}>{row.email}</:col>
+      <:empty>
+        <.empty
+          variant="compact"
+          size="sm"
+          title="No orders yet"
+          description="Orders show up here the moment your first customer checks out."
+        />
+      </:empty>
+    </.data_table>
+    """
+  end
+end

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -29,6 +29,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.Command,
     PetalComponents.Showcase.Confetti,
     PetalComponents.Showcase.Dropdown,
+    PetalComponents.Showcase.Empty,
     PetalComponents.Showcase.LanguageSelect,
     PetalComponents.Showcase.SocialButton,
     PetalComponents.Showcase.Field,

--- a/test/petal/empty_test.exs
+++ b/test/petal/empty_test.exs
@@ -1,0 +1,238 @@
+defmodule PetalComponents.EmptyTest do
+  use ComponentCase
+
+  import PetalComponents.Button
+  import PetalComponents.DataTable
+  import PetalComponents.Empty
+  import PetalComponents.Icon
+
+  alias PetalComponents.DataTable.State
+
+  test "renders the root with title and description" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.empty title="No results found" description="Try a broader search." />
+      """)
+
+    assert_has_class(html, "pc-empty")
+    assert html =~ "No results found"
+    assert html =~ "Try a broader search."
+
+    doc = LazyHTML.from_fragment(html)
+    assert doc |> LazyHTML.query(".pc-empty__title") |> LazyHTML.text() == "No results found"
+    assert doc |> LazyHTML.query(".pc-empty__description") |> LazyHTML.text() =~ "broader search"
+
+    # media, title, description in DOM order - the screen reader read
+    positions =
+      Enum.map(
+        ~w(pc-empty__media pc-empty__title pc-empty__description),
+        fn class -> html |> :binary.match(class) |> elem(0) end
+      )
+
+    assert positions == Enum.sort(positions)
+  end
+
+  test "the root is a plain div - no landmark or live region" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.empty title="Nothing here" />
+      """)
+
+    root = html |> LazyHTML.from_fragment() |> LazyHTML.query(".pc-empty")
+
+    assert LazyHTML.attribute(root, "role") == []
+    assert LazyHTML.attribute(root, "aria-live") == []
+    refute html =~ "aria-live"
+  end
+
+  for variant <- ~w(default compact card dashed) do
+    test "variant #{variant} emits its modifier class" do
+      assigns = %{variant: unquote(variant)}
+
+      html =
+        rendered_to_string(~H"""
+        <.empty variant={@variant} title="Nothing here" />
+        """)
+
+      assert_has_class(html, "pc-empty--#{unquote(variant)}")
+    end
+  end
+
+  for size <- ~w(sm md lg) do
+    test "size #{size} emits its modifier class" do
+      assigns = %{size: unquote(size)}
+
+      html =
+        rendered_to_string(~H"""
+        <.empty size={@size} title="Nothing here" />
+        """)
+
+      assert_has_class(html, "pc-empty--#{unquote(size)}")
+    end
+  end
+
+  test "defaults to the default variant at md" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.empty title="Nothing here" />
+      """)
+
+    assert_has_class(html, "pc-empty--default")
+    assert_has_class(html, "pc-empty--md")
+  end
+
+  test "the default media is a decorative icon treatment" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.empty title="Nothing here" />
+      """)
+
+    assert_has_class(html, "pc-empty__media--default")
+    assert has_icon?(html, "hero-inbox")
+
+    media = html |> LazyHTML.from_fragment() |> LazyHTML.query(".pc-empty__media")
+    assert LazyHTML.attribute(media, "aria-hidden") == ["true"]
+  end
+
+  test "the icon slot replaces the default media and stays decorative" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.empty title="Nothing here">
+        <:icon><.icon name="hero-folder-plus" class="w-8 h-8" /></:icon>
+      </.empty>
+      """)
+
+    assert has_icon?(html, "hero-folder-plus")
+    refute has_icon?(html, "hero-inbox")
+    refute_has_class(html, "pc-empty__media--default")
+
+    media = html |> LazyHTML.from_fragment() |> LazyHTML.query(".pc-empty__media")
+    assert LazyHTML.attribute(media, "aria-hidden") == ["true"]
+  end
+
+  test "actions render inside the actions row" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.empty title="No projects yet">
+        <:actions>
+          <.button size="sm" label="Create project" />
+          <.button size="sm" variant="outline" color="gray" label="Import" />
+        </:actions>
+      </.empty>
+      """)
+
+    actions = html |> LazyHTML.from_fragment() |> LazyHTML.query(".pc-empty__actions")
+
+    assert LazyHTML.text(actions) =~ "Create project"
+    assert LazyHTML.text(actions) =~ "Import"
+    assert actions |> LazyHTML.query("button") |> Enum.count() == 2
+  end
+
+  test "the actions row is absent when the slot is empty" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.empty title="No projects yet" />
+      """)
+
+    refute_has_class(html, "pc-empty__actions")
+  end
+
+  test "inner_block renders as the trailing footer line" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.empty title="No projects yet">
+        <a href="/docs">Learn more</a>
+      </.empty>
+      """)
+
+    footer = html |> LazyHTML.from_fragment() |> LazyHTML.query(".pc-empty__footer")
+
+    assert LazyHTML.text(footer) =~ "Learn more"
+    assert footer |> LazyHTML.query("a") |> LazyHTML.attribute("href") == ["/docs"]
+  end
+
+  test "the footer is absent without an inner_block" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.empty title="No projects yet" />
+      """)
+
+    refute_has_class(html, "pc-empty__footer")
+  end
+
+  test "class merges onto the root and rest passes through" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.empty id="orders-empty" class="my-8 bg-white" title="Nothing here" data-test="empty" />
+      """)
+
+    assert_has_class(html, "pc-empty")
+    assert_has_class(html, "my-8")
+    assert_has_class(html, "bg-white")
+    assert_attribute(html, "id", "orders-empty")
+    assert_attribute(html, "data-test", "empty")
+  end
+
+  test "every part is optional - title only, and nothing at all" do
+    assigns = %{}
+
+    title_only =
+      rendered_to_string(~H"""
+      <.empty title="No results found" />
+      """)
+
+    assert title_only =~ "No results found"
+    refute_has_class(title_only, "pc-empty__description")
+    refute_has_class(title_only, "pc-empty__actions")
+    refute_has_class(title_only, "pc-empty__footer")
+
+    bare =
+      rendered_to_string(~H"""
+      <.empty />
+      """)
+
+    assert_has_class(bare, "pc-empty")
+    refute_has_class(bare, "pc-empty__title")
+    refute_has_class(bare, "pc-empty__description")
+  end
+
+  test "composes inside the data table's empty slot" do
+    assigns = %{state: %State{total: 0}}
+
+    html =
+      rendered_to_string(~H"""
+      <.data_table id="orders" rows={[]} state={@state} path="/orders">
+        <:col :let={row} field={:name}>{row.name}</:col>
+        <:empty>
+          <.empty variant="compact" size="sm" title="No orders yet" />
+        </:empty>
+      </.data_table>
+      """)
+
+    assert_has_class(html, "pc-empty--compact")
+    assert_has_class(html, "pc-empty--sm")
+    assert html =~ "No orders yet"
+    # the slot replaces the data table's own default empty line
+    refute html =~ "No results for these filters"
+  end
+end


### PR DESCRIPTION
Closes #603

## Summary

`<.empty>` is the empty-state primitive: what a list, table, inbox or search renders when it has nothing to show. Media, title, description, an actions row and an optional trailing line, centred in a column. Every part is optional, so a title on its own renders fine. Pure markup and CSS - no JS, no hook, no LiveView.JS.

Four variants (`default`, `compact`, `card`, `dashed`), three sizes (`sm`/`md`/`lg`) that scale media, type and spacing together, and a default media treatment - a muted circle with a dashed ring around `hero-inbox`, `aria-hidden` because it is decorative - which the `:icon` slot replaces.

It drops straight into `<.data_table>`'s existing `:empty` slot, so a table's empty state and a page's are the same component. No changes to `data_table` itself.

## Files

- `lib/petal_components/empty.ex` - the component
- `lib/petal_components/showcase/empty.ex` - four examples (search, first run, four treatments, inside a data table)
- `test/petal/empty_test.exs` - 19 tests
- `assets/default.css` - appended `pc-empty` section, light + dark
- `dev.exs` - nav entry + `/c/empty` page with variant / size / actions dials and a live snippet
- `lib/petal_components.ex`, `lib/petal_components/showcase/registry.ex`, `CHANGELOG.md`

## Deviations from the issue's API sketch

None to the API. Attrs, slots, values and class names are exactly as sketched: `title`, `description`, `variant`, `size`, `class`, `rest`, and the `:icon` / `:actions` / `inner_block` slots; classes are `pc-empty`, `pc-empty--{variant}`, `pc-empty--{size}`, `pc-empty__media`, `__title`, `__description`, `__actions`, `__footer`.

Two additions inside that shape:

- `pc-empty__media--default` is a second class on the media wrapper, only when the `:icon` slot is empty. The circle-and-dashed-ring treatment has to be removable when a custom illustration comes in, and a modifier is cheaper than a second base class. `pc-empty__icon` sizes the default glyph per size band.
- The title renders as a `<p>` with heading styles, not an `h*` - as the issue argued. An empty state's outline level depends on its context, and the component cannot know it.

## Implementation decisions

- **No `role`, no `aria-live` on the root.** An empty state is static content. Whatever changed the result set is what should announce the change; a live region here would double-announce inside a data table that already manages its own updates. Covered by a test.
- **`card` and `dashed` reuse the panel radius formula** (`min(calc(var(--pc-radius) * 1.2), 1.25rem)`) and the same border tones `pc-card--basic` uses, so an empty card sits flush next to a real one at any radius setting. No new grays.
- **Sizes are descendant rules** (`.pc-empty--sm .pc-empty__title` etc.) rather than per-part modifier classes - one dial on the root, and a custom `:icon` slot still gets scaled spacing around it without having to opt in.
- **`compact` overrides two spacing steps** on top of its size band. It lives inside a table frame or a list, where page-level air reads as a gap.
- The CSS section is appended to `assets/default.css`; no existing rules were touched or reflowed.

## Verification

- `mix format --check-formatted` clean; `mix credo` reports nothing in the new files (pre-existing findings only)
- `mix test`: **932 tests, 0 failures, 1 skipped** (baseline 913, +19 new)
- `npm test`: **157 passing** (unchanged - no JS ships with this)
- Live-verified at `/c/empty`: every dial exercised, all four variants and three sizes, light and dark, plus the data_table composition rendering inside the table frame

## Gaps

Screenshots are not attached to this PR - the light/dark verification was done in the playground but I have no way to upload images to the PR body from the CLI. Happy for them to be added on review, or say the word and I will describe each state in a comment.