### PR TITLE
feat(scrollspy): the "on this page" rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,28 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **New `scrollspy` component: the "on this page" rail that follows the
+  reader down a long article.** Pass the sections as `items` and the
+  `PetalScrollspy` hook takes it from there, watching them with an
+  IntersectionObserver and sliding an indicator bar to whichever one is
+  at reading position. The fiddly parts are the point: when several
+  sections are on screen the one that most recently reached the
+  activation line wins, a closing section too short to ever reach that
+  line still highlights once you hit the bottom of the scroll, and a
+  `#hash` in the URL activates immediately on load instead of waiting
+  for the first observer callback. `offset` sets `scroll-margin-top` on
+  the targets so a fixed site header stops covering the heading you just
+  jumped to, `threshold` moves the activation line, `indicator="none"`
+  drops the bar for a colour-only active state, and one level of
+  nesting handles h2/h3 structure. The hook is not tied to the renderer:
+  put `phx-hook="PetalScrollspy"` on any container whose links carry
+  `data-scrollspy-target` and it drives your own markup, setting
+  `aria-current="location"` and `pc-scrollspy-link--active` on the active
+  link. Smooth scrolling and the indicator transition both drop out under
+  `prefers-reduced-motion`, and scrolling never moves focus.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,67 @@
       transition-duration: 1ms;
     }
   }
+
+/* Scrollspy - the "on this page" rail.
+   Layered, unlike the tail above it: unlayered rules outrank every Tailwind
+   utility, which would stop a consumer overriding these with a class. */
+@layer components {
+  .pc-scrollspy {
+    @apply relative text-sm;
+  }
+
+  .pc-scrollspy__heading {
+    @apply block mb-3 text-xs font-semibold tracking-wide uppercase text-gray-900 dark:text-white;
+  }
+
+  .pc-scrollspy__list {
+    @apply flex flex-col;
+  }
+
+  /* The rail the bar slides along. Only the bar variant draws it - with
+     indicator="none" the active state is carried by the link alone. */
+  .pc-scrollspy--bar .pc-scrollspy__list {
+    @apply border-l border-gray-200 dark:border-gray-800;
+  }
+
+  .pc-scrollspy__sublist {
+    @apply flex flex-col;
+  }
+
+  .pc-scrollspy-link {
+    @apply block py-1.5 pl-4 pr-2 text-gray-500 transition-colors dark:text-gray-400;
+    @apply hover:text-gray-900 dark:hover:text-white;
+    @apply focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:rounded-sm;
+  }
+
+  .pc-scrollspy-link--nested {
+    @apply pl-8 text-[0.8125rem];
+  }
+
+  .pc-scrollspy-link--active {
+    @apply font-medium text-primary-600 dark:text-primary-300;
+  }
+
+  .pc-scrollspy-link--active:hover {
+    @apply text-primary-700 dark:text-primary-200;
+  }
+
+  /* Positioned by the hook (transform + height); the glide is CSS so the
+     hook never owns timing. Hidden until it has a link to sit against. */
+  .pc-scrollspy__indicator {
+    @apply absolute left-0 top-0 w-0.5 bg-primary-600 dark:bg-primary-300;
+    transition:
+      transform 200ms ease,
+      height 200ms ease;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pc-scrollspy__indicator {
+      transition: none;
+    }
+
+    .pc-scrollspy-link {
+      transition: none;
+    }
+  }
+}

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -5424,6 +5424,272 @@ export const PetalDataTable = {
   },
 };
 
+// Scrollspy: highlight the nav entry for the section being read.
+//
+// The observer is only a cheap trigger - every decision is made from live
+// rects, so a section that grew, a window resize, or a LiveView patch can
+// never leave the rail describing a page that no longer exists.
+//
+// Band, not line, for the observer: rootMargin crops the viewport down to a
+// reading strip near the top, so callbacks fire when a heading arrives there
+// rather than on every pixel of scroll.
+const SCROLLSPY_ROOT_MARGIN = "-25% 0px -70% 0px";
+
+// Which section owns the activation line.
+//
+// `sections` is [{ id, top }] in document order, `top` in viewport
+// coordinates; `line` is the activation line, also in viewport coordinates.
+// The last section that has reached the line wins, which is the one nearest
+// the top of the viewport that the reader has actually got to - a new heading
+// takes over as it arrives, not when the previous section finally leaves.
+//
+// Exported for the spec: this is the whole behaviour of the hook expressed as
+// a pure function, so it can be tested without an IntersectionObserver.
+export function scrollspyActive(sections, { line = 0, atBottom = false } = {}) {
+  if (!sections.length) return null;
+  // At the very bottom there is no scroll left to bring a short final section
+  // to the line, so nothing below would ever be reachable. Snap to the last.
+  if (atBottom) return sections[sections.length - 1].id;
+
+  let active = sections[0].id;
+  // 1px of slack: sub-pixel layout means a section resting exactly on the
+  // line can measure a hair below it and flicker back to its predecessor.
+  for (const section of sections) {
+    if (section.top - line <= 1) active = section.id;
+  }
+  return active;
+}
+
+// The scrollable box the sections live in. Sections inside an overflow pane
+// (an app shell with its own scroller) still measure against the viewport for
+// the observer, but "am I at the bottom" is a question about their scroller.
+function scrollspyScrollRoot(el) {
+  let node = el?.parentElement;
+  while (node && node !== document.body) {
+    const { overflowY } = getComputedStyle(node);
+    if (
+      (overflowY === "auto" || overflowY === "scroll") &&
+      node.scrollHeight > node.clientHeight + 1
+    ) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return document.scrollingElement || document.documentElement;
+}
+
+// rootMargin's top component, resolved to viewport pixels. A negative top
+// margin crops the root downward, so the cropped edge - the activation line -
+// sits that far below the top of the viewport.
+function scrollspyLine(rootMargin, height) {
+  const top = String(rootMargin).trim().split(/\s+/)[0] || "0px";
+  const value = parseFloat(top);
+  if (Number.isNaN(value)) return 0;
+  return top.endsWith("%") ? (-value / 100) * height : -value;
+}
+
+export const PetalScrollspy = {
+  mounted() {
+    this.active = null;
+    this.frame = null;
+    this.targetStyles = new Map();
+
+    this.onHashChange = () => this.applyHash();
+    // Coalesce to one pass per frame: scroll outruns paint, and each pass
+    // reads layout.
+    this.onScroll = () => {
+      if (this.frame) return;
+      this.frame = requestAnimationFrame(() => {
+        this.frame = null;
+        this.sync();
+      });
+    };
+
+    this.scan();
+    this.enableSmoothScroll();
+    window.addEventListener("hashchange", this.onHashChange);
+    window.addEventListener("resize", this.onScroll, { passive: true });
+
+    // A deep link should be right from the first paint rather than after the
+    // observer's first callback.
+    if (!this.applyHash()) this.sync();
+  },
+
+  // LiveView can replace the rail or the article wholesale; re-measure both.
+  updated() {
+    this.scan();
+    this.sync();
+  },
+
+  destroyed() {
+    if (this.frame) cancelAnimationFrame(this.frame);
+    this.observer?.disconnect();
+    window.removeEventListener("hashchange", this.onHashChange);
+    window.removeEventListener("resize", this.onScroll);
+    this.listenToScrollRoot(null);
+    this.restoreScroll();
+  },
+
+  // Re-read the links, re-resolve the targets, re-point the observer. Safe to
+  // call repeatedly - the old observer is dropped first.
+  scan() {
+    this.links = Array.from(
+      this.el.querySelectorAll("[data-scrollspy-target]"),
+    );
+    this.targets = this.links
+      .map((link) => document.getElementById(link.dataset.scrollspyTarget))
+      .filter(Boolean);
+
+    this.listenToScrollRoot(scrollspyScrollRoot(this.targets[0] || this.el));
+    this.rootMargin = this.el.dataset.threshold || SCROLLSPY_ROOT_MARGIN;
+
+    // scroll-margin-top is what keeps a fixed header off the heading you just
+    // jumped to. It belongs on the target, which the component can't reach.
+    const offset = this.el.dataset.offset;
+    if (offset) {
+      this.targets.forEach((target) => {
+        if (!this.targetStyles.has(target)) {
+          this.targetStyles.set(target, target.style.scrollMarginTop);
+        }
+        target.style.scrollMarginTop = offset;
+      });
+    }
+
+    this.observer?.disconnect();
+    if (typeof IntersectionObserver === "undefined") return;
+    this.observer = new IntersectionObserver(() => this.sync(), {
+      rootMargin: this.rootMargin,
+      threshold: 0,
+    });
+    this.targets.forEach((target) => this.observer.observe(target));
+  },
+
+  // Bottom snap can't come from the observer: a short final section may never
+  // reach the line, so no callback ever fires for it. A patch can move the
+  // sections into a different scroller, so the listener follows rather than
+  // being left on the old one. Pass null to detach.
+  listenToScrollRoot(root) {
+    if (this.scrollRoot === root) return;
+    this.scrollRoot?.removeEventListener("scroll", this.onScroll);
+    this.scrollRoot = root;
+    this.scrollRoot?.addEventListener("scroll", this.onScroll, {
+      passive: true,
+    });
+  },
+
+  reducedMotion() {
+    return !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+  },
+
+  // Clicking a link is a native anchor jump; smooth is a property of the
+  // scroller, not of the click. Under reduced motion, leave it instant.
+  enableSmoothScroll() {
+    if (this.reducedMotion()) return;
+    const root =
+      this.scrollRoot === document.scrollingElement ||
+      this.scrollRoot === document.documentElement
+        ? document.documentElement
+        : this.scrollRoot;
+    this.smoothedEl = root;
+    this.priorScrollBehavior = root.style.scrollBehavior;
+    root.style.scrollBehavior = "smooth";
+  },
+
+  // The page is not ours: hand back every style we borrowed.
+  restoreScroll() {
+    if (this.smoothedEl) {
+      this.smoothedEl.style.scrollBehavior = this.priorScrollBehavior || "";
+      this.smoothedEl = null;
+    }
+    this.targetStyles.forEach((prior, target) => {
+      target.style.scrollMarginTop = prior || "";
+    });
+    this.targetStyles.clear();
+  },
+
+  atBottom() {
+    const root = this.scrollRoot;
+    if (!root) return false;
+    // A page with nothing to scroll is not "at the bottom" in any sense the
+    // reader would recognise - snapping there would highlight the last entry
+    // on a short page that is entirely visible.
+    if (root.scrollHeight <= root.clientHeight + 1) return false;
+    // 2px of slack: fractional device pixels mean scrollTop rarely lands
+    // exactly on the arithmetic bottom.
+    return root.scrollTop + root.clientHeight >= root.scrollHeight - 2;
+  },
+
+  sync() {
+    if (!this.targets?.length) return;
+
+    const height = window.innerHeight || 0;
+    const sections = this.targets.map((target) => ({
+      id: target.id,
+      top: target.getBoundingClientRect().top,
+    }));
+
+    this.setActive(
+      scrollspyActive(sections, {
+        line: scrollspyLine(this.rootMargin, height),
+        atBottom: this.atBottom(),
+      }),
+    );
+  },
+
+  // A hash beats the observer on arrival: the reader asked for that section
+  // explicitly, and the scroll that gets them there hasn't happened yet.
+  applyHash() {
+    const id = decodeURIComponent(window.location.hash.replace(/^#/, ""));
+    if (!id || !this.targets?.some((target) => target.id === id)) return false;
+    this.setActive(id);
+    return true;
+  },
+
+  setActive(id) {
+    if (id === this.active) {
+      // Same link, but it may have moved (resize, patched rail).
+      this.moveIndicator();
+      return;
+    }
+    this.active = id;
+
+    this.links.forEach((link) => {
+      const on = link.dataset.scrollspyTarget === id;
+      link.classList.toggle("pc-scrollspy-link--active", on);
+      // aria-current is the non-visual half of the active state - without it
+      // the highlight is colour alone.
+      if (on) {
+        link.setAttribute("aria-current", "location");
+      } else {
+        link.removeAttribute("aria-current");
+      }
+    });
+
+    this.moveIndicator();
+  },
+
+  // The bar is positioned, not animated, by JS: transform + height here, the
+  // transition (and its reduced-motion opt-out) in CSS.
+  moveIndicator() {
+    const bar = this.el.querySelector(".pc-scrollspy__indicator");
+    if (!bar) return;
+
+    const link = this.links?.find(
+      (candidate) => candidate.dataset.scrollspyTarget === this.active,
+    );
+    if (!link) {
+      bar.style.opacity = "0";
+      return;
+    }
+
+    const navRect = this.el.getBoundingClientRect();
+    const linkRect = link.getBoundingClientRect();
+    bar.style.opacity = "";
+    bar.style.height = `${linkRect.height}px`;
+    bar.style.transform = `translateY(${linkRect.top - navRect.top}px)`;
+  },
+};
+
 export default {
   PetalChart,
   PetalColorScheme,
@@ -5454,4 +5720,5 @@ export default {
   PetalCommandDialog,
   PetalComboBox,
   PetalDataTable,
+  PetalScrollspy,
 };

--- a/dev.exs
+++ b/dev.exs
@@ -274,6 +274,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "stepper", name: "Stepper", ready: true},
         %{slug: "menu", name: "Menu", ready: true},
         %{slug: "navigation-menu", name: "Navigation menu", ready: true},
+        %{slug: "scrollspy", name: "Scrollspy", ready: true},
         %{slug: "user-menu", name: "User menu", ready: true},
         %{slug: "language-select", name: "Language select", ready: true}
       ]
@@ -851,6 +852,7 @@ defmodule Dev.PlaygroundLive do
        ticker: %{value: 1024},
        tooltip: %{placement: "top", arrow: true},
        popover: %{placement: "bottom", top_layer: false},
+       scrollspy: %{offset: "6rem", nested: false, indicator: "bar"},
        chart: %{
          revenue: gen_wave(1100, 1),
          expenses: gen_wave(650, 4),
@@ -1437,6 +1439,17 @@ defmodule Dev.PlaygroundLive do
   def handle_event("ctl_popover", %{"k" => "top_layer"}, socket),
     do: {:noreply, update(socket, :popover, &%{&1 | top_layer: !&1.top_layer})}
 
+  def handle_event("ctl_scrollspy", %{"k" => "offset", "v" => v}, socket)
+      when v in ~w(2rem 6rem 12rem),
+      do: {:noreply, update(socket, :scrollspy, &%{&1 | offset: v})}
+
+  def handle_event("ctl_scrollspy", %{"k" => "indicator", "v" => v}, socket)
+      when v in ~w(bar none),
+      do: {:noreply, update(socket, :scrollspy, &%{&1 | indicator: v})}
+
+  def handle_event("ctl_scrollspy", %{"k" => "nested"}, socket),
+    do: {:noreply, update(socket, :scrollspy, &%{&1 | nested: !&1.nested})}
+
   def handle_event("ctl_otp", %{"k" => "length", "v" => v}, socket) when v in ~w(4 6),
     do: {:noreply, update(socket, :otp, &%{&1 | length: String.to_integer(v)})}
 
@@ -1849,6 +1862,61 @@ defmodule Dev.PlaygroundLive do
   # component (so one registry module), but the playground splits its examples
   # across the input / select / checkbox / radio / switch pages. Raises on a
   # typo'd id so a page can't silently drop an example.
+  # Flat mode lists the h2s only, which is what most docs rails do. Nested
+  # mode folds the two h3s under the section they belong to.
+  defp scrollspy_items(%{nested: nested}) do
+    wiring =
+      if nested do
+        %{
+          label: "Wiring it up",
+          target: "ss-wiring",
+          children: [
+            %{label: "The items list", target: "ss-items"},
+            %{label: "The targets", target: "ss-targets"}
+          ]
+        }
+      else
+        %{label: "Wiring it up", target: "ss-wiring"}
+      end
+
+    [
+      %{label: "Why a rail", target: "ss-why"},
+      wiring,
+      %{label: "Clearing a header", target: "ss-offset"},
+      %{label: "Motion", target: "ss-motion"},
+      %{label: "Accessibility", target: "ss-a11y"},
+      %{label: "Wrapping up", target: "ss-end"}
+    ]
+  end
+
+  defp scrollspy_snippet(ss) do
+    """
+    <.scrollspy
+      id="docs-toc"
+      heading="On this page"
+      offset="#{ss.offset}"#{if ss.indicator == "none", do: ~s|\n  indicator="none"|, else: ""}
+      items={[
+        %{label: "Why a rail", target: "ss-why"},#{if ss.nested, do: nested_snippet(), else: ~s|\n    %{label: "Wiring it up", target: "ss-wiring"},|}
+        %{label: "Wrapping up", target: "ss-end"}
+      ]}
+    />
+    """
+  end
+
+  defp nested_snippet do
+    """
+
+        %{
+          label: "Wiring it up",
+          target: "ss-wiring",
+          children: [
+            %{label: "The items list", target: "ss-items"},
+            %{label: "The targets", target: "ss-targets"}
+          ]
+        },\
+    """
+  end
+
   defp examples_for(module, ids) do
     by_id = Map.new(module.examples(), &{&1.id, &1})
     Enum.map(ids, &Map.fetch!(by_id, &1))
@@ -9123,6 +9191,218 @@ defmodule Dev.PlaygroundLive do
 
       <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
         These examples render from the shared <code>PetalComponents.Showcase.Badge</code>
+        registry - the same source petal.build renders, so the playground and the marketing
+        docs can't drift.
+      </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "scrollspy"} = assigns) do
+    assigns = assign(assigns, :ss_items, scrollspy_items(assigns.scrollspy))
+
+    ~H"""
+    <div class="max-w-5xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">Scrollspy</h1>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        The "on this page" rail. A hook watches the sections with an
+        IntersectionObserver and moves the highlight to whichever one you're reading.
+        Scroll this page and watch it track.
+      </p>
+
+      <div class="flex flex-wrap items-end px-4 py-4 mt-8 border border-gray-200 gap-x-8 gap-y-4 rounded-xl dark:border-gray-800">
+        <div>
+          <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">offset</div>
+          <.toggle_group
+            variant="outline"
+            size="sm"
+            aria_label="Offset"
+            value={@scrollspy.offset}
+            on_change="ctl_scrollspy"
+          >
+            <:item
+              :for={v <- ~w(2rem 6rem 12rem)}
+              value={v}
+              phx-value-k="offset"
+              phx-value-v={v}
+            >
+              {v}
+            </:item>
+          </.toggle_group>
+        </div>
+        <div>
+          <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">indicator</div>
+          <.toggle_group
+            variant="outline"
+            size="sm"
+            aria_label="Indicator"
+            value={@scrollspy.indicator}
+            on_change="ctl_scrollspy"
+          >
+            <:item :for={v <- ~w(bar none)} value={v} phx-value-k="indicator" phx-value-v={v}>
+              {v}
+            </:item>
+          </.toggle_group>
+        </div>
+        <div>
+          <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">nesting</div>
+          <.toggle_group
+            multiple
+            variant="outline"
+            size="sm"
+            aria_label="Nesting"
+            value={for {k, on} <- [{"nested", @scrollspy.nested}], on, do: k}
+            on_change="ctl_scrollspy"
+          >
+            <:item value="nested" phx-value-k="nested">nested</:item>
+          </.toggle_group>
+        </div>
+      </div>
+
+      <div class="sticky top-0 z-10 px-4 py-3 mt-8 -mx-4 text-xs font-medium text-gray-500 border-b border-gray-200 sm:-mx-8 sm:px-8 bg-white/85 dark:bg-gray-950/85 backdrop-blur dark:border-gray-800 dark:text-gray-400">
+        Sticky page header - the offset dial is what keeps this bar off a heading you jump to.
+      </div>
+
+      <div class="flex gap-10 mt-8">
+        <article class="flex-1 min-w-0">
+          <section id="ss-why" class="pb-16">
+            <h2 class="text-xl font-semibold tracking-tight">Why a rail</h2>
+            <p class="mt-3 text-gray-600 dark:text-gray-400">
+              Long pages lose people. A reader who scrolls past three headings has no
+              idea how much is left or where they are, and the browser's own scrollbar
+              is too coarse to answer either question. A rail down the side answers both
+              at a glance: here is the shape of the page, and here is you.
+            </p>
+            <p class="mt-3 text-gray-600 dark:text-gray-400">
+              Every docs site rebuilds this by hand and most of them get the edge cases
+              wrong. Two sections visible at once, a closing section too short to ever
+              reach the activation line, a deep link that lands mid-page. Those are the
+              parts worth absorbing into a component.
+            </p>
+          </section>
+
+          <section id="ss-wiring" class="pb-16">
+            <h2 class="text-xl font-semibold tracking-tight">Wiring it up</h2>
+            <p class="mt-3 text-gray-600 dark:text-gray-400">
+              There are two moving parts and they meet at an id. The rail names the
+              sections it wants to track; the page gives those sections ids. Nothing
+              else connects them, which is why the hook works just as well on markup you
+              wrote yourself.
+            </p>
+          </section>
+
+          <section id="ss-items" class="pb-16">
+            <h3 class="text-base font-semibold">The items list</h3>
+            <p class="mt-3 text-gray-600 dark:text-gray-400">
+              Each entry is a map with a label and a target. The target is the section
+              id without the hash. Add a children key and you get one level of nesting
+              for h3s underneath an h2, which is where the rail stops: past two levels
+              it is no longer something you can scan.
+            </p>
+          </section>
+
+          <section id="ss-targets" class="pb-16">
+            <h3 class="text-base font-semibold">The targets</h3>
+            <p class="mt-3 text-gray-600 dark:text-gray-400">
+              Give the section elements those ids and you are done. Missing targets are
+              skipped rather than treated as an error, so a rail built from a CMS table
+              of contents degrades quietly when a section gets deleted.
+            </p>
+          </section>
+
+          <section id="ss-offset" class="pb-16">
+            <h2 class="text-xl font-semibold tracking-tight">Clearing a fixed header</h2>
+            <p class="mt-3 text-gray-600 dark:text-gray-400">
+              Click a link and the browser scrolls the heading to the very top of the
+              viewport, which is exactly where a sticky site header already is. The
+              offset sets scroll-margin-top on every target so the heading parks below
+              the bar instead of behind it.
+            </p>
+            <p class="mt-3 text-gray-600 dark:text-gray-400">
+              Try the dial above, then click a link in the rail. At 2rem the heading
+              tucks under the sticky bar on this page. At 12rem it lands well clear of it.
+            </p>
+          </section>
+
+          <section id="ss-motion" class="pb-16">
+            <h2 class="text-xl font-semibold tracking-tight">Motion</h2>
+            <p class="mt-3 text-gray-600 dark:text-gray-400">
+              Smooth scrolling is a property of the scroll container, not of the click,
+              so the hook sets it there and puts it back the way it found it when the
+              component unmounts. The indicator bar is positioned by the hook and
+              animated by CSS, which keeps the timing in one place.
+            </p>
+            <p class="mt-3 text-gray-600 dark:text-gray-400">
+              Turn on reduce motion in your OS and both go away. Jumps land instantly,
+              the bar moves without a transition, and nothing about the resting state
+              changes.
+            </p>
+          </section>
+
+          <section id="ss-a11y" class="pb-16">
+            <h2 class="text-xl font-semibold tracking-tight">Accessibility</h2>
+            <p class="mt-3 text-gray-600 dark:text-gray-400">
+              The rail is a nav landmark with a label, so it can be found and skipped.
+              The active link carries aria-current="location", which is the right token
+              for "you are here within this page" and means the highlight is not colour
+              alone.
+            </p>
+            <p class="mt-3 text-gray-600 dark:text-gray-400">
+              Entries are plain anchors, so Tab and Enter already work and there is no
+              custom key handling to learn. Scrolling never moves focus: the hook only
+              touches classes and one attribute, so a keyboard user's place in the page
+              is theirs to lose.
+            </p>
+          </section>
+
+          <section id="ss-end" class="pb-4">
+            <h2 class="text-xl font-semibold tracking-tight">Wrapping up</h2>
+            <p class="mt-3 text-gray-600 dark:text-gray-400">
+              This last section is deliberately short. Scroll to the very bottom and it
+              still highlights, because the last entry snaps active there.
+            </p>
+          </section>
+        </article>
+
+        <.scrollspy
+          id="pg-scrollspy"
+          heading="On this page"
+          items={@ss_items}
+          offset={@scrollspy.offset}
+          indicator={@scrollspy.indicator}
+          class="self-start flex-none hidden w-56 lg:block sticky top-16"
+        />
+      </div>
+
+      <button
+        phx-click="flip"
+        phx-value-k="show_code"
+        class="mt-10 inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+      >
+        <.icon name="hero-code-bracket" class="w-4 h-4" />
+        {if @show_code, do: "Hide code", else: "View code"}
+      </button>
+      <pre
+        :if={@show_code}
+        class="p-4 mt-2 overflow-x-auto text-sm text-gray-100 bg-gray-900 rounded-xl dark:border dark:border-gray-800"
+      ><code>{scrollspy_snippet(@scrollspy)}</code></pre>
+
+      <div
+        :for={ex <- examples_for(PetalComponents.Showcase.Scrollspy, ~w(nested bare)a)}
+        class="mt-10"
+      >
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
+      <.showcase_props component={PetalComponents.Scrollspy} function={:scrollspy} />
+
+      <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        These examples render from the shared <code>PetalComponents.Showcase.Scrollspy</code>
         registry - the same source petal.build renders, so the playground and the marketing
         docs can't drift.
       </div>

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -59,6 +59,7 @@ defmodule PetalComponents do
         Popover,
         Progress,
         Rating,
+        Scrollspy,
         Skeleton,
         SlideOver,
         SocialButton,

--- a/lib/petal_components/scrollspy.ex
+++ b/lib/petal_components/scrollspy.ex
@@ -1,0 +1,198 @@
+defmodule PetalComponents.Scrollspy do
+  @moduledoc """
+  Scroll-position-aware navigation: the "On this page" rail that sits beside a
+  long docs article and highlights the section you are currently reading.
+
+  The markup is inert on its own. A `PetalScrollspy` JS hook watches the
+  sections with an `IntersectionObserver` and moves the active state as the
+  reader scrolls - there is no CSS-only way to know which heading is at the
+  reading position, so this component ships a hook.
+
+  ## Built-in renderer
+
+  Pass the entries as `items`. Each one is a map with a `:label` and a
+  `:target` - the `id` of the section element on the page, without the leading
+  `#`:
+
+      <.scrollspy
+        id="docs-toc"
+        heading="On this page"
+        items={[
+          %{label: "Install", target: "install"},
+          %{label: "Usage", target: "usage"},
+          %{label: "Theming", target: "theming"}
+        ]}
+      />
+
+  One level of nesting (h2 with its h3s) is supported through `:children`:
+
+      items={[
+        %{
+          label: "Usage",
+          target: "usage",
+          children: [
+            %{label: "Options", target: "options"},
+            %{label: "Events", target: "events"}
+          ]
+        }
+      ]}
+
+  Deeper nesting is deliberately not supported - past two levels a rail stops
+  being scannable and wants a different component.
+
+  ## Bare markup (the data-attribute contract)
+
+  The hook is not tied to this renderer. Put `phx-hook="PetalScrollspy"` on any
+  container and give its descendant links a `data-scrollspy-target` pointing at
+  a section id, and the hook takes over - zero `pc-scrollspy` classes required:
+
+      <nav id="my-toc" phx-hook="PetalScrollspy" data-offset="6rem" aria-label="On this page">
+        <ul>
+          <li><a href="#install" data-scrollspy-target="install">Install</a></li>
+          <li><a href="#usage" data-scrollspy-target="usage">Usage</a></li>
+        </ul>
+      </nav>
+
+  On the active link the hook sets `aria-current="location"` and adds
+  `pc-scrollspy-link--active`, removing both from every other link. Style the
+  active state however you like; `pc-scrollspy-link--active` is just a class.
+
+  The hook reads two attributes off its own element:
+
+    * `data-offset` - a length applied as `scroll-margin-top` to every target,
+      so a fixed site header does not cover the heading you just jumped to
+    * `data-threshold` - an optional `rootMargin` override for the observer,
+      which is what moves the activation line up or down the viewport
+
+  ## How the active section is chosen
+
+    * **The section owning the activation line wins.** When several sections
+      are in view at once, the active one is the section nearest the top of the
+      viewport that has already reached the line - so a new heading takes over
+      the moment it arrives at reading position, not when the previous section
+      finally scrolls away.
+    * **Bottom snap.** At the very bottom of the scroll container the last
+      section activates even if it is too short to ever reach the line -
+      otherwise a two-line closing section could never be highlighted.
+    * **Hash navigation.** On mount and on `hashchange`, a `location.hash` that
+      matches a target activates immediately instead of waiting for the
+      observer. Scrolling never rewrites the hash (that would spam history);
+      only clicking a link does, natively.
+
+  ## Motion
+
+  The hook sets `scroll-behavior: smooth` on the scroll container so clicking a
+  link glides, and restores the previous value when the component unmounts.
+  Under `prefers-reduced-motion: reduce` it leaves the scroll behaviour alone
+  (jumps are instant) and CSS drops the indicator transition - the bar still
+  tracks the active link, it just moves without animating.
+
+  ## Accessibility
+
+    * The rail is a `<nav>` with an `aria-label` ("On this page" by default),
+      so screen reader users can find and skip it.
+    * The active link carries `aria-current="location"` - the correct token for
+      "you are here within this page" - so the state is not colour-only.
+    * Entries are plain `<a href="#id">` anchors: Tab moves through them, Enter
+      follows them, and the browser's own focus handling applies. There is no
+      roving tabindex and no custom key handling.
+    * Scrolling never moves focus. The hook only toggles classes and
+      `aria-current`; the reader's focus and caret stay where they were.
+    * The indicator bar is decorative and marked `aria-hidden="true"`.
+  """
+  use Phoenix.Component
+
+  attr :id, :string, required: true, doc: "id of the nav element; required by the JS hook"
+
+  attr :items, :list,
+    required: true,
+    doc: """
+    The nav entries. Each item is a map: `%{label: "Install", target: "install"}`,
+    where `target` is the id of the section element (no leading `#`). One level
+    of nesting is supported for h2/h3 structure via a `:children` key:
+    `%{label: "Usage", target: "usage", children: [%{label: "Options", target: "options"}]}`.
+    """
+
+  attr :offset, :string,
+    default: "6rem",
+    doc:
+      "scroll-margin-top applied to the target sections, so a click-scroll clears a fixed header"
+
+  attr :threshold, :string,
+    default: nil,
+    doc:
+      ~s|optional override for the observer rootMargin (the activation line), e.g. "-20% 0px -70% 0px". Defaults to a reading-position tuned value baked into the hook|
+
+  attr :indicator, :string,
+    default: "bar",
+    values: ["bar", "none"],
+    doc:
+      ~s|the active indicator. "bar": a rail with a bar that slides to the active link. "none": no rail and no bar, active state is carried by the link colour and aria-current alone|
+
+  attr :heading, :string,
+    default: nil,
+    doc: ~s|optional small heading above the list, e.g. "On this page"|
+
+  attr :aria_label, :string,
+    default: "On this page",
+    doc: "accessible name for the nav landmark"
+
+  attr :class, :any, default: nil, doc: "extra classes for the nav element"
+  attr :rest, :global
+
+  @doc """
+  Renders a scrollspy navigation rail.
+
+  See `PetalComponents.Scrollspy` for the item shape, the bare-markup
+  contract, and how the active section is chosen.
+
+      <.scrollspy
+        id="docs-toc"
+        heading="On this page"
+        items={[%{label: "Install", target: "install"}, %{label: "Usage", target: "usage"}]}
+      />
+  """
+  def scrollspy(assigns) do
+    ~H"""
+    <nav
+      id={@id}
+      class={["pc-scrollspy", "pc-scrollspy--#{@indicator}", @class]}
+      phx-hook="PetalScrollspy"
+      data-offset={@offset}
+      data-threshold={@threshold}
+      aria-label={@aria_label}
+      {@rest}
+    >
+      <span :if={@heading} class="pc-scrollspy__heading">{@heading}</span>
+      <div :if={@indicator == "bar"} class="pc-scrollspy__indicator" aria-hidden="true"></div>
+      <ul class="pc-scrollspy__list">
+        <li :for={item <- @items} class="pc-scrollspy__item">
+          <a
+            href={"##{item.target}"}
+            class="pc-scrollspy-link"
+            data-scrollspy-target={item.target}
+          >
+            {item.label}
+          </a>
+          <ul :if={children(item) != []} class="pc-scrollspy__sublist">
+            <li :for={child <- children(item)} class="pc-scrollspy__item">
+              <a
+                href={"##{child.target}"}
+                class="pc-scrollspy-link pc-scrollspy-link--nested"
+                data-scrollspy-target={child.target}
+              >
+                {child.label}
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+    """
+  end
+
+  # Children are optional, and one level deep only - a grandchild key is
+  # ignored rather than rendered, so a too-deep tree degrades instead of
+  # producing a rail nobody can scan.
+  defp children(item), do: Map.get(item, :children) || []
+end

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -44,6 +44,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.Popover,
     PetalComponents.Showcase.Progress,
     PetalComponents.Showcase.Rating,
+    PetalComponents.Showcase.Scrollspy,
     PetalComponents.Showcase.ShineBorder,
     PetalComponents.Showcase.Skeleton,
     PetalComponents.Showcase.SlideOver,

--- a/lib/petal_components/showcase/scrollspy.ex
+++ b/lib/petal_components/showcase/scrollspy.ex
@@ -1,0 +1,169 @@
+defmodule PetalComponents.Showcase.Scrollspy do
+  @moduledoc false
+  use PetalComponents.Showcase, component: PetalComponents.Scrollspy, title: "Scrollspy"
+
+  example :basic, "On this page",
+    description:
+      "The docs rail: pass the sections as items and the hook highlights the one you are reading. Scroll the article on the right and watch the bar move." do
+    ~H"""
+    <div class="flex gap-8">
+      <.scrollspy
+        id="showcase-scrollspy"
+        heading="On this page"
+        class="flex-none w-40"
+        items={[
+          %{label: "Install", target: "ss-install"},
+          %{label: "Usage", target: "ss-usage"},
+          %{label: "Theming", target: "ss-theming"},
+          %{label: "Upgrading", target: "ss-upgrading"}
+        ]}
+      />
+      <div class="flex-1 h-64 pr-2 overflow-y-auto">
+        <section id="ss-install" class="pb-24">
+          <h2 class="text-base font-semibold">Install</h2>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            Add the dependency, run mix deps.get, then point your CSS at the
+            package so the component classes get built.
+          </p>
+        </section>
+        <section id="ss-usage" class="pb-24">
+          <h2 class="text-base font-semibold">Usage</h2>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            Give every section an id and hand the same ids to the rail as
+            targets. That is the whole contract.
+          </p>
+        </section>
+        <section id="ss-theming" class="pb-24">
+          <h2 class="text-base font-semibold">Theming</h2>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            The active link and the bar both ride the primary ramp, so the rail
+            picks up your brand without being told.
+          </p>
+        </section>
+        <section id="ss-upgrading" class="pb-4">
+          <h2 class="text-base font-semibold">Upgrading</h2>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            A short closing section still highlights at the bottom of the
+            scroll, because the last entry snaps active there.
+          </p>
+        </section>
+      </div>
+    </div>
+    """
+  end
+
+  example :nested, "Nested sections",
+    description:
+      "One level of nesting for h2/h3 structure. Children indent and set their own active state; the rail stays scannable because it stops there." do
+    ~H"""
+    <div class="flex gap-8">
+      <.scrollspy
+        id="showcase-scrollspy-nested"
+        class="flex-none w-44"
+        items={[
+          %{label: "Getting started", target: "ssn-start"},
+          %{
+            label: "Components",
+            target: "ssn-components",
+            children: [
+              %{label: "Buttons", target: "ssn-buttons"},
+              %{label: "Modals", target: "ssn-modals"}
+            ]
+          },
+          %{label: "Deploying", target: "ssn-deploy"}
+        ]}
+      />
+      <div class="flex-1 h-64 pr-2 overflow-y-auto">
+        <section id="ssn-start" class="pb-24">
+          <h2 class="text-base font-semibold">Getting started</h2>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            Everything you need for the first five minutes.
+          </p>
+        </section>
+        <section id="ssn-components" class="pb-16">
+          <h2 class="text-base font-semibold">Components</h2>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            The set, grouped the way you would reach for them.
+          </p>
+        </section>
+        <section id="ssn-buttons" class="pb-16">
+          <h3 class="text-sm font-semibold">Buttons</h3>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            Sizes, variants, and the loading state.
+          </p>
+        </section>
+        <section id="ssn-modals" class="pb-24">
+          <h3 class="text-sm font-semibold">Modals</h3>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            Focus trapping and dismissal come wired.
+          </p>
+        </section>
+        <section id="ssn-deploy" class="pb-4">
+          <h2 class="text-base font-semibold">Deploying</h2>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            Ship it.
+          </p>
+        </section>
+      </div>
+    </div>
+    """
+  end
+
+  example :bare, "Your own markup",
+    description:
+      "The hook is not tied to the renderer. Put phx-hook=\"PetalScrollspy\" on any container whose links carry data-scrollspy-target and it drives them, adding pc-scrollspy-link--active and aria-current=\"location\" to the one being read." do
+    ~H"""
+    <div class="flex gap-8">
+      <nav
+        id="showcase-scrollspy-bare"
+        phx-hook="PetalScrollspy"
+        data-offset="1rem"
+        aria-label="On this page"
+        class="flex-none w-40 space-y-1 text-sm"
+      >
+        <a
+          href="#ssb-one"
+          data-scrollspy-target="ssb-one"
+          class="block text-gray-500 dark:text-gray-400 [&.pc-scrollspy-link--active]:font-semibold [&.pc-scrollspy-link--active]:text-primary-600 dark:[&.pc-scrollspy-link--active]:text-primary-400"
+        >
+          First
+        </a>
+        <a
+          href="#ssb-two"
+          data-scrollspy-target="ssb-two"
+          class="block text-gray-500 dark:text-gray-400 [&.pc-scrollspy-link--active]:font-semibold [&.pc-scrollspy-link--active]:text-primary-600 dark:[&.pc-scrollspy-link--active]:text-primary-400"
+        >
+          Second
+        </a>
+        <a
+          href="#ssb-three"
+          data-scrollspy-target="ssb-three"
+          class="block text-gray-500 dark:text-gray-400 [&.pc-scrollspy-link--active]:font-semibold [&.pc-scrollspy-link--active]:text-primary-600 dark:[&.pc-scrollspy-link--active]:text-primary-400"
+        >
+          Third
+        </a>
+      </nav>
+      <div class="flex-1 h-56 pr-2 overflow-y-auto">
+        <section id="ssb-one" class="pb-24">
+          <h2 class="text-base font-semibold">First</h2>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            No pc-scrollspy classes anywhere in this example.
+          </p>
+        </section>
+        <section id="ssb-two" class="pb-24">
+          <h2 class="text-base font-semibold">Second</h2>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            The links style themselves off the active class.
+          </p>
+        </section>
+        <section id="ssb-three" class="pb-4">
+          <h2 class="text-base font-semibold">Third</h2>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            Same hook, your markup.
+          </p>
+        </section>
+      </div>
+    </div>
+    """
+  end
+end

--- a/test/js/scrollspy.test.js
+++ b/test/js/scrollspy.test.js
@@ -1,0 +1,364 @@
+// PetalScrollspy hook: which nav entry is highlighted while you read.
+//
+// jsdom has no IntersectionObserver and no layout, so the specs stub the
+// observer and feed rects by hand. That is not a workaround for the test
+// environment - the hook decides from rects rather than from observer entries
+// precisely so the decision is a pure function anyone can reason about.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import hooks, { scrollspyActive } from "../../assets/js/petal_components.js";
+
+const mounted = [];
+
+// A stub with the same shape LiveView's DOM would give us: it records what
+// was observed and hands back a way to fire the callback.
+function stubIntersectionObserver() {
+  const instances = [];
+
+  class FakeIntersectionObserver {
+    constructor(callback, options) {
+      this.callback = callback;
+      this.options = options;
+      this.observed = [];
+      this.disconnected = false;
+      instances.push(this);
+    }
+    observe(el) {
+      this.observed.push(el);
+    }
+    disconnect() {
+      this.disconnected = true;
+    }
+  }
+
+  globalThis.IntersectionObserver = FakeIntersectionObserver;
+  return instances;
+}
+
+beforeEach(() => {
+  window.location.hash = "";
+  // Nothing in these specs cares about frame timing; run the work now so the
+  // assertions read straight through.
+  vi.stubGlobal("requestAnimationFrame", (cb) => {
+    cb();
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => ({ matches: false, addEventListener() {}, removeEventListener() {} })),
+  );
+});
+
+afterEach(() => {
+  mounted.splice(0).forEach(({ hook, wrap }) => {
+    try {
+      hook.destroyed();
+    } finally {
+      wrap.remove();
+    }
+  });
+  vi.unstubAllGlobals();
+});
+
+// A rail plus its sections. `tops` sets each section's rect top in viewport
+// coordinates, which is the only geometry the hook reads.
+function mount({ ids = ["a", "b", "c"], tops = {}, offset = "6rem" } = {}) {
+  const observers = stubIntersectionObserver();
+
+  const wrap = document.createElement("div");
+  wrap.innerHTML = `
+    <nav id="toc" class="pc-scrollspy" data-offset="${offset}" aria-label="On this page">
+      <div class="pc-scrollspy__indicator" aria-hidden="true"></div>
+      <ul>
+        ${ids
+          .map(
+            (id) =>
+              `<li><a href="#${id}" class="pc-scrollspy-link" data-scrollspy-target="${id}">${id}</a></li>`,
+          )
+          .join("")}
+      </ul>
+    </nav>
+    <div class="sections">
+      ${ids.map((id) => `<section id="${id}"></section>`).join("")}
+    </div>
+  `;
+  document.body.appendChild(wrap);
+
+  ids.forEach((id, i) => {
+    const section = wrap.querySelector(`#${id}`);
+    const top = tops[id] ?? i * 1000;
+    section.getBoundingClientRect = () => ({ top, height: 1000, bottom: top + 1000 });
+  });
+
+  const el = wrap.querySelector("#toc");
+  const hook = Object.create(hooks.PetalScrollspy);
+  hook.el = el;
+  hook.mounted();
+  mounted.push({ hook, wrap });
+
+  return { hook, el, wrap, observers, link: (id) => wrap.querySelector(`[href="#${id}"]`) };
+}
+
+// jsdom lays nothing out, so a scroll container has to be described rather
+// than built. Listener stubs keep destroyed() happy.
+const fakeScroller = (metrics) => ({
+  addEventListener() {},
+  removeEventListener() {},
+  style: {},
+  ...metrics,
+});
+
+const activeIds = (wrap) =>
+  Array.from(wrap.querySelectorAll(".pc-scrollspy-link--active")).map(
+    (el) => el.dataset.scrollspyTarget,
+  );
+
+const currentIds = (wrap) =>
+  Array.from(wrap.querySelectorAll('[aria-current="location"]')).map(
+    (el) => el.dataset.scrollspyTarget,
+  );
+
+describe("scrollspyActive", () => {
+  it("picks the section that owns the activation line", () => {
+    const sections = [
+      { id: "a", top: -400 },
+      { id: "b", top: 120 },
+      { id: "c", top: 900 },
+    ];
+
+    expect(scrollspyActive(sections, { line: 200 })).toBe("b");
+  });
+
+  it("topmost wins: the newest section to reach the line takes over", () => {
+    // Three short sections all crowded above the line at once.
+    const sections = [
+      { id: "a", top: -50 },
+      { id: "b", top: 30 },
+      { id: "c", top: 120 },
+    ];
+
+    expect(scrollspyActive(sections, { line: 200 })).toBe("c");
+    // Back the line off above `c` and the previous section owns it again.
+    expect(scrollspyActive(sections, { line: 100 })).toBe("b");
+  });
+
+  it("holds the first section while the page is still above the line", () => {
+    const sections = [
+      { id: "a", top: 600 },
+      { id: "b", top: 1600 },
+    ];
+
+    expect(scrollspyActive(sections, { line: 200 })).toBe("a");
+  });
+
+  it("snaps to the last section at the bottom of the scroll", () => {
+    // `c` is short and never reaches the line - without the snap it could
+    // never be highlighted at all.
+    const sections = [
+      { id: "a", top: -1200 },
+      { id: "b", top: -200 },
+      { id: "c", top: 700 },
+    ];
+
+    expect(scrollspyActive(sections, { line: 200 })).toBe("b");
+    expect(scrollspyActive(sections, { line: 200, atBottom: true })).toBe("c");
+  });
+
+  it("returns null with nothing to spy on", () => {
+    expect(scrollspyActive([], { line: 200 })).toBe(null);
+  });
+});
+
+describe("PetalScrollspy", () => {
+  it("observes every section a link points at", () => {
+    const { observers, wrap } = mount();
+
+    expect(observers).toHaveLength(1);
+    expect(observers[0].observed).toEqual([
+      wrap.querySelector("#a"),
+      wrap.querySelector("#b"),
+      wrap.querySelector("#c"),
+    ]);
+    expect(observers[0].options.rootMargin).toBe("-25% 0px -70% 0px");
+  });
+
+  it("honours a data-threshold rootMargin override", () => {
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = `<nav id="t2" data-threshold="-10% 0px -80% 0px"></nav>`;
+    document.body.appendChild(wrapper);
+
+    const observers = stubIntersectionObserver();
+    const hook = Object.create(hooks.PetalScrollspy);
+    hook.el = wrapper.querySelector("#t2");
+    hook.mounted();
+    mounted.push({ hook, wrap: wrapper });
+
+    expect(observers[0].options.rootMargin).toBe("-10% 0px -80% 0px");
+  });
+
+  it("ignores links whose target is not on the page", () => {
+    const { observers, wrap } = mount({ ids: ["a", "b"] });
+    wrap.querySelector("#b").remove();
+
+    mounted[mounted.length - 1].hook.updated();
+    const latest = observers[observers.length - 1];
+
+    expect(latest.observed.map((el) => el.id)).toEqual(["a"]);
+  });
+
+  it("applies data-offset as scroll-margin-top on the targets", () => {
+    const { wrap } = mount({ offset: "8rem" });
+
+    expect(wrap.querySelector("#a").style.scrollMarginTop).toBe("8rem");
+    expect(wrap.querySelector("#c").style.scrollMarginTop).toBe("8rem");
+  });
+
+  it("marks exactly one link active, with aria-current", () => {
+    // Only `b` has reached the line (window.innerHeight is 768 in jsdom, so
+    // the default -25% line sits at 192).
+    const { hook, wrap } = mount({ tops: { a: -500, b: 100, c: 900 } });
+    hook.sync();
+
+    expect(activeIds(wrap)).toEqual(["b"]);
+    expect(currentIds(wrap)).toEqual(["b"]);
+  });
+
+  it("moves the active state, leaving nothing stale behind", () => {
+    const { hook, wrap } = mount({ tops: { a: -500, b: 100, c: 900 } });
+    hook.sync();
+    expect(activeIds(wrap)).toEqual(["b"]);
+
+    wrap.querySelector("#c").getBoundingClientRect = () => ({ top: 20, height: 1000, bottom: 1020 });
+    hook.sync();
+
+    expect(activeIds(wrap)).toEqual(["c"]);
+    expect(currentIds(wrap)).toEqual(["c"]);
+  });
+
+  it("re-syncs when the observer fires", () => {
+    const { observers, wrap } = mount({ tops: { a: -500, b: 100, c: 900 } });
+
+    observers[0].callback([]);
+
+    expect(activeIds(wrap)).toEqual(["b"]);
+  });
+
+  it("snaps to the last entry at the bottom of a real scroll", () => {
+    const { hook, wrap } = mount({ tops: { a: -1200, b: -200, c: 700 } });
+    hook.scrollRoot = fakeScroller({ scrollTop: 900, clientHeight: 700, scrollHeight: 1600 });
+
+    hook.sync();
+
+    expect(activeIds(wrap)).toEqual(["c"]);
+  });
+
+  it("does not snap when there is nothing to scroll", () => {
+    // A short page that fits entirely on screen is not at any bottom worth
+    // reacting to - the first section stays active.
+    const { hook, wrap } = mount({ tops: { a: 0, b: 1000, c: 2000 } });
+    hook.scrollRoot = fakeScroller({ scrollTop: 0, clientHeight: 700, scrollHeight: 700 });
+
+    hook.sync();
+
+    expect(activeIds(wrap)).toEqual(["a"]);
+  });
+
+  it("activates a matching hash on mount without waiting for the observer", () => {
+    window.location.hash = "#c";
+    const { wrap } = mount({ tops: { a: 0, b: 1000, c: 2000 } });
+
+    // Geometry alone would say `a`; the explicit deep link wins.
+    expect(activeIds(wrap)).toEqual(["c"]);
+    expect(currentIds(wrap)).toEqual(["c"]);
+  });
+
+  it("follows hashchange", () => {
+    const { wrap } = mount({ tops: { a: 0, b: 1000, c: 2000 } });
+    expect(activeIds(wrap)).toEqual(["a"]);
+
+    window.location.hash = "#b";
+    window.dispatchEvent(new Event("hashchange"));
+
+    expect(activeIds(wrap)).toEqual(["b"]);
+  });
+
+  it("ignores a hash that is not one of the targets", () => {
+    window.location.hash = "#somewhere-else";
+    const { wrap } = mount({ tops: { a: -500, b: 100, c: 900 } });
+
+    expect(activeIds(wrap)).toEqual(["b"]);
+  });
+
+  it("never moves focus", () => {
+    const { hook, wrap } = mount({ tops: { a: -500, b: 100, c: 900 } });
+    const outside = document.createElement("input");
+    document.body.appendChild(outside);
+    outside.focus();
+
+    hook.sync();
+
+    expect(document.activeElement).toBe(outside);
+    expect(activeIds(wrap)).toEqual(["b"]);
+    outside.remove();
+  });
+
+  it("turns smooth scrolling on, and off again on destroy", () => {
+    const { hook } = mount();
+    expect(document.documentElement.style.scrollBehavior).toBe("smooth");
+
+    hook.destroyed();
+    expect(document.documentElement.style.scrollBehavior).toBe("");
+    mounted.pop();
+  });
+
+  it("leaves scrolling instant under prefers-reduced-motion", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: true, addEventListener() {}, removeEventListener() {} })),
+    );
+
+    mount();
+    expect(document.documentElement.style.scrollBehavior).toBe("");
+  });
+
+  it("cleans up the observer, the listeners and the borrowed styles", () => {
+    const { hook, wrap, observers } = mount();
+    const removed = [];
+    const realRemove = window.removeEventListener.bind(window);
+    window.removeEventListener = (type, ...rest) => {
+      removed.push(type);
+      realRemove(type, ...rest);
+    };
+
+    hook.destroyed();
+    window.removeEventListener = realRemove;
+    mounted.pop();
+
+    expect(observers[0].disconnected).toBe(true);
+    expect(removed).toContain("hashchange");
+    expect(removed).toContain("resize");
+    expect(wrap.querySelector("#a").style.scrollMarginTop).toBe("");
+    expect(document.documentElement.style.scrollBehavior).toBe("");
+
+    // A stale hook must not keep driving a page it no longer owns.
+    expect(activeIds(wrap)).toEqual(["a"]);
+    window.location.hash = "#c";
+    window.dispatchEvent(new Event("hashchange"));
+    expect(activeIds(wrap)).toEqual(["a"]);
+    wrap.remove();
+  });
+
+  it("re-scans after a LiveView patch replaces the rail", () => {
+    const { hook, wrap, observers } = mount({ ids: ["a", "b"] });
+
+    wrap.querySelector("nav ul").innerHTML = `
+      <li><a href="#b" class="pc-scrollspy-link" data-scrollspy-target="b">b</a></li>
+    `;
+    hook.updated();
+
+    expect(observers).toHaveLength(2);
+    expect(observers[0].disconnected).toBe(true);
+    expect(observers[1].observed.map((el) => el.id)).toEqual(["b"]);
+  });
+});

--- a/test/petal/scrollspy_test.exs
+++ b/test/petal/scrollspy_test.exs
@@ -1,0 +1,216 @@
+defmodule PetalComponents.ScrollspyTest do
+  use ComponentCase
+
+  import PetalComponents.Scrollspy
+
+  @items [
+    %{label: "Install", target: "install"},
+    %{label: "Usage", target: "usage"}
+  ]
+
+  @nested [
+    %{
+      label: "Usage",
+      target: "usage",
+      children: [
+        %{label: "Options", target: "options"},
+        %{label: "Events", target: "events"}
+      ]
+    }
+  ]
+
+  defp render_scrollspy(assigns) do
+    assigns = Map.new(assigns)
+
+    rendered_to_string(~H"""
+    <.scrollspy id={@id} items={@items} {Map.drop(assigns, [:id, :items])} />
+    """)
+  end
+
+  describe "scrollspy/1" do
+    test "renders a hooked nav landmark with the given id" do
+      html = render_scrollspy(id: "toc", items: @items)
+      nav = html |> parse_html() |> LazyHTML.query("nav#toc")
+
+      assert Enum.count(nav) == 1
+      assert LazyHTML.attribute(nav, "phx-hook") == ["PetalScrollspy"]
+      assert LazyHTML.attribute(nav, "aria-label") == ["On this page"]
+      assert_has_class(html, "pc-scrollspy")
+    end
+
+    test "aria_label overrides the default landmark name" do
+      html = render_scrollspy(id: "toc", items: @items, aria_label: "Sections")
+
+      assert html |> parse_html() |> LazyHTML.query("nav") |> LazyHTML.attribute("aria-label") ==
+               [
+                 "Sections"
+               ]
+    end
+
+    test "every item renders an anchor carrying its href and data target" do
+      links = render_scrollspy(id: "toc", items: @items) |> parse_html() |> LazyHTML.query("a")
+
+      assert LazyHTML.attribute(links, "href") == ["#install", "#usage"]
+      assert LazyHTML.attribute(links, "data-scrollspy-target") == ["install", "usage"]
+      assert LazyHTML.text(links) =~ "Install"
+      assert LazyHTML.text(links) =~ "Usage"
+    end
+
+    test "the initial render owns no active state - the hook does" do
+      html = render_scrollspy(id: "toc", items: @items)
+
+      refute html =~ "aria-current"
+      refute_has_class(html, "pc-scrollspy-link--active")
+    end
+
+    test "offset lands on the hook element and defaults to 6rem" do
+      nav =
+        render_scrollspy(id: "toc", items: @items) |> parse_html() |> LazyHTML.query("nav")
+
+      assert LazyHTML.attribute(nav, "data-offset") == ["6rem"]
+    end
+
+    test "offset is configurable" do
+      nav =
+        render_scrollspy(id: "toc", items: @items, offset: "10rem")
+        |> parse_html()
+        |> LazyHTML.query("nav")
+
+      assert LazyHTML.attribute(nav, "data-offset") == ["10rem"]
+    end
+
+    test "threshold is omitted when nil and rendered when given" do
+      html = render_scrollspy(id: "toc", items: @items)
+      refute html =~ "data-threshold"
+
+      nav =
+        render_scrollspy(id: "toc", items: @items, threshold: "-20% 0px -70% 0px")
+        |> parse_html()
+        |> LazyHTML.query("nav")
+
+      assert LazyHTML.attribute(nav, "data-threshold") == ["-20% 0px -70% 0px"]
+    end
+  end
+
+  describe "nesting" do
+    test "children render one level down with the nested class" do
+      html = render_scrollspy(id: "toc", items: @nested)
+      doc = parse_html(html)
+
+      assert doc |> LazyHTML.query(".pc-scrollspy__sublist") |> Enum.count() == 1
+
+      nested = LazyHTML.query(doc, ".pc-scrollspy-link--nested")
+      assert LazyHTML.attribute(nested, "data-scrollspy-target") == ["options", "events"]
+
+      # The parent is still a plain link, not a nested one
+      assert doc
+             |> LazyHTML.query(~s|a[data-scrollspy-target="usage"]|)
+             |> LazyHTML.attribute("class") == ["pc-scrollspy-link"]
+    end
+
+    test "a grandchild key is ignored rather than rendered" do
+      items = [
+        %{
+          label: "Usage",
+          target: "usage",
+          children: [
+            %{label: "Options", target: "options", children: [%{label: "Deep", target: "deep"}]}
+          ]
+        }
+      ]
+
+      html = render_scrollspy(id: "toc", items: items)
+
+      refute html =~ "deep"
+      assert html =~ "options"
+    end
+
+    test "items without a children key render fine" do
+      html = render_scrollspy(id: "toc", items: @items)
+
+      refute html =~ "pc-scrollspy__sublist"
+      refute_has_class(html, "pc-scrollspy-link--nested")
+    end
+
+    test "an explicit empty children list renders no sublist" do
+      html =
+        render_scrollspy(id: "toc", items: [%{label: "Install", target: "install", children: []}])
+
+      refute html =~ "pc-scrollspy__sublist"
+    end
+  end
+
+  describe "indicator" do
+    test "bar (the default) renders a decorative indicator and the rail modifier" do
+      html = render_scrollspy(id: "toc", items: @items)
+      bar = html |> parse_html() |> LazyHTML.query(".pc-scrollspy__indicator")
+
+      assert Enum.count(bar) == 1
+      assert LazyHTML.attribute(bar, "aria-hidden") == ["true"]
+      assert_has_class(html, "pc-scrollspy--bar")
+    end
+
+    test "none omits the indicator entirely" do
+      html = render_scrollspy(id: "toc", items: @items, indicator: "none")
+
+      refute html =~ "pc-scrollspy__indicator"
+      assert_has_class(html, "pc-scrollspy--none")
+    end
+  end
+
+  describe "heading" do
+    test "renders above the list when given" do
+      heading =
+        render_scrollspy(id: "toc", items: @items, heading: "On this page")
+        |> parse_html()
+        |> LazyHTML.query(".pc-scrollspy__heading")
+
+      assert LazyHTML.text(heading) == "On this page"
+    end
+
+    test "is absent by default" do
+      refute render_scrollspy(id: "toc", items: @items) =~ "pc-scrollspy__heading"
+    end
+  end
+
+  describe "pass-through" do
+    test "class is appended to the nav, not replacing the base class" do
+      classes =
+        render_scrollspy(id: "toc", items: @items, class: "sticky top-24")
+        |> parse_html()
+        |> LazyHTML.query("nav")
+        |> LazyHTML.attribute("class")
+        |> List.first()
+
+      assert classes =~ "pc-scrollspy"
+      assert classes =~ "sticky top-24"
+    end
+
+    test "global attributes land on the nav" do
+      nav =
+        render_scrollspy(id: "toc", items: @items, "data-role": "toc")
+        |> parse_html()
+        |> LazyHTML.query("nav")
+
+      assert LazyHTML.attribute(nav, "data-role") == ["toc"]
+    end
+  end
+
+  describe "edge cases" do
+    test "an empty item list still renders the landmark" do
+      html = render_scrollspy(id: "toc", items: [])
+      doc = parse_html(html)
+
+      assert doc |> LazyHTML.query("nav#toc") |> Enum.count() == 1
+      assert doc |> LazyHTML.query("a") |> Enum.count() == 0
+    end
+
+    test "labels are escaped, not injected" do
+      html =
+        render_scrollspy(id: "toc", items: [%{label: "<b>Install</b>", target: "install"}])
+
+      refute html =~ "<b>Install</b>"
+      assert html =~ html_escape("<b>Install</b>")
+    end
+  end
+end


### PR DESCRIPTION
Closes #613

## Summary

A new `<.scrollspy>` component plus a `PetalScrollspy` hook: the docs "on this page" rail that follows the reader down a long article.

Two APIs, both first-class in the moduledoc:

1. **The built-in renderer.** Pass `items` (label + target id, optionally one level of `children`), get a `<nav>` with an animated indicator bar. `offset`, `threshold`, `indicator` (`bar` / `none`), `heading`, `aria_label`, `class`, `rest`.
2. **The bare data-attribute contract.** `phx-hook="PetalScrollspy"` on any container whose links carry `data-scrollspy-target`, and the hook drives your own markup. It sets `aria-current="location"` and `pc-scrollspy-link--active` on the active link and nothing else. Zero `pc-scrollspy` classes needed.

The hook uses an `IntersectionObserver` over a reading band near the top of the viewport, but only as a *trigger* - every decision is recomputed from live rects. That keeps the rail honest when a section grows, the window resizes, or a LiveView patch swaps the content, and it makes the selection logic a pure function.

### Files

| File | What |
|---|---|
| `lib/petal_components/scrollspy.ex` | new component |
| `lib/petal_components/showcase/scrollspy.ex` | 3 registry examples (basic, nested, bare markup) |
| `assets/js/petal_components.js` | `PetalScrollspy` hook + exported `scrollspyActive/2` |
| `assets/default.css` | `pc-scrollspy` section, inside `@layer components` |
| `dev.exs` | `/c/scrollspy` playground: a real mini guide with offset / nesting / indicator dials |
| `test/petal/scrollspy_test.exs` | 19 component tests |
| `test/js/scrollspy.test.js` | 22 vitest specs |
| `lib/petal_components.ex`, `showcase/registry.ex`, `CHANGELOG.md` | registration |

## Deviations from the issue's API sketch

- **Added an `aria_label` attr** (default `"On this page"`). The sketch hardcoded `aria-label` next to `{@rest}`; since `rest` is a global, a consumer passing their own `aria-label` would have produced a duplicate attribute on the element. An explicit attr is the only way to let them override it.
- **`"topmost wins"` is implemented as "the last section to have reached the activation line".** Read literally, "closest to the top of the viewport" is ambiguous when three short sections are all crowded above the line. The rule shipped is: among the sections that have reached the line, the one furthest down the page wins - i.e. the section that *owns* the reading position. It agrees with the issue's example cases and is unambiguous in the crowded one. Both are covered in the spec.
- **The nav carries a `pc-scrollspy--bar` / `pc-scrollspy--none` modifier.** The rail line is drawn on the list only in bar mode, so `indicator="none"` is genuinely a plain text list rather than a railed one with the bar removed.
- **Nested children render in a `pc-scrollspy__sublist` `<ul>`** inside the parent `<li>`. The sketch only named the link class; the sublist element is what makes the nesting real markup rather than indentation.
- **The selection logic is a named export, `scrollspyActive(sections, {line, atBottom})`**, alongside the hook object. That is what lets the vitest suite test the behaviour directly rather than through a fake observer.
- **Bottom snap only fires on a container that actually scrolls.** Without that guard a short page whose content fits entirely on screen would highlight its last entry forever, which is not a bottom any reader would recognise.
- **Default `rootMargin` is `-25% 0px -70% 0px`** (activation line at 25% of the viewport), overridable via `data-threshold` exactly as specified.

## Observer cleanup

`destroyed()` disconnects the observer, removes the `hashchange` and `resize` listeners from `window`, detaches the `scroll` listener from the scroll root, cancels any pending `requestAnimationFrame`, and restores every style the hook borrowed - the container's previous `scroll-behavior` and each target's previous inline `scroll-margin-top`. `scan()` disconnects the old observer before creating a new one, and the scroll listener *moves* with the scroll root rather than being left on the old one when a patch relocates the sections. There is a spec that destroys a hook and then fires a `hashchange` to prove the stale hook no longer drives the page.

The scroll listener exists because bottom snap is invisible to the observer: a closing section too short to reach the activation line never generates a callback. It is `passive` and coalesced to one pass per animation frame.

## Reduced motion and smooth scroll

Smooth scrolling is a property of the scroll container, not of the click, so the hook sets `scroll-behavior: smooth` on the scroll root at mount and puts the previous value back on destroy. Under `prefers-reduced-motion: reduce` it never sets it at all, so jumps are instant. The indicator bar is *positioned* by JS (transform + height) and *animated* by CSS, which means the reduced-motion opt-out for the transition is one media query in `default.css` - the bar still tracks the active link, it just arrives without the glide. Scrolling never moves focus in either case.

## Tests

| Suite | Before | After |
|---|---|---|
| `mix test` | 913 tests, 0 failures, 1 skipped | **932 tests, 0 failures, 1 skipped** |
| `npm test` | 157 passing | **179 passing** |

`mix format --check-formatted`, `mix compile --force --warnings-as-errors` and `mix credo` are all clean - credo reports the same 14 refactoring opportunities / 31 readability issues as `main`, so zero new entries.

## Screenshots

Captured and eyeballed locally at 1280x1800 on `/c/scrollspy`: light, dark, and a scrolled shot where a non-first entry is active (a scrollspy screenshot with the first item highlighted proves nothing). Verified in both schemes that the active link reads stronger than the rest, the indicator sits against it, the nested example indents correctly, and the bare-markup example highlights with no `pc-scrollspy` classes on it. Images are not committed - happy to attach them to this thread on request.
