### PR TITLE
feat(scroll_area): themed native scrollbars, one div, zero JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,34 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **New `scroll_area` component: one themed treatment for every overflow
+  region, in one div and zero JavaScript.** The library already had eight
+  hand-rolled scroll regions, each styling overflow slightly differently -
+  this is the canonical version they can all adopt. `scrollbar-width` and
+  `scrollbar-color` do the work on Chrome 121+ and Firefox, a
+  `::-webkit-scrollbar` block covers Safari and older Chromium, and the two
+  never fight because an engine that honours the modern properties ignores
+  the webkit pseudo-elements outright. The thumb rides the gray ramp in
+  light and dark and steps one shade toward the foreground on hover.
+  `orientation` picks the axis (vertical, horizontal or both, with the off
+  axis clipped rather than left scrollable by accident), `fade_edges` masks
+  the scrolling axis so content dissolves at the clip instead of being cut,
+  and `gutter_stable` reserves the scrollbar's space so content does not
+  shift the moment it appears. Sizing is deliberately class-driven, so
+  there is no second sizing vocabulary sitting next to Tailwind's. Unlike
+  the Radix-style approach we do not reimplement the scrollbar in JS: you
+  keep native momentum scrolling, native keyboard handling and native
+  assistive-tech behaviour for free, and the trade is that we theme what
+  the platform exposes rather than overriding it - `visibility="always"` is
+  a request WebKit honours and Firefox cannot, and `gutter_stable` is a
+  no-op wherever scrollbars are overlays. The moduledoc says so in plain
+  language. The container is focusable by default (`tabindex="0"`), which
+  is what makes arrow keys and Page Up/Down work at all, and it only takes
+  `role="region"` when you give it a name - an unnamed landmark is noise,
+  not a service.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,143 @@
       transition-duration: 1ms;
     }
   }
+
+/* Scroll area - one themed treatment for every overflow region.
+ *
+ * CSS only, by design. `scrollbar-width` + `scrollbar-color` do the work on
+ * Chrome 121+ and Firefox; the ::-webkit-scrollbar block below covers older
+ * Chromium and current Safari. The two never fight: an engine that honours
+ * `scrollbar-color` ignores the webkit pseudo-elements outright.
+ *
+ * Note the base deliberately sets NO ::-webkit-scrollbar width/height. Giving
+ * one is what opts a WebKit element out of overlay scrollbars, so it belongs
+ * to --always, not to every scroll area on the page.
+ *
+ * Layered on purpose - these are component defaults and a consumer's own
+ * utilities must be able to beat them. */
+@layer components {
+  .pc-scroll-area {
+    --pc-scroll-area-thumb: var(--color-gray-300);
+    --pc-scroll-area-thumb-hover: var(--color-gray-400);
+    --pc-scroll-area-size: 8px;
+    --pc-scroll-area-fade: 1.5rem;
+
+    scrollbar-width: thin;
+    scrollbar-color: var(--pc-scroll-area-thumb) transparent;
+    overscroll-behavior: contain;
+    @apply focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500/50;
+  }
+
+  .pc-scroll-area:where(.dark, .dark *) {
+    --pc-scroll-area-thumb: var(--color-gray-600);
+    --pc-scroll-area-thumb-hover: var(--color-gray-500);
+  }
+
+  /* Fallback path: Safari and Chromium < 121 */
+  .pc-scroll-area::-webkit-scrollbar-track,
+  .pc-scroll-area::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+  .pc-scroll-area::-webkit-scrollbar-thumb {
+    background-color: var(--pc-scroll-area-thumb);
+    background-clip: padding-box;
+    border: 2px solid transparent;
+    border-radius: 9999px;
+  }
+  .pc-scroll-area::-webkit-scrollbar-thumb:hover {
+    background-color: var(--pc-scroll-area-thumb-hover);
+  }
+
+  /* Orientation - the off axis is clipped, never scrollable by accident */
+  .pc-scroll-area--vertical {
+    @apply overflow-x-hidden overflow-y-auto;
+  }
+  .pc-scroll-area--horizontal {
+    @apply overflow-x-auto overflow-y-hidden;
+  }
+  .pc-scroll-area--both {
+    @apply overflow-auto;
+  }
+
+  .pc-scroll-area--gutter-stable {
+    scrollbar-gutter: stable;
+  }
+
+  /* An explicit track size is the WebKit opt-out from overlay scrollbars.
+     Firefox has no equivalent, so there this is a no-op - documented. */
+  .pc-scroll-area--always::-webkit-scrollbar {
+    width: var(--pc-scroll-area-size);
+    height: var(--pc-scroll-area-size);
+  }
+
+  /* Fade edges - static masks on the scrolling axis. The mask is anchored to
+     the element's box, not to the content, so it stays put while you scroll. */
+  .pc-scroll-area--fade.pc-scroll-area--vertical {
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      transparent 0,
+      #000 var(--pc-scroll-area-fade),
+      #000 calc(100% - var(--pc-scroll-area-fade)),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to bottom,
+      transparent 0,
+      #000 var(--pc-scroll-area-fade),
+      #000 calc(100% - var(--pc-scroll-area-fade)),
+      transparent 100%
+    );
+  }
+
+  .pc-scroll-area--fade.pc-scroll-area--horizontal {
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      #000 var(--pc-scroll-area-fade),
+      #000 calc(100% - var(--pc-scroll-area-fade)),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      #000 var(--pc-scroll-area-fade),
+      #000 calc(100% - var(--pc-scroll-area-fade)),
+      transparent 100%
+    );
+  }
+
+  .pc-scroll-area--fade.pc-scroll-area--both {
+    -webkit-mask-image:
+      linear-gradient(
+        to bottom,
+        transparent 0,
+        #000 var(--pc-scroll-area-fade),
+        #000 calc(100% - var(--pc-scroll-area-fade)),
+        transparent 100%
+      ),
+      linear-gradient(
+        to right,
+        transparent 0,
+        #000 var(--pc-scroll-area-fade),
+        #000 calc(100% - var(--pc-scroll-area-fade)),
+        transparent 100%
+      );
+    mask-image:
+      linear-gradient(
+        to bottom,
+        transparent 0,
+        #000 var(--pc-scroll-area-fade),
+        #000 calc(100% - var(--pc-scroll-area-fade)),
+        transparent 100%
+      ),
+      linear-gradient(
+        to right,
+        transparent 0,
+        #000 var(--pc-scroll-area-fade),
+        #000 calc(100% - var(--pc-scroll-area-fade)),
+        transparent 100%
+      );
+    -webkit-mask-composite: source-in;
+    mask-composite: intersect;
+  }
+}

--- a/dev.exs
+++ b/dev.exs
@@ -224,6 +224,18 @@ defmodule Dev.PlaygroundLive do
     }
   ]
 
+  @scroll_log """
+  09:14:01.118 [info]  release v4.15.0 building on builder-04 (elixir 1.19.1 / otp 28)
+  09:14:04.902 [info]  ==> deps compiled in 3.7s, 214 modules
+  09:14:11.470 [info]  ==> assets: tailwind 4.1.3 wrote priv/static/assets/app.css in 812ms
+  09:14:12.006 [info]  ==> digest: 46 files, 1.9MB total, gzip 412KB
+  09:14:19.331 [info]  image pushed: registry.fly.io/acme-prod:deployment-01K2 (sha256:9f21c4ab)
+  09:14:26.884 [info]  machine 5683d9 updating in syd, waiting for health checks
+  09:14:38.019 [info]  machine 5683d9 healthy after 11.1s, 1 of 2 machines updated
+  09:14:51.744 [info]  machine 90e8ff healthy after 9.4s, 2 of 2 machines updated
+  09:14:52.100 [info]  deployment complete, 0 failed, rollback not required\
+  """
+
   @nav [
     %{
       group: "Foundations",
@@ -295,6 +307,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "card", name: "Card", ready: true},
         %{slug: "carousel", name: "Carousel", ready: true},
         %{slug: "accordion", name: "Accordion", ready: true},
+        %{slug: "scroll-area", name: "Scroll area", ready: true},
         %{slug: "container", name: "Container", ready: true}
       ]
     },
@@ -809,6 +822,8 @@ defmodule Dev.PlaygroundLive do
          glow: "outside",
          palette: "rainbow"
        },
+       scroll: %{orientation: "vertical", fade: "off", gutter: "auto", visibility: "auto"},
+       scroll_log: @scroll_log,
        shine: %{scheme: "mono", duration: "14s", width: "1px"},
        meteors: %{count: 20, angle: "215deg", color: "slate", reverse: false, seed: 0},
        rating: %{
@@ -1051,6 +1066,20 @@ defmodule Dev.PlaygroundLive do
 
   def handle_event("ctl_plasma", %{"k" => "width", "v" => v}, socket) when v in ~w(1px 2px 4px),
     do: {:noreply, update(socket, :plasma, &%{&1 | width: v})}
+
+  def handle_event("ctl_scroll", %{"k" => "orientation", "v" => v}, socket)
+      when v in ~w(vertical horizontal both),
+      do: {:noreply, update(socket, :scroll, &%{&1 | orientation: v})}
+
+  def handle_event("ctl_scroll", %{"k" => "fade", "v" => v}, socket) when v in ~w(off on),
+    do: {:noreply, update(socket, :scroll, &%{&1 | fade: v})}
+
+  def handle_event("ctl_scroll", %{"k" => "gutter", "v" => v}, socket) when v in ~w(auto stable),
+    do: {:noreply, update(socket, :scroll, &%{&1 | gutter: v})}
+
+  def handle_event("ctl_scroll", %{"k" => "visibility", "v" => v}, socket)
+      when v in ~w(auto always),
+      do: {:noreply, update(socket, :scroll, &%{&1 | visibility: v})}
 
   def handle_event("ctl_beam", %{"k" => "glow"}, socket),
     do: {:noreply, update(socket, :beam, &%{&1 | glow: !&1.glow})}
@@ -8633,6 +8662,221 @@ defmodule Dev.PlaygroundLive do
           :navigation_menu_footer_link
         ]}
       />
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "scroll-area"} = assigns) do
+    ~H"""
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">Scroll area</h1>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        One themed treatment for every overflow region, so a scrolling panel
+        looks like it belongs to the design system instead of inheriting
+        whatever the OS decided. One div, zero JavaScript: modern
+        scrollbar-width and scrollbar-color where the engine honours them, a
+        ::-webkit-scrollbar fallback where it does not. Size the viewport with
+        classes; the component never grows sizing attrs of its own.
+      </p>
+
+      <div class="mt-8 overflow-hidden border border-gray-200 rounded-xl dark:border-gray-800">
+        <%!-- The border lives on the wrapper, not the scroll area: fade_edges
+        masks the whole element, border included. --%>
+        <div class="px-6 py-10">
+          <div class="p-4 border border-gray-200 rounded-lg dark:border-gray-800">
+            <.scroll_area
+              orientation={@scroll.orientation}
+              fade_edges={@scroll.fade == "on"}
+              gutter_stable={@scroll.gutter == "stable"}
+              visibility={@scroll.visibility}
+              aria-label="Playground content"
+              class="w-full max-h-64"
+            >
+              <div class={[
+                "space-y-3 text-sm text-gray-700 dark:text-gray-300",
+                @scroll.orientation != "vertical" && "w-max"
+              ]}>
+                <p :for={n <- 1..12}>
+                  Line {n} - long enough to run past the right edge, so the horizontal scrollbar has somewhere to go and you can see both axes at once.
+                </p>
+              </div>
+            </.scroll_area>
+          </div>
+        </div>
+        <div class="flex flex-wrap items-end gap-x-8 gap-y-4 px-4 sm:px-6 py-4 [&>div]:min-w-0 [&>div]:max-w-full border-t border-gray-200 dark:border-gray-800">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">orientation</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Orientation"
+              value={@scroll.orientation}
+              on_change="ctl_scroll"
+            >
+              <:item
+                :for={o <- ~w(vertical horizontal both)}
+                value={o}
+                phx-value-k="orientation"
+                phx-value-v={o}
+              >
+                {o}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">fade edges</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Fade edges"
+              value={@scroll.fade}
+              on_change="ctl_scroll"
+            >
+              <:item :for={f <- ~w(off on)} value={f} phx-value-k="fade" phx-value-v={f}>
+                {f}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">gutter</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Gutter"
+              value={@scroll.gutter}
+              on_change="ctl_scroll"
+            >
+              <:item :for={g <- ~w(auto stable)} value={g} phx-value-k="gutter" phx-value-v={g}>
+                {g}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">visibility</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Visibility"
+              value={@scroll.visibility}
+              on_change="ctl_scroll"
+            >
+              <:item
+                :for={v <- ~w(auto always)}
+                value={v}
+                phx-value-k="visibility"
+                phx-value-v={v}
+              >
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+        </div>
+        <p class="px-6 pb-4 -mt-1 text-xs text-gray-400 dark:text-gray-500">
+          tab into the panel and the arrow keys, Page Up/Down, Home and End all scroll it - that is native browser behaviour, not a hook
+        </p>
+      </div>
+
+      <div class="p-4 mt-6 text-sm border rounded-xl border-gray-200 bg-gray-50 text-gray-600 dark:border-gray-800 dark:bg-gray-900/40 dark:text-gray-400">
+        <div class="mb-1 font-medium text-gray-900 dark:text-gray-100">
+          Scrollbars belong to the OS
+        </div>
+        <p>
+          On macOS with "Show scroll bars: Automatically" - the default - the
+          scrollbar is an overlay: it appears while you scroll, sits over the
+          content, ignores most theming and has no gutter to reserve. Most
+          mobile browsers do the same. On Windows, Linux, and macOS set to
+          "Always", you get a classic scrollbar that takes real layout space and
+          picks up the theming in full.
+        </p>
+        <p class="mt-2">
+          So <code class="font-mono text-xs">visibility="always"</code>
+          is a request, not a guarantee - WebKit honours it, Firefox has no
+          mechanism for it. <code class="font-mono text-xs">gutter_stable</code>
+          is a no-op wherever scrollbars are overlays, because there is no
+          gutter to reserve. This component themes what the platform exposes.
+          It does not fight the OS.
+        </p>
+      </div>
+
+      <div class="mt-12 mb-3 text-xs font-medium tracking-wide text-gray-400 dark:text-gray-500">
+        Three places it earns its keep
+      </div>
+
+      <div class="grid gap-6 p-6 border border-gray-200 rounded-xl dark:border-gray-800">
+        <div>
+          <div class="mb-3 text-xs text-gray-400 dark:text-gray-500">
+            A tag rail - horizontal, faded edges
+          </div>
+          <div class="max-w-sm p-4 border border-gray-200 rounded-lg dark:border-gray-800">
+            <div class="mb-3 text-sm font-medium text-gray-900 dark:text-gray-100">Topics</div>
+            <.scroll_area orientation="horizontal" fade_edges class="w-full pb-2">
+              <div class="flex gap-2 w-max">
+                <.badge
+                  :for={
+                    tag <-
+                      ~w(elixir phoenix liveview heex tailwind oban ecto postgres fly accessibility)
+                  }
+                  label={tag}
+                  variant="soft"
+                />
+              </div>
+            </.scroll_area>
+          </div>
+        </div>
+
+        <div>
+          <div class="mb-3 text-xs text-gray-400 dark:text-gray-500">
+            A chat transcript - vertical, faded edges, named for screen readers
+          </div>
+          <div class="max-w-md p-4 border border-gray-200 rounded-lg dark:border-gray-800">
+            <.scroll_area fade_edges aria-label="Chat messages" class="max-h-56">
+              <div class="space-y-3">
+                <div
+                  :for={
+                    {role, text} <- [
+                      {:user, "Can I theme the scrollbar without shipping a JS scrollbar?"},
+                      {:assistant,
+                       "Yes. scrollbar-width and scrollbar-color cover Chrome 121+ and Firefox, and ::-webkit-scrollbar covers Safari and older Chromium."},
+                      {:user, "What about macOS overlay scrollbars?"},
+                      {:assistant,
+                       "Those are the OS's call. We theme what the platform exposes and leave the behaviour alone - you keep native momentum, keyboard and AT support for free."},
+                      {:user, "And the fade at the edges?"},
+                      {:assistant,
+                       "A mask-image gradient on the scrolling axis. No extra DOM, so there is nothing for a screen reader to trip over."}
+                    ]
+                  }
+                  class={[
+                    "max-w-[85%] rounded-lg px-3 py-2 text-sm",
+                    role == :user &&
+                      "ml-auto bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900",
+                    role == :assistant &&
+                      "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200"
+                  ]}
+                >
+                  {text}
+                </div>
+              </div>
+            </.scroll_area>
+          </div>
+        </div>
+
+        <div>
+          <div class="mb-3 text-xs text-gray-400 dark:text-gray-500">
+            A deploy log - both axes, gutter reserved
+          </div>
+          <.scroll_area
+            orientation="both"
+            gutter_stable
+            aria-label="Deploy log"
+            class="max-h-48 max-w-md p-4 rounded-lg bg-gray-900 dark:border dark:border-gray-800"
+          >
+            <pre class="font-mono text-xs leading-6 text-gray-100 w-max">{@scroll_log}</pre>
+          </.scroll_area>
+        </div>
+      </div>
+
+      <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
+      <.showcase_props component={PetalComponents.ScrollArea} function={:scroll_area} />
     </div>
     """
   end

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -59,6 +59,7 @@ defmodule PetalComponents do
         Popover,
         Progress,
         Rating,
+        ScrollArea,
         Skeleton,
         SlideOver,
         SocialButton,

--- a/lib/petal_components/scroll_area.ex
+++ b/lib/petal_components/scroll_area.ex
@@ -1,0 +1,173 @@
+defmodule PetalComponents.ScrollArea do
+  @moduledoc """
+  A themed scroll container, so an overflow region looks like it belongs to
+  the design system instead of inheriting whatever the OS decided.
+
+  It is one `<div>` and zero JavaScript. Modern `scrollbar-width` and
+  `scrollbar-color` do the work where the engine honours them (Chrome 121+,
+  Firefox), and a `::-webkit-scrollbar` block covers older Chromium and
+  current Safari. The thumb rides the gray ramp in both light and dark mode
+  and steps one shade toward the foreground on hover.
+
+  Size the viewport with classes, not attrs - that is deliberate, so the
+  component never grows a parallel sizing vocabulary next to Tailwind's:
+
+      <.scroll_area class="max-h-72 rounded-lg border border-gray-200 p-4 dark:border-gray-800">
+        <p :for={item <- @items}>{item}</p>
+      </.scroll_area>
+
+  Scroll sideways instead, and hint at the content past the edge:
+
+      <.scroll_area orientation="horizontal" fade_edges class="w-full pb-2">
+        <div class="flex gap-2">
+          <.badge :for={tag <- @tags} label={tag} />
+        </div>
+      </.scroll_area>
+
+  Both axes at once, with the scrollbar space reserved so the content does
+  not shift the moment a scrollbar appears:
+
+      <.scroll_area orientation="both" gutter_stable class="max-h-64 max-w-full">
+        <pre><code>{@snippet}</code></pre>
+      </.scroll_area>
+
+  ## The platform truth
+
+  Scrollbars are the operating system's, not ours. On macOS with "Show
+  scroll bars: Automatically" - the default - the scrollbar is an overlay
+  that appears while you scroll, sits on top of the content, ignores most
+  theming and has no gutter to reserve. Most mobile browsers behave the
+  same way. On Windows and Linux, and on macOS set to "Always", you get a
+  classic scrollbar that takes real layout space and picks up the theming
+  in full.
+
+  So `<.scroll_area>` themes what the platform exposes. It does not fight
+  the OS, and it will not make a Mac look like a PC:
+
+    * `visibility="always"` is a *request*. WebKit honours it, because
+      giving `::-webkit-scrollbar` an explicit size opts that element out
+      of overlay rendering. Firefox has no force-visible mechanism, so
+      there it is silently ignored.
+    * `gutter_stable` is a no-op wherever scrollbars are overlays, because
+      an overlay has no gutter to reserve. It is not broken; there is
+      simply nothing to reserve.
+    * `scrollbar-color` has no hover state, so on Chrome 121+ and Firefox
+      the thumb keeps one colour. The hover step only shows on engines
+      taking the `::-webkit-scrollbar` path.
+
+  ## Fade edges
+
+  `fade_edges` applies a `mask-image` gradient on the scrolling axis (both,
+  composited, when `orientation="both"`). The mask is static: it fades both
+  edges regardless of scroll position, so content that fits without
+  scrolling still gets softened at its edges. That is the v1 trade -
+  scroll-position-aware fading needs either JS or `animation-timeline`,
+  and neither earns its keep yet. Reach for `fade_edges` on regions that
+  genuinely overflow.
+
+  The mask is decorative and adds no DOM, so there is nothing for assistive
+  tech to skip. It does apply to the whole element, though, border and
+  background included - so put the border on a wrapper rather than on the
+  scroll area itself when you combine the two, or you will watch the border
+  fade out along with the content:
+
+      <div class="rounded-lg border border-gray-200 p-4 dark:border-gray-800">
+        <.scroll_area fade_edges class="max-h-56">...</.scroll_area>
+      </div>
+
+  ## Accessibility
+
+  There is no ARIA pattern for a scroll container. What matters is that a
+  keyboard user can reach the content and move it:
+
+    * The container renders `tabindex="0"`, which is what makes arrow keys,
+      Page Up/Down, Home and End scroll it. That is native browser
+      behaviour and needs no JS. Being focusable, it takes the standard
+      `focus-visible` ring - never a persistent focus fill.
+    * Pass `tabindex="-1"` to remove the tab stop when everything inside is
+      already focusable (a list of links, a menu). A second tab stop in
+      front of focusable content is noise; a tab stop in front of a wall of
+      unreachable text is the only way in.
+    * Give it a name when it is a standalone region:
+      `<.scroll_area aria-label="Chat messages">`. With `aria-label` or
+      `aria-labelledby` present the container also renders `role="region"`,
+      so it lands in the landmark list under that name. Without a name no
+      role is emitted - an unnamed region is landmark noise, not a service.
+      An explicit `role` you pass always wins.
+  """
+  use Phoenix.Component
+
+  attr :orientation, :string,
+    default: "vertical",
+    values: ["vertical", "horizontal", "both"],
+    doc: "which axis scrolls: vertical (overflow-y), horizontal (overflow-x), or both"
+
+  attr :fade_edges, :boolean,
+    default: false,
+    doc:
+      "fade content out at the scroll edges with a mask-image gradient, hinting that more content exists past the clip. Masks apply on the scrolling axis only, and are static - they do not track scroll position"
+
+  attr :gutter_stable, :boolean,
+    default: false,
+    doc:
+      "reserve scrollbar space with scrollbar-gutter: stable so content does not shift when the scrollbar appears or disappears. Classic scrollbars only - overlay scrollbars have no gutter to reserve"
+
+  attr :visibility, :string,
+    default: "auto",
+    values: ["auto", "always"],
+    doc:
+      "auto follows the platform (overlay scrollbars appear on scroll on macOS); always requests a persistently visible scrollbar where the engine allows it - see the platform-truth note in the module docs"
+
+  attr :class, :any,
+    default: nil,
+    doc:
+      "size the viewport here, e.g. class=\"max-h-72\" or class=\"max-w-full\" - sizing is deliberately class-driven, not attr-driven"
+
+  attr :rest, :global
+
+  slot :inner_block, required: true
+
+  @doc """
+  A themed scroll container: native scrollbars, styled to match.
+
+  See `PetalComponents.ScrollArea` for usage, the platform caveats around
+  overlay scrollbars, and the accessibility notes.
+  """
+  def scroll_area(assigns) do
+    assigns = update(assigns, :rest, &a11y_defaults/1)
+
+    ~H"""
+    <div
+      class={[
+        "pc-scroll-area",
+        "pc-scroll-area--#{@orientation}",
+        @fade_edges && "pc-scroll-area--fade",
+        @gutter_stable && "pc-scroll-area--gutter-stable",
+        @visibility == "always" && "pc-scroll-area--always",
+        @class
+      ]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+
+  # tabindex="0" is what makes the arrow keys work, so it is the default -
+  # but it is a plain global, so `tabindex="-1"` from the caller wins.
+  # role="region" only rides along when there is a name to give it: an
+  # unnamed landmark adds an entry to the region list that says nothing.
+  defp a11y_defaults(rest) do
+    rest = Map.put_new(rest, :tabindex, "0")
+
+    if named?(rest) do
+      Map.put_new(rest, :role, "region")
+    else
+      rest
+    end
+  end
+
+  defp named?(rest) do
+    Map.has_key?(rest, :"aria-label") or Map.has_key?(rest, :"aria-labelledby")
+  end
+end

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -44,6 +44,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.Popover,
     PetalComponents.Showcase.Progress,
     PetalComponents.Showcase.Rating,
+    PetalComponents.Showcase.ScrollArea,
     PetalComponents.Showcase.ShineBorder,
     PetalComponents.Showcase.Skeleton,
     PetalComponents.Showcase.SlideOver,

--- a/lib/petal_components/showcase/scroll_area.ex
+++ b/lib/petal_components/showcase/scroll_area.ex
@@ -1,0 +1,96 @@
+defmodule PetalComponents.Showcase.ScrollArea do
+  @moduledoc false
+  use PetalComponents.Showcase,
+    component: PetalComponents.ScrollArea,
+    title: "Scroll area"
+
+  @deploy_log """
+  09:14:01.118 [info]  release v4.15.0 building on builder-04 (elixir 1.19.1 / otp 28)
+  09:14:04.902 [info]  ==> deps compiled in 3.7s, 214 modules
+  09:14:11.470 [info]  ==> assets: tailwind 4.1.3 wrote priv/static/assets/app.css in 812ms
+  09:14:12.006 [info]  ==> digest: 46 files, 1.9MB total, gzip 412KB
+  09:14:19.331 [info]  image pushed: registry.fly.io/acme-prod:deployment-01K2 (sha256:9f21c4ab)
+  09:14:26.884 [info]  machine 5683d9 updating in syd, waiting for health checks
+  09:14:38.019 [info]  machine 5683d9 healthy after 11.1s, 1 of 2 machines updated
+  09:14:51.744 [info]  machine 90e8ff healthy after 9.4s, 2 of 2 machines updated
+  09:14:52.100 [info]  deployment complete, 0 failed, rollback not required\
+  """
+
+  @doc false
+  def deploy_log, do: @deploy_log
+
+  example :basic, "A vertical list",
+    description:
+      "The default. Size the viewport with classes - here max-h-56 - and everything past it scrolls with a thin themed scrollbar instead of the browser's default slab. tabindex=\"0\" comes for free, so the arrow keys and Page Up/Down work the moment you tab into it." do
+    ~H"""
+    <.scroll_area
+      aria-label="Recent releases"
+      class="max-h-56 w-full max-w-sm rounded-lg border border-gray-200 p-3 dark:border-gray-800"
+    >
+      <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-300">
+        <li :for={n <- 1..14} class="flex items-center justify-between gap-4">
+          <span>Release note {n}</span>
+          <span class="text-xs text-gray-400">v4.{n}.0</span>
+        </li>
+      </ul>
+    </.scroll_area>
+    """
+  end
+
+  example :horizontal_tags, "Horizontal, with faded edges",
+    description:
+      "A tag rail that runs off the side of a card. fade_edges masks the scrolling axis so the row dissolves at the clip rather than being guillotined - the visual cue that says there is more this way." do
+    ~H"""
+    <div class="w-full max-w-sm rounded-lg border border-gray-200 p-4 dark:border-gray-800">
+      <div class="mb-3 text-sm font-medium text-gray-900 dark:text-gray-100">Topics</div>
+      <.scroll_area orientation="horizontal" fade_edges class="w-full pb-2">
+        <div class="flex w-max gap-2">
+          <.badge
+            :for={
+              tag <- ~w(elixir phoenix liveview heex tailwind oban ecto postgres fly accessibility)
+            }
+            label={tag}
+            variant="soft"
+          />
+        </div>
+      </.scroll_area>
+    </div>
+    """
+  end
+
+  example :both_axes, "Both axes, gutter reserved",
+    description:
+      "A deploy log with orientation=\"both\": one container, two themed scrollbars and a themed corner where they meet. gutter_stable reserves the scrollbar's space up front, so the lines do not shuffle sideways the first time a scrollbar appears. On overlay scrollbars (the macOS default) there is no gutter to reserve and the flag quietly does nothing." do
+    ~H"""
+    <.scroll_area
+      orientation="both"
+      gutter_stable
+      aria-label="Deploy log"
+      class="max-h-48 w-full max-w-md rounded-lg bg-gray-900 p-4 dark:border dark:border-gray-800"
+    >
+      <pre class="w-max font-mono text-xs leading-6 text-gray-100">{PetalComponents.Showcase.ScrollArea.deploy_log()}</pre>
+    </.scroll_area>
+    """
+  end
+
+  example :always_visible, "Asking for a permanent scrollbar",
+    description:
+      "visibility=\"always\" asks the engine to keep the scrollbar drawn instead of fading it in on scroll. It is a request, not a guarantee: WebKit honours it, Firefox has no mechanism for it, and no browser overrides an OS set to hide scrollbars. Reach for it when a region would otherwise look like static text." do
+    ~H"""
+    <.scroll_area
+      visibility="always"
+      class="max-h-40 w-full max-w-sm rounded-lg border border-gray-200 p-3 text-sm text-gray-700 dark:border-gray-800 dark:text-gray-300"
+    >
+      <p class="mb-3">
+        Scrollbars belong to the operating system. This component themes what the platform hands it - the thumb colour, the track, the width where that is ours to set - and leaves the behaviour alone.
+      </p>
+      <p class="mb-3">
+        That means native momentum scrolling, native keyboard handling and native assistive-tech behaviour, none of which a JavaScript scrollbar reimplementation gets for free.
+      </p>
+      <p>
+        The trade is that a Mac still looks like a Mac. We think that is the right way round.
+      </p>
+    </.scroll_area>
+    """
+  end
+end

--- a/test/petal/scroll_area_test.exs
+++ b/test/petal/scroll_area_test.exs
@@ -1,0 +1,348 @@
+defmodule PetalComponents.ScrollAreaTest do
+  use ComponentCase
+
+  import PetalComponents.ScrollArea
+
+  defp container(html) do
+    html |> parse_html() |> LazyHTML.query("div.pc-scroll-area")
+  end
+
+  defp classes(html) do
+    html
+    |> container()
+    |> LazyHTML.attribute("class")
+    |> List.first()
+    |> to_string()
+    |> String.split(" ", trim: true)
+  end
+
+  defp attribute(html, name) do
+    html |> container() |> LazyHTML.attribute(name) |> List.first()
+  end
+
+  # ComponentCase only IMPORTS Phoenix.Component, so attr `values:` validation
+  # never runs in this suite - it runs in the consumer's module. Compile a
+  # caller the way a consumer project does and read stderr.
+  defp warn_for(attrs) do
+    ExUnit.CaptureIO.capture_io(:stderr, fn ->
+      Code.compile_string("""
+      defmodule ScrollAreaProbe#{:erlang.unique_integer([:positive])} do
+        use Phoenix.Component
+        import PetalComponents.ScrollArea
+
+        def render(assigns) do
+          ~H\"\"\"
+          <.scroll_area #{attrs}>x</.scroll_area>
+          \"\"\"
+        end
+      end
+      """)
+    end)
+  end
+
+  describe "scroll_area/1" do
+    test "renders a single container with the base and default orientation classes" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area>Content</.scroll_area>
+        """)
+
+      assert Enum.count(container(html)) == 1
+      assert "pc-scroll-area" in classes(html)
+      assert "pc-scroll-area--vertical" in classes(html)
+      assert html =~ "Content"
+    end
+
+    test "renders the inner block inside the container" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area>
+          <p class="inner">A paragraph</p>
+        </.scroll_area>
+        """)
+
+      inner = html |> parse_html() |> LazyHTML.query("div.pc-scroll-area p.inner")
+
+      assert Enum.count(inner) == 1
+      assert LazyHTML.text(inner) =~ "A paragraph"
+    end
+
+    test "no wrapper soup - the component is exactly one element" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area>x</.scroll_area>
+        """)
+
+      assert html |> parse_html() |> LazyHTML.query("div") |> Enum.count() == 1
+    end
+  end
+
+  describe "orientation" do
+    for orientation <- ~w(vertical horizontal both) do
+      test "#{orientation} emits its modifier and no other orientation modifier" do
+        assigns = %{orientation: unquote(orientation)}
+
+        html =
+          rendered_to_string(~H"""
+          <.scroll_area orientation={@orientation}>x</.scroll_area>
+          """)
+
+        orientation_classes =
+          Enum.filter(classes(html), &(&1 in ~w(
+             pc-scroll-area--vertical
+             pc-scroll-area--horizontal
+             pc-scroll-area--both
+           )))
+
+        assert orientation_classes == ["pc-scroll-area--#{unquote(orientation)}"]
+      end
+    end
+
+    test "an unknown orientation warns at compile time in the consumer's module" do
+      refute warn_for(~s|orientation="horizontal"|) =~ "must be one of"
+      assert warn_for(~s|orientation="diagonal"|) =~ "must be one of"
+    end
+  end
+
+  describe "fade_edges" do
+    test "off by default" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area>x</.scroll_area>
+        """)
+
+      refute "pc-scroll-area--fade" in classes(html)
+    end
+
+    test "on emits the fade modifier" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area fade_edges>x</.scroll_area>
+        """)
+
+      assert "pc-scroll-area--fade" in classes(html)
+    end
+  end
+
+  describe "gutter_stable" do
+    test "off by default" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area>x</.scroll_area>
+        """)
+
+      refute "pc-scroll-area--gutter-stable" in classes(html)
+    end
+
+    test "on emits the gutter modifier" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area gutter_stable>x</.scroll_area>
+        """)
+
+      assert "pc-scroll-area--gutter-stable" in classes(html)
+    end
+  end
+
+  describe "visibility" do
+    test "auto adds nothing" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area visibility="auto">x</.scroll_area>
+        """)
+
+      refute "pc-scroll-area--always" in classes(html)
+    end
+
+    test "always emits the always modifier" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area visibility="always">x</.scroll_area>
+        """)
+
+      assert "pc-scroll-area--always" in classes(html)
+    end
+
+    test "an unknown visibility warns at compile time in the consumer's module" do
+      refute warn_for(~s|visibility="always"|) =~ "must be one of"
+      assert warn_for(~s|visibility="never"|) =~ "must be one of"
+    end
+  end
+
+  describe "class merging" do
+    test "consumer classes ride alongside the pc-* classes" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area class="max-h-72 rounded-lg">x</.scroll_area>
+        """)
+
+      assert "pc-scroll-area" in classes(html)
+      assert "pc-scroll-area--vertical" in classes(html)
+      assert "max-h-72" in classes(html)
+      assert "rounded-lg" in classes(html)
+    end
+
+    test "class accepts a list" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area class={["max-h-40", nil, "w-full"]}>x</.scroll_area>
+        """)
+
+      assert "max-h-40" in classes(html)
+      assert "w-full" in classes(html)
+    end
+  end
+
+  describe "accessibility" do
+    test "focusable by default so the arrow keys scroll it" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area>x</.scroll_area>
+        """)
+
+      assert attribute(html, "tabindex") == "0"
+    end
+
+    test "a caller-supplied tabindex wins, so a second tab stop can be removed" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area tabindex="-1">x</.scroll_area>
+        """)
+
+      assert attribute(html, "tabindex") == "-1"
+      assert count_substring(html, "tabindex=") == 1
+    end
+
+    test "an aria-label lands on the container and promotes it to a named region" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area aria-label="Chat messages">x</.scroll_area>
+        """)
+
+      assert attribute(html, "aria-label") == "Chat messages"
+      assert attribute(html, "role") == "region"
+    end
+
+    test "aria-labelledby also names the region" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area aria-labelledby="thread-heading">x</.scroll_area>
+        """)
+
+      assert attribute(html, "aria-labelledby") == "thread-heading"
+      assert attribute(html, "role") == "region"
+    end
+
+    test "no name means no role - an unnamed landmark is noise" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area>x</.scroll_area>
+        """)
+
+      assert attribute(html, "role") == nil
+      refute html =~ "role="
+    end
+
+    test "an explicit role wins over the region default" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area aria-label="Log output" role="log">x</.scroll_area>
+        """)
+
+      assert attribute(html, "role") == "log"
+      assert count_substring(html, "role=") == 1
+    end
+  end
+
+  describe "global attributes" do
+    test "id, data-* and phx-* pass through" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area id="thread" data-testid="thread" phx-hook="Sticky">x</.scroll_area>
+        """)
+
+      assert attribute(html, "id") == "thread"
+      assert attribute(html, "data-testid") == "thread"
+      assert attribute(html, "phx-hook") == "Sticky"
+    end
+  end
+
+  describe "edge cases" do
+    test "every dial at once composes rather than conflicts" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area
+          orientation="both"
+          fade_edges
+          gutter_stable
+          visibility="always"
+          aria-label="Everything"
+          class="max-h-64"
+        >
+          x
+        </.scroll_area>
+        """)
+
+      for class <- ~w(
+            pc-scroll-area
+            pc-scroll-area--both
+            pc-scroll-area--fade
+            pc-scroll-area--gutter-stable
+            pc-scroll-area--always
+            max-h-64
+          ) do
+        assert class in classes(html)
+      end
+    end
+
+    test "empty content still renders a valid container" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.scroll_area></.scroll_area>
+        """)
+
+      assert Enum.count(container(html)) == 1
+      assert attribute(html, "tabindex") == "0"
+    end
+  end
+end


### PR DESCRIPTION
Closes #609

## What this is

`<.scroll_area>` - a themed scroll container, so an overflow region looks like it belongs to the design system instead of inheriting whatever the OS decided. One `<div>`, zero JavaScript.

- `scrollbar-width` + `scrollbar-color` do the work on Chrome 121+ and Firefox; a `::-webkit-scrollbar` block covers Safari and older Chromium. The two never fight - an engine that honours the modern properties ignores the webkit pseudo-elements outright.
- `orientation` is `vertical` / `horizontal` / `both`, with the off axis clipped rather than left scrollable by accident.
- `fade_edges` masks the scrolling axis with a `mask-image` gradient (both gradients composited via `mask-composite: intersect` when `orientation="both"`).
- `gutter_stable` adds `scrollbar-gutter: stable`.
- `visibility="always"` gives `::-webkit-scrollbar` an explicit size, which is the WebKit opt-out from overlay scrollbars.
- Thumb rides the gray ramp in light and dark, one step toward the foreground on hover. No new grays invented.
- Sizing stays class-driven. No `max_height` attr, no second sizing vocabulary next to Tailwind's.

## CSS vs a JS hook

**No hook.** Radix (and shadcn on top of it) reimplements the scrollbar in JS with custom thumb elements. We deliberately do not: native scrollbars mean native momentum scrolling, native keyboard handling and native assistive-tech behaviour, all for free and all of it hard to get right by hand.

The trade is that we theme what the platform exposes rather than overriding it, and that trade is written out in plain language in the moduledoc and repeated as a visible note on the playground page:

- `visibility="always"` is a request. WebKit honours it, Firefox has no force-visible mechanism, and no browser overrides an OS set to hide scrollbars.
- `gutter_stable` is a no-op wherever scrollbars are overlays (the macOS default), because an overlay has no gutter to reserve.
- `scrollbar-color` has no hover state, so the hover step only shows on engines taking the `::-webkit-scrollbar` path.

Nothing here needed JS to work, so nothing here ships JS. No `test/js/` file, because there is no hook to test.

## Deviations from the issue's API sketch

1. **`role="region"` is conditional, not absent and not unconditional.** The sketch rendered `tabindex="0"` and no role; the issue's a11y section asked for the call to be made deliberately. The container renders `role="region"` only when `aria-label` or `aria-labelledby` is present. An unnamed region is an entry in the landmark list that says nothing, and an explicit `role` you pass always wins. Documented in the moduledoc, covered by four tests.
2. **`tabindex` is a defaulted global, not hard-coded.** The sketch hard-coded `tabindex="0"` on the element, which would have produced a duplicate attribute for anyone passing `tabindex="-1"` through `@rest`. It is `Map.put_new/3` on `@rest` instead, so the caller can remove the tab stop when everything inside is already focusable - the case the issue asked to consider.
3. **Scroll-position-aware fading not attempted.** The issue lists it as a nice-to-have. Static masks only, as the issue's own CSS sketch permits for v1. Getting it right needs `@property` registration plus `animation-timeline: scroll()` keyframes and a Firefox fallback path, and a half-tested progressive enhancement is worse than none.
4. **New caveat found and documented:** `mask-image` masks the whole element, border and background included, so a bordered scroll area with `fade_edges` watches its own border fade out. The moduledoc says to put the border on a wrapper, and both playground examples that combine the two do exactly that.
5. **Adoption checklist deferred.** The eight existing ad-hoc scroll regions are untouched here. They are each a separately reviewable change and the issue leaves the call to the maintainer - happy to do them in this PR or a follow-up, whichever @nhobes prefers.

## Playground

`/c/scroll-area`, in the Display group. Four live dials (orientation, fade edges, gutter, visibility) wired via `handle_event`, the platform-truth note, and three scenarios: a horizontal tag rail with faded edges, a chat transcript, and a two-axis deploy log with the gutter reserved.

Showcase module carries four engine-run examples for petal.build.

## Verification

| | before | after |
|---|---|---|
| `mix test` | 913 tests, 0 failures, 1 skipped | **938 tests, 0 failures, 1 skipped** |
| `npm test` | 157 passing | **157 passing** (no JS shipped) |
| `mix credo --all` | 45 entries | **45 entries** (zero new) |

`mix format --check-formatted` clean. `mix compile --force --warnings-as-errors` clean.

Screenshots of the playground page in light and dark, captured in headless Chromium launched with native scrollbars visible, to be attached by hand - they are not committed to the repo.
