### PR TITLE
refactor(playground): fold the link-mode page into /c/data-table

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -283,7 +283,6 @@ defmodule Dev.PlaygroundLive do
       items: [
         %{slug: "table", name: "Table", ready: true},
         %{slug: "data-table", name: "Data table", ready: true},
-        %{slug: "data-table-link", name: "Data table · links", ready: true},
         %{slug: "chart", name: "Chart", ready: true},
         %{slug: "local-time", name: "Local time", ready: true}
       ]
@@ -868,9 +867,14 @@ defmodule Dev.PlaygroundLive do
 
   # Theme state lives in the URL, so any look is shareable / screenshotable.
   def handle_params(params, uri, socket) do
+    # /c/data-table-link folded into /c/data-table (Aug 2026). Old shared
+    # links keep working: same page, and the State query params decode as
+    # before. The address bar normalises on the first link-mode click.
+    c = if params["c"] == "data-table-link", do: "data-table", else: params["c"]
+
     socket =
       socket
-      |> assign(:active, allow(params["c"], @slugs, "button"))
+      |> assign(:active, allow(c, @slugs, "button"))
       |> assign(:primary, allow(params["primary"] || params["accent"], @primary_names, "neutral"))
       |> assign(:gray, allow(params["gray"], @gray_names, "zinc"))
       |> assign(:secondary, allow(params["secondary"], @secondary_names, "pink"))
@@ -888,16 +892,16 @@ defmodule Dev.PlaygroundLive do
   # Link mode's whole loop: the table patches State-encoded URLs, this
   # decodes them back through the same whitelist and re-runs the engine.
   # No events, no other server state - the URL IS the table state.
-  defp maybe_run_dt_link(%{assigns: %{active: "data-table-link"}} = socket, params, uri) do
+  defp maybe_run_dt_link(%{assigns: %{active: "data-table"}} = socket, params, uri) do
     alias PetalComponents.DataTable.State
 
     # PhoenixPlayground's dead render hands handle_params only the path
     # params - the query string arrives solely in uri (the theme dials
     # have always had this flash). Decode it from there so a shared or
     # curled URL renders the right rows on FIRST paint, which is the
-    # claim this page exists to make. Plug's decoder, not URI's, because
-    # filters use bracket-indexed params. On connected patches params
-    # already carries the query and the merge is a no-op.
+    # claim the link-mode demo exists to make. Plug's decoder, not URI's,
+    # because filters use bracket-indexed params. On connected patches
+    # params already carries the query and the merge is a no-op.
     query = uri |> URI.parse() |> Map.get(:query) || ""
     params = Map.merge(Plug.Conn.Query.decode(query), params)
 
@@ -7668,12 +7672,17 @@ defmodule Dev.PlaygroundLive do
     <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
       <h1 class="text-3xl font-bold tracking-tight">Data table</h1>
       <p class="mt-2 mb-6 text-gray-600 dark:text-gray-300">
-        Sortable, paged and filter-aware, driven by one State struct. This live demo runs
-        EVENT mode: every interaction pushes a single op-grammar event, the handler applies it
-        with State helpers and re-runs the free in-memory engine. Link mode does the same
-        through patch URLs - state you can curl.
+        Sortable, paged and filter-aware, driven by one State struct. Wire it to events or
+        to the URL - the two live demos below run the same free in-memory engine, one per
+        mode.
       </p>
 
+      <h2 class="mb-1 text-lg font-semibold">Event mode</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        Every interaction pushes a single op-grammar event, the handler applies it with
+        State helpers and re-runs the engine. Sort this one and the URL stays put -
+        the state lives on the server.
+      </p>
       <div class="border border-gray-200 dark:border-gray-400/20 rounded-xl p-6">
         <% {state, rows} = @dt %>
         <.data_table
@@ -7729,48 +7738,24 @@ defmodule Dev.PlaygroundLive do
         </.data_table>
       </div>
 
-      <div
-        :for={
-          ex <-
-            examples_for(
-              PetalComponents.Showcase.DataTable,
-              ~w(basic toolbar selection columns loading empty)a
-            )
-        }
-        class="mt-10"
-      >
-        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
-        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
-          {ex.description}
-        </p>
-        <.showcase_example example={ex} />
-      </div>
-
-      <.showcase_props component={PetalComponents.DataTable} function={:data_table} />
-    </div>
-    """
-  end
-
-  defp render_page(%{active: "data-table-link"} = assigns) do
-    ~H"""
-    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
-      <h1 class="text-3xl font-bold tracking-tight">Data table &middot; link mode</h1>
-      <p class="mt-2 mb-6 text-gray-600 dark:text-gray-300">
-        The same table, driven entirely by the URL: sort, filter, search and page all patch
-        State-encoded query params, <code class="text-sm">handle_params</code>
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Link mode</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        The same rows and engine, driven entirely by the URL: sort, filter, search and page
+        all patch State-encoded query params, <code class="text-sm">handle_params</code>
         decodes them back through the field whitelist and re-runs the engine. No events -
-        every view is a link you can share, bookmark or curl. Try sorting, then reload.
+        every view is a link you can share, bookmark or curl. No selection or column
+        controls here either: those are UI state, and UI state rides events, never URLs.
+        Try sorting, then reload.
       </p>
-
       <div class="border border-gray-200 dark:border-gray-400/20 rounded-xl p-6">
-        <% {state, rows} = @dt_link %>
+        <% {link_state, link_rows} = @dt_link %>
         <.data_table
           id="pg-dt-link"
-          rows={rows}
-          state={state}
+          rows={link_rows}
+          state={link_state}
           path={
             theme_path(%{
-              active: "data-table-link",
+              active: "data-table",
               primary: @primary,
               secondary: @secondary,
               gray: @gray,
@@ -7810,10 +7795,29 @@ defmodule Dev.PlaygroundLive do
 
       <div class="mt-4">
         <p class="mb-1 text-sm text-gray-500 dark:text-gray-400">
-          The state this page decoded from the URL:
+          The state this demo decoded from the URL:
         </p>
         <pre class="p-3 overflow-x-auto text-xs rounded-lg bg-gray-100 dark:bg-gray-800"><code>{inspect(elem(@dt_link, 0), pretty: true, width: 60)}</code></pre>
       </div>
+
+      <div
+        :for={
+          ex <-
+            examples_for(
+              PetalComponents.Showcase.DataTable,
+              ~w(basic toolbar selection columns loading empty)a
+            )
+        }
+        class="mt-10"
+      >
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <.showcase_props component={PetalComponents.DataTable} function={:data_table} />
     </div>
     """
   end


### PR DESCRIPTION
## What

`/c/data-table-link` was the only variant entry in the playground sidebar - every other slug is one component, one page. This folds it into `/c/data-table` as a second live demo and deletes the separate page.

The merged page now reads: intro → **Event mode** (the existing demo: selection, bulk action, column toggle, reorder) → **Link mode** (the URL-driven table + the decoded `%State{}` block) → the six static showcase examples → props. The two wiring modes side by side make the contrast visible: sort the event table and the URL stays put; sort the link table and the URL is the state.

## How

- Registry entry removed; `data-table-link` leaves `@slugs`.
- `handle_params` aliases `c=data-table-link` → `data-table` before the `allow/3` whitelist, so old shared URLs land on the merged page with their State query params decoding as before (instead of falling through to Button). The address bar normalises on the first link-mode click.
- `maybe_run_dt_link/3` guard widened to the `data-table` slug; the dead-render query decode (#589) is unchanged.
- Link-mode intro updated: with both tables one scroll apart, "the same table" was visibly false (no selection/column controls on the link table), so the copy now carries the doctrine instead - selection and column prefs are UI state, they ride events, never URLs.

## Verified live (localhost, real browser)

- Merged page renders all sections; sidebar shows a single Data table entry; 0 console errors.
- Event sort re-sorts server-side, URL untouched; link sort patches `?order_by=…` and the decoded State block updates.
- Full reload restores link-table state from the URL; cold `curl` with query params renders sorted rows on first paint.
- Filter popover round-trips bracket-indexed params (`filters[0][field]=status…`).
- `/c/data-table-link?order_by=amount:desc&page_size=5` lands on the merged page fully decoded; URL normalises to `/c/data-table` on first interaction, `page_size` preserved.
- `mix format --check-formatted dev.exs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)