### PR TITLE
feat(number_field): a real spinbutton for quantities, prices and percentages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,35 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **New `number_field` component: a real spinbutton for quantities,
+  prices and percentages, in place of a bare
+  `<input type="number">`.** The native number input has spinners you
+  can't style, that differ in every browser, and a value the browser
+  sanitises out from under you the moment you try to format it. This one
+  is a text input carrying `role="spinbutton"` on the existing
+  `input_group` surface, so it inherits the border, radius, focus ring
+  and error tone the rest of the form family already uses, and the
+  steppers are ours to draw. Three variants: `stacked` chevrons at the
+  inline end, `split` minus and plus with the value centred - the cart
+  quantity look - and `plain` for keyboard only. `min`, `max` and `step`
+  clamp and mirror to `aria-valuemin` / `aria-valuemax` /
+  `aria-valuenow`; `big_step` (defaulting to ten steps) rides
+  shift+arrow and page up/down; Home and End jump to the bounds.
+  `precision` rounds and pads on blur while the raw text stands while
+  you type, so `7.5` becomes `7.50` only once you're done - and the
+  moduledoc documents the `Intl.NumberFormat` pattern for currency and
+  percent display, because no formatting dependency ships with this. The
+  `PetalNumberField` hook owns the stepping, the clamping, wheel while
+  focused, and hold-to-repeat that accelerates and stops on
+  `pointerleave` as well as `pointerup`. The input is the single tab
+  stop, the buttons are labelled at `tabindex="-1"`, and a button at its
+  bound takes `aria-disabled` rather than `disabled` so it keeps its
+  name for a screen reader. `<.field type="number-field">` wires it into
+  the label/help/error machinery, and `<.field type="number">` is
+  untouched.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,85 @@
       transition-duration: 1ms;
     }
   }
+
+/* Number field
+ *
+ * A spinbutton riding the input-group surface: the group keeps the border,
+ * radius and focus ring, so this section only paints the input density and
+ * the step buttons. Inside @layer components so a consumer's own utilities
+ * still outrank it.
+ */
+@layer components {
+  .pc-number-field .pc-number-field__input {
+    /* text-base below sm, like pc-text-input: iOS Safari zooms the viewport
+       when focusing an input under 16px, and a re-layout mid-interaction
+       makes the next tap land on stale coordinates. */
+    @apply w-full min-w-0 px-3 py-2 text-base sm:text-sm text-gray-900 tabular-nums placeholder:text-gray-400 focus:outline-none disabled:cursor-not-allowed dark:text-gray-100 dark:placeholder:text-gray-500;
+  }
+  .pc-number-field--sm .pc-number-field__input {
+    @apply px-2.5 py-1.5 sm:text-xs;
+  }
+  .pc-number-field--lg .pc-number-field__input {
+    @apply py-2.5 sm:text-base;
+  }
+  /* Split sits the value between two buttons, so centring it is what stops
+     the field reading as lopsided. */
+  .pc-number-field--split .pc-number-field__input {
+    @apply text-center;
+  }
+
+  /* Addons holding buttons shed the text inset and wear the same 2px inset
+     frame as an input-group button chip. */
+  .pc-number-field .pc-input-group__addon:has(.pc-number-field__button) {
+    @apply gap-1 p-0.5;
+  }
+  .pc-number-field .pc-input-group__addon--leading:has(.pc-number-field__button) {
+    @apply pl-0.5;
+  }
+  .pc-number-field .pc-input-group__addon--trailing:has(.pc-number-field__button) {
+    @apply pr-0.5;
+  }
+
+  .pc-number-field__button {
+    @apply flex items-center justify-center shrink-0 w-7 text-gray-500 cursor-pointer select-none transition-colors duration-150 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/50 disabled:cursor-not-allowed dark:text-gray-400 dark:hover:bg-gray-400/17 dark:hover:text-gray-100;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.125rem), 0px);
+  }
+  .pc-number-field--sm .pc-number-field__button {
+    @apply w-6;
+  }
+  .pc-number-field--lg .pc-number-field__button {
+    @apply w-8;
+  }
+  /* At a bound the button keeps its place and its label (aria-disabled, not
+     disabled) but reads as spent and stops answering the pointer. */
+  .pc-number-field__button[aria-disabled="true"] {
+    @apply text-gray-300 pointer-events-none dark:text-gray-600;
+  }
+  /* Doubled selector: the icon sizing contract, same as the combobox chevron. */
+  .pc-number-field__icon.pc-number-field__icon {
+    @apply w-4! h-4!;
+  }
+  .pc-number-field--sm .pc-number-field__icon.pc-number-field__icon {
+    @apply w-3.5! h-3.5!;
+  }
+
+  /* Stacked: two half-height buttons splitting the trailing addon's height,
+     the classic spinner. */
+  .pc-number-field__stack {
+    @apply flex flex-col self-stretch gap-px;
+  }
+  .pc-number-field__stack .pc-number-field__button {
+    @apply flex-1 min-h-0;
+  }
+  .pc-number-field__stack .pc-number-field__button--inc {
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.125rem), 0px)
+      max(calc(var(--pc-radius, 0.625rem) - 0.125rem), 0px) 0 0;
+  }
+  .pc-number-field__stack .pc-number-field__button--dec {
+    border-radius: 0 0 max(calc(var(--pc-radius, 0.625rem) - 0.125rem), 0px)
+      max(calc(var(--pc-radius, 0.625rem) - 0.125rem), 0px);
+  }
+  .pc-number-field--split .pc-number-field__button {
+    @apply self-stretch;
+  }
+}

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -1435,6 +1435,263 @@ export const PetalInputOTP = {
   },
 };
 
+// Number field maths, kept pure and exported so the specs can pin the rules
+// without a DOM: parsing, clamping, decimal-safe stepping and blur formatting.
+export const numberFieldMath = {
+  // "" and "abc" are both "no number yet" - a half-typed field must not
+  // resolve to 0, or every keystroke would fight the user.
+  parse(text) {
+    if (text === null || text === undefined) return null;
+    const trimmed = String(text).trim();
+    if (trimmed === "") return null;
+    const n = Number(trimmed);
+    return Number.isFinite(n) ? n : null;
+  },
+
+  clamp(n, min, max) {
+    if (n === null) return null;
+    let out = n;
+    if (min !== null && out < min) out = min;
+    if (max !== null && out > max) out = max;
+    return out;
+  },
+
+  decimals(n) {
+    const s = String(n);
+    const dot = s.indexOf(".");
+    if (dot === -1 || s.includes("e") || s.includes("E")) return 0;
+    return s.length - dot - 1;
+  },
+
+  // 0.1 + 0.2 is 0.30000000000000004 in every browser. Re-round to the
+  // decimals the operands actually carry so a 0.1 step reads as 0.3.
+  add(value, delta) {
+    const places = Math.min(
+      Math.max(this.decimals(value), this.decimals(delta)),
+      12,
+    );
+    return Number((value + delta).toFixed(places));
+  },
+
+  format(n, precision) {
+    if (n === null) return "";
+    if (precision === null || precision === undefined) return String(n);
+    return n.toFixed(precision);
+  },
+};
+
+// Number field: one text input carrying role="spinbutton", plus the buttons.
+// The hook owns everything the markup can't - stepping, clamping, the keyboard
+// map, wheel, hold-to-repeat, and keeping aria-valuenow honest.
+export const PetalNumberField = {
+  mounted() {
+    this.repeatTimer = null;
+    // A variant switch swaps which buttons exist, so binding is idempotent
+    // and re-runs on every patch rather than assuming mount-time nodes.
+    this.bound = new WeakSet();
+    this.stopRepeat = () => this.cancelRepeat();
+    window.addEventListener("pointerup", this.stopRepeat);
+    window.addEventListener("blur", this.stopRepeat);
+
+    this.bind();
+    if (this.input) this.syncAria();
+  },
+
+  updated() {
+    this.bind();
+    if (this.input) this.syncAria();
+  },
+
+  bind() {
+    this.input = this.el.querySelector("[data-pc-number-input]");
+    if (!this.input) return;
+    this.buttons = Array.from(this.el.querySelectorAll("[data-pc-number-step]"));
+
+    if (!this.bound.has(this.input)) {
+      this.bound.add(this.input);
+      this.input.addEventListener("keydown", (e) => this.handleKeydown(e));
+      // passive: false or preventDefault is ignored and the page scrolls
+      // out from under the field.
+      this.input.addEventListener("wheel", (e) => this.handleWheel(e), {
+        passive: false,
+      });
+      this.input.addEventListener("blur", () => this.commitTyped());
+      this.input.addEventListener("input", () => this.syncAria());
+    }
+
+    this.buttons.forEach((btn) => {
+      if (this.bound.has(btn)) return;
+      this.bound.add(btn);
+      btn.addEventListener("pointerdown", (e) => this.startRepeat(e, btn));
+      // pointerup alone leaks a stuck repeat when the finger slides off the
+      // button before lifting.
+      ["pointerup", "pointerleave", "pointercancel"].forEach((type) =>
+        btn.addEventListener(type, this.stopRepeat),
+      );
+    });
+  },
+
+  destroyed() {
+    this.cancelRepeat();
+    if (this.stopRepeat) {
+      window.removeEventListener("pointerup", this.stopRepeat);
+      window.removeEventListener("blur", this.stopRepeat);
+    }
+  },
+
+  config() {
+    const d = this.el.dataset;
+    const step = numberFieldMath.parse(d.step);
+    const bigStep = numberFieldMath.parse(d.bigStep);
+    const precision = numberFieldMath.parse(d.precision);
+    const resolvedStep = step === null ? 1 : step;
+
+    return {
+      min: numberFieldMath.parse(d.min),
+      max: numberFieldMath.parse(d.max),
+      step: resolvedStep,
+      bigStep: bigStep === null ? resolvedStep * 10 : bigStep,
+      precision: precision === null ? null : Math.trunc(precision),
+    };
+  },
+
+  currentValue() {
+    return numberFieldMath.parse(this.input.value);
+  },
+
+  // An empty field starts from the lower bound when there is one, so the
+  // first press on a 1..99 quantity lands on 1, not 0.
+  origin(cfg) {
+    if (cfg.min !== null) return cfg.min;
+    if (cfg.max !== null && cfg.max < 0) return cfg.max;
+    return 0;
+  },
+
+  step(delta) {
+    if (this.input.disabled || this.input.readOnly) return;
+    const cfg = this.config();
+    const current = this.currentValue();
+    const base = current === null ? this.origin(cfg) - delta : current;
+    const next = numberFieldMath.clamp(
+      numberFieldMath.add(base, delta),
+      cfg.min,
+      cfg.max,
+    );
+    this.write(next, cfg.precision);
+  },
+
+  write(value, precision) {
+    const text = numberFieldMath.format(value, precision);
+    if (text === this.input.value) {
+      this.syncAria();
+      return;
+    }
+    this.input.value = text;
+    this.syncAria();
+    this.input.dispatchEvent(new Event("input", { bubbles: true }));
+  },
+
+  // Typed text is left alone until blur: clamping mid-keystroke would snap
+  // "1" to the maximum on the way to "15".
+  commitTyped() {
+    const cfg = this.config();
+    const current = this.currentValue();
+    if (current === null) {
+      this.syncAria();
+      return;
+    }
+    this.write(numberFieldMath.clamp(current, cfg.min, cfg.max), cfg.precision);
+    this.input.dispatchEvent(new Event("change", { bubbles: true }));
+  },
+
+  handleKeydown(e) {
+    const cfg = this.config();
+    const big = e.shiftKey ? cfg.bigStep : cfg.step;
+
+    switch (e.key) {
+      case "ArrowUp":
+        e.preventDefault();
+        return this.step(big);
+      case "ArrowDown":
+        e.preventDefault();
+        return this.step(-big);
+      case "PageUp":
+        e.preventDefault();
+        return this.step(cfg.bigStep);
+      case "PageDown":
+        e.preventDefault();
+        return this.step(-cfg.bigStep);
+      case "Home":
+        if (cfg.min === null) return;
+        e.preventDefault();
+        return this.write(cfg.min, cfg.precision);
+      case "End":
+        if (cfg.max === null) return;
+        e.preventDefault();
+        return this.write(cfg.max, cfg.precision);
+      default:
+        return undefined;
+    }
+  },
+
+  // Only while focused, so a scroll down the page never rewrites a number
+  // the pointer happened to pass over.
+  handleWheel(e) {
+    if (document.activeElement !== this.input) return;
+    if (this.input.disabled || this.input.readOnly) return;
+    if (e.deltaY === 0) return;
+    e.preventDefault();
+    const cfg = this.config();
+    this.step(e.deltaY < 0 ? cfg.step : -cfg.step);
+  },
+
+  startRepeat(e, btn) {
+    if (e.button !== undefined && e.button !== 0) return;
+    if (btn.disabled || btn.getAttribute("aria-disabled") === "true") return;
+    e.preventDefault();
+    this.input.focus();
+
+    const cfg = this.config();
+    const delta = btn.dataset.pcNumberStep === "inc" ? cfg.step : -cfg.step;
+    this.step(delta);
+
+    // A press is one step; a hold accelerates from a deliberate pause down
+    // to a fast repeat, the way a native spinner feels.
+    let interval = 120;
+    const tick = () => {
+      if (btn.getAttribute("aria-disabled") === "true") return;
+      this.step(delta);
+      interval = Math.max(40, interval - 12);
+      this.repeatTimer = setTimeout(tick, interval);
+    };
+    this.repeatTimer = setTimeout(tick, 400);
+  },
+
+  cancelRepeat() {
+    if (this.repeatTimer) clearTimeout(this.repeatTimer);
+    this.repeatTimer = null;
+  },
+
+  syncAria() {
+    const cfg = this.config();
+    const value = this.currentValue();
+
+    if (value === null) this.input.removeAttribute("aria-valuenow");
+    else this.input.setAttribute("aria-valuenow", String(value));
+
+    this.buttons.forEach((btn) => {
+      const inc = btn.dataset.pcNumberStep === "inc";
+      const bound = inc ? cfg.max : cfg.min;
+      const atBound =
+        value !== null &&
+        bound !== null &&
+        (inc ? value >= bound : value <= bound);
+      if (atBound) btn.setAttribute("aria-disabled", "true");
+      else btn.removeAttribute("aria-disabled");
+    });
+  },
+};
+
 // Positions a top-layer popover (<div popover>) next to its trigger.
 // The browser handles open/close and light-dismiss via the popover attribute;
 // this hook only computes fixed coordinates, flipping to the opposite side
@@ -5446,6 +5703,7 @@ export default {
   PetalWordRotate,
   PetalTypingEffect,
   PetalInputOTP,
+  PetalNumberField,
   PetalPopover,
   PetalCommand,
   PetalCommandTrigger,

--- a/dev.exs
+++ b/dev.exs
@@ -243,6 +243,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "toggle-group", name: "Toggle group", ready: true},
         %{slug: "input", name: "Input", ready: true},
         %{slug: "input-group", name: "Input group", ready: true},
+        %{slug: "number-field", name: "Number field", ready: true},
         %{slug: "checkbox", name: "Checkbox", ready: true},
         %{slug: "select", name: "Select", ready: true},
         %{slug: "combo-box", name: "Combobox", ready: true},
@@ -785,6 +786,7 @@ defmodule Dev.PlaygroundLive do
        slider: %{thumbs: "dual", format: "money", disabled: false, fill: true},
        slider_form: slider_form("money"),
        otp: %{length: 6, grouped: false, pattern: "numeric", disabled: false},
+       number: %{variant: "stacked", size: "md", bounds: "qty", disabled: false},
        progress: %{
          value: 0,
          color: "primary",
@@ -1448,6 +1450,20 @@ defmodule Dev.PlaygroundLive do
     do:
       {:noreply,
        update(socket, :otp, &Map.update!(&1, String.to_existing_atom(k), fn v -> !v end))}
+
+  def handle_event("ctl_number", %{"k" => "variant", "v" => v}, socket)
+      when v in ~w(stacked split plain),
+      do: {:noreply, update(socket, :number, &%{&1 | variant: v})}
+
+  def handle_event("ctl_number", %{"k" => "size", "v" => v}, socket) when v in ~w(sm md lg),
+    do: {:noreply, update(socket, :number, &%{&1 | size: v})}
+
+  def handle_event("ctl_number", %{"k" => "bounds", "v" => v}, socket)
+      when v in ~w(qty pct free),
+      do: {:noreply, update(socket, :number, &%{&1 | bounds: v})}
+
+  def handle_event("ctl_number", %{"k" => "disabled"}, socket),
+    do: {:noreply, update(socket, :number, &%{&1 | disabled: !&1.disabled})}
 
   def handle_event("ctl_switch", %{"k" => "size", "v" => v}, socket) when v in ~w(xs sm md lg xl),
     do: {:noreply, update(socket, :switch, &%{&1 | size: v})}
@@ -2135,6 +2151,29 @@ defmodule Dev.PlaygroundLive do
       |> Enum.filter(& &1)
 
     "<.input_otp #{Enum.join(attrs, " ")} />"
+  end
+
+  defp number_bounds("qty"), do: %{min: 1, max: 99, step: 1, label: "1 to 99, step 1"}
+  defp number_bounds("pct"), do: %{min: 0, max: 100, step: 5, label: "0 to 100, step 5"}
+  defp number_bounds("free"), do: %{min: nil, max: nil, step: 0.5, label: "unbounded, step 0.5"}
+
+  defp number_snippet(n) do
+    b = number_bounds(n.bounds)
+
+    attrs =
+      [
+        ~s(name="quantity"),
+        ~s(value="12"),
+        b.min && ~s(min={#{b.min}}),
+        b.max && ~s(max={#{b.max}}),
+        b.step != 1 && ~s(step={#{b.step}}),
+        n.variant != "stacked" && ~s(variant="#{n.variant}"),
+        n.size != "md" && ~s(size="#{n.size}"),
+        n.disabled && "disabled"
+      ]
+      |> Enum.filter(& &1)
+
+    "<.number_field #{Enum.join(attrs, " ")} />"
   end
 
   defp slider_form("money"), do: to_form(%{"min" => "250", "max" => "750"}, as: :pg_range)
@@ -7025,6 +7064,196 @@ defmodule Dev.PlaygroundLive do
 
       <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
         These examples render from the shared <code>PetalComponents.Showcase.InputOtp</code>
+        registry - the same source petal.build renders, so the playground and the marketing
+        docs can't drift.
+      </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "number-field"} = assigns) do
+    assigns = assign(assigns, :bounds, number_bounds(assigns.number.bounds))
+
+    ~H"""
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">Number field</h1>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        A real spinbutton for quantities, prices and percentages. One text
+        input carrying <code>role="spinbutton"</code>, not <code>&lt;input type="number"&gt;</code>, so the steppers look the same
+        in every browser and a half-typed value survives. It's live - type in
+        it, hold a button, spin the wheel.
+      </p>
+
+      <div class="mt-8 overflow-hidden border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="flex items-center justify-center px-6 py-12">
+          <div class="w-full max-w-xs">
+            <.number_field
+              name="pg_quantity"
+              value="12"
+              min={@bounds.min}
+              max={@bounds.max}
+              step={@bounds.step}
+              variant={@number.variant}
+              size={@number.size}
+              disabled={@number.disabled}
+            />
+          </div>
+        </div>
+        <div class="flex flex-wrap items-end gap-x-8 gap-y-4 px-4 sm:px-6 py-4 [&>div]:min-w-0 [&>div]:max-w-full border-t border-gray-200 dark:border-gray-800">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">variant</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Variant"
+              value={@number.variant}
+              on_change="ctl_number"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={v <- ~w(stacked split plain)}
+                value={v}
+                phx-value-k="variant"
+                phx-value-v={v}
+              >
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">size</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Size"
+              value={@number.size}
+              on_change="ctl_number"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item :for={z <- ~w(sm md lg)} value={z} phx-value-k="size" phx-value-v={z}>{z}</:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">bounds</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Bounds"
+              value={@number.bounds}
+              on_change="ctl_number"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item :for={b <- ~w(qty pct free)} value={b} phx-value-k="bounds" phx-value-v={b}>
+                {number_bounds(b).label}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">state</div>
+            <.toggle_group
+              multiple
+              variant="outline"
+              size="sm"
+              aria_label="State"
+              value={if @number.disabled, do: ["disabled"], else: []}
+              on_change="ctl_number"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item value="disabled" phx-value-k="disabled">disabled</:item>
+            </.toggle_group>
+          </div>
+        </div>
+      </div>
+
+      <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+        Keyboard only: <kbd class="pc-kbd">↑</kbd>
+        and <kbd class="pc-kbd">↓</kbd>
+        step, <kbd class="pc-kbd">shift</kbd>
+        + arrow steps by <code>big_step</code>, <kbd class="pc-kbd">page up</kbd>
+        and <kbd class="pc-kbd">page down</kbd>
+        do the same without the modifier, and <kbd class="pc-kbd">home</kbd>
+        / <kbd class="pc-kbd">end</kbd>
+        jump to the bounds. The buttons are never tab stops - the input is the
+        one stop, the way the ARIA spinbutton pattern asks.
+      </p>
+
+      <button
+        phx-click="flip"
+        phx-value-k="show_code"
+        class="mt-3 inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+      >
+        <.icon name="hero-code-bracket" class="w-4 h-4" />
+        {if @show_code, do: "Hide code", else: "View code"}
+      </button>
+      <pre
+        :if={@show_code}
+        class="p-4 mt-2 overflow-x-auto text-sm text-gray-100 bg-gray-900 rounded-xl dark:border dark:border-gray-800"
+      ><code>{number_snippet(@number)}</code></pre>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Cart quantity</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        The split variant in its natural home: a line-item row where the value
+        wants to sit between the two controls. At the minimum the decrement
+        greys out with <code>aria-disabled</code>, so it keeps its label for a
+        screen reader instead of disappearing.
+      </p>
+      <div class="p-4 border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="flex items-center gap-4">
+          <div class="w-12 h-12 rounded-lg bg-gray-100 dark:bg-gray-800"></div>
+          <div class="flex-1 min-w-0">
+            <div class="font-medium truncate">Ceramic pour-over</div>
+            <div class="text-sm text-gray-500 dark:text-gray-400">$48.00</div>
+          </div>
+          <div class="w-32">
+            <.number_field name="pg_cart_qty" value="1" min={1} max={10} variant="split" size="sm" />
+          </div>
+        </div>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Price, formatted on blur</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        <code>precision={2}</code>
+        rounds and pads when you leave the field, and leaves the raw text alone
+        while you type - so <code>7.5</code>
+        becomes <code>7.50</code>, but only once you're done. Tab out to watch
+        it. Currency and percent display go through <code>Intl.NumberFormat</code>
+        on the same blur; the moduledoc has that pattern.
+      </p>
+      <div class="max-w-xs">
+        <.number_field name="pg_price" value="24.5" min={0} step={0.5} precision={2}>
+          <:leading>$</:leading>
+        </.number_field>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Percentage allocation</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        Bounded 0 to 100 with a step of 5 and a <code>big_step</code>
+        of 25, so shift+arrow moves a quarter at a time. Clamping is the hook's
+        job on the client, but bounds are advice a browser cannot enforce for
+        you - validate them on the server too.
+      </p>
+      <div class="max-w-xs">
+        <.number_field name="pg_allocation" value="25" min={0} max={100} step={5} big_step={25}>
+          <:trailing>%</:trailing>
+        </.number_field>
+      </div>
+
+      <div
+        :for={ex <- examples_for(PetalComponents.Showcase.NumberField, ~w(sizes in_a_field)a)}
+        class="mt-10"
+      >
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
+      <.showcase_props component={PetalComponents.NumberField} function={:number_field} />
+
+      <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        These examples render from the shared <code>PetalComponents.Showcase.NumberField</code>
         registry - the same source petal.build renders, so the playground and the marketing
         docs can't drift.
       </div>

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -54,6 +54,7 @@ defmodule PetalComponents do
         Meteors,
         Modal,
         NavigationMenu,
+        NumberField,
         NumberTicker,
         Pagination,
         Popover,

--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -32,7 +32,7 @@ defmodule PetalComponents.Field do
   attr :type, :string,
     default: "text",
     values:
-      ~w(checkbox checkbox-group color combobox date datetime-local email file hidden month number password
+      ~w(checkbox checkbox-group color combobox date datetime-local email file hidden month number number-field password
                range range-dual radio-group radio-card search select switch tel text textarea time url week),
     doc: "the type of input"
 
@@ -46,6 +46,11 @@ defmodule PetalComponents.Field do
   attr :combo_variant, :string,
     values: ["input", "trigger"],
     doc: "combobox only: the anatomy - searchable input (default) or select-like trigger button"
+
+  attr :number_variant, :string,
+    values: ["stacked", "split", "plain"],
+    doc:
+      "number-field only: the anatomy - \"stacked\" spinner, the default, \"split\" minus/plus, or \"plain\" with no buttons"
 
   attr :indicator_position, :string,
     default: "end",
@@ -154,7 +159,8 @@ defmodule PetalComponents.Field do
     include:
       ~w(autocomplete autocorrect autocapitalize disabled form max maxlength min minlength list
     pattern placeholder readonly required size step value name multiple prompt default year month day hour minute second builder options layout cols rows wrap checked accept
-    free_text create create_label max_items count_label search_placeholder listbox_label no_results_text results_label clear_label remove_label loading_label remote_options_event_name remote_options_target form_id),
+    free_text create create_label max_items count_label search_placeholder listbox_label no_results_text results_label clear_label remove_label loading_label remote_options_event_name remote_options_target form_id
+    big_step precision decrement_label increment_label inputmode),
     doc: "All other props go on the input"
 
   def field(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
@@ -321,6 +327,50 @@ defmodule PetalComponents.Field do
         variant={@combo_variant}
         clearable={@clearable}
         class={@class}
+        {@rest}
+      />
+      <.field_error :for={msg <- @errors}>{msg}</.field_error>
+      <.field_help_text help_text={@help_text} />
+    </.field_wrapper>
+    """
+  end
+
+  # The spinbutton flavour of a number input. It paints its own surface (the
+  # input group), so the wrapper contributes the label, help text and the
+  # error tone that `.pc-form-field-wrapper--error .pc-input-group` picks up.
+  def field(%{type: "number-field"} = assigns) do
+    assigns =
+      assigns
+      # the field size family spans xs-xl; the number field speaks sm/md/lg
+      |> assign(
+        :number_size,
+        case assigns.size do
+          "xs" -> "sm"
+          "xl" -> "lg"
+          s -> s
+        end
+      )
+      |> assign_new(:number_variant, fn -> "stacked" end)
+      # the label's for= has to name the control that actually exists, and the
+      # number field derives its own id from the name when none is passed -
+      # so resolve it HERE, once, and hand it down.
+      |> then(fn a ->
+        assign(a, :id, PetalComponents.NumberField.resolve_id(a.id, a[:name]))
+      end)
+
+    ~H"""
+    <.field_wrapper errors={@errors} name={@name} class={@wrapper_class} no_margin={@no_margin}>
+      <.field_label required={@required} for={@id} class={@label_class}>
+        {@label}
+      </.field_label>
+      <PetalComponents.NumberField.number_field
+        id={@id}
+        name={@name}
+        value={@value}
+        variant={@number_variant}
+        size={@number_size}
+        class={@class}
+        required={@required}
         {@rest}
       />
       <.field_error :for={msg <- @errors}>{msg}</.field_error>

--- a/lib/petal_components/number_field.ex
+++ b/lib/petal_components/number_field.ex
@@ -1,0 +1,385 @@
+defmodule PetalComponents.NumberField do
+  @moduledoc """
+  A numeric spinbutton: one real input on the input-group surface, with
+  decrement and increment buttons, clamping, and a full keyboard map.
+
+  Reach for it wherever a quantity, a price or a percentage is typed. It
+  replaces `<input type="number">`, whose spinners are unstyleable and
+  inconsistent across browsers, and whose value sanitising fights any kind of
+  display formatting.
+
+  ## Why not `type="number"`
+
+  The control renders `<input type="text" inputmode="decimal">` carrying
+  `role="spinbutton"`, the WAI-ARIA pattern for exactly this widget. That buys:
+
+    * spinners we draw ourselves, identical in every browser
+    * `precision` formatting on blur, which `type="number"` silently discards
+    * a value that stays readable while editing, since the browser never
+      "sanitises" a half-typed number to the empty string
+    * the numeric keypad on mobile, via `inputmode`
+
+  What it costs: native constraint validation. `min` and `max` are enforced by
+  the hook and mirrored to `aria-valuemin` / `aria-valuemax`, not by the
+  browser, so **validate the bound on the server too** - the same as you would
+  for any user-supplied number.
+
+  ## Examples
+
+      <.number_field name="quantity" value="1" min={1} max={99} />
+
+      <.number_field field={@form[:quantity]} min={1} max={99} />
+
+      <.number_field field={@form[:price]} variant="split" precision={2} step={0.5}>
+        <:leading>$</:leading>
+      </.number_field>
+
+      <.number_field field={@form[:share]} min={0} max={100} step={5} big_step={25}>
+        <:trailing>%</:trailing>
+      </.number_field>
+
+  Inside `<.field>` it gets a label, help text and error styling for free:
+
+      <.field type="number-field" field={@form[:quantity]} label="Quantity" min={1} />
+
+  ## Variants
+
+    * `stacked` (default) - chevron up/down stacked at the inline end
+    * `split` - minus at the inline start, plus at the inline end, value centred
+    * `plain` - no buttons; typing, arrows and wheel only
+
+  ## Keyboard and pointer
+
+  | Input | Effect |
+  | --- | --- |
+  | `ArrowUp` / `ArrowDown` | step by `step` |
+  | `Shift` + arrow | step by `big_step` (defaults to `step * 10`) |
+  | `PageUp` / `PageDown` | step by `big_step` |
+  | `Home` / `End` | jump to `min` / `max` when set |
+  | Wheel | steps while the input is focused, and only then |
+  | Press and hold a button | one step, then repeat, accelerating |
+
+  Typed text is never clamped mid-keystroke - it is clamped and formatted on
+  blur, so `1` on the way to `15` does not snap to the maximum under your
+  fingers.
+
+  ## Accessibility
+
+  The input is the single tab stop: the buttons are `tabindex="-1"` with
+  `aria-label`s, the way the APG spinbutton pattern prescribes. `aria-valuenow`
+  tracks the value on every change, and a button at its bound gets
+  `aria-disabled` rather than `disabled`, so it stays discoverable to a screen
+  reader. A `disabled` control uses the native attribute throughout.
+
+  ## Formatting beyond `precision`
+
+  `precision` rounds and pads to a fixed number of decimals on blur. That is the
+  whole built-in formatting story - no locale engine, no masking dependency.
+
+  For currency or percent display, format the visible text on blur and keep the
+  raw number in the posted value, using the platform's own `Intl.NumberFormat`:
+
+      // in your app's JS, alongside the petal hooks
+      export const PriceField = {
+        mounted() {
+          const input = this.el.querySelector("[data-pc-number-input]");
+          const fmt = new Intl.NumberFormat("en-US", {
+            style: "currency",
+            currency: "USD"
+          });
+
+          input.addEventListener("focus", () => {
+            input.value = input.dataset.raw ?? input.value;
+          });
+
+          input.addEventListener("blur", () => {
+            const n = parseFloat(input.value);
+            if (Number.isNaN(n)) return;
+            input.dataset.raw = String(n);
+            input.value = fmt.format(n);
+          });
+        }
+      };
+
+  Post the raw number in a hidden input if the formatted text would confuse
+  your changeset.
+
+  ## Setup
+
+  Needs the `PetalNumberField` hook from the petal_components JS bundle:
+
+      import PetalComponents from "../../deps/petal_components/assets/js/petal_components.js"
+
+      let liveSocket = new LiveSocket("/live", Socket, {
+        hooks: { ...PetalComponents }
+      })
+
+  Without the hook it degrades to a plain text input that still posts its value.
+  """
+  use Phoenix.Component
+
+  @doc """
+  Renders a numeric spinbutton. Full documentation, including the keyboard map
+  and the `Intl.NumberFormat` pattern, lives on `PetalComponents.NumberField`.
+  """
+  attr :id, :any, default: nil, doc: "input id; generated from the field or name if not passed"
+
+  attr :name, :any, doc: "input name; generated from the field if not passed"
+
+  attr :value, :any, doc: "current value; generated from the field if not passed"
+
+  attr :field, Phoenix.HTML.FormField,
+    doc: "a form field struct, e.g. @form[:quantity]; sets id, name and value like other inputs"
+
+  attr :min, :any,
+    default: nil,
+    doc: "lower bound; values are clamped and mirrored to aria-valuemin"
+
+  attr :max, :any, default: nil, doc: "upper bound; clamped and mirrored to aria-valuemax"
+
+  attr :step, :any, default: 1, doc: "increment for the buttons, arrow keys and wheel"
+
+  attr :big_step, :any,
+    default: nil,
+    doc: "increment for shift+arrow and page up/down; defaults to step * 10"
+
+  attr :precision, :integer,
+    default: nil,
+    doc:
+      "decimal places shown on blur; the raw text stands while editing. nil means no formatting"
+
+  attr :variant, :string,
+    default: "stacked",
+    values: ~w(stacked split plain),
+    doc:
+      "stacked: both buttons at the inline end; split: minus at the start, plus at the end; plain: no buttons"
+
+  attr :size, :string, default: "md", values: ~w(sm md lg), doc: "input height and text size"
+
+  attr :disabled, :boolean, default: false, doc: "disables the input and both buttons natively"
+
+  attr :decrement_label, :string,
+    default: "Decrease value",
+    doc: "accessible name for the decrement button"
+
+  attr :increment_label, :string,
+    default: "Increase value",
+    doc: "accessible name for the increment button"
+
+  attr :class, :any, default: nil, doc: "extra classes for the field surface"
+
+  attr :rest, :global,
+    include: ~w(autocomplete form placeholder readonly required inputmode aria-describedby),
+    doc: "all other attributes land on the input"
+
+  slot :leading, doc: "addon before the input, e.g. a currency symbol"
+  slot :trailing, doc: "addon after the input, e.g. a unit"
+
+  def number_field(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
+    assigns
+    |> assign(:field, nil)
+    |> assign(:id, assigns.id || field.id)
+    |> assign_new(:name, fn -> field.name end)
+    |> assign_new(:value, fn -> field.value end)
+    |> number_field()
+  end
+
+  def number_field(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:name, fn -> nil end)
+      |> assign_new(:value, fn -> nil end)
+
+    number = to_number(assigns.value)
+    min = to_number(assigns.min)
+    max = to_number(assigns.max)
+
+    assigns =
+      assigns
+      |> assign(:id, resolve_id(assigns.id, assigns.name))
+      |> assign(:display, display_value(number, assigns.value, assigns.precision))
+      |> assign(:value_now, number)
+      |> assign(:at_min, at_bound?(number, min, :min))
+      |> assign(:at_max, at_bound?(number, max, :max))
+      |> assign(:big_step, assigns.big_step || big_step_default(assigns.step))
+      |> assign(:show_buttons, assigns.variant != "plain")
+
+    ~H"""
+    <PetalComponents.InputGroup.input_group
+      id={@id <> "-field"}
+      phx-hook="PetalNumberField"
+      class={[
+        "pc-number-field",
+        "pc-number-field--#{@variant}",
+        "pc-number-field--#{@size}",
+        @class
+      ]}
+      data-min={@min}
+      data-max={@max}
+      data-step={@step}
+      data-big-step={@big_step}
+      data-precision={@precision}
+    >
+      <:leading :if={@leading != [] or (@show_buttons and @variant == "split")}>
+        <.spin_button
+          :if={@show_buttons and @variant == "split"}
+          direction="dec"
+          icon="minus"
+          label={@decrement_label}
+          disabled={@disabled}
+          at_bound={@at_min}
+        />
+        {render_slot(@leading)}
+      </:leading>
+      <input
+        type="text"
+        inputmode="decimal"
+        autocomplete="off"
+        id={@id}
+        name={@name}
+        value={@display}
+        class="pc-number-field__input"
+        role="spinbutton"
+        aria-valuenow={@value_now}
+        aria-valuemin={@min}
+        aria-valuemax={@max}
+        disabled={@disabled}
+        data-pc-number-input
+        {@rest}
+      />
+      <:trailing :if={@trailing != [] or @show_buttons}>
+        {render_slot(@trailing)}
+        <div :if={@show_buttons and @variant == "stacked"} class="pc-number-field__stack">
+          <.spin_button
+            direction="inc"
+            icon="chevron-up"
+            label={@increment_label}
+            disabled={@disabled}
+            at_bound={@at_max}
+          />
+          <.spin_button
+            direction="dec"
+            icon="chevron-down"
+            label={@decrement_label}
+            disabled={@disabled}
+            at_bound={@at_min}
+          />
+        </div>
+        <.spin_button
+          :if={@show_buttons and @variant == "split"}
+          direction="inc"
+          icon="plus"
+          label={@increment_label}
+          disabled={@disabled}
+          at_bound={@at_max}
+        />
+      </:trailing>
+    </PetalComponents.InputGroup.input_group>
+    """
+  end
+
+  attr :direction, :string, required: true
+  attr :icon, :string, required: true
+  attr :label, :string, required: true
+  attr :disabled, :boolean, required: true
+  attr :at_bound, :boolean, required: true
+
+  defp spin_button(assigns) do
+    ~H"""
+    <button
+      type="button"
+      tabindex="-1"
+      class={["pc-number-field__button", "pc-number-field__button--#{@direction}"]}
+      aria-label={@label}
+      aria-disabled={@at_bound && "true"}
+      disabled={@disabled}
+      data-pc-number-step={@direction}
+    >
+      <PetalComponents.Icon.icon name={"hero-#{@icon}-micro"} class="pc-number-field__icon" />
+    </button>
+    """
+  end
+
+  @doc """
+  The input id this component would render for a given `id` and `name`.
+
+  `<.field type="number-field">` calls it so the label's `for=` names the same
+  control the hook addresses. One identity, no way for the two to drift.
+  """
+  # No identity at all is a programming error, not something to paper over
+  # with a constant id that would collide on the second instance.
+  @spec resolve_id(String.t() | nil, String.t() | nil) :: String.t()
+  def resolve_id(id, _name) when is_binary(id) and id != "", do: id
+
+  def resolve_id(_id, name) when is_binary(name) and name != "",
+    do: "number_field_" <> String.replace(name, ~r/[^A-Za-z0-9_]/, "_")
+
+  def resolve_id(_id, _name) do
+    raise ArgumentError,
+          "number_field requires a field, an id or a name to derive its id from " <>
+            "(the hook and the label both need to address the input)"
+  end
+
+  # Bounds only bite once we know the value is a number. A blank or
+  # part-typed field disables nothing.
+  defp at_bound?(nil, _bound, _side), do: false
+  defp at_bound?(_value, nil, _side), do: false
+  defp at_bound?(value, bound, :min), do: value <= bound
+  defp at_bound?(value, bound, :max), do: value >= bound
+
+  defp big_step_default(step) do
+    case to_number(step) do
+      nil -> 10
+      n -> trim_float(n * 10)
+    end
+  end
+
+  # `precision` is a display concern: it fires on blur in the hook, and the
+  # server renders the same shape so the first paint matches. Anything we
+  # cannot read as a number rides through untouched - a half-typed value
+  # belongs to the user, not to us.
+  defp display_value(nil, raw, _precision), do: normalize(raw)
+  defp display_value(_number, raw, nil), do: normalize(raw)
+
+  defp display_value(number, _raw, precision) when is_integer(precision) and precision >= 0 do
+    :erlang.float_to_binary(number / 1, decimals: precision)
+  end
+
+  defp display_value(_number, raw, _precision), do: normalize(raw)
+
+  defp normalize(nil), do: nil
+  defp normalize(value) when is_binary(value), do: value
+  defp normalize(value), do: to_string(value)
+
+  defp to_number(nil), do: nil
+  defp to_number(value) when is_integer(value), do: value
+  defp to_number(value) when is_float(value), do: trim_float(value)
+
+  defp to_number(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} ->
+        int
+
+      _ ->
+        case Float.parse(value) do
+          {float, ""} -> trim_float(float)
+          _ -> nil
+        end
+    end
+  end
+
+  # Decimal is not a dependency here, so a Decimal (or any other struct that
+  # prints as a number) goes through its String.Chars form.
+  defp to_number(%_{} = value) do
+    if String.Chars.impl_for(value), do: value |> to_string() |> to_number()
+  end
+
+  defp to_number(_), do: nil
+
+  # 5.0 renders as "5" in aria-valuenow and in a step default; a trailing .0
+  # is noise a screen reader would read aloud.
+  defp trim_float(float) do
+    truncated = trunc(float)
+    if float == truncated, do: truncated, else: float
+  end
+end

--- a/lib/petal_components/showcase/number_field.ex
+++ b/lib/petal_components/showcase/number_field.ex
@@ -1,0 +1,84 @@
+defmodule PetalComponents.Showcase.NumberField do
+  @moduledoc false
+  use PetalComponents.Showcase, component: PetalComponents.NumberField, title: "Number field"
+
+  example :basic, "The default spinner",
+    description:
+      "A text input carrying role=\"spinbutton\", not <input type=\"number\">, so the steppers look the same in every browser and a half-typed value survives. Arrows step, shift+arrow steps by big_step, Home and End jump to the bounds. The input is the only tab stop; the buttons sit at tabindex=\"-1\" with labels, the way the ARIA spinbutton pattern asks." do
+    ~H"""
+    <.number_field name="quantity" value="12" min={0} max={99} />
+    """
+  end
+
+  example :split, "Split buttons",
+    description:
+      "Minus at the start, plus at the end, value centred - the cart-quantity anatomy. At a bound the button greys out with aria-disabled rather than disabled, so it keeps its name for a screen reader instead of vanishing. This one sits at its minimum." do
+    ~H"""
+    <.number_field name="cart_quantity" value="1" min={1} max={10} variant="split" />
+    """
+  end
+
+  example :addons, "Addons and precision",
+    description:
+      "Leading and trailing addons ride the same input-group surface the rest of the library uses. precision rounds and pads on blur while the raw text stands while you type - the whole built-in formatting story. For currency or percent display, format on blur with Intl.NumberFormat; the moduledoc has the pattern." do
+    ~H"""
+    <div class="flex flex-col gap-4">
+      <.number_field name="price" value="24.5" min={0} step={0.5} precision={2}>
+        <:leading>$</:leading>
+      </.number_field>
+      <.number_field name="allocation" value="25" min={0} max={100} step={5} big_step={25}>
+        <:trailing>%</:trailing>
+      </.number_field>
+    </div>
+    """
+  end
+
+  example :sizes, "Sizes",
+    description:
+      "sm, md and lg move the input density and the button hit areas together, so the control stays square with the inputs beside it." do
+    ~H"""
+    <div class="flex flex-col gap-4">
+      <.number_field name="size_sm" value="1" size="sm" />
+      <.number_field name="size_md" value="1" size="md" />
+      <.number_field name="size_lg" value="1" size="lg" />
+    </div>
+    """
+  end
+
+  example :plain, "Plain, and disabled",
+    description:
+      "variant=\"plain\" drops the buttons for keyboard, wheel and typing only - the dense-table flavour. disabled uses the native attribute on the input and both buttons, so nothing is reachable by pointer or keyboard." do
+    ~H"""
+    <div class="flex flex-col gap-4">
+      <.number_field name="plain_qty" value="7" variant="plain" min={0} max={100} />
+      <.number_field name="disabled_qty" value="7" disabled />
+    </div>
+    """
+  end
+
+  example :in_a_field, "In a form field",
+    description:
+      "type=\"number-field\" wires it into <.field>, so the label, help text and error tone come from the shared form-field machinery - the error ring is painted by the wrapper on the input-group surface, with no number-field-specific styling." do
+    ~H"""
+    <div class="flex flex-col gap-2">
+      <.field
+        type="number-field"
+        name="seats"
+        value="3"
+        label="Seats"
+        min={1}
+        max={20}
+        help_text="Between 1 and 20."
+      />
+      <.field
+        type="number-field"
+        name="seats_error"
+        value="0"
+        label="Seats"
+        min={1}
+        errors={["must be at least 1"]}
+      />
+    </div>
+    """
+  end
+end

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -39,6 +39,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.Marquee,
     PetalComponents.Showcase.Meteors,
     PetalComponents.Showcase.Modal,
+    PetalComponents.Showcase.NumberField,
     PetalComponents.Showcase.NumberTicker,
     PetalComponents.Showcase.Pagination,
     PetalComponents.Showcase.Popover,

--- a/test/js/number_field.test.js
+++ b/test/js/number_field.test.js
@@ -1,0 +1,464 @@
+// PetalNumberField hook: stepping, clamping, the keyboard map, wheel and
+// hold-to-repeat. The markup here mirrors what PetalComponents.NumberField
+// renders - test/petal/number_field_test.exs pins that structure on the
+// Elixir side; update both together if the anatomy changes.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import hooks, { numberFieldMath } from "../../assets/js/petal_components.js";
+
+const mounted = [];
+
+function mount({
+  value = "",
+  min,
+  max,
+  step,
+  bigStep,
+  precision,
+  variant = "stacked",
+  disabled = false,
+  readOnly = false,
+} = {}) {
+  const el = document.createElement("div");
+  el.id = "nf-field";
+  el.className = `pc-input-group pc-number-field pc-number-field--${variant}`;
+  if (min !== undefined) el.dataset.min = String(min);
+  if (max !== undefined) el.dataset.max = String(max);
+  if (step !== undefined) el.dataset.step = String(step);
+  if (bigStep !== undefined) el.dataset.bigStep = String(bigStep);
+  if (precision !== undefined) el.dataset.precision = String(precision);
+
+  const buttons =
+    variant === "plain"
+      ? ""
+      : `
+        <button type="button" tabindex="-1" data-pc-number-step="dec" aria-label="Decrease value"></button>
+        <button type="button" tabindex="-1" data-pc-number-step="inc" aria-label="Increase value"></button>
+      `;
+
+  el.innerHTML = `
+    <div class="pc-input-group__row">
+      <input type="text" inputmode="decimal" role="spinbutton" data-pc-number-input value="${value}" />
+      ${buttons}
+    </div>
+  `;
+  document.body.appendChild(el);
+
+  const input = el.querySelector("[data-pc-number-input]");
+  input.disabled = disabled;
+  input.readOnly = readOnly;
+
+  const hook = Object.create(hooks.PetalNumberField);
+  hook.el = el;
+  hook.mounted();
+  mounted.push(hook);
+
+  const inputEvents = [];
+  input.addEventListener("input", () => inputEvents.push(input.value));
+
+  return {
+    hook,
+    el,
+    input,
+    inputEvents,
+    dec: el.querySelector("[data-pc-number-step=dec]"),
+    inc: el.querySelector("[data-pc-number-step=inc]"),
+  };
+}
+
+// jsdom has no PointerEvent constructor; a MouseEvent under the pointer name
+// walks and quacks the same for addEventListener purposes.
+function pointer(type, props = {}) {
+  return new MouseEvent(type, { bubbles: true, cancelable: true, ...props });
+}
+
+function key(input, k, props = {}) {
+  const ev = new KeyboardEvent("keydown", {
+    key: k,
+    bubbles: true,
+    cancelable: true,
+    ...props,
+  });
+  input.dispatchEvent(ev);
+  return ev;
+}
+
+function wheel(input, deltaY) {
+  const ev = new Event("wheel", { bubbles: true, cancelable: true });
+  Object.defineProperty(ev, "deltaY", { value: deltaY });
+  input.dispatchEvent(ev);
+  return ev;
+}
+
+afterEach(() => {
+  mounted.splice(0).forEach((hook) => hook.destroyed());
+  document.body.innerHTML = "";
+});
+
+describe("numberFieldMath", () => {
+  it("reads a number, and nothing else", () => {
+    expect(numberFieldMath.parse("12")).toBe(12);
+    expect(numberFieldMath.parse(" 12.5 ")).toBe(12.5);
+    expect(numberFieldMath.parse("-3")).toBe(-3);
+    expect(numberFieldMath.parse("")).toBe(null);
+    expect(numberFieldMath.parse("   ")).toBe(null);
+    expect(numberFieldMath.parse("abc")).toBe(null);
+    expect(numberFieldMath.parse("12.")).toBe(12);
+    expect(numberFieldMath.parse(null)).toBe(null);
+    expect(numberFieldMath.parse(undefined)).toBe(null);
+    expect(numberFieldMath.parse("Infinity")).toBe(null);
+  });
+
+  it("clamps against either bound, or neither", () => {
+    expect(numberFieldMath.clamp(5, 1, 10)).toBe(5);
+    expect(numberFieldMath.clamp(0, 1, 10)).toBe(1);
+    expect(numberFieldMath.clamp(99, 1, 10)).toBe(10);
+    expect(numberFieldMath.clamp(-99, null, null)).toBe(-99);
+    expect(numberFieldMath.clamp(null, 1, 10)).toBe(null);
+  });
+
+  it("steps without float drift", () => {
+    expect(numberFieldMath.add(0.1, 0.2)).toBe(0.3);
+    expect(numberFieldMath.add(1.1, -0.1)).toBe(1);
+    expect(numberFieldMath.add(24.5, 0.5)).toBe(25);
+    expect(numberFieldMath.add(3, 1)).toBe(4);
+  });
+
+  it("formats to precision, or leaves the number alone", () => {
+    expect(numberFieldMath.format(24.5, 2)).toBe("24.50");
+    expect(numberFieldMath.format(24.567, 2)).toBe("24.57");
+    expect(numberFieldMath.format(24.5, 0)).toBe("25");
+    expect(numberFieldMath.format(24.5, null)).toBe("24.5");
+    expect(numberFieldMath.format(null, 2)).toBe("");
+  });
+});
+
+describe("PetalNumberField keyboard", () => {
+  it("arrows step by step and preventDefault so the caret stays put", () => {
+    const { input } = mount({ value: "5", step: 1 });
+
+    const up = key(input, "ArrowUp");
+    expect(input.value).toBe("6");
+    expect(up.defaultPrevented).toBe(true);
+
+    key(input, "ArrowDown");
+    key(input, "ArrowDown");
+    expect(input.value).toBe("4");
+  });
+
+  it("shift+arrow steps by big_step, defaulting to ten steps", () => {
+    const { input } = mount({ value: "5", step: 0.5 });
+
+    key(input, "ArrowUp", { shiftKey: true });
+    expect(input.value).toBe("10");
+
+    key(input, "ArrowDown", { shiftKey: true });
+    expect(input.value).toBe("5");
+  });
+
+  it("an explicit big_step wins", () => {
+    const { input } = mount({ value: "25", step: 5, bigStep: 25 });
+
+    key(input, "ArrowUp", { shiftKey: true });
+    expect(input.value).toBe("50");
+  });
+
+  it("page up and page down step by big_step without shift", () => {
+    const { input } = mount({ value: "0", step: 1, bigStep: 100 });
+
+    key(input, "PageUp");
+    expect(input.value).toBe("100");
+    key(input, "PageDown");
+    expect(input.value).toBe("0");
+  });
+
+  it("home and end jump to the bounds", () => {
+    const { input } = mount({ value: "5", min: 1, max: 99 });
+
+    key(input, "End");
+    expect(input.value).toBe("99");
+    key(input, "Home");
+    expect(input.value).toBe("1");
+  });
+
+  it("home and end do nothing when that bound is unset", () => {
+    const { input } = mount({ value: "5" });
+
+    const home = key(input, "Home");
+    expect(input.value).toBe("5");
+    expect(home.defaultPrevented).toBe(false);
+  });
+
+  it("a plain character keystroke is left to the browser", () => {
+    const { input } = mount({ value: "5" });
+
+    const ev = key(input, "7");
+    expect(ev.defaultPrevented).toBe(false);
+    expect(input.value).toBe("5");
+  });
+
+  it("stepping steps to no further than the bounds", () => {
+    const { input } = mount({ value: "9", min: 0, max: 10, step: 5 });
+
+    key(input, "ArrowUp");
+    expect(input.value).toBe("10");
+    key(input, "ArrowUp");
+    expect(input.value).toBe("10");
+  });
+
+  it("an empty field starts from the lower bound", () => {
+    const { input } = mount({ value: "", min: 1, max: 99 });
+
+    key(input, "ArrowUp");
+    expect(input.value).toBe("1");
+  });
+
+  it("an empty and unbounded field starts from zero", () => {
+    const { input } = mount({ value: "", step: 1 });
+
+    key(input, "ArrowDown");
+    expect(input.value).toBe("0");
+  });
+
+  it("steps decimals cleanly", () => {
+    const { input } = mount({ value: "0.1", step: 0.2 });
+
+    key(input, "ArrowUp");
+    expect(input.value).toBe("0.3");
+  });
+
+  it("stepping formats to precision", () => {
+    const { input } = mount({ value: "24.5", step: 0.5, precision: 2 });
+
+    key(input, "ArrowUp");
+    expect(input.value).toBe("25.00");
+  });
+
+  it("does nothing when disabled or readonly", () => {
+    const disabled = mount({ value: "5", disabled: true });
+    key(disabled.input, "ArrowUp");
+    expect(disabled.input.value).toBe("5");
+
+    const readonly = mount({ value: "5", readOnly: true });
+    key(readonly.input, "ArrowUp");
+    expect(readonly.input.value).toBe("5");
+  });
+
+  it("dispatches an input event so phx-change fires", () => {
+    const { input, inputEvents } = mount({ value: "5" });
+
+    key(input, "ArrowUp");
+    expect(inputEvents).toEqual(["6"]);
+  });
+
+  it("does not re-dispatch when the value could not move", () => {
+    const { input, inputEvents } = mount({ value: "10", max: 10 });
+
+    key(input, "ArrowUp");
+    expect(input.value).toBe("10");
+    expect(inputEvents).toEqual([]);
+  });
+});
+
+describe("PetalNumberField wheel", () => {
+  it("steps while focused and stops the page scrolling underneath", () => {
+    const { input } = mount({ value: "5", step: 1 });
+    input.focus();
+
+    const up = wheel(input, -100);
+    expect(input.value).toBe("6");
+    expect(up.defaultPrevented).toBe(true);
+
+    wheel(input, 100);
+    expect(input.value).toBe("5");
+  });
+
+  it("ignores the wheel when the input is not focused", () => {
+    const { input } = mount({ value: "5" });
+    input.blur();
+
+    const ev = wheel(input, -100);
+    expect(input.value).toBe("5");
+    expect(ev.defaultPrevented).toBe(false);
+  });
+});
+
+describe("PetalNumberField blur", () => {
+  it("clamps typed text on blur, never mid-keystroke", () => {
+    const { input } = mount({ value: "", min: 1, max: 99 });
+    input.focus();
+
+    input.value = "1";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(input.value).toBe("1");
+
+    input.value = "150";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(input.value).toBe("150");
+
+    input.dispatchEvent(new Event("blur"));
+    expect(input.value).toBe("99");
+  });
+
+  it("formats to precision on blur", () => {
+    const { input } = mount({ value: "", precision: 2 });
+
+    input.value = "3.5";
+    input.dispatchEvent(new Event("blur"));
+    expect(input.value).toBe("3.50");
+  });
+
+  it("leaves an empty field empty", () => {
+    const { input } = mount({ value: "", min: 1, precision: 2 });
+
+    input.dispatchEvent(new Event("blur"));
+    expect(input.value).toBe("");
+  });
+
+  it("leaves text that is not a number for the server to reject", () => {
+    const { input } = mount({ value: "" });
+
+    input.value = "abc";
+    input.dispatchEvent(new Event("blur"));
+    expect(input.value).toBe("abc");
+  });
+});
+
+describe("PetalNumberField buttons", () => {
+  it("a press steps once in each direction", () => {
+    const { input, inc, dec } = mount({ value: "5", step: 1 });
+
+    inc.dispatchEvent(pointer("pointerdown"));
+    inc.dispatchEvent(pointer("pointerup"));
+    expect(input.value).toBe("6");
+
+    dec.dispatchEvent(pointer("pointerdown"));
+    dec.dispatchEvent(pointer("pointerup"));
+    expect(input.value).toBe("5");
+  });
+
+  it("a right-click is not a step", () => {
+    const { input, inc } = mount({ value: "5" });
+
+    inc.dispatchEvent(pointer("pointerdown", { button: 2 }));
+    expect(input.value).toBe("5");
+  });
+
+  it("a button at its bound does nothing", () => {
+    const { input, inc } = mount({ value: "10", max: 10 });
+
+    expect(inc.getAttribute("aria-disabled")).toBe("true");
+    inc.dispatchEvent(pointer("pointerdown"));
+    expect(input.value).toBe("10");
+  });
+
+  it("a disabled button does nothing", () => {
+    const { input, inc } = mount({ value: "5", disabled: true });
+    inc.disabled = true;
+
+    inc.dispatchEvent(pointer("pointerdown"));
+    expect(input.value).toBe("5");
+  });
+
+  it("plain renders no buttons and the hook survives it", () => {
+    const { el, input } = mount({ value: "5", variant: "plain" });
+
+    expect(el.querySelectorAll("[data-pc-number-step]").length).toBe(0);
+    key(input, "ArrowUp");
+    expect(input.value).toBe("6");
+  });
+});
+
+describe("PetalNumberField hold to repeat", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("holds, pauses, then repeats and accelerates", () => {
+    const { input, inc } = mount({ value: "0", step: 1 });
+
+    inc.dispatchEvent(pointer("pointerdown"));
+    expect(input.value).toBe("1");
+
+    // nothing until the initial delay is served
+    vi.advanceTimersByTime(399);
+    expect(input.value).toBe("1");
+
+    vi.advanceTimersByTime(1);
+    expect(input.value).toBe("2");
+
+    vi.advanceTimersByTime(1000);
+    expect(Number(input.value)).toBeGreaterThan(8);
+  });
+
+  it("stops on pointerup", () => {
+    const { input, inc } = mount({ value: "0", step: 1 });
+
+    inc.dispatchEvent(pointer("pointerdown"));
+    inc.dispatchEvent(pointer("pointerup"));
+    vi.advanceTimersByTime(2000);
+    expect(input.value).toBe("1");
+  });
+
+  it("stops when the pointer slides off the button", () => {
+    const { input, inc } = mount({ value: "0", step: 1 });
+
+    inc.dispatchEvent(pointer("pointerdown"));
+    inc.dispatchEvent(pointer("pointerleave"));
+    vi.advanceTimersByTime(2000);
+    expect(input.value).toBe("1");
+  });
+
+  it("stops on pointercancel", () => {
+    const { input, dec } = mount({ value: "9", step: 1 });
+
+    dec.dispatchEvent(pointer("pointerdown"));
+    dec.dispatchEvent(pointer("pointercancel"));
+    vi.advanceTimersByTime(2000);
+    expect(input.value).toBe("8");
+  });
+
+  it("stops itself at a bound instead of spinning forever", () => {
+    const { input, inc } = mount({ value: "0", max: 3, step: 1 });
+
+    inc.dispatchEvent(pointer("pointerdown"));
+    vi.advanceTimersByTime(5000);
+    expect(input.value).toBe("3");
+  });
+});
+
+describe("PetalNumberField aria", () => {
+  it("keeps aria-valuenow in step with the value", () => {
+    const { input } = mount({ value: "5" });
+
+    expect(input.getAttribute("aria-valuenow")).toBe("5");
+    key(input, "ArrowUp");
+    expect(input.getAttribute("aria-valuenow")).toBe("6");
+
+    input.value = "";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(input.hasAttribute("aria-valuenow")).toBe(false);
+  });
+
+  it("marks the button at its bound aria-disabled, and unmarks it on the way back", () => {
+    const { input, inc, dec } = mount({ value: "9", min: 0, max: 10, step: 1 });
+
+    expect(inc.hasAttribute("aria-disabled")).toBe(false);
+
+    key(input, "ArrowUp");
+    expect(inc.getAttribute("aria-disabled")).toBe("true");
+    expect(dec.hasAttribute("aria-disabled")).toBe(false);
+
+    key(input, "ArrowDown");
+    expect(inc.hasAttribute("aria-disabled")).toBe(false);
+  });
+
+  it("re-syncs after a LiveView patch", () => {
+    const { hook, input, inc } = mount({ value: "5", max: 10 });
+
+    input.value = "10";
+    hook.updated();
+
+    expect(input.getAttribute("aria-valuenow")).toBe("10");
+    expect(inc.getAttribute("aria-disabled")).toBe("true");
+  });
+});

--- a/test/petal/number_field_test.exs
+++ b/test/petal/number_field_test.exs
@@ -1,0 +1,491 @@
+defmodule PetalComponents.NumberFieldTest do
+  @moduledoc """
+  Tests for PetalComponents.NumberField - the spinbutton composition on the
+  input-group surface. The hook consumes the data-* attrs asserted here, and
+  test/js/number_field.test.js pins the other half of that contract; change
+  the anatomy and both move together.
+  """
+
+  use ComponentCase
+
+  import PetalComponents.Field
+  import PetalComponents.NumberField
+
+  defp doc(html), do: LazyHTML.from_fragment(html)
+  defp one(html, selector), do: html |> doc() |> LazyHTML.query(selector) |> Enum.at(0)
+  defp all(html, selector), do: html |> doc() |> LazyHTML.query(selector) |> Enum.to_list()
+
+  defp at(nil, _name), do: nil
+
+  defp at(node, name) do
+    node |> LazyHTML.attribute(name) |> Enum.at(0)
+  end
+
+  describe "anatomy" do
+    test "renders the input-group surface, the input and the stacked buttons by default" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="quantity" value="3" />
+        """)
+
+      assert_has_class(html, "pc-input-group")
+      assert_has_class(html, "pc-number-field")
+      assert_has_class(html, "pc-number-field--stacked")
+      assert_has_class(html, "pc-number-field--md")
+      assert_has_class(html, "pc-number-field__stack")
+
+      input = one(html, "input.pc-number-field__input")
+      assert at(input, "type") == "text"
+      assert at(input, "inputmode") == "decimal"
+      assert at(input, "name") == "quantity"
+      assert at(input, "value") == "3"
+
+      assert length(all(html, "button[data-pc-number-step]")) == 2
+    end
+
+    test "split puts the decrement in the leading addon and the increment in the trailing one" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="qty" value="3" variant="split" />
+        """)
+
+      assert_has_class(html, "pc-number-field--split")
+      refute_has_class(html, "pc-number-field__stack")
+
+      leading = one(html, ".pc-input-group__addon--leading button")
+      trailing = one(html, ".pc-input-group__addon--trailing button")
+
+      assert at(leading, "data-pc-number-step") == "dec"
+      assert at(trailing, "data-pc-number-step") == "inc"
+    end
+
+    test "plain renders no buttons at all" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="qty" value="3" variant="plain" />
+        """)
+
+      assert_has_class(html, "pc-number-field--plain")
+      assert all(html, "button[data-pc-number-step]") == []
+      assert all(html, ".pc-input-group__addon") == []
+    end
+
+    test "renders leading and trailing slots alongside the buttons" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="price" value="10">
+          <:leading>$</:leading>
+          <:trailing>USD</:trailing>
+        </.number_field>
+        """)
+
+      assert html =~ "$"
+      assert html =~ "USD"
+      assert length(all(html, "button[data-pc-number-step]")) == 2
+    end
+
+    test "each size lands its modifier and extra classes ride along" do
+      for size <- ~w(sm md lg) do
+        assigns = %{size: size}
+
+        html =
+          rendered_to_string(~H"""
+          <.number_field name="qty" value="1" size={@size} class="max-w-xs" />
+          """)
+
+        assert_has_class(html, "pc-number-field--#{size}")
+        assert_has_class(html, "max-w-xs")
+      end
+    end
+  end
+
+  describe "hook wiring" do
+    test "emits the hook, a stable wrapper id and every data-* the hook reads" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field
+          id="qty"
+          name="quantity"
+          value="5"
+          min={1}
+          max={99}
+          step={0.5}
+          big_step={5}
+          precision={2}
+        />
+        """)
+
+      group = one(html, ".pc-number-field")
+      assert at(group, "phx-hook") == "PetalNumberField"
+      assert at(group, "id") == "qty-field"
+      assert at(group, "data-min") == "1"
+      assert at(group, "data-max") == "99"
+      assert at(group, "data-step") == "0.5"
+      assert at(group, "data-big-step") == "5"
+      assert at(group, "data-precision") == "2"
+
+      assert at(one(html, "input"), "id") == "qty"
+    end
+
+    test "big_step defaults to ten steps" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="qty" value="1" step={0.5} />
+        """)
+
+      assert at(one(html, ".pc-number-field"), "data-big-step") == "5"
+    end
+
+    test "unset bounds emit no data attributes to read" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="qty" value="1" />
+        """)
+
+      group = one(html, ".pc-number-field")
+      assert at(group, "data-min") == nil
+      assert at(group, "data-max") == nil
+      assert at(group, "data-precision") == nil
+    end
+
+    test "the id is derived from the name when none is passed" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="order[quantity]" value="1" />
+        """)
+
+      assert at(one(html, "input"), "id") == "number_field_order_quantity_"
+      assert at(one(html, ".pc-number-field"), "id") == "number_field_order_quantity_-field"
+    end
+
+    test "no identity at all is a loud programming error" do
+      assigns = %{}
+
+      assert_raise ArgumentError, ~r/requires a field, an id or a name/, fn ->
+        rendered_to_string(~H"""
+        <.number_field value="1" />
+        """)
+      end
+    end
+  end
+
+  describe "accessibility" do
+    test "the input is a spinbutton with its bounds and value mirrored" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="qty" value="7" min={1} max={99} />
+        """)
+
+      input = one(html, "input")
+      assert at(input, "role") == "spinbutton"
+      assert at(input, "aria-valuenow") == "7"
+      assert at(input, "aria-valuemin") == "1"
+      assert at(input, "aria-valuemax") == "99"
+    end
+
+    test "a blank or unparseable value reports no aria-valuenow" do
+      for value <- [nil, "", "abc"] do
+        assigns = %{value: value}
+
+        html =
+          rendered_to_string(~H"""
+          <.number_field name="qty" value={@value} />
+          """)
+
+        assert at(one(html, "input"), "aria-valuenow") == nil
+      end
+    end
+
+    test "buttons are labelled, typed and kept out of the tab order" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="qty" value="3" />
+        """)
+
+      for button <- all(html, "button[data-pc-number-step]") do
+        assert at(button, "type") == "button"
+        assert at(button, "tabindex") == "-1"
+        assert at(button, "aria-label") in ["Increase value", "Decrease value"]
+      end
+    end
+
+    test "button labels are overridable" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field
+          name="qty"
+          value="3"
+          increment_label="Add one seat"
+          decrement_label="Remove one seat"
+        />
+        """)
+
+      assert html =~ "Add one seat"
+      assert html =~ "Remove one seat"
+    end
+
+    test "a value at a bound marks that button aria-disabled, not disabled" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="qty" value="1" min={1} max={10} />
+        """)
+
+      dec = one(html, "button[data-pc-number-step=dec]")
+      inc = one(html, "button[data-pc-number-step=inc]")
+
+      assert at(dec, "aria-disabled") == "true"
+      assert at(dec, "disabled") == nil
+      assert at(inc, "aria-disabled") == nil
+    end
+
+    test "a value past the upper bound still marks the increment spent" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="qty" value="42" max={10} />
+        """)
+
+      assert at(one(html, "button[data-pc-number-step=inc]"), "aria-disabled") == "true"
+      assert at(one(html, "button[data-pc-number-step=dec]"), "aria-disabled") == nil
+    end
+
+    test "an empty value disables neither button" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="qty" value="" min={1} max={10} />
+        """)
+
+      for button <- all(html, "button[data-pc-number-step]") do
+        assert at(button, "aria-disabled") == nil
+      end
+    end
+
+    test "disabled uses the native attribute on the input and both buttons" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="qty" value="3" disabled />
+        """)
+
+      assert at(one(html, "input"), "disabled") == ""
+
+      for button <- all(html, "button[data-pc-number-step]") do
+        assert at(button, "disabled") == ""
+      end
+    end
+
+    test "readonly and required pass through to the input" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="qty" value="3" readonly required placeholder="0" />
+        """)
+
+      input = one(html, "input")
+      assert at(input, "readonly") == ""
+      assert at(input, "required") == ""
+      assert at(input, "placeholder") == "0"
+    end
+  end
+
+  describe "precision" do
+    test "pads and rounds the rendered value so the first paint matches post-blur" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="price" value="24.5" precision={2} />
+        """)
+
+      assert at(one(html, "input"), "value") == "24.50"
+    end
+
+    test "precision 0 rounds to a whole number" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="price" value="24.6" precision={0} />
+        """)
+
+      assert at(one(html, "input"), "value") == "25"
+    end
+
+    test "without precision the value is rendered as given" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="price" value="24.50" />
+        """)
+
+      assert at(one(html, "input"), "value") == "24.50"
+    end
+
+    test "text that is not a number rides through untouched" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field name="price" value="12." precision={2} />
+        """)
+
+      assert at(one(html, "input"), "value") == "12."
+    end
+
+    test "integer and float values both render" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <div>
+          <.number_field name="a" value={5} />
+          <.number_field name="b" value={5.5} />
+        </div>
+        """)
+
+      assert at(Enum.at(all(html, "input"), 0), "value") == "5"
+      assert at(Enum.at(all(html, "input"), 1), "value") == "5.5"
+    end
+  end
+
+  describe "form integration" do
+    defp form_field(value, errors \\ []) do
+      %Phoenix.HTML.FormField{
+        id: "order_quantity",
+        name: "order[quantity]",
+        errors: errors,
+        field: :quantity,
+        # errors only surface for a field the user has actually touched, so
+        # the form has to carry params for the error case to be honest
+        form: %Phoenix.HTML.Form{params: %{"quantity" => value}},
+        value: value
+      }
+    end
+
+    test "derives id, name and value from a form field" do
+      assigns = %{field: form_field("4")}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field field={@field} min={1} />
+        """)
+
+      input = one(html, "input")
+      assert at(input, "id") == "order_quantity"
+      assert at(input, "name") == "order[quantity]"
+      assert at(input, "value") == "4"
+      assert at(input, "aria-valuenow") == "4"
+      assert at(one(html, ".pc-number-field"), "id") == "order_quantity-field"
+    end
+
+    test "an explicit id wins over the form field's" do
+      assigns = %{field: form_field("4")}
+
+      html =
+        rendered_to_string(~H"""
+        <.number_field field={@field} id="custom" />
+        """)
+
+      assert at(one(html, "input"), "id") == "custom"
+      assert at(one(html, "input"), "name") == "order[quantity]"
+    end
+
+    test "type=\"number-field\" renders the label, the control and the help text" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.field type="number-field" name="seats" value="3" label="Seats" min={1} help_text="1 to 20" />
+        """)
+
+      assert_has_class(html, "pc-form-field-wrapper")
+      assert_has_class(html, "pc-number-field")
+      assert html =~ "Seats"
+      assert html =~ "1 to 20"
+
+      label = one(html, "label")
+      assert at(label, "for") == at(one(html, "input"), "id")
+      assert at(one(html, ".pc-number-field"), "data-min") == "1"
+    end
+
+    test "type=\"number-field\" surfaces errors through the wrapper" do
+      assigns = %{field: form_field("0", [{"must be at least 1", []}])}
+
+      html =
+        rendered_to_string(~H"""
+        <.field type="number-field" field={@field} label="Quantity" min={1} />
+        """)
+
+      assert_has_class(html, "pc-form-field-wrapper--error")
+      assert html =~ "must be at least 1"
+      assert at(one(html, "input"), "name") == "order[quantity]"
+    end
+
+    test "type=\"number-field\" maps the xs-xl field sizes onto sm/md/lg" do
+      for {field_size, expected} <- [{"xs", "sm"}, {"sm", "sm"}, {"md", "md"}, {"xl", "lg"}] do
+        assigns = %{size: field_size}
+
+        html =
+          rendered_to_string(~H"""
+          <.field type="number-field" name="qty" value="1" size={@size} />
+          """)
+
+        assert_has_class(html, "pc-number-field--#{expected}")
+      end
+    end
+
+    test "type=\"number-field\" carries the variant and the hook attrs through" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.field
+          type="number-field"
+          name="qty"
+          value="2"
+          number_variant="split"
+          min={1}
+          max={9}
+          step={0.5}
+          precision={1}
+        />
+        """)
+
+      group = one(html, ".pc-number-field")
+      assert_has_class(html, "pc-number-field--split")
+      assert at(group, "data-step") == "0.5"
+      assert at(group, "data-precision") == "1"
+      assert at(one(html, "input"), "value") == "2.0"
+    end
+  end
+end


### PR DESCRIPTION
Closes #607

## Summary

A net-new `<.number_field>`: a real spinbutton for quantities, prices and percentages, composed on the existing `pc-input-group` surface rather than standing up a new one. Three variants (`stacked`, `split`, `plain`), three sizes, clamping mirrored to ARIA, a full keyboard map, wheel-while-focused, and hold-to-repeat.

- `lib/petal_components/number_field.ex` - the component. `@moduledoc` carries the docs (why not `type="number"`, variants, keyboard table, a11y contract, the `Intl.NumberFormat` pattern for currency/percent); the public function's `@doc` points at it.
- `assets/js/petal_components.js` - `PetalNumberField` hook plus `numberFieldMath` (parse / clamp / decimal-safe add / format), exported so the specs can pin the rules without a DOM.
- `assets/default.css` - a `pc-number-field` section appended inside its own `@layer components { }` block, so it doesn't inherit the unlayered tail's habit of beating consumer utilities.
- `lib/petal_components/field.ex` - a `"number-field"` type: label, help text and the error tone for free.
- `dev.exs` - `/c/number-field` with live dials and the three scenarios from the issue.
- Showcase module, registry entry, `PetalComponents` import, changelog.

## The spinbutton vs native-input decision

**`<input type="text" inputmode="decimal">` carrying `role="spinbutton"`**, per the issue's sketch and the Base UI approach. Not `type="number"`. The reasons, in order of weight:

1. **`precision` is impossible on `type="number"`.** Writing `"24.50"` back into a number input is a value the browser normalises to `24.5` on read and re-renders however it likes. Format-on-blur is the component's whole formatting story, and the native type fights it.
2. **A half-typed value survives.** `type="number"` reports `value === ""` for `"12."` or `"1e"`, so any hook reading the input mid-keystroke sees an empty field. That makes "clamp on blur, never mid-keystroke" unimplementable.
3. **Spinners.** Unstyleable and different in Chrome, Firefox and Safari - the thing this component exists to replace.
4. `inputmode="decimal"` still gets the numeric keypad on mobile, which is most of what `type="number"` was buying.

What it costs: **native constraint validation**. `min`/`max` no longer participate in `:invalid` or in the browser's own form validation. The moduledoc says so in as many words and tells you to validate the bound server-side. `aria-valuemin` / `aria-valuemax` / `aria-valuenow` carry the semantics to assistive tech, which is what the APG spinbutton pattern asks for, and the hook enforces the clamp.

Bound buttons take `aria-disabled`, not `disabled` - a disabled button leaves the a11y tree, and a screen reader user tabbing the value up to 99 should still hear that an increment exists and is spent. A `disabled` *control* uses the native attribute everywhere, since then it genuinely isn't operable.

## Deviations from the issue's API sketch

- **`:leading` / `:trailing` slots added.** The sketch had no slots, but two of its three required scenarios need a `$` and a `%` addon. They render into the input-group's own addon rows alongside the buttons.
- **`decrement_label` / `increment_label` attrs added.** The sketch hard-coded "Increase value" / "Decrease value". Those are the defaults; the cart scenario wants "Remove one seat".
- **`<.field type="number-field">` variant rides `number_variant`, not `variant`.** `variant` is already taken on `<.field>` by radio-card. This follows the existing `combo_variant` precedent rather than inventing a third convention.
- **No `errors` attr on `number_field/1`.** The sketch mentioned it. The error ring is painted by `.pc-form-field-wrapper--error .pc-input-group`, which is the wrapper's job - so `<.field>` renders the messages and the standalone component stays a control, matching `<.input>`.
- **No identity is a raise, not a generated id.** `<.number_field />` with no `field`, `id` or `name` raises `ArgumentError`. The hook needs a stable element id and the label's `for=` needs to name the input; minting a constant would collide on the second instance. Same call `combo_box` already makes.
- **`step` defaults to `1` and `big_step` to `step * 10`, as sketched** - but `big_step` also drives `PageUp`/`PageDown`, not only shift+arrow.
- **Wrapper id is `"#{id}-field"`.** The hook lives on the group, the input keeps the clean id so `for=` and any `aria-describedby` still work.

## Tests

| Suite | Before | After |
| --- | --- | --- |
| `mix test` | 913 tests, 0 failures, 1 skipped | 943 tests, 0 failures, 1 skipped |
| `npm test` | 157 passing | 195 passing |

30 new Elixir tests (anatomy per variant, sizes, hook data attrs, id derivation, ARIA, bounds, disabled/readonly, precision, `%Phoenix.HTML.FormField{}` integration, `<.field type="number-field">` including errors and size mapping) and 38 new JS tests (the pure maths, the keyboard map, wheel focused vs not, blur clamping and formatting, button presses, hold-to-repeat with fake timers including every stop path, ARIA sync across a patch).

`mix format --check-formatted` clean, `mix compile --force --warnings-as-errors` clean, `mix credo` identical to `main` (14 refactoring opportunities, 31 readability issues on both).

## Verified in the playground

Live on `/c/number-field`, light and dark: every dial, keyboard-only stepping (arrow, shift+arrow to 23, End to 99 with `aria-valuenow` following), the wheel, hold-to-repeat, `precision` turning `7.5` into `7.50` on tab-out, and the buttons still stepping after a variant switch rewires them mid-patch.
