### PR TITLE
feat(timeline): a record of what happened, not a wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,33 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **New `timeline` component: a record of things that happened, in
+  order.** Activity feeds, deploy logs, order tracking, audit trails,
+  company history - the app chrome that until now meant hand-rolling a
+  rail out of raw Tailwind. It is deliberately not a stepper: stepper is
+  interactive progress you click through, timeline is an append-only
+  display with nothing to press. The root is an `<ol>` and each entry an
+  `<li>`, so screen readers announce position and count without a single
+  ARIA role being invented. Four layouts: `default` (left rail),
+  `alternating` (entries either side of a centre rail from `md` up,
+  folding back to the left rail below), `compact` (activity-feed density)
+  and `orientation="horizontal"` for milestones, which scrolls sideways
+  with CSS scroll-snap and takes keyboard focus so the scroller isn't a
+  mouse-only region. Markers are `dot`, `icon`, `avatar` (composing
+  `<.avatar>`, initials fallback included) or `number`, which counts the
+  entries for you, each in any of the seven semantic colours. Per-entry
+  `state` of `complete`, `current` or `upcoming` rings the current
+  marker, carries `aria-current="step"`, and mutes upcoming entries along
+  with the connector running into them - and because colour alone is
+  never the signal, each of those entries also carries a
+  visually-hidden state label. Connectors come `solid` or `dashed`, and
+  each entry's inner block renders below the description, so a card, a
+  diff or an image grid drops straight in. Pure CSS and HEEx: no hook,
+  nothing to wire up, and the horizontal scroller's smooth behaviour sits
+  behind a `prefers-reduced-motion` guard.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,268 @@
       transition-duration: 1ms;
     }
   }
+
+/* ==========================================================================
+   Timeline
+   A record, not a wizard - see the stepper section above for the interactive
+   sibling. The rail is a flex column (or row, when horizontal) whose connector
+   is `flex: 1`, so it always reaches the next marker no matter how tall the
+   entry's content grows. Vertical rhythm lives on the content's padding rather
+   than the <li>, so the line runs through the gap instead of stopping short.
+   ========================================================================== */
+@layer components {
+  .pc-timeline {
+    @apply m-0 list-none p-0;
+  }
+
+  .pc-timeline--vertical {
+    @apply flex flex-col;
+  }
+
+  .pc-timeline__item {
+    @apply flex gap-4;
+  }
+
+  /* Rail width is fixed rather than shrink-to-fit so a timeline that mixes dot
+     and icon markers keeps one straight line and one content indent. */
+  .pc-timeline__rail {
+    @apply flex w-8 flex-none flex-col items-center;
+  }
+
+  .pc-timeline__content {
+    @apply min-w-0 flex-1 pb-6;
+  }
+
+  .pc-timeline__item--last .pc-timeline__content {
+    @apply pb-0;
+  }
+
+  /* Markers */
+  .pc-timeline__marker {
+    @apply flex flex-none items-center justify-center rounded-full;
+  }
+
+  .pc-timeline__marker--dot {
+    @apply h-2.5 w-2.5;
+  }
+
+  .pc-timeline--vertical .pc-timeline__marker--dot {
+    @apply mt-1.5;
+  }
+
+  .pc-timeline__marker--icon,
+  .pc-timeline__marker--number,
+  .pc-timeline__marker--avatar {
+    @apply h-8 w-8;
+  }
+
+  .pc-timeline__icon {
+    @apply h-4 w-4;
+  }
+
+  .pc-timeline__number {
+    @apply text-xs font-semibold;
+  }
+
+  .pc-timeline__marker--avatar {
+    @apply bg-transparent;
+  }
+
+  /* Semantic colours. Dots carry a text colour as well as a background so the
+     current-state ring (currentColor) works the same for every marker type. */
+  .pc-timeline__marker--dot.pc-timeline__marker--primary {
+    @apply bg-primary-500 text-primary-500;
+  }
+
+  .pc-timeline__marker--dot.pc-timeline__marker--secondary {
+    @apply bg-secondary-500 text-secondary-500;
+  }
+
+  .pc-timeline__marker--dot.pc-timeline__marker--gray {
+    @apply bg-gray-400 text-gray-400;
+  }
+
+  .pc-timeline__marker--dot.pc-timeline__marker--info {
+    @apply bg-info-500 text-info-500;
+  }
+
+  .pc-timeline__marker--dot.pc-timeline__marker--success {
+    @apply bg-success-500 text-success-500;
+  }
+
+  .pc-timeline__marker--dot.pc-timeline__marker--warning {
+    @apply bg-warning-500 text-warning-500;
+  }
+
+  .pc-timeline__marker--dot.pc-timeline__marker--danger {
+    @apply bg-danger-500 text-danger-500;
+  }
+
+  .pc-timeline__marker--icon.pc-timeline__marker--primary,
+  .pc-timeline__marker--number.pc-timeline__marker--primary {
+    @apply bg-primary-50 text-primary-600 dark:bg-primary-500/15 dark:text-primary-300;
+  }
+
+  .pc-timeline__marker--icon.pc-timeline__marker--secondary,
+  .pc-timeline__marker--number.pc-timeline__marker--secondary {
+    @apply bg-secondary-50 text-secondary-600 dark:bg-secondary-500/15 dark:text-secondary-300;
+  }
+
+  .pc-timeline__marker--icon.pc-timeline__marker--gray,
+  .pc-timeline__marker--number.pc-timeline__marker--gray {
+    @apply bg-gray-100 text-gray-600 dark:bg-gray-400/15 dark:text-gray-300;
+  }
+
+  .pc-timeline__marker--icon.pc-timeline__marker--info,
+  .pc-timeline__marker--number.pc-timeline__marker--info {
+    @apply bg-info-50 text-info-600 dark:bg-info-500/15 dark:text-info-300;
+  }
+
+  .pc-timeline__marker--icon.pc-timeline__marker--success,
+  .pc-timeline__marker--number.pc-timeline__marker--success {
+    @apply bg-success-50 text-success-600 dark:bg-success-500/15 dark:text-success-300;
+  }
+
+  .pc-timeline__marker--icon.pc-timeline__marker--warning,
+  .pc-timeline__marker--number.pc-timeline__marker--warning {
+    @apply bg-warning-50 text-warning-600 dark:bg-warning-500/15 dark:text-warning-300;
+  }
+
+  .pc-timeline__marker--icon.pc-timeline__marker--danger,
+  .pc-timeline__marker--number.pc-timeline__marker--danger {
+    @apply bg-danger-50 text-danger-600 dark:bg-danger-500/15 dark:text-danger-300;
+  }
+
+  /* States. Two classes deep so they land on top of the colour rules above
+     without an `!important` fight. */
+  .pc-timeline__marker.pc-timeline__marker--current {
+    box-shadow: 0 0 0 4px color-mix(in oklab, currentColor 20%, transparent);
+  }
+
+  .pc-timeline__marker.pc-timeline__marker--upcoming {
+    @apply border-2 border-gray-300 bg-transparent text-gray-400 dark:border-gray-400/30 dark:text-gray-500;
+  }
+
+  .pc-timeline__marker--dot.pc-timeline__marker--upcoming {
+    @apply h-3 w-3;
+  }
+
+  /* Connectors */
+  .pc-timeline--vertical .pc-timeline__connector {
+    @apply my-1.5 w-0 flex-1 border-l-2 border-gray-200 dark:border-gray-400/25;
+  }
+
+  .pc-timeline--horizontal .pc-timeline__connector {
+    @apply mx-2 h-0 flex-1 border-t-2 border-gray-200 dark:border-gray-400/25;
+  }
+
+  .pc-timeline--dashed .pc-timeline__connector {
+    @apply border-dashed;
+  }
+
+  .pc-timeline__connector--upcoming {
+    @apply border-gray-100 dark:border-gray-400/12;
+  }
+
+  /* Content */
+  .pc-timeline__time {
+    @apply text-xs text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-timeline__title {
+    @apply mt-0.5 text-sm font-semibold text-gray-900 dark:text-gray-100;
+  }
+
+  .pc-timeline__description {
+    @apply mt-1 text-sm text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-timeline__body {
+    @apply mt-3;
+  }
+
+  .pc-timeline__state-label {
+    @apply sr-only;
+  }
+
+  /* Upcoming entries read as not-yet-happened, without relying on colour: the
+     visually-hidden state label is always there for screen readers. */
+  .pc-timeline__item--upcoming .pc-timeline__title {
+    @apply font-medium text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-timeline__item--upcoming .pc-timeline__description,
+  .pc-timeline__item--upcoming .pc-timeline__time {
+    @apply text-gray-400 dark:text-gray-500;
+  }
+
+  /* Alternating: a centre rail with entries either side, from md up. Below
+     that it stays the default left rail, which is the only thing that fits on
+     a phone. The rail sits in the middle grid column and each entry's content
+     takes column 1 or 3 depending on its side. */
+  .pc-timeline--alternating .pc-timeline__item {
+    @apply md:grid md:grid-cols-[1fr_2rem_1fr] md:gap-0;
+  }
+
+  .pc-timeline--alternating .pc-timeline__rail {
+    @apply md:col-start-2 md:row-start-1;
+  }
+
+  .pc-timeline--alternating .pc-timeline__item--start .pc-timeline__content {
+    @apply md:col-start-3 md:row-start-1 md:pl-4;
+  }
+
+  .pc-timeline--alternating .pc-timeline__item--end .pc-timeline__content {
+    @apply md:col-start-1 md:row-start-1 md:pr-4 md:text-right;
+  }
+
+  /* Compact: activity-feed density. Marker sizes hold so avatars stay
+     legible - it's the rhythm and the type that tighten. */
+  .pc-timeline--compact .pc-timeline__item {
+    @apply gap-3;
+  }
+
+  .pc-timeline--compact .pc-timeline__content {
+    @apply pb-4;
+  }
+
+  .pc-timeline--compact .pc-timeline__title {
+    @apply mt-0 text-[13px] font-medium;
+  }
+
+  .pc-timeline--compact .pc-timeline__description {
+    @apply mt-0.5 text-xs;
+  }
+
+  .pc-timeline--compact .pc-timeline__time {
+    @apply text-[11px];
+  }
+
+  /* Horizontal: milestones on a rail, content underneath, scrolling sideways
+     with snap points when the row outgrows its container. The list itself is
+     the scroller, so it takes focus and shows a ring - a scroll region that
+     can't be reached by keyboard is a trap for anyone not using a mouse. */
+  .pc-timeline--horizontal {
+    @apply flex snap-x snap-mandatory gap-6 overflow-x-auto pb-2;
+    @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-950;
+    border-radius: var(--pc-radius, 0.625rem);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .pc-timeline--horizontal {
+      scroll-behavior: smooth;
+    }
+  }
+
+  .pc-timeline--horizontal .pc-timeline__item {
+    @apply w-56 flex-none snap-start flex-col gap-3;
+  }
+
+  .pc-timeline--horizontal .pc-timeline__rail {
+    @apply w-full flex-row items-center;
+  }
+
+  .pc-timeline--horizontal .pc-timeline__content {
+    @apply w-full pb-0;
+  }
+}

--- a/dev.exs
+++ b/dev.exs
@@ -295,6 +295,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "card", name: "Card", ready: true},
         %{slug: "carousel", name: "Carousel", ready: true},
         %{slug: "accordion", name: "Accordion", ready: true},
+        %{slug: "timeline", name: "Timeline", ready: true},
         %{slug: "container", name: "Container", ready: true}
       ]
     },
@@ -834,6 +835,13 @@ defmodule Dev.PlaygroundLive do
        skeleton: %{animation: "pulse", loading: false},
        accordion: %{variant: "default", multiple: false, size: "md"},
        stepper: %{orientation: "horizontal", size: "md", labels: "beside", at: 0, done: false},
+       timeline: %{
+         variant: "default",
+         orientation: "vertical",
+         marker: "icon",
+         connector: "solid",
+         states: true
+       },
        toast: %{pos: "bottom-right", undone: 0},
        car: %{
          transition: "fade",
@@ -1248,6 +1256,25 @@ defmodule Dev.PlaygroundLive do
   def handle_event("ctl_stepper", %{"k" => "labels", "v" => v}, socket)
       when v in ~w(beside bottom),
       do: {:noreply, update(socket, :stepper, &%{&1 | labels: v})}
+
+  def handle_event("ctl_timeline", %{"k" => "variant", "v" => v}, socket)
+      when v in ~w(default alternating compact),
+      do: {:noreply, update(socket, :timeline, &%{&1 | variant: v})}
+
+  def handle_event("ctl_timeline", %{"k" => "orientation", "v" => v}, socket)
+      when v in ~w(vertical horizontal),
+      do: {:noreply, update(socket, :timeline, &%{&1 | orientation: v})}
+
+  def handle_event("ctl_timeline", %{"k" => "marker", "v" => v}, socket)
+      when v in ~w(dot icon avatar number),
+      do: {:noreply, update(socket, :timeline, &%{&1 | marker: v})}
+
+  def handle_event("ctl_timeline", %{"k" => "connector", "v" => v}, socket)
+      when v in ~w(solid dashed),
+      do: {:noreply, update(socket, :timeline, &%{&1 | connector: v})}
+
+  def handle_event("ctl_timeline", %{"k" => "states"}, socket),
+    do: {:noreply, update(socket, :timeline, &%{&1 | states: !&1.states})}
 
   def handle_event("ctl_carousel", %{"k" => "transition", "v" => v}, socket)
       when v in ~w(fade slide),
@@ -2356,6 +2383,56 @@ defmodule Dev.PlaygroundLive do
       }
     ]
   end
+
+  # The dial demo: one release pipeline, re-dressed by whichever marker and
+  # state the dials are set to.
+  defp pg_timeline_entries(tl) do
+    [
+      %{
+        icon: "hero-code-bracket",
+        name: "Alex Chen",
+        color: "gray",
+        time: "9:41am",
+        title: "Commit pushed",
+        description: "fix: retry the webhook worker with a backoff"
+      },
+      %{
+        icon: "hero-check-circle",
+        name: "Sam Rivera",
+        color: "success",
+        time: "9:47am",
+        title: "CI passed",
+        description: "418 tests, 2m 51s"
+      },
+      %{
+        icon: "hero-rocket-launch",
+        name: "Jo Park",
+        color: "primary",
+        time: "9:52am",
+        title: "Deploying to production",
+        description: "Rolling through Sydney, Dublin and Ohio."
+      },
+      %{
+        icon: "hero-bell-alert",
+        name: "Robin Lee",
+        color: "primary",
+        time: "in a few minutes",
+        title: "Release notes published",
+        description: "Sent to everyone watching the repo."
+      }
+    ]
+    |> Enum.with_index()
+    |> Enum.map(fn {entry, i} ->
+      entry
+      |> Map.put(:marker, tl.marker)
+      |> Map.put(:state, pg_timeline_state(tl.states, i))
+    end)
+  end
+
+  defp pg_timeline_state(false, _index), do: "complete"
+  defp pg_timeline_state(true, index) when index < 2, do: "complete"
+  defp pg_timeline_state(true, 2), do: "current"
+  defp pg_timeline_state(true, _index), do: "upcoming"
 
   defp pg_step_defs do
     [
@@ -5862,6 +5939,151 @@ defmodule Dev.PlaygroundLive do
         These examples render from the shared <code>PetalComponents.Showcase.Stepper</code>
         registry - the same source petal.build renders, so the playground and the marketing
         docs can't drift. (The wizard above is playground-only - its steps push events.)
+      </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "timeline"} = assigns) do
+    ~H"""
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">Timeline</h1>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        A record of things that happened - activity feeds, deploy logs, order tracking,
+        company history. Nothing here is clickable: if the user is meant to move through
+        it, you want the stepper instead.
+      </p>
+      <div class="mt-8 border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="px-6 py-8">
+          <.timeline
+            orientation={@timeline.orientation}
+            variant={@timeline.variant}
+            connector={@timeline.connector}
+            label="Release pipeline"
+          >
+            <:item
+              :for={e <- pg_timeline_entries(@timeline)}
+              marker={e.marker}
+              icon={e.icon}
+              name={e.name}
+              color={e.color}
+              state={e.state}
+              time={e.time}
+              title={e.title}
+              description={e.description}
+            />
+          </.timeline>
+        </div>
+        <div class="grid gap-5 px-6 py-5 border-t border-gray-100 md:grid-cols-2 dark:border-gray-800/80">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">orientation</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Orientation"
+              value={@timeline.orientation}
+              on_change="ctl_timeline"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={o <- ~w(vertical horizontal)}
+                value={o}
+                phx-value-k="orientation"
+                phx-value-v={o}
+              >
+                {o}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">variant</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Variant"
+              value={@timeline.variant}
+              on_change="ctl_timeline"
+              disabled={@timeline.orientation == "horizontal"}
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={v <- ~w(default alternating compact)}
+                value={v}
+                phx-value-k="variant"
+                phx-value-v={v}
+              >
+                {v}
+              </:item>
+            </.toggle_group>
+            <div :if={@timeline.orientation == "horizontal"} class="mt-1.5 text-[10px] text-gray-400">
+              vertical only
+            </div>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">marker</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Marker"
+              value={@timeline.marker}
+              on_change="ctl_timeline"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={m <- ~w(dot icon avatar number)}
+                value={m}
+                phx-value-k="marker"
+                phx-value-v={m}
+              >
+                {m}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">connector</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Connector"
+              value={@timeline.connector}
+              on_change="ctl_timeline"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item :for={c <- ~w(solid dashed)} value={c} phx-value-k="connector" phx-value-v={c}>
+                {c}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div class="md:col-span-2">
+            <.button
+              size="sm"
+              color="gray"
+              variant={if(@timeline.states, do: "solid", else: "outline")}
+              phx-click="ctl_timeline"
+              phx-value-k="states"
+            >
+              {if @timeline.states,
+                do: "States on: complete, current, upcoming",
+                else: "States off: everything complete"}
+            </.button>
+          </div>
+        </div>
+      </div>
+      <div :for={ex <- PetalComponents.Showcase.Timeline.examples()} class="mt-10">
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
+      <.showcase_props component={PetalComponents.Timeline} function={:timeline} />
+
+      <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        These examples render from the shared <code>PetalComponents.Showcase.Timeline</code>
+        registry - the same source petal.build renders, so the playground and the marketing
+        docs can't drift. (The pipeline above is playground-only - its dials push events.)
       </div>
     </div>
     """

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -67,6 +67,7 @@ defmodule PetalComponents do
         SpotlightCard,
         Stepper,
         Table,
+        Timeline,
         Toast,
         Tabs,
         ToggleGroup,

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -53,6 +53,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.Table,
     PetalComponents.Showcase.Tabs,
     PetalComponents.Showcase.TextAnimation,
+    PetalComponents.Showcase.Timeline,
     PetalComponents.Showcase.Toast,
     PetalComponents.Showcase.ToggleGroup,
     PetalComponents.Showcase.Tooltip,

--- a/lib/petal_components/showcase/timeline.ex
+++ b/lib/petal_components/showcase/timeline.ex
@@ -1,0 +1,167 @@
+defmodule PetalComponents.Showcase.Timeline do
+  @moduledoc false
+  use PetalComponents.Showcase, component: PetalComponents.Timeline, title: "Timeline"
+
+  example :order_tracking, "Order tracking",
+    description:
+      "The default left rail. Icon markers carry the meaning of each step, the entry in flight is state=\"current\" (ringed, and the only one with aria-current), and everything after it is upcoming - muted, hollow marker, faded line running into it." do
+    ~H"""
+    <.timeline label="Order history">
+      <:item
+        marker="icon"
+        icon="hero-check"
+        color="success"
+        time="Mon 9:41am"
+        title="Order placed"
+        description="Payment authorised, receipt emailed."
+      />
+      <:item
+        marker="icon"
+        icon="hero-cube"
+        color="success"
+        time="Mon 4:20pm"
+        title="Packed"
+        description="Picked and boxed at the Melbourne warehouse."
+      />
+      <:item
+        marker="icon"
+        icon="hero-truck"
+        state="current"
+        time="Tue 7:05am"
+        title="Out for delivery"
+        description="With the courier, tracking updates every 20 minutes."
+      />
+      <:item
+        marker="icon"
+        icon="hero-home"
+        state="upcoming"
+        time="Tue, by 6pm"
+        title="Delivered"
+        description="Signature required."
+      />
+    </.timeline>
+    """
+  end
+
+  example :activity_feed, "Activity feed",
+    description:
+      "variant=\"compact\" is the density you want for a feed: tighter rhythm, smaller type, avatar markers. Timestamps are plain strings here - swap in <.local_time format=\"relative\"> and they stay right without a re-render." do
+    ~H"""
+    <.timeline variant="compact" label="Recent activity">
+      <:item
+        marker="avatar"
+        name="Alex Chen"
+        time="12 minutes ago"
+        title="Alex pushed 3 commits to main"
+        description="Fix the retry backoff on the webhook worker"
+      />
+      <:item
+        marker="icon"
+        icon="hero-check-circle"
+        color="success"
+        time="9 minutes ago"
+        title="CI passed"
+        description="418 tests, 2m 51s"
+      />
+      <:item
+        marker="avatar"
+        name="Sam Rivera"
+        time="6 minutes ago"
+        title="Sam approved the release"
+      />
+      <:item
+        marker="icon"
+        icon="hero-rocket-launch"
+        state="current"
+        time="just now"
+        title="Deploying v4.2.0 to production"
+      />
+    </.timeline>
+    """
+  end
+
+  example :rich_entries, "Rich entry bodies",
+    description:
+      "Anything in an entry's inner block renders under the description, in every variant - a card, a diff, a thumbnail grid. Dashed connectors suit a log that has gaps in it." do
+    ~H"""
+    <.timeline connector="dashed">
+      <:item color="gray" time="Yesterday" title="Incident opened">
+        <div class="p-3 mt-3 text-sm border border-gray-200 rounded-lg text-gray-600 dark:border-gray-400/17 dark:text-gray-300">
+          <span class="font-mono text-xs">api-gateway</span>
+          returned 503 for 4% of requests over 11 minutes.
+        </div>
+      </:item>
+      <:item color="success" time="Today" title="Resolved" description="Connection pool doubled.">
+        <div class="flex gap-2 mt-3">
+          <.badge color="success" label="No customer impact" />
+          <.badge color="gray" label="Postmortem filed" />
+        </div>
+      </:item>
+    </.timeline>
+    """
+  end
+
+  example :alternating, "Alternating",
+    description:
+      "variant=\"alternating\" swings entries either side of a centre rail from md up, and folds back to the default left rail below that - two columns of text on a phone is not a timeline, it's a puzzle." do
+    ~H"""
+    <.timeline variant="alternating">
+      <:item
+        marker="number"
+        time="2019"
+        title="Founded"
+        description="Two people, one office above a bakery."
+      />
+      <:item
+        marker="number"
+        time="2021"
+        title="Series A"
+        description="Team of 14, first 1,000 customers."
+      />
+      <:item
+        marker="number"
+        time="2023"
+        title="Went global"
+        description="Regions in Sydney, Dublin and Ohio."
+      />
+    </.timeline>
+    """
+  end
+
+  example :horizontal, "Horizontal milestones",
+    description:
+      "orientation=\"horizontal\" puts the rail across the top with content underneath. It scrolls sideways with snap points when the row runs out of room, and the scroller takes keyboard focus so arrow keys work." do
+    ~H"""
+    <.timeline orientation="horizontal" label="Company milestones">
+      <:item
+        marker="number"
+        color="gray"
+        time="Q1"
+        title="Research"
+        description="40 customer interviews."
+      />
+      <:item
+        marker="number"
+        color="gray"
+        time="Q2"
+        title="Private beta"
+        description="200 teams on the waitlist."
+      />
+      <:item
+        marker="number"
+        state="current"
+        time="Q3"
+        title="Launch"
+        description="Public pricing goes live."
+      />
+      <:item
+        marker="number"
+        state="upcoming"
+        time="Q4"
+        title="Enterprise"
+        description="SSO, audit logs, SLAs."
+      />
+    </.timeline>
+    """
+  end
+end

--- a/lib/petal_components/timeline.ex
+++ b/lib/petal_components/timeline.ex
@@ -1,0 +1,271 @@
+defmodule PetalComponents.Timeline do
+  @moduledoc """
+  A record of things that happened, in order: activity feeds, deploy logs,
+  order tracking, audit trails, company history.
+
+  ## Timeline or stepper?
+
+  `PetalComponents.Stepper` is **interactive progress** - clickable steps in a
+  flow the user is moving through, with a notion of "where you are" that the app
+  changes as they work. A timeline is a **record** - an append-only display of
+  events. Nothing in it is clickable, nothing pushes an event, and the entries
+  are whatever your data says they are. If the user is meant to navigate it,
+  reach for `stepper/1`; if they are meant to read it, reach for `timeline/1`.
+
+  ## Anatomy
+
+  The root is an `<ol>` and each entry is an `<li>`, so screen readers announce
+  position and count with no ARIA at all. Every entry has a marker on a rail, a
+  connector to the next entry, and content: an optional time, title and
+  description, plus an inner block for anything richer.
+
+      <.timeline>
+        <:item time="9:41am" title="Order placed" description="Payment authorised." />
+        <:item time="11:02am" title="Packed" description="Left the Melbourne warehouse." />
+        <:item time="Tomorrow" title="Delivered" state="upcoming" />
+      </.timeline>
+
+  ## Variants
+
+  `default` is a left rail with the content beside it. `alternating` swings
+  entries either side of a centre rail on `md` and up (collapsing back to
+  `default` below). `compact` is activity-feed density - tighter spacing and
+  smaller type, which is what you want with avatar markers:
+
+      <.timeline variant="compact">
+        <:item
+          marker="avatar"
+          src={~p"/images/alex.jpg"}
+          name="Alex Chen"
+          time="12 minutes ago"
+          title="Alex pushed 3 commits"
+        />
+        <:item marker="icon" icon="hero-check-circle" color="success" time="10 minutes ago" title="CI passed" />
+      </.timeline>
+
+  `orientation="horizontal"` is the milestones layout instead - markers on a
+  horizontal rail with content underneath, scrolling sideways with CSS
+  scroll-snap when the row runs out of room. The `variant` attr is vertical-only
+  and is ignored when horizontal.
+
+  ## Markers
+
+  `marker` takes `"dot"` (the default), `"icon"` (pass `icon`), `"avatar"` (pass
+  `src` and/or `name`, exactly as `PetalComponents.Avatar.avatar/1` takes them),
+  or `"number"`, which prints the entry's 1-based position for you. `color`
+  paints the marker in any of the seven semantic colours.
+
+  ## States
+
+  `state` is `"complete"` (default), `"current"` or `"upcoming"`. The current
+  entry is ringed and carries `aria-current="step"`; upcoming entries render
+  muted with a hollow marker, and the connector running down to them is
+  de-emphasised.
+
+  ## Accessibility
+
+  There is no WAI-ARIA pattern for a timeline, so this leans on native list
+  semantics rather than inventing a role.
+
+    * `<ol>` root, `<li>` entries. No `role` overrides, no interactive wrappers.
+    * `aria-current="step"` on the current entry, and nowhere else.
+    * The rail (markers and connectors) is decorative and `aria-hidden`. State
+      is never conveyed by colour alone - `current` and `upcoming` entries each
+      carry a visually-hidden label.
+    * The horizontal scroll container takes focus so it can be scrolled by
+      keyboard, with a visible focus ring, and its smooth scrolling is behind a
+      `prefers-reduced-motion` guard.
+
+  Rich content in the inner block renders below the description, in every
+  variant:
+
+      <.timeline>
+        <:item time="2 hours ago" title="Deployed v4.2.0 to production">
+          <.card class="mt-3">
+            <.card_content>Rolled out to all regions in 3m 12s.</.card_content>
+          </.card>
+        </:item>
+      </.timeline>
+  """
+  use Phoenix.Component
+
+  import PetalComponents.Avatar
+  import PetalComponents.Icon
+
+  @colors ~w(primary secondary gray info success warning danger)
+  @markers ~w(dot icon avatar number)
+  @states ~w(complete current upcoming)
+
+  attr :orientation, :string,
+    default: "vertical",
+    values: ["vertical", "horizontal"],
+    doc: "horizontal is the milestones layout; scroll-snaps on small screens"
+
+  attr :variant, :string,
+    default: "default",
+    values: ["default", "alternating", "compact"],
+    doc: """
+    vertical only, ignored when horizontal.
+    default: left rail with entries to the right.
+    alternating: entries alternate sides of a centre rail on md and up, collapsing to default below.
+    compact: activity-feed density (tighter spacing, smaller type, suits avatar markers).
+    """
+
+  attr :connector, :string,
+    default: "solid",
+    values: ["solid", "dashed"],
+    doc: "line style of the rail between markers"
+
+  attr :label, :string,
+    default: nil,
+    doc:
+      "accessible name for the list, announced instead of the generic \"list\" (e.g. \"Order history\")"
+
+  attr :class, :any, default: nil, doc: "CSS class on the root list"
+  attr :rest, :global
+
+  slot :item, required: true, doc: "one entry per event, rendered in author order" do
+    attr :title, :string, doc: "entry heading"
+
+    attr :time, :string,
+      doc:
+        "plain-text timestamp; omit and slot in <.local_time> yourself for client-side formatting"
+
+    attr :description, :string, doc: "one-line body; use the inner block instead for rich content"
+    attr :marker, :string, doc: ~s|"dot" (default), "icon", "avatar", or "number"|
+    attr :icon, :string, doc: ~s|heroicon name when marker="icon", e.g. "hero-truck"|
+    attr :src, :string, doc: ~s|image URL when marker="avatar"|
+
+    attr :name, :string,
+      doc:
+        ~s|fallback initials source when marker="avatar" and src is absent (matches <.avatar> behaviour)|
+
+    attr :color, :string,
+      doc:
+        ~s|semantic colour of the marker: "primary" (default), "secondary", "gray", "info", "success", "warning", "danger"|
+
+    attr :state, :string,
+      doc:
+        ~s|"complete" (default), "current", or "upcoming". current gets a ringed marker + aria-current="step"; upcoming renders muted with the connector into it de-emphasised|
+
+    attr :class, :any, doc: "CSS class on this entry's <li>"
+  end
+
+  @doc """
+  Renders a timeline of events.
+
+  See `PetalComponents.Timeline` for the variants, markers, states and the
+  accessibility contract.
+  """
+  def timeline(assigns) do
+    assigns =
+      assigns
+      |> assign(:entries, entries(assigns.item))
+      |> assign(:horizontal?, assigns.orientation == "horizontal")
+
+    ~H"""
+    <ol
+      class={[
+        "pc-timeline",
+        "pc-timeline--#{@orientation}",
+        !@horizontal? && "pc-timeline--#{@variant}",
+        @connector == "dashed" && "pc-timeline--dashed",
+        @class
+      ]}
+      aria-label={@label}
+      tabindex={@horizontal? && "0"}
+      {@rest}
+    >
+      <li
+        :for={entry <- @entries}
+        class={[
+          "pc-timeline__item",
+          "pc-timeline__item--#{entry.state}",
+          entry.side && "pc-timeline__item--#{entry.side}",
+          entry.last? && "pc-timeline__item--last",
+          entry.class
+        ]}
+        aria-current={entry.state == "current" && "step"}
+      >
+        <div class="pc-timeline__rail" aria-hidden="true">
+          <span class={[
+            "pc-timeline__marker",
+            "pc-timeline__marker--#{entry.marker}",
+            "pc-timeline__marker--#{entry.color}",
+            "pc-timeline__marker--#{entry.state}"
+          ]}>
+            <.icon :if={entry.marker == "icon"} name={entry.icon} class="pc-timeline__icon" />
+            <span :if={entry.marker == "number"} class="pc-timeline__number">{entry.index + 1}</span>
+            <.avatar
+              :if={entry.marker == "avatar"}
+              src={entry.src}
+              name={entry.name}
+              alt={entry.name}
+              size="sm"
+              class="pc-timeline__avatar"
+            />
+          </span>
+          <span
+            :if={!entry.last?}
+            class={[
+              "pc-timeline__connector",
+              entry.next_state == "upcoming" && "pc-timeline__connector--upcoming"
+            ]}
+          />
+        </div>
+        <div class="pc-timeline__content">
+          <span :if={state_label(entry.state)} class="pc-timeline__state-label">
+            {state_label(entry.state)}
+          </span>
+          <div :if={entry.time} class="pc-timeline__time">{entry.time}</div>
+          <h3 :if={entry.title} class="pc-timeline__title">{entry.title}</h3>
+          <p :if={entry.description} class="pc-timeline__description">{entry.description}</p>
+          <div :if={entry.body?} class="pc-timeline__body">{render_slot(entry.slot)}</div>
+        </div>
+      </li>
+    </ol>
+    """
+  end
+
+  # Flattens each :item slot into everything the markup needs, so the template
+  # stays a straight loop: defaults applied, 1-based numbering resolved, and the
+  # neighbour lookups (last entry, next entry's state) done once.
+  defp entries(items) do
+    states = Enum.map(items, &one_of(&1, :state, @states, "complete"))
+    count = length(items)
+
+    items
+    |> Enum.with_index()
+    |> Enum.map(fn {item, index} ->
+      %{
+        slot: item,
+        index: index,
+        last?: index == count - 1,
+        state: Enum.at(states, index),
+        next_state: Enum.at(states, index + 1),
+        side: if(rem(index, 2) == 0, do: "start", else: "end"),
+        marker: one_of(item, :marker, @markers, "dot"),
+        color: one_of(item, :color, @colors, "primary"),
+        icon: Map.get(item, :icon) || "hero-check",
+        src: Map.get(item, :src),
+        name: Map.get(item, :name),
+        time: Map.get(item, :time),
+        title: Map.get(item, :title),
+        description: Map.get(item, :description),
+        class: Map.get(item, :class),
+        body?: item.inner_block != nil
+      }
+    end)
+  end
+
+  # Slot attrs are free-form strings, so an unknown value falls back to the
+  # default rather than emitting a class nothing styles.
+  defp one_of(item, key, allowed, default) do
+    value = Map.get(item, key)
+    if value in allowed, do: value, else: default
+  end
+
+  defp state_label("current"), do: "Current"
+  defp state_label("upcoming"), do: "Upcoming"
+  defp state_label(_), do: nil
+end

--- a/test/petal/timeline_test.exs
+++ b/test/petal/timeline_test.exs
@@ -1,0 +1,490 @@
+defmodule PetalComponents.TimelineTest do
+  use ComponentCase
+
+  import PetalComponents.Timeline
+
+  describe "structure" do
+    test "renders an ordered list with one item per entry" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="Placed" />
+          <:item title="Packed" />
+          <:item title="Delivered" />
+        </.timeline>
+        """)
+
+      doc = LazyHTML.from_fragment(html)
+
+      assert doc |> LazyHTML.query("ol.pc-timeline") |> Enum.count() == 1
+      assert doc |> LazyHTML.query("ol.pc-timeline > li.pc-timeline__item") |> Enum.count() == 3
+      assert html =~ "Placed"
+      assert html =~ "Delivered"
+    end
+
+    test "renders time, title and description" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item time="9:41am" title="Order placed" description="Payment authorised." />
+        </.timeline>
+        """)
+
+      doc = LazyHTML.from_fragment(html)
+
+      assert doc |> LazyHTML.query(".pc-timeline__time") |> LazyHTML.text() =~ "9:41am"
+      assert doc |> LazyHTML.query("h3.pc-timeline__title") |> LazyHTML.text() =~ "Order placed"
+
+      assert doc |> LazyHTML.query("p.pc-timeline__description") |> LazyHTML.text() =~
+               "Payment authorised."
+    end
+
+    test "omits the optional parts when they aren't given" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="Just a title" />
+        </.timeline>
+        """)
+
+      refute html =~ "pc-timeline__time"
+      refute html =~ "pc-timeline__description"
+      refute html =~ "pc-timeline__body"
+    end
+
+    test "the last entry drops its connector and its trailing space" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" />
+          <:item title="Two" />
+          <:item title="Three" />
+        </.timeline>
+        """)
+
+      doc = LazyHTML.from_fragment(html)
+
+      assert doc |> LazyHTML.query(".pc-timeline__connector") |> Enum.count() == 2
+      assert doc |> LazyHTML.query("li.pc-timeline__item--last") |> Enum.count() == 1
+    end
+
+    test "class and rest pass through to the root" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline class="my-timeline" id="deploys" data-testid="tl">
+          <:item title="One" />
+        </.timeline>
+        """)
+
+      root = html |> LazyHTML.from_fragment() |> LazyHTML.query("ol")
+
+      assert_has_class(html, "my-timeline")
+      assert LazyHTML.attribute(root, "id") == ["deploys"]
+      assert LazyHTML.attribute(root, "data-testid") == ["tl"]
+    end
+
+    test "an entry takes its own class" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" class="entry-one" />
+        </.timeline>
+        """)
+
+      assert html |> LazyHTML.from_fragment() |> LazyHTML.query("li.entry-one") |> Enum.count() ==
+               1
+    end
+  end
+
+  describe "variants and orientation" do
+    test "defaults to a vertical default-variant list" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" />
+        </.timeline>
+        """)
+
+      assert_has_class(html, "pc-timeline--vertical")
+      assert_has_class(html, "pc-timeline--default")
+      refute_has_class(html, "pc-timeline--horizontal")
+    end
+
+    test "each variant emits its modifier class" do
+      for variant <- ~w(default alternating compact) do
+        assigns = %{variant: variant}
+
+        html =
+          rendered_to_string(~H"""
+          <.timeline variant={@variant}>
+            <:item title="One" />
+          </.timeline>
+          """)
+
+        assert_has_class(html, "pc-timeline--#{variant}")
+      end
+    end
+
+    test "alternating sides alternate by entry index" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline variant="alternating">
+          <:item title="One" />
+          <:item title="Two" />
+          <:item title="Three" />
+        </.timeline>
+        """)
+
+      doc = LazyHTML.from_fragment(html)
+
+      assert doc |> LazyHTML.query("li.pc-timeline__item--start") |> Enum.count() == 2
+      assert doc |> LazyHTML.query("li.pc-timeline__item--end") |> Enum.count() == 1
+    end
+
+    test "horizontal drops the variant class and takes keyboard focus" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline orientation="horizontal" variant="compact">
+          <:item title="One" />
+        </.timeline>
+        """)
+
+      assert_has_class(html, "pc-timeline--horizontal")
+      refute_has_class(html, "pc-timeline--compact")
+      assert_attribute(html, "tabindex", "0")
+    end
+
+    test "vertical timelines aren't focus targets" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" />
+        </.timeline>
+        """)
+
+      refute_attribute(html, "tabindex")
+    end
+  end
+
+  describe "connector" do
+    test "solid is the default and emits no modifier" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" />
+          <:item title="Two" />
+        </.timeline>
+        """)
+
+      refute_has_class(html, "pc-timeline--dashed")
+    end
+
+    test "dashed emits the modifier class" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline connector="dashed">
+          <:item title="One" />
+          <:item title="Two" />
+        </.timeline>
+        """)
+
+      assert_has_class(html, "pc-timeline--dashed")
+    end
+
+    test "the connector running into an upcoming entry is de-emphasised" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" />
+          <:item title="Two" state="upcoming" />
+          <:item title="Three" state="upcoming" />
+        </.timeline>
+        """)
+
+      doc = LazyHTML.from_fragment(html)
+
+      assert doc |> LazyHTML.query(".pc-timeline__connector--upcoming") |> Enum.count() == 2
+    end
+  end
+
+  describe "markers" do
+    test "dot is the default marker, in primary" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" />
+        </.timeline>
+        """)
+
+      assert_has_class(html, "pc-timeline__marker--dot")
+      assert_has_class(html, "pc-timeline__marker--primary")
+    end
+
+    test "every semantic colour renders its modifier" do
+      for color <- ~w(primary secondary gray info success warning danger) do
+        assigns = %{color: color}
+
+        html =
+          rendered_to_string(~H"""
+          <.timeline>
+            <:item title="One" color={@color} />
+          </.timeline>
+          """)
+
+        assert_has_class(html, "pc-timeline__marker--#{color}")
+      end
+    end
+
+    test "an unknown colour or marker falls back to the default" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" color="chartreuse" marker="hologram" />
+        </.timeline>
+        """)
+
+      assert_has_class(html, "pc-timeline__marker--primary")
+      assert_has_class(html, "pc-timeline__marker--dot")
+      refute_has_class(html, "pc-timeline__marker--chartreuse")
+      refute_has_class(html, "pc-timeline__marker--hologram")
+    end
+
+    test "icon markers render the heroicon" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="Out for delivery" marker="icon" icon="hero-truck" color="info" />
+        </.timeline>
+        """)
+
+      assert has_icon?(html, "hero-truck")
+      assert_has_class(html, "pc-timeline__marker--icon")
+    end
+
+    test "number markers count from one" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" marker="number" />
+          <:item title="Two" marker="number" />
+          <:item title="Three" marker="number" />
+        </.timeline>
+        """)
+
+      numbers =
+        html
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query(".pc-timeline__number")
+        |> Enum.map(&(&1 |> LazyHTML.text() |> String.trim()))
+
+      assert numbers == ["1", "2", "3"]
+    end
+
+    test "avatar markers render an image, and fall back to initials" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline variant="compact">
+          <:item title="Alex pushed" marker="avatar" src="/images/alex.jpg" name="Alex Chen" />
+          <:item title="Sam approved" marker="avatar" name="Sam Rivera" />
+        </.timeline>
+        """)
+
+      doc = LazyHTML.from_fragment(html)
+      img = LazyHTML.query(doc, ".pc-timeline__marker--avatar img")
+
+      assert LazyHTML.attribute(img, "src") == ["/images/alex.jpg"]
+      assert LazyHTML.attribute(img, "alt") == ["Alex Chen"]
+      assert html =~ "SR"
+    end
+  end
+
+  describe "states" do
+    test "entries default to complete" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" />
+        </.timeline>
+        """)
+
+      assert_has_class(html, "pc-timeline__item--complete")
+      assert_has_class(html, "pc-timeline__marker--complete")
+    end
+
+    test "each state emits its modifier on the item and the marker" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" state="complete" />
+          <:item title="Two" state="current" />
+          <:item title="Three" state="upcoming" />
+        </.timeline>
+        """)
+
+      doc = LazyHTML.from_fragment(html)
+
+      for state <- ~w(complete current upcoming) do
+        assert doc |> LazyHTML.query("li.pc-timeline__item--#{state}") |> Enum.count() == 1
+        assert doc |> LazyHTML.query(".pc-timeline__marker--#{state}") |> Enum.count() == 1
+      end
+    end
+  end
+
+  describe "accessibility" do
+    test "aria-current is on the current entry and nowhere else" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" />
+          <:item title="Two" state="current" />
+          <:item title="Three" state="upcoming" />
+        </.timeline>
+        """)
+
+      doc = LazyHTML.from_fragment(html)
+      current = LazyHTML.query(doc, "li[aria-current]")
+
+      assert Enum.count(current) == 1
+      assert LazyHTML.attribute(current, "aria-current") == ["step"]
+      assert current |> LazyHTML.text() =~ "Two"
+    end
+
+    test "the rail is hidden from assistive tech" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" marker="icon" icon="hero-truck" />
+          <:item title="Two" />
+        </.timeline>
+        """)
+
+      doc = LazyHTML.from_fragment(html)
+      rails = LazyHTML.query(doc, ".pc-timeline__rail")
+
+      assert Enum.count(rails) == 2
+      assert LazyHTML.attribute(rails, "aria-hidden") == ["true", "true"]
+
+      assert doc
+             |> LazyHTML.query(".pc-timeline__rail[aria-hidden] .pc-timeline__marker")
+             |> Enum.count() == 2
+    end
+
+    test "state is carried by text, not colour alone" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" />
+          <:item title="Two" state="current" />
+          <:item title="Three" state="upcoming" />
+        </.timeline>
+        """)
+
+      labels =
+        html
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query(".pc-timeline__state-label")
+        |> Enum.map(&(&1 |> LazyHTML.text() |> String.trim()))
+
+      assert labels == ["Current", "Upcoming"]
+    end
+
+    test "no role overrides are invented on the list" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="One" />
+        </.timeline>
+        """)
+
+      refute html =~ ~s(role="list")
+      refute html =~ ~s(role="listitem")
+      refute html =~ "<button"
+    end
+
+    test "label names the list" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline label="Order history">
+          <:item title="One" />
+        </.timeline>
+        """)
+
+      assert_attribute(html, "aria-label", "Order history")
+    end
+  end
+
+  describe "inner block" do
+    test "renders rich content inside the entry body" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.timeline>
+          <:item title="Deployed" description="v4.2.0">
+            <p class="release-notes">Rolled out to all regions.</p>
+          </:item>
+          <:item title="Nothing extra" />
+        </.timeline>
+        """)
+
+      doc = LazyHTML.from_fragment(html)
+
+      assert doc |> LazyHTML.query(".pc-timeline__body") |> Enum.count() == 1
+
+      assert doc
+             |> LazyHTML.query(".pc-timeline__content .pc-timeline__body p.release-notes")
+             |> LazyHTML.text() =~
+               "Rolled out to all regions."
+    end
+  end
+end


### PR DESCRIPTION
Closes #612

## What this is

`<.timeline>` - a record of things that happened, in order: activity feeds, deploy logs, order tracking, audit trails, company history. Pure presentational, zero JS.

The moduledoc leads with the stepper distinction the issue asked for: stepper is interactive progress you click through, timeline is an append-only display with nothing to press.

Shipped:

- **Root is an `<ol>`, entries are `<li>`.** No invented roles, no button wrappers. `aria-current="step"` on the current entry and nowhere else, rail and markers `aria-hidden`, and a visually-hidden state label ("Current" / "Upcoming") so state is never carried by colour alone.
- **Four layouts.** `default` (left rail), `alternating` (either side of a centre rail from `md` up, folding back to the left rail below), `compact` (activity-feed density), and `orientation="horizontal"` milestones - a scroll-snapping row that takes keyboard focus with a visible ring, and whose smooth scrolling sits behind a `prefers-reduced-motion` guard.
- **Four markers.** `dot`, `icon`, `avatar` (composing `<.avatar>`, initials fallback included) and `number`, which prints the 1-based index for you. All seven semantic colours.
- **Three per-entry states.** `complete`, `current` (ringed + `aria-current`), `upcoming` (hollow marker, muted type, and the connector running *into* it de-emphasised).
- `solid` / `dashed` connectors, and each entry's inner block renders below the description, so a card, a diff or an image grid drops straight in.
- Light and dark throughout, gray ramp only.

## Deviations from the issue's API sketch

Two small additions, no removals or renames:

1. **`label` attr on the root.** The sketch had no way to name the list. An `<ol>` with four entries announces as "list, 4 items" with no idea what of, so `label` sets `aria-label` ("Order history", "Recent activity"). Optional; omit it and nothing changes.
2. **`class` on the `:item` slot.** Per-entry styling had no escape hatch otherwise, and every other slot-based component in the library has one.

Two judgement calls worth flagging:

3. **Unknown `marker` / `color` / `state` values fall back to the default rather than emitting a class nothing styles.** Slot attrs can't carry `values:` validation, so `color="chartreuse"` silently produced a dead `pc-timeline__marker--chartreuse` class in the naive version. Now it renders as primary. Tested.
4. **No bespoke surface on `.pc-timeline__body`,** so the "radius token for card-like entry bodies" checkbox is honoured by composition rather than by a rule of our own: the body is an unstyled wrapper and the radius comes from whatever you slot into it (usually `<.card>`, which already consumes `--pc-radius`). Adding a second card surface here would duplicate the token in a place users would immediately want to override. The horizontal scroller does consume `--pc-radius` for its focus ring.

## Implementation notes

- **The connector is `flex: 1`, and the vertical rhythm lives on the content's padding, not the `<li>`.** That way the line always reaches the next marker no matter how tall an entry's body grows, and it runs *through* the gap instead of stopping short of it. Last entry drops both.
- **Rail width is fixed (`w-8`), not shrink-to-fit.** A timeline that mixes dot and icon markers otherwise gets a kinked line and a ragged content indent.
- **Dot markers carry a text colour as well as a background** so the current-state ring can be one rule - `box-shadow: 0 0 0 4px color-mix(in oklab, currentColor 20%, transparent)` - rather than seven.
- **State rules are two classes deep** (`.pc-timeline__marker.pc-timeline__marker--upcoming`) so they beat the colour rules on specificity without an `!important` fight.
- **Alternating is a 3-column grid at `md`+** with the rail pinned to the middle column and each entry's content taking column 1 or 3 by index parity. Below `md` it's the plain flex row, because two columns of text on a phone is a puzzle, not a timeline.
- **New CSS lives inside its own `@layer components` block** at the end of `assets/default.css`, appended - nothing above it moved.
- **Slot flattening happens once** in a private `entries/1` before the template, so the markup stays a straight loop and the neighbour lookups (last entry, next entry's state) aren't re-derived per element.

## Verification

| Check | Result |
|---|---|
| `mix format --check-formatted` | clean |
| `mix compile --force --warnings-as-errors` | clean |
| `mix test` | 913 -> **941 tests, 0 failures, 1 skipped** (28 new) |
| `npm test` | **157 passing**, unchanged (no JS hook shipped) |
| `mix credo` | 14 refactoring / 31 readability on `main`, **identical** on this branch - zero new entries |

Tests cover the `<ol>`/`<li>` structure, every variant and orientation modifier, both connector styles plus the upcoming-connector de-emphasis, all four marker types (including 1-based numbering and the avatar initials fallback), all seven colours, the unknown-value fallbacks, every state modifier, `aria-current` presence *and* absence, the `aria-hidden` rail, the visually-hidden state labels, absence of `role="list"` / `<button>`, inner-block rendering, and `class` / `rest` pass-through.

Manually exercised in the playground at `/c/timeline`: every dial, light and dark, and the horizontal variant's scroll-snap at mobile width.

## Screenshots

Light and dark captures of the full `/c/timeline` page are taken and will be attached here before this leaves draft.
