### PR TITLE
feat(tree): hierarchical tree view with the full APG keyboard map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,37 @@
 # Changelog
+
+### Unreleased
+
+#### Added
+
+- **New `tree` component: a hierarchical tree view for arbitrary-depth
+  data.** The file-explorer staple, and the gap between `menu`,
+  `navigation_menu` and `accordion` - none of which render a hierarchy.
+  Feed it a nested list of maps (`%{id:, label:, children: [...]}`) and
+  it renders itself down as far as the data goes: chevrons and
+  folder/document icons on the branches, a reserved chevron column so
+  leaf labels stay aligned, optional connecting indent guides
+  (`show_guides`), and single selection with a soft primary fill.
+  Two expansion models, both rendering identical markup and ARIA:
+  client-side by default (`default_expanded` seeds it, the chevron
+  toggles `data-expanded` with `Phoenix.LiveView.JS` and CSS animates
+  the height, zero round-trips), or server-controlled by passing
+  `expanded` plus an `on_expand` event - which is what `:lazy` branches
+  need, since their children only exist once the server has been asked.
+  A `:loading` row covers the wait, an `:empty` slot covers no data, and
+  an `:item` slot takes over the row content while the component keeps
+  the chevron, the indent and every ARIA attribute.
+  Accessibility is the WAI-ARIA TreeView pattern in full:
+  `role="tree"` / `treeitem` / `group`, computed `aria-level`,
+  `aria-setsize` and `aria-posinset`, `aria-expanded` on branches only,
+  `aria-selected`, `aria-disabled`, and the complete keyboard map
+  (up/down through visible nodes, right to expand or descend, left to
+  collapse or ascend, Home/End, Enter/Space to select, `*` to expand
+  siblings) over a roving tabindex, so the whole tree is one Tab stop.
+  The new `PetalTree` hook does the keyboard work and nothing else -
+  expansion and selection stay in JS commands and server events, so a
+  pointer user gets a working tree even if the hook never mounts.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,159 @@
       transition-duration: 1ms;
     }
   }
+
+@layer components {
+  /* Tree (WAI-ARIA TreeView)
+
+     Indentation is a single custom property per row (--pc-tree-depth) times a
+     fixed step, so a node at any depth costs one inline style and nothing else.
+     The guide lines ride an absolutely positioned decorative layer over that
+     same step, which is why they line up under the parent chevron without any
+     per-level rules. */
+  .pc-tree {
+    --pc-tree-step: 1.25rem;
+    @apply m-0 list-none p-0 text-sm text-gray-700 select-none dark:text-gray-300;
+  }
+
+  .pc-tree__item {
+    @apply list-none;
+  }
+
+  .pc-tree__row {
+    @apply relative flex min-w-0 items-center gap-1 py-1 pe-2 transition-colors;
+    padding-inline-start: calc(var(--pc-tree-depth, 0) * var(--pc-tree-step));
+    border-radius: max(calc(min(var(--pc-radius, 0.625rem), 1rem) - 0.25rem), 0px);
+  }
+
+  .pc-tree__row:hover {
+    @apply bg-gray-100 dark:bg-gray-400/10;
+  }
+
+  .pc-tree__item--selected > .pc-tree__row,
+  .pc-tree__item--selected > .pc-tree__row:hover {
+    @apply bg-primary-100 text-primary-800 dark:bg-primary-500/15 dark:text-primary-300;
+  }
+
+  /* Focus is the tree item (the li), but the ring belongs on the row - the li
+     also wraps the whole collapsed subtree and would draw a box around it. */
+  .pc-tree__item:focus {
+    @apply outline-hidden;
+  }
+
+  .pc-tree__item:focus-visible > .pc-tree__row {
+    @apply ring-2 ring-primary-500/50;
+  }
+
+  .pc-tree__item--disabled > .pc-tree__row {
+    @apply opacity-50;
+  }
+
+  .pc-tree__item--disabled > .pc-tree__row:hover {
+    @apply bg-transparent;
+  }
+
+  .pc-tree__chevron {
+    @apply flex shrink-0 cursor-pointer items-center justify-center text-gray-400 dark:text-gray-500;
+    width: var(--pc-tree-step);
+    height: var(--pc-tree-step);
+    border-radius: max(calc(min(var(--pc-radius, 0.625rem), 1rem) - 0.375rem), 0px);
+  }
+
+  .pc-tree__chevron:hover {
+    @apply bg-gray-200 text-gray-600 dark:bg-gray-400/17 dark:text-gray-300;
+  }
+
+  /* The leaf chevron is empty on purpose: it reserves the same column so leaf
+     labels line up with their sibling branches. */
+  .pc-tree__chevron--leaf {
+    @apply cursor-default;
+  }
+
+  .pc-tree__chevron--leaf:hover {
+    @apply bg-transparent;
+  }
+
+  .pc-tree__chevron-icon {
+    @apply h-4 w-4 transition-transform duration-200;
+  }
+
+  .pc-tree__item[data-expanded="true"] > .pc-tree__row .pc-tree__chevron-icon {
+    @apply rotate-90;
+  }
+
+  .pc-tree__content {
+    @apply flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 py-0.5;
+  }
+
+  .pc-tree__item--disabled .pc-tree__content {
+    @apply cursor-not-allowed;
+  }
+
+  .pc-tree__icon {
+    @apply h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500;
+  }
+
+  .pc-tree__item--selected > .pc-tree__row .pc-tree__icon {
+    @apply text-primary-600 dark:text-primary-300;
+  }
+
+  .pc-tree__label {
+    @apply truncate;
+  }
+
+  /* Decorative only - one 1px column per ancestor level, offset half a step so
+     each line falls through the middle of its parent's chevron. */
+  .pc-tree__guides {
+    @apply pointer-events-none absolute inset-y-0 start-0 flex;
+    padding-inline-start: calc(var(--pc-tree-step) / 2);
+  }
+
+  .pc-tree__guide {
+    @apply border-s border-gray-200 dark:border-gray-400/17;
+    width: var(--pc-tree-step);
+  }
+
+  /* The 0fr -> 1fr grid trick animates to the children's natural height with no
+     measured pixel value. visibility rides along so a collapsed branch leaves
+     the accessibility tree instead of sitting there clipped but exposed. */
+  .pc-tree__group-wrap {
+    @apply grid;
+    grid-template-rows: 0fr;
+    visibility: hidden;
+    transition:
+      grid-template-rows 200ms ease,
+      visibility 200ms;
+  }
+
+  .pc-tree__item[data-expanded="true"] > .pc-tree__group-wrap {
+    grid-template-rows: 1fr;
+    visibility: visible;
+  }
+
+  .pc-tree__group {
+    @apply m-0 min-h-0 list-none overflow-hidden p-0;
+  }
+
+  .pc-tree__empty {
+    @apply px-2 py-3 text-sm text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-tree__loading {
+    @apply flex list-none items-center gap-2 py-1 pe-2 text-xs text-gray-500 dark:text-gray-400;
+    padding-inline-start: calc(
+      var(--pc-tree-depth, 0) * var(--pc-tree-step) + var(--pc-tree-step)
+    );
+  }
+
+  .pc-tree__spinner {
+    @apply h-3.5 w-3.5 text-gray-400 dark:text-gray-500;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pc-tree__group-wrap,
+    .pc-tree__chevron-icon,
+    .pc-tree__row {
+      transition-duration: 1ms;
+    }
+  }
+}

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -5424,6 +5424,210 @@ export const PetalDataTable = {
   },
 };
 
+// Keyboard navigation for <.tree> (WAI-ARIA TreeView), and nothing else.
+//
+// Roving tabindex is the whole reason this hook exists: the tree must be a
+// single tab stop with exactly one treeitem carrying tabindex="0", and moving
+// DOM focus between arbitrary nodes on an arrow key is not something CSS or
+// LiveView.JS can do. Expansion and selection are deliberately NOT implemented
+// here - the hook clicks the chevron and the label the component already wired,
+// so both expansion models work identically and a pointer user still gets a
+// working tree if the hook never mounts.
+export const PetalTree = {
+  mounted() {
+    this.onKeydown = this.onKeydown.bind(this);
+    this.onFocusIn = this.onFocusIn.bind(this);
+    this.onClick = this.onClick.bind(this);
+    this.el.addEventListener("keydown", this.onKeydown);
+    this.el.addEventListener("focusin", this.onFocusIn);
+    this.el.addEventListener("click", this.onClick);
+    this.syncTabIndex();
+  },
+
+  // A server patch re-renders tabindex from the server's own guess. Put the
+  // tab stop back on whichever node the user was actually on.
+  updated() {
+    this.syncTabIndex();
+  },
+
+  destroyed() {
+    this.el.removeEventListener("keydown", this.onKeydown);
+    this.el.removeEventListener("focusin", this.onFocusIn);
+    this.el.removeEventListener("click", this.onClick);
+  },
+
+  nodes() {
+    return Array.from(this.el.querySelectorAll("[data-pc-tree-node]"));
+  },
+
+  // "Visible" is an ARIA term here, not a CSS one: a node whose every ancestor
+  // branch is expanded. Collapsed subtrees stay in the DOM, so this walk is the
+  // only honest test.
+  isVisible(node) {
+    let parent =
+      node.parentElement && node.parentElement.closest("[data-pc-tree-node]");
+    while (parent) {
+      if (parent.dataset.expanded !== "true") return false;
+      parent =
+        parent.parentElement &&
+        parent.parentElement.closest("[data-pc-tree-node]");
+    }
+    return true;
+  },
+
+  visibleNodes() {
+    return this.nodes().filter((node) => this.isVisible(node));
+  },
+
+  current() {
+    const active = document.activeElement;
+    if (active && this.el.contains(active)) {
+      const node = active.closest("[data-pc-tree-node]");
+      if (node) return node;
+    }
+    return (
+      this.el.querySelector('[data-pc-tree-node][tabindex="0"]') ||
+      this.visibleNodes()[0] ||
+      null
+    );
+  },
+
+  syncTabIndex() {
+    const nodes = this.nodes();
+    if (nodes.length === 0) return;
+
+    let target =
+      this.activeId && nodes.find((n) => n.dataset.nodeId === this.activeId);
+    if (!target) {
+      target =
+        nodes.find((n) => n.getAttribute("tabindex") === "0") ||
+        this.visibleNodes()[0] ||
+        nodes[0];
+    }
+    // the branch above the tab stop may have closed under it
+    if (!this.isVisible(target)) target = this.visibleNodes()[0] || nodes[0];
+
+    this.activeId = target.dataset.nodeId;
+    nodes.forEach((node) =>
+      node.setAttribute("tabindex", node === target ? "0" : "-1"),
+    );
+  },
+
+  focusNode(node) {
+    if (!node) return;
+    this.activeId = node.dataset.nodeId;
+    this.syncTabIndex();
+    node.focus();
+  },
+
+  // :scope keeps us on this node's own row - a descendant node has a chevron
+  // and a label too, and querySelector would happily hand one of those back.
+  own(node, selector) {
+    return node.querySelector(`:scope > .pc-tree__row ${selector}`);
+  },
+
+  toggle(node) {
+    const chevron = this.own(node, "[data-pc-tree-chevron]");
+    if (chevron) chevron.click();
+  },
+
+  select(node) {
+    if (node.getAttribute("aria-disabled") === "true") return;
+    const label = this.own(node, "[data-pc-tree-select]");
+    if (label) label.click();
+  },
+
+  step(node, delta) {
+    const visible = this.visibleNodes();
+    this.focusNode(visible[visible.indexOf(node) + delta]);
+  },
+
+  expandOrDescend(node) {
+    if (node.dataset.branch !== "true") return;
+    if (node.dataset.expanded === "true") {
+      this.focusNode(node.querySelector("[data-pc-tree-node]"));
+    } else {
+      this.toggle(node);
+    }
+  },
+
+  collapseOrAscend(node) {
+    if (node.dataset.branch === "true" && node.dataset.expanded === "true") {
+      this.toggle(node);
+      return;
+    }
+    this.focusNode(
+      node.parentElement && node.parentElement.closest("[data-pc-tree-node]"),
+    );
+  },
+
+  expandSiblings(node) {
+    const container = node.parentElement;
+    if (!container) return;
+    Array.from(container.children)
+      .filter((el) => el.matches("[data-pc-tree-node]"))
+      .filter((el) => el.dataset.branch === "true" && el.dataset.expanded !== "true")
+      .forEach((el) => this.toggle(el));
+  },
+
+  onFocusIn(event) {
+    const node =
+      event.target.closest && event.target.closest("[data-pc-tree-node]");
+    if (!node) return;
+    this.activeId = node.dataset.nodeId;
+    this.syncTabIndex();
+  },
+
+  // Clicking a row does not focus anything on its own (the label is a span, on
+  // purpose - a button inside the tree would be a second tab stop), so move the
+  // roving tab stop by hand.
+  onClick(event) {
+    const node =
+      event.target.closest && event.target.closest("[data-pc-tree-node]");
+    if (node) this.focusNode(node);
+  },
+
+  onKeydown(event) {
+    const node = this.current();
+    if (!node) return;
+
+    switch (event.key) {
+      case "ArrowDown":
+        this.step(node, 1);
+        break;
+      case "ArrowUp":
+        this.step(node, -1);
+        break;
+      case "ArrowRight":
+        this.expandOrDescend(node);
+        break;
+      case "ArrowLeft":
+        this.collapseOrAscend(node);
+        break;
+      case "Home":
+        this.focusNode(this.visibleNodes()[0]);
+        break;
+      case "End": {
+        const visible = this.visibleNodes();
+        this.focusNode(visible[visible.length - 1]);
+        break;
+      }
+      case "Enter":
+      case " ":
+        this.select(node);
+        break;
+      case "*":
+        this.expandSiblings(node);
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+  },
+};
+
 export default {
   PetalChart,
   PetalColorScheme,
@@ -5454,4 +5658,5 @@ export default {
   PetalCommandDialog,
   PetalComboBox,
   PetalDataTable,
+  PetalTree,
 };

--- a/dev.exs
+++ b/dev.exs
@@ -274,6 +274,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "stepper", name: "Stepper", ready: true},
         %{slug: "menu", name: "Menu", ready: true},
         %{slug: "navigation-menu", name: "Navigation menu", ready: true},
+        %{slug: "tree", name: "Tree", ready: true},
         %{slug: "user-menu", name: "User menu", ready: true},
         %{slug: "language-select", name: "Language select", ready: true}
       ]
@@ -833,6 +834,18 @@ defmodule Dev.PlaygroundLive do
        page: %{current: 3, sibling: 1, boundary: 1},
        skeleton: %{animation: "pulse", loading: false},
        accordion: %{variant: "default", multiple: false, size: "md"},
+       tree: %{
+         guides: true,
+         expand: "first",
+         picked: nil,
+         # the file explorer scenario runs the server-controlled model
+         expanded: MapSet.new(["lib", "petal_components"]),
+         opened: "tree.ex",
+         loaded: %{},
+         # the settings nav scenario, same model, different data
+         settings_expanded: MapSet.new(["workspace"]),
+         settings_page: "members"
+       },
        stepper: %{orientation: "horizontal", size: "md", labels: "beside", at: 0, done: false},
        toast: %{pos: "bottom-right", undone: 0},
        car: %{
@@ -1203,6 +1216,16 @@ defmodule Dev.PlaygroundLive do
   def handle_info(:pg_skeleton_loaded, socket),
     do: {:noreply, update(socket, :skeleton, &%{&1 | loading: false})}
 
+  # The lazy branch's children finally arriving. In a real app this is the
+  # reply from a query or an API call; here it is a 900ms delay so the
+  # :loading row is actually visible.
+  def handle_info({:tree_loaded, id}, socket) do
+    {:noreply,
+     update(socket, :tree, fn tree ->
+       %{tree | loaded: Map.put(tree.loaded, id, tree_lazy_children(id))}
+     end)}
+  end
+
   def handle_info({:chat_tick, id, chunks}, socket) do
     chat = socket.assigns.chat
 
@@ -1237,6 +1260,41 @@ defmodule Dev.PlaygroundLive do
 
   def handle_event("ctl_accordion", %{"k" => "size", "v" => v}, socket) when v in ~w(sm md),
     do: {:noreply, update(socket, :accordion, &%{&1 | size: v})}
+
+  def handle_event("ctl_tree", %{"k" => "guides"}, socket),
+    do: {:noreply, update(socket, :tree, &%{&1 | guides: !&1.guides})}
+
+  def handle_event("ctl_tree", %{"k" => "expand", "v" => v}, socket) when v in ~w(none first all),
+    do: {:noreply, update(socket, :tree, &%{&1 | expand: v})}
+
+  # The dial tree runs the client-side model, so the server never hears about
+  # expansion - only about the node the user chose.
+  def handle_event("tree_pick", %{"id" => id}, socket),
+    do: {:noreply, update(socket, :tree, &%{&1 | picked: id})}
+
+  # The file explorer runs the server-controlled model: this is the entire
+  # backend for it, plus the lazy fetch below.
+  def handle_event("tree_toggle", %{"id" => id}, socket) do
+    tree = socket.assigns.tree
+    opening? = not MapSet.member?(tree.expanded, id)
+
+    # a lazy branch has no children until we go and get them
+    if opening? and id in tree_lazy_ids() and not Map.has_key?(tree.loaded, id),
+      do: Process.send_after(self(), {:tree_loaded, id}, 900)
+
+    {:noreply, assign(socket, :tree, %{tree | expanded: toggle_member(tree.expanded, id)})}
+  end
+
+  def handle_event("tree_open", %{"id" => id}, socket),
+    do: {:noreply, update(socket, :tree, &%{&1 | opened: id})}
+
+  def handle_event("settings_toggle", %{"id" => id}, socket),
+    do:
+      {:noreply,
+       update(socket, :tree, &%{&1 | settings_expanded: toggle_member(&1.settings_expanded, id)})}
+
+  def handle_event("settings_pick", %{"id" => id}, socket),
+    do: {:noreply, update(socket, :tree, &%{&1 | settings_page: id})}
 
   def handle_event("ctl_stepper", %{"k" => "orientation", "v" => v}, socket)
       when v in ~w(horizontal vertical),
@@ -1852,6 +1910,155 @@ defmodule Dev.PlaygroundLive do
   defp examples_for(module, ids) do
     by_id = Map.new(module.examples(), &{&1.id, &1})
     Enum.map(ids, &Map.fetch!(by_id, &1))
+  end
+
+  # --- Tree page data -------------------------------------------------------
+
+  defp toggle_member(set, id) do
+    if MapSet.member?(set, id), do: MapSet.delete(set, id), else: MapSet.put(set, id)
+  end
+
+  defp sample_tree do
+    [
+      %{
+        id: "lib",
+        label: "lib",
+        children: [
+          %{
+            id: "petal_components",
+            label: "petal_components",
+            children: [
+              %{id: "button.ex", label: "button.ex"},
+              %{id: "modal.ex", label: "modal.ex"},
+              %{id: "tree.ex", label: "tree.ex"}
+            ]
+          },
+          %{id: "petal_components.ex", label: "petal_components.ex"}
+        ]
+      },
+      %{
+        id: "assets",
+        label: "assets",
+        children: [
+          %{id: "default.css", label: "default.css"},
+          %{
+            id: "js",
+            label: "js",
+            children: [%{id: "petal_components.js", label: "petal_components.js"}]
+          }
+        ]
+      },
+      %{id: "mix.exs", label: "mix.exs"},
+      %{id: "README.md", label: "README.md"}
+    ]
+  end
+
+  defp hero_expanded("all"), do: :all
+  defp hero_expanded("first"), do: ["lib", "assets"]
+  defp hero_expanded(_none), do: []
+
+  defp tree_lazy_ids, do: ["deps"]
+
+  defp tree_lazy_children("deps") do
+    [
+      %{id: "phoenix", label: "phoenix", icon: "hero-cube"},
+      %{id: "phoenix_live_view", label: "phoenix_live_view", icon: "hero-cube"},
+      %{id: "heroicons", label: "heroicons", icon: "hero-cube"}
+    ]
+  end
+
+  # The lazy branch keeps :lazy set so it stays a branch before its children
+  # exist; once they land they are just children like any others.
+  defp explorer_items(tree) do
+    sample_tree() ++
+      [
+        %{
+          id: "deps",
+          label: "deps",
+          lazy: true,
+          children: Map.get(tree.loaded, "deps", [])
+        },
+        %{id: "_build", label: "_build", disabled: true}
+      ]
+  end
+
+  defp org_tree do
+    [
+      %{
+        id: "dana",
+        label: "Dana Okafor",
+        initials: "DO",
+        role: "VP Engineering",
+        city: "Melbourne",
+        children: [
+          %{
+            id: "sam",
+            label: "Sam Reyes",
+            initials: "SR",
+            role: "Platform lead",
+            city: "Sydney",
+            children: [
+              %{
+                id: "kit",
+                label: "Kit Alvarez",
+                initials: "KA",
+                role: "Senior engineer",
+                city: "Perth"
+              },
+              %{
+                id: "noor",
+                label: "Noor Haddad",
+                initials: "NH",
+                role: "Engineer",
+                city: "Sydney"
+              }
+            ]
+          },
+          %{
+            id: "wren",
+            label: "Wren Costa",
+            initials: "WC",
+            role: "Design lead",
+            city: "Melbourne",
+            children: [
+              %{
+                id: "ida",
+                label: "Ida Bergstrom",
+                initials: "IB",
+                role: "Designer",
+                city: "Hobart"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  end
+
+  defp settings_tree do
+    [
+      %{
+        id: "workspace",
+        label: "Workspace",
+        icon: "hero-building-office-2",
+        children: [
+          %{id: "general", label: "General", icon: "hero-cog-6-tooth"},
+          %{id: "members", label: "Members", icon: "hero-users"},
+          %{id: "billing", label: "Billing", icon: "hero-credit-card"}
+        ]
+      },
+      %{
+        id: "security",
+        label: "Security",
+        icon: "hero-shield-check",
+        children: [
+          %{id: "sso", label: "Single sign-on", icon: "hero-key"},
+          %{id: "audit-log", label: "Audit log", icon: "hero-document-text"}
+        ]
+      },
+      %{id: "api-keys", label: "API keys", icon: "hero-command-line"},
+      %{id: "legal-hold", label: "Legal hold", icon: "hero-lock-closed", disabled: true}
+    ]
   end
 
   defp input_meta("text"), do: {"Full name", "Ada Lovelace"}
@@ -9123,6 +9330,197 @@ defmodule Dev.PlaygroundLive do
 
       <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
         These examples render from the shared <code>PetalComponents.Showcase.Badge</code>
+        registry - the same source petal.build renders, so the playground and the marketing
+        docs can't drift.
+      </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "tree"} = assigns) do
+    assigns =
+      assigns
+      |> assign(:explorer_items, explorer_items(assigns.tree))
+      |> assign(:hero_expanded, hero_expanded(assigns.tree.expand))
+
+    ~H"""
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">Tree</h1>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        Nested data, arbitrary depth, the full WAI-ARIA TreeView keyboard map. Click into
+        the tree and drive it with the keyboard: up and down walk the visible nodes,
+        right expands or descends, left collapses or goes up a level, Home and End jump
+        to the ends, Enter or Space selects, and * opens every branch at the current
+        level. The whole tree is one Tab stop.
+      </p>
+
+      <div class="mt-8 border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="px-6 py-8">
+          <div class="max-w-md mx-auto">
+            <.tree
+              id={"pg-tree-#{@tree.expand}-#{@tree.guides}"}
+              label="Project files"
+              show_guides={@tree.guides}
+              default_expanded={@hero_expanded}
+              selected={@tree.picked}
+              select_event="tree_pick"
+              items={sample_tree()}
+            />
+          </div>
+        </div>
+
+        <div class="grid gap-5 px-6 py-5 border-t border-gray-100 md:grid-cols-3 dark:border-gray-800/80">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">
+              default_expanded
+            </div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Expanded at render"
+              value={@tree.expand}
+              on_change="ctl_tree"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item :for={v <- ~w(none first all)} value={v} phx-value-k="expand" phx-value-v={v}>
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">extras</div>
+            <.toggle_group
+              multiple
+              variant="outline"
+              size="sm"
+              aria_label="Extras"
+              value={for {k, on} <- [{"guides", @tree.guides}], on, do: k}
+              on_change="ctl_tree"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item value="guides" phx-value-k="guides">show_guides</:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">
+              last on_select payload
+            </div>
+            <code class="inline-block px-2 py-1 font-mono text-xs bg-gray-100 rounded dark:bg-gray-800">
+              {if @tree.picked, do: ~s|%{"id" => "#{@tree.picked}"}|, else: "nothing picked yet"}
+            </code>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-4 mt-3 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        This tree runs the client-side expansion model: the chevron toggles two attributes
+        with LiveView.JS and CSS animates the height, so opening a folder costs no round
+        trip. The trade is that the open branches live only in the DOM - flip a dial above
+        and the tree re-renders back to default_expanded. Trees that must survive a patch,
+        or that load children on demand, want the server-controlled model instead (the
+        file explorer below).
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Scenario: a file explorer</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        The server-controlled model end to end. A MapSet of expanded ids in assigns, one
+        handle_event for the chevron, one for selection. <code>deps/</code>
+        is marked :lazy - open it and the loading row shows until its children arrive
+        900ms later, the way a real query or API call would land.
+      </p>
+      <div class="grid gap-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <div class="p-3 border border-gray-200 rounded-xl dark:border-gray-800">
+          <.tree
+            id="pg-tree-explorer"
+            label="Explorer"
+            show_guides
+            expanded={@tree.expanded}
+            on_expand="tree_toggle"
+            selected={@tree.opened}
+            select_event="tree_open"
+            items={@explorer_items}
+          />
+        </div>
+        <div class="p-4 text-sm border border-gray-200 rounded-xl dark:border-gray-800">
+          <div class="font-mono text-xs text-gray-400">selected</div>
+          <div class="mt-1 font-medium">{@tree.opened || "nothing open"}</div>
+          <div class="mt-4 font-mono text-xs text-gray-400">expanded</div>
+          <div class="mt-1 font-mono text-xs break-all text-gray-500 dark:text-gray-400">
+            {@tree.expanded |> Enum.sort() |> inspect()}
+          </div>
+        </div>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Scenario: reporting lines</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        The :item slot takes over the row content and receives the whole node map, so the
+        extra keys on this data (a role, a location) render however you like. Everything
+        structural - the chevron, the indent, the guides, aria-level, the roving tabindex -
+        stays with the component.
+      </p>
+      <div class="p-3 border border-gray-200 rounded-xl dark:border-gray-800">
+        <.tree
+          id="pg-tree-org"
+          label="Reporting lines"
+          show_guides
+          default_expanded={:all}
+          items={org_tree()}
+        >
+          <:item :let={person}>
+            <span class="flex items-center justify-center w-6 h-6 text-[10px] font-semibold rounded-full shrink-0 bg-primary-100 text-primary-700 dark:bg-primary-500/15 dark:text-primary-300">
+              {person.initials}
+            </span>
+            <span class="font-medium">{person.label}</span>
+            <span class="text-xs text-gray-500 dark:text-gray-400">{person.role}</span>
+            <span class="ml-auto text-[11px] text-gray-400">{person.city}</span>
+          </:item>
+        </.tree>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Scenario: settings navigation</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        A two-level settings outline where selection drives the page next to it. Same
+        server-controlled model as the explorer, custom icons per node, and one disabled
+        node the user can still focus but not choose.
+      </p>
+      <div class="grid gap-4 sm:grid-cols-[minmax(0,14rem)_minmax(0,1fr)]">
+        <div class="p-3 border border-gray-200 rounded-xl dark:border-gray-800">
+          <.tree
+            id="pg-tree-settings"
+            label="Settings"
+            expanded={@tree.settings_expanded}
+            on_expand="settings_toggle"
+            selected={@tree.settings_page}
+            select_event="settings_pick"
+            items={settings_tree()}
+          />
+        </div>
+        <div class="p-6 border border-gray-200 rounded-xl dark:border-gray-800">
+          <div class="text-xs tracking-wide text-gray-400 uppercase">Now showing</div>
+          <div class="mt-1 text-xl font-semibold capitalize">
+            {@tree.settings_page |> to_string() |> String.replace("-", " ")}
+          </div>
+          <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+            Selection is single-select and the server owns it: the component sets
+            aria-selected and the soft primary fill on click so the highlight is instant,
+            then pushes the id so your LiveView can swap the panel.
+          </p>
+        </div>
+      </div>
+
+      <div :for={ex <- PetalComponents.Showcase.Tree.examples()} class="mt-10">
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} content_left />
+      </div>
+
+      <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
+      <.showcase_props component={PetalComponents.Tree} function={:tree} />
+
+      <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        These examples render from the shared <code>PetalComponents.Showcase.Tree</code>
         registry - the same source petal.build renders, so the playground and the marketing
         docs can't drift.
       </div>

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -69,6 +69,7 @@ defmodule PetalComponents do
         Table,
         Toast,
         Tabs,
+        Tree,
         ToggleGroup,
         Tooltip,
         TextAnimation,

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -56,6 +56,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.Toast,
     PetalComponents.Showcase.ToggleGroup,
     PetalComponents.Showcase.Tooltip,
+    PetalComponents.Showcase.Tree,
     PetalComponents.Showcase.UserDropdownMenu
   ]
 

--- a/lib/petal_components/showcase/tree.ex
+++ b/lib/petal_components/showcase/tree.ex
@@ -1,0 +1,160 @@
+defmodule PetalComponents.Showcase.Tree do
+  @moduledoc false
+  use PetalComponents.Showcase,
+    component: PetalComponents.Tree,
+    title: "Tree"
+
+  example :basic, "A project tree",
+    description:
+      "Nested maps in, arbitrary depth out. Branches get a chevron and folder icons, leaves get a document icon and the reserved chevron column so labels stay aligned. default_expanded seeds which branches open at first render; the chevron toggles the rest client-side, no round-trip." do
+    ~H"""
+    <.tree
+      id="sx-tree-basic"
+      label="Project files"
+      default_expanded={["lib", "petal_components"]}
+      items={[
+        %{
+          id: "lib",
+          label: "lib",
+          children: [
+            %{
+              id: "petal_components",
+              label: "petal_components",
+              children: [
+                %{id: "button.ex", label: "button.ex"},
+                %{id: "tree.ex", label: "tree.ex"}
+              ]
+            },
+            %{id: "petal_components.ex", label: "petal_components.ex"}
+          ]
+        },
+        %{
+          id: "assets",
+          label: "assets",
+          children: [%{id: "default.css", label: "default.css"}]
+        },
+        %{id: "mix.exs", label: "mix.exs"},
+        %{id: "README.md", label: "README.md"}
+      ]}
+    />
+    """
+  end
+
+  example :guides, "Indent guides and a selected node",
+    description:
+      "show_guides draws a hairline down each open branch so a deep tree still reads as a hierarchy. The guides are a decorative aria-hidden layer, so screen readers never meet them. selected marks one node with aria-selected and the soft primary fill; selection is single-select and the server owns which id is current." do
+    ~H"""
+    <.tree
+      id="sx-tree-guides"
+      label="Explorer"
+      show_guides
+      selected="checkout.ex"
+      default_expanded={:all}
+      items={[
+        %{
+          id: "accounts",
+          label: "accounts",
+          children: [
+            %{id: "user.ex", label: "user.ex"},
+            %{
+              id: "billing",
+              label: "billing",
+              children: [
+                %{id: "checkout.ex", label: "checkout.ex"},
+                %{id: "invoice.ex", label: "invoice.ex"}
+              ]
+            }
+          ]
+        },
+        %{id: "application.ex", label: "application.ex"},
+        %{id: "_build", label: "_build", disabled: true}
+      ]}
+    />
+    """
+  end
+
+  example :icons, "Custom icons and a lazy branch",
+    description:
+      "Any node can name its own heroicon with :icon. A node marked :lazy is a branch before its children exist: expand it and the tree shows the loading row until the server hands over the children. Lazy branches need the server-controlled expansion model, so this one passes :expanded and an :on_expand event." do
+    ~H"""
+    <.tree
+      id="sx-tree-icons"
+      label="Settings"
+      show_guides
+      expanded={["workspace", "integrations"]}
+      on_expand="toggle_branch"
+      select_event="open_setting"
+      selected="members"
+      items={[
+        %{
+          id: "workspace",
+          label: "Workspace",
+          icon: "hero-building-office-2",
+          children: [
+            %{id: "general", label: "General", icon: "hero-cog-6-tooth"},
+            %{id: "members", label: "Members", icon: "hero-users"},
+            %{id: "billing-plan", label: "Billing", icon: "hero-credit-card"}
+          ]
+        },
+        %{
+          id: "integrations",
+          label: "Integrations",
+          icon: "hero-puzzle-piece",
+          lazy: true
+        },
+        %{id: "danger", label: "Danger zone", icon: "hero-exclamation-triangle"}
+      ]}
+    />
+    """
+  end
+
+  example :slot, "Custom rows with the :item slot",
+    description:
+      "The :item slot replaces the icon and label content of every row and receives the whole node map, so extra keys on your data are yours to render. The chevron, the indent, the guides and every ARIA attribute stay owned by the component - you are styling a row, not rebuilding a tree." do
+    ~H"""
+    <.tree
+      id="sx-tree-slot"
+      label="Reporting lines"
+      show_guides
+      default_expanded={:all}
+      items={[
+        %{
+          id: "dana",
+          label: "Dana Okafor",
+          title: "VP Engineering",
+          children: [
+            %{
+              id: "sam",
+              label: "Sam Reyes",
+              title: "Platform lead",
+              children: [
+                %{id: "kit", label: "Kit Alvarez", title: "Senior engineer"},
+                %{id: "noor", label: "Noor Haddad", title: "Engineer"}
+              ]
+            },
+            %{id: "wren", label: "Wren Costa", title: "Design lead"}
+          ]
+        }
+      ]}
+    >
+      <:item :let={person}>
+        <span class="flex items-center justify-center w-5 h-5 text-[10px] font-semibold rounded-full shrink-0 bg-primary-100 text-primary-700 dark:bg-primary-500/15 dark:text-primary-300">
+          {String.first(person.label)}
+        </span>
+        <span class="font-medium">{person.label}</span>
+        <span class="text-xs text-gray-500 dark:text-gray-400">{person.title}</span>
+      </:item>
+    </.tree>
+    """
+  end
+
+  example :empty, "The empty state",
+    description:
+      "Nothing to show gets its own row rather than a blank box. Override the wording with the :empty slot." do
+    ~H"""
+    <.tree id="sx-tree-empty" label="Archived files" items={[]}>
+      <:empty>No archived files. Anything you archive shows up here.</:empty>
+    </.tree>
+    """
+  end
+end

--- a/lib/petal_components/tree.ex
+++ b/lib/petal_components/tree.ex
@@ -1,0 +1,416 @@
+defmodule PetalComponents.Tree do
+  @moduledoc """
+  A hierarchical tree view: the file-explorer staple.
+
+  `tree/1` takes a nested list of maps and renders arbitrary depth with
+  expand/collapse, single selection, optional connecting indent guides, and the
+  WAI-ARIA [TreeView](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/)
+  keyboard map. Nodes need nothing but an `:id` and a `:label`; `:children`
+  makes a node a branch.
+
+      <.tree
+        id="files"
+        label="Project files"
+        show_guides
+        default_expanded={["lib"]}
+        items={[
+          %{id: "lib", label: "lib", children: [%{id: "app.ex", label: "app.ex"}]},
+          %{id: "mix.exs", label: "mix.exs"}
+        ]}
+      />
+
+  ## Node maps
+
+  | key | meaning |
+  | --- | --- |
+  | `:id` | required, unique within the tree; stringified for the DOM |
+  | `:label` | required, the visible text |
+  | `:children` | a list of node maps; a non-empty list makes the node a branch |
+  | `:icon` | a heroicon name overriding the default folder/document icon |
+  | `:disabled` | renders the node non-selectable (still focusable, per the APG) |
+  | `:lazy` | marks a branch whose children arrive later; shows the `:loading` row while `:children` is empty |
+
+  Any other key rides along untouched and is handed to the `:item` slot, so
+  custom rows can read whatever they need off the node.
+
+  ## The two expansion models
+
+  Pick one. Both render identical markup and identical ARIA, so a tree can move
+  from one to the other without a visual change.
+
+  **Client-side (the default).** Leave `:expanded` unset and seed the open
+  branches with `:default_expanded`. The chevron toggles `data-expanded` and
+  `aria-expanded` with `Phoenix.LiveView.JS`, and CSS animates the height. No
+  round-trip, no assigns to keep, nothing to handle. The catch: the open/closed
+  state lives only in the DOM, so a LiveView patch that re-renders the tree
+  resets it to `:default_expanded`. Right for static trees (docs navigation, a
+  settings outline, anything that renders once).
+
+  **Server-controlled.** Pass `:expanded` (a list or `MapSet` of branch ids) and
+  an `:on_expand` event name. The chevron pushes that event with the node id in
+  `phx-value-id` and your `handle_event/3` decides what opens. Required for
+  `:lazy` branches, whose children only exist after the server has been asked
+  for them, and for any tree that has to survive `phx-update` patches.
+
+      def handle_event("toggle", %{"id" => id}, socket) do
+        {:noreply, update(socket, :expanded, &toggle(&1, id))}
+      end
+
+  ## Selection
+
+  Selection is single-select and always server-owned: pass the chosen id as
+  `:selected` and give `:select_event` a name to hear about clicks (the node id
+  arrives as `phx-value-id`). The component also flips `aria-selected` and the
+  selected class client-side on click, so the highlight lands immediately rather
+  than a round-trip later. `:on_select` composes your own JS commands onto that.
+
+  ## Keyboard
+
+  The `PetalTree` hook implements the APG map over a roving tabindex: the tree
+  is a single tab stop and exactly one node carries `tabindex="0"`.
+
+  | key | does |
+  | --- | --- |
+  | `Down` / `Up` | move through visible nodes |
+  | `Right` | expand a collapsed branch, or move to its first child |
+  | `Left` | collapse an expanded branch, or move to the parent |
+  | `Home` / `End` | first / last visible node |
+  | `Enter` / `Space` | select the focused node |
+  | `*` | expand every sibling branch of the focused node |
+
+  Expansion and selection are JS commands and server events, not hook internals,
+  so a tree still expands and selects with the pointer if the hook never runs.
+  """
+  use Phoenix.Component
+
+  import PetalComponents.Icon
+  import PetalComponents.Helpers, only: [compose_js: 2]
+  import PetalComponents.Loading, only: [spinner: 1]
+
+  alias Phoenix.LiveView.JS
+
+  attr :id, :string,
+    required: true,
+    doc: "unique id; the PetalTree hook mounts here for roving focus"
+
+  attr :items, :list,
+    default: [],
+    doc:
+      "nested node maps, e.g. `%{id: \"lib\", label: \"lib\", children: [...]}`. `:id` and `:label` are required; `:children` makes a node a branch, `:icon` overrides the default icon, `:disabled` makes it non-selectable and `:lazy` marks a branch whose children load async. Extra keys pass through to the `:item` slot"
+
+  attr :label, :string,
+    default: nil,
+    doc:
+      "accessible name for the tree, rendered as aria-label. Skip it if you label the tree with aria-labelledby via rest"
+
+  attr :selected, :string,
+    default: nil,
+    doc: "id of the currently selected node (single selection)"
+
+  attr :select_event, :string,
+    default: nil,
+    doc: "event name pushed when a node is chosen; the node id rides in phx-value-id"
+
+  attr :on_select, JS,
+    default: %JS{},
+    doc: "extra JS commands composed onto the built-in selection behaviour when a node is chosen"
+
+  attr :expanded, :any,
+    default: nil,
+    doc:
+      "ids of the currently expanded branches (list or MapSet), or `:all`. Setting this switches the tree to the server-controlled expansion model; leave it nil for the client-side default"
+
+  attr :on_expand, :string,
+    default: nil,
+    doc:
+      "event name pushed by the chevron in the server-controlled model, with the node id in phx-value-id. Ignored when :expanded is nil"
+
+  attr :default_expanded, :any,
+    default: [],
+    doc:
+      "ids of branches expanded at first render, or `:all` to expand everything. Client-side model only"
+
+  attr :target, :any,
+    default: nil,
+    doc: "phx-target for the select and expand events, for trees inside a LiveComponent"
+
+  attr :show_guides, :boolean,
+    default: false,
+    doc: "render connecting indent guide lines down each expanded branch"
+
+  attr :class, :any, default: nil, doc: "extra classes for the tree container"
+  attr :rest, :global
+
+  slot :item,
+    doc:
+      "custom node rendering; receives the node map via :let. The chevron, indent and ARIA wiring stay owned by the component - the slot replaces the icon and label row content only"
+
+  slot :empty, doc: "rendered when :items is empty"
+
+  slot :loading,
+    doc:
+      "rendered inside a :lazy branch while its children are pending (default: a small spinner row)"
+
+  @doc """
+  Renders a tree.
+
+  ## Examples
+
+      <.tree id="files" label="Files" items={@files} />
+
+      <.tree
+        id="explorer"
+        label="Explorer"
+        show_guides
+        default_expanded={:all}
+        selected={@current}
+        select_event="pick_file"
+        items={@files}
+      />
+
+      <.tree id="org" items={@people}>
+        <:item :let={person}>
+          <span class="font-medium">{person.label}</span>
+          <span class="text-xs text-gray-500">{person.title}</span>
+        </:item>
+        <:empty>Nobody reports into this team yet.</:empty>
+      </.tree>
+  """
+  def tree(assigns) do
+    expanded = expanded_set(assigns.expanded, assigns.default_expanded, assigns.items)
+
+    ctx = %{
+      id: assigns.id,
+      expanded: expanded,
+      server: not is_nil(assigns.expanded),
+      selected: assigns.selected,
+      select_event: assigns.select_event,
+      on_select: assigns.on_select,
+      on_expand: assigns.on_expand,
+      target: assigns.target,
+      show_guides: assigns.show_guides,
+      focus_id: focus_id(assigns.items, expanded, assigns.selected),
+      item: assigns.item,
+      loading: assigns.loading
+    }
+
+    assigns = assign(assigns, :ctx, ctx)
+
+    ~H"""
+    <ul
+      id={@id}
+      role="tree"
+      aria-label={@label}
+      phx-hook="PetalTree"
+      data-pc-tree
+      class={["pc-tree", @show_guides && "pc-tree--guides", @class]}
+      {@rest}
+    >
+      <li :if={@items == []} role="none" class="pc-tree__empty">
+        {if @empty == [], do: "Nothing here yet.", else: render_slot(@empty)}
+      </li>
+      <.tree_node
+        :for={{node, i} <- Enum.with_index(@items, 1)}
+        node={node}
+        ctx={@ctx}
+        level={1}
+        posinset={i}
+        setsize={length(@items)}
+      />
+    </ul>
+    """
+  end
+
+  # The recursive half. A node renders its own row and, when it is an expanded
+  # branch, a role="group" list that calls straight back into this function -
+  # depth is whatever the data has, not a fixed number of levels.
+  defp tree_node(assigns) do
+    node = assigns.node
+    children = List.wrap(Map.get(node, :children))
+    lazy? = Map.get(node, :lazy) == true
+    branch? = children != [] or lazy?
+    node_id = to_string(node.id)
+    expanded? = branch? and MapSet.member?(assigns.ctx.expanded, node_id)
+
+    assigns =
+      assigns
+      |> assign(:children, children)
+      |> assign(:branch, branch?)
+      |> assign(:node_id, node_id)
+      |> assign(:expanded, expanded?)
+      |> assign(:disabled, Map.get(node, :disabled) == true)
+      |> assign(:selected, assigns.ctx.selected == node_id)
+      |> assign(:pending, lazy? and children == [])
+      |> assign(:icon, node_icon(node, branch?, expanded?))
+      |> assign(:guide_count, assigns.level - 1)
+
+    ~H"""
+    <li
+      id={node_dom_id(@ctx.id, @node_id)}
+      role="treeitem"
+      aria-level={@level}
+      aria-posinset={@posinset}
+      aria-setsize={@setsize}
+      aria-labelledby={label_dom_id(@ctx.id, @node_id)}
+      aria-expanded={@branch && to_string(@expanded)}
+      aria-selected={to_string(@selected)}
+      aria-disabled={@disabled && "true"}
+      tabindex={if @ctx.focus_id == @node_id, do: "0", else: "-1"}
+      data-pc-tree-node
+      data-node-id={@node_id}
+      data-branch={@branch && "true"}
+      data-expanded={@branch && to_string(@expanded)}
+      class={[
+        "pc-tree__item",
+        @selected && "pc-tree__item--selected",
+        @disabled && "pc-tree__item--disabled"
+      ]}
+    >
+      <div class="pc-tree__row" style={"--pc-tree-depth: #{@level - 1};"}>
+        <span :if={@ctx.show_guides && @guide_count > 0} class="pc-tree__guides" aria-hidden="true">
+          <span :for={_ <- 1..@guide_count//1} class="pc-tree__guide"></span>
+        </span>
+
+        <span
+          :if={@branch}
+          class="pc-tree__chevron"
+          aria-hidden="true"
+          data-pc-tree-chevron
+          phx-click={chevron_click(@ctx, @node_id)}
+          phx-value-id={@node_id}
+          phx-target={@ctx.server && @ctx.target}
+        >
+          <.icon name="hero-chevron-right-mini" class="pc-tree__chevron-icon" />
+        </span>
+        <span :if={!@branch} class="pc-tree__chevron pc-tree__chevron--leaf" aria-hidden="true"></span>
+
+        <span
+          id={label_dom_id(@ctx.id, @node_id)}
+          class="pc-tree__content"
+          data-pc-tree-select
+          phx-click={!@disabled && select_click(@ctx, @node_id)}
+          phx-value-id={@node_id}
+          phx-target={!@disabled && @ctx.select_event && @ctx.target}
+        >
+          <%= if @ctx.item == [] do %>
+            <.icon :if={@icon} name={@icon} class="pc-tree__icon" aria-hidden="true" />
+            <span class="pc-tree__label">{@node.label}</span>
+          <% else %>
+            {render_slot(@ctx.item, @node)}
+          <% end %>
+        </span>
+      </div>
+
+      <div :if={@branch} class="pc-tree__group-wrap">
+        <ul role="group" class="pc-tree__group">
+          <li
+            :if={@pending}
+            role="none"
+            class="pc-tree__loading"
+            style={"--pc-tree-depth: #{@level};"}
+          >
+            <%= if @ctx.loading == [] do %>
+              <.spinner size="sm" class="pc-tree__spinner" /> Loading...
+            <% else %>
+              {render_slot(@ctx.loading)}
+            <% end %>
+          </li>
+          <.tree_node
+            :for={{child, i} <- Enum.with_index(@children, 1)}
+            node={child}
+            ctx={@ctx}
+            level={@level + 1}
+            posinset={i}
+            setsize={length(@children)}
+          />
+        </ul>
+      </div>
+    </li>
+    """
+  end
+
+  # In the server-controlled model the chevron is a plain event push, so the
+  # LiveView owns what is open. Otherwise it flips the two attributes the CSS
+  # and the hook both read, entirely client-side.
+  defp chevron_click(%{server: true} = ctx, _node_id), do: ctx.on_expand
+
+  defp chevron_click(ctx, node_id) do
+    selector = "#" <> node_dom_id(ctx.id, node_id)
+
+    %JS{}
+    |> JS.toggle_attribute({"aria-expanded", "true", "false"}, to: selector)
+    |> JS.toggle_attribute({"data-expanded", "true", "false"}, to: selector)
+  end
+
+  # User JS first, then the built-in highlight move, then the push (so the
+  # server hears about a selection the user's own commands did not cancel).
+  defp select_click(ctx, node_id) do
+    ctx.on_select
+    |> compose_js(selection_js(ctx, node_id))
+    |> push_select(ctx)
+  end
+
+  defp selection_js(ctx, node_id) do
+    self_selector = "#" <> node_dom_id(ctx.id, node_id)
+    tree_selector = "##{ctx.id} [role='treeitem'][aria-selected='true']"
+
+    %JS{}
+    |> JS.set_attribute({"aria-selected", "false"}, to: tree_selector)
+    |> JS.remove_class("pc-tree__item--selected", to: "##{ctx.id} .pc-tree__item--selected")
+    |> JS.set_attribute({"aria-selected", "true"}, to: self_selector)
+    |> JS.add_class("pc-tree__item--selected", to: self_selector)
+  end
+
+  defp push_select(js, %{select_event: nil}), do: js
+  defp push_select(js, ctx), do: JS.push(js, ctx.select_event, target: ctx.target)
+
+  defp node_icon(node, branch?, expanded?) do
+    case Map.get(node, :icon) do
+      nil when branch? and expanded? -> "hero-folder-open"
+      nil when branch? -> "hero-folder"
+      nil -> "hero-document"
+      icon -> icon
+    end
+  end
+
+  defp node_dom_id(tree_id, node_id), do: "#{tree_id}-node-#{node_id}"
+  defp label_dom_id(tree_id, node_id), do: "#{tree_id}-label-#{node_id}"
+
+  # :expanded (server-controlled) wins over :default_expanded (client-side seed).
+  defp expanded_set(nil, default, items), do: to_id_set(default, items)
+  defp expanded_set(expanded, _default, items), do: to_id_set(expanded, items)
+
+  defp to_id_set(:all, items), do: MapSet.new(branch_ids(items))
+  defp to_id_set(ids, _items) when is_list(ids), do: MapSet.new(ids, &to_string/1)
+  defp to_id_set(%MapSet{} = ids, _items), do: MapSet.new(ids, &to_string/1)
+  defp to_id_set(_other, _items), do: MapSet.new()
+
+  defp branch_ids(items) do
+    Enum.flat_map(items, fn node ->
+      children = List.wrap(Map.get(node, :children))
+
+      if children == [] and Map.get(node, :lazy) != true,
+        do: [],
+        else: [to_string(node.id) | branch_ids(children)]
+    end)
+  end
+
+  # Exactly one node carries tabindex="0" at render: the selected node when it
+  # is reachable without expanding anything, otherwise the first visible node.
+  defp focus_id(items, expanded, selected) do
+    visible = visible_ids(items, expanded)
+
+    if selected && selected in visible, do: selected, else: List.first(visible)
+  end
+
+  defp visible_ids(items, expanded) do
+    Enum.flat_map(items, fn node ->
+      id = to_string(node.id)
+      children = List.wrap(Map.get(node, :children))
+
+      if MapSet.member?(expanded, id),
+        do: [id | visible_ids(children, expanded)],
+        else: [id]
+    end)
+  end
+end

--- a/test/js/tree.test.js
+++ b/test/js/tree.test.js
@@ -1,0 +1,441 @@
+// PetalTree hook: the WAI-ARIA TreeView keyboard map over a roving tabindex.
+// The markup here mirrors what PetalComponents.Tree renders (test/petal/
+// tree_test.exs pins that structure on the Elixir side) - update both together
+// if the anatomy changes.
+import { afterEach, describe, expect, it } from "vitest";
+
+import hooks from "../../assets/js/petal_components.js";
+
+const mounted = [];
+
+// lib/                 branch, expanded
+//   petal/             branch, collapsed
+//     app.ex           leaf
+//   petal.ex           leaf
+// mix.exs              leaf
+// blocked              leaf, disabled
+const TREE = `
+  <li id="t-node-lib" role="treeitem" aria-level="1" aria-posinset="1" aria-setsize="4"
+      aria-expanded="true" aria-selected="false" tabindex="0"
+      data-pc-tree-node data-node-id="lib" data-branch="true" data-expanded="true"
+      class="pc-tree__item">
+    <div class="pc-tree__row">
+      <span class="pc-tree__chevron" data-pc-tree-chevron></span>
+      <span id="t-label-lib" class="pc-tree__content" data-pc-tree-select>lib</span>
+    </div>
+    <div class="pc-tree__group-wrap">
+      <ul role="group" class="pc-tree__group">
+        <li id="t-node-petal" role="treeitem" aria-level="2" aria-posinset="1" aria-setsize="2"
+            aria-expanded="false" aria-selected="false" tabindex="-1"
+            data-pc-tree-node data-node-id="petal" data-branch="true" data-expanded="false"
+            class="pc-tree__item">
+          <div class="pc-tree__row">
+            <span class="pc-tree__chevron" data-pc-tree-chevron></span>
+            <span id="t-label-petal" class="pc-tree__content" data-pc-tree-select>petal</span>
+          </div>
+          <div class="pc-tree__group-wrap">
+            <ul role="group" class="pc-tree__group">
+              <li id="t-node-app" role="treeitem" aria-level="3" aria-posinset="1" aria-setsize="1"
+                  aria-selected="false" tabindex="-1"
+                  data-pc-tree-node data-node-id="app" class="pc-tree__item">
+                <div class="pc-tree__row">
+                  <span class="pc-tree__chevron pc-tree__chevron--leaf"></span>
+                  <span id="t-label-app" class="pc-tree__content" data-pc-tree-select>app.ex</span>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li id="t-node-petalex" role="treeitem" aria-level="2" aria-posinset="2" aria-setsize="2"
+            aria-selected="false" tabindex="-1"
+            data-pc-tree-node data-node-id="petalex" class="pc-tree__item">
+          <div class="pc-tree__row">
+            <span class="pc-tree__chevron pc-tree__chevron--leaf"></span>
+            <span id="t-label-petalex" class="pc-tree__content" data-pc-tree-select>petal.ex</span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </li>
+  <li id="t-node-mix" role="treeitem" aria-level="1" aria-posinset="2" aria-setsize="4"
+      aria-selected="false" tabindex="-1"
+      data-pc-tree-node data-node-id="mix" class="pc-tree__item">
+    <div class="pc-tree__row">
+      <span class="pc-tree__chevron pc-tree__chevron--leaf"></span>
+      <span id="t-label-mix" class="pc-tree__content" data-pc-tree-select>mix.exs</span>
+    </div>
+  </li>
+  <li id="t-node-assets" role="treeitem" aria-level="1" aria-posinset="3" aria-setsize="4"
+      aria-expanded="false" aria-selected="false" tabindex="-1"
+      data-pc-tree-node data-node-id="assets" data-branch="true" data-expanded="false"
+      class="pc-tree__item">
+    <div class="pc-tree__row">
+      <span class="pc-tree__chevron" data-pc-tree-chevron></span>
+      <span id="t-label-assets" class="pc-tree__content" data-pc-tree-select>assets</span>
+    </div>
+    <div class="pc-tree__group-wrap">
+      <ul role="group" class="pc-tree__group">
+        <li id="t-node-css" role="treeitem" aria-level="2" aria-posinset="1" aria-setsize="1"
+            aria-selected="false" tabindex="-1"
+            data-pc-tree-node data-node-id="css" class="pc-tree__item">
+          <div class="pc-tree__row">
+            <span class="pc-tree__chevron pc-tree__chevron--leaf"></span>
+            <span id="t-label-css" class="pc-tree__content" data-pc-tree-select>app.css</span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </li>
+  <li id="t-node-blocked" role="treeitem" aria-level="1" aria-posinset="4" aria-setsize="4"
+      aria-selected="false" aria-disabled="true" tabindex="-1"
+      data-pc-tree-node data-node-id="blocked" class="pc-tree__item pc-tree__item--disabled">
+    <div class="pc-tree__row">
+      <span class="pc-tree__chevron pc-tree__chevron--leaf"></span>
+      <span id="t-label-blocked" class="pc-tree__content" data-pc-tree-select>_build</span>
+    </div>
+  </li>
+`;
+
+function mount() {
+  const el = document.createElement("ul");
+  el.id = "t";
+  el.setAttribute("role", "tree");
+  el.className = "pc-tree";
+  el.innerHTML = TREE;
+  document.body.appendChild(el);
+
+  const hook = Object.create(hooks.PetalTree);
+  hook.el = el;
+  hook.mounted();
+  mounted.push(hook);
+
+  // The component wires the chevron to a JS command (client mode) or a server
+  // event; either way the hook's only contract with it is a click, so record
+  // clicks and apply the client-mode toggle by hand.
+  const chevronClicks = [];
+  el.querySelectorAll("[data-pc-tree-chevron]").forEach((chevron) => {
+    chevron.addEventListener("click", () => {
+      const node = chevron.closest("[data-pc-tree-node]");
+      chevronClicks.push(node.dataset.nodeId);
+      const open = node.dataset.expanded === "true";
+      node.dataset.expanded = open ? "false" : "true";
+      node.setAttribute("aria-expanded", open ? "false" : "true");
+    });
+  });
+
+  const selectClicks = [];
+  el.querySelectorAll("[data-pc-tree-select]").forEach((label) => {
+    label.addEventListener("click", () =>
+      selectClicks.push(label.closest("[data-pc-tree-node]").dataset.nodeId),
+    );
+  });
+
+  const node = (id) => el.querySelector(`[data-node-id="${id}"]`);
+  const focus = (id) => node(id).focus();
+  const key = (k) =>
+    document.activeElement.dispatchEvent(
+      new window.KeyboardEvent("keydown", { key: k, bubbles: true, cancelable: true }),
+    );
+  const activeId = () => document.activeElement.dataset.nodeId;
+
+  return { hook, el, node, focus, key, activeId, chevronClicks, selectClicks };
+}
+
+afterEach(() => {
+  mounted.splice(0).forEach((hook) => hook.destroyed());
+  document.body.innerHTML = "";
+});
+
+describe("roving tabindex", () => {
+  it("keeps exactly one node at tabindex=0", () => {
+    const { el, focus } = mount();
+    const stops = () => el.querySelectorAll('[data-pc-tree-node][tabindex="0"]');
+
+    expect(stops()).toHaveLength(1);
+    expect(stops()[0].dataset.nodeId).toBe("lib");
+
+    focus("mix");
+    expect(stops()).toHaveLength(1);
+    expect(stops()[0].dataset.nodeId).toBe("mix");
+  });
+
+  it("moves the tab stop when a row is clicked", () => {
+    const { el, node } = mount();
+
+    node("mix").querySelector("[data-pc-tree-select]").click();
+
+    expect(el.querySelector('[tabindex="0"]').dataset.nodeId).toBe("mix");
+  });
+
+  it("restores the tab stop after a server patch reset it", () => {
+    const { hook, el, focus, node } = mount();
+
+    focus("mix");
+    // what a re-render looks like: the server's own guess lands on the first node
+    el.querySelectorAll("[data-pc-tree-node]").forEach((n) =>
+      n.setAttribute("tabindex", n.dataset.nodeId === "lib" ? "0" : "-1"),
+    );
+    hook.updated();
+
+    expect(node("mix").getAttribute("tabindex")).toBe("0");
+    expect(node("lib").getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("hands the tab stop back when its branch collapses under it", () => {
+    const { hook, focus, key, node } = mount();
+
+    focus("petalex");
+    expect(node("petalex").getAttribute("tabindex")).toBe("0");
+
+    focus("lib");
+    key("ArrowLeft"); // collapses lib, hiding petalex
+    hook.updated();
+
+    expect(node("petalex").getAttribute("tabindex")).toBe("-1");
+  });
+});
+
+describe("Down and Up", () => {
+  it("walk visible nodes only, skipping collapsed subtrees", () => {
+    const { focus, key, activeId } = mount();
+
+    focus("lib");
+    key("ArrowDown");
+    expect(activeId()).toBe("petal");
+    key("ArrowDown");
+    // app.ex is inside collapsed petal, so it is skipped
+    expect(activeId()).toBe("petalex");
+    key("ArrowDown");
+    expect(activeId()).toBe("mix");
+    key("ArrowDown");
+    expect(activeId()).toBe("assets");
+    key("ArrowUp");
+    expect(activeId()).toBe("mix");
+  });
+
+  it("stop at the ends rather than wrapping", () => {
+    const { focus, key, activeId } = mount();
+
+    focus("lib");
+    key("ArrowUp");
+    expect(activeId()).toBe("lib");
+
+    focus("blocked");
+    key("ArrowDown");
+    expect(activeId()).toBe("blocked");
+  });
+
+  it("descend into a branch that is already open", () => {
+    const { focus, key, activeId } = mount();
+
+    focus("assets");
+    key("ArrowRight"); // expands
+    key("ArrowDown");
+    expect(activeId()).toBe("css");
+  });
+});
+
+describe("Right", () => {
+  it("expands a collapsed branch without moving focus", () => {
+    const { focus, key, activeId, node, chevronClicks } = mount();
+
+    focus("petal");
+    key("ArrowRight");
+
+    expect(chevronClicks).toEqual(["petal"]);
+    expect(node("petal").getAttribute("aria-expanded")).toBe("true");
+    expect(activeId()).toBe("petal");
+  });
+
+  it("moves into the first child of an already expanded branch", () => {
+    const { focus, key, activeId } = mount();
+
+    focus("lib");
+    key("ArrowRight");
+
+    expect(activeId()).toBe("petal");
+  });
+
+  it("does nothing on a leaf", () => {
+    const { focus, key, activeId, chevronClicks } = mount();
+
+    focus("mix");
+    key("ArrowRight");
+
+    expect(activeId()).toBe("mix");
+    expect(chevronClicks).toEqual([]);
+  });
+});
+
+describe("Left", () => {
+  it("collapses an expanded branch without moving focus", () => {
+    const { focus, key, activeId, node, chevronClicks } = mount();
+
+    focus("lib");
+    key("ArrowLeft");
+
+    expect(chevronClicks).toEqual(["lib"]);
+    expect(node("lib").getAttribute("aria-expanded")).toBe("false");
+    expect(activeId()).toBe("lib");
+  });
+
+  it("moves to the parent from a collapsed branch", () => {
+    const { focus, key, activeId } = mount();
+
+    focus("petal");
+    key("ArrowLeft");
+
+    expect(activeId()).toBe("lib");
+  });
+
+  it("moves to the parent from a leaf", () => {
+    const { focus, key, activeId } = mount();
+
+    focus("petalex");
+    key("ArrowLeft");
+
+    expect(activeId()).toBe("lib");
+  });
+
+  it("does nothing at the root level", () => {
+    const { focus, key, activeId } = mount();
+
+    focus("mix");
+    key("ArrowLeft");
+
+    expect(activeId()).toBe("mix");
+  });
+});
+
+describe("Home and End", () => {
+  it("jump to the first and last visible nodes", () => {
+    const { focus, key, activeId } = mount();
+
+    focus("mix");
+    key("Home");
+    expect(activeId()).toBe("lib");
+
+    key("End");
+    expect(activeId()).toBe("blocked");
+  });
+
+  it("End respects collapsed subtrees", () => {
+    const { focus, key, activeId } = mount();
+
+    focus("assets");
+    key("ArrowRight"); // open assets, so app.css becomes visible
+    focus("blocked");
+    key("ArrowUp");
+    expect(activeId()).toBe("css");
+  });
+});
+
+describe("Enter and Space", () => {
+  it("select the focused node", () => {
+    const { focus, key, selectClicks } = mount();
+
+    focus("mix");
+    key("Enter");
+    expect(selectClicks).toEqual(["mix"]);
+
+    focus("petalex");
+    key(" ");
+    expect(selectClicks).toEqual(["mix", "petalex"]);
+  });
+
+  it("do not select a disabled node", () => {
+    const { focus, key, selectClicks } = mount();
+
+    focus("blocked");
+    key("Enter");
+    key(" ");
+
+    expect(selectClicks).toEqual([]);
+  });
+});
+
+describe("asterisk", () => {
+  it("expands every collapsed sibling branch at the focused level", () => {
+    const { focus, key, node, chevronClicks } = mount();
+
+    focus("assets");
+    key("*");
+
+    // lib was already open and is left alone; assets opens; leaves are skipped
+    expect(chevronClicks).toEqual(["assets"]);
+    expect(node("assets").getAttribute("aria-expanded")).toBe("true");
+    expect(node("lib").getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("only touches the focused node's own sibling group", () => {
+    const { focus, key, node } = mount();
+
+    focus("petal");
+    key("*");
+
+    expect(node("petal").getAttribute("aria-expanded")).toBe("true");
+    // a branch one level up is not a sibling
+    expect(node("assets").getAttribute("aria-expanded")).toBe("false");
+  });
+});
+
+describe("event handling", () => {
+  it("swallows the keys it handles so the page does not scroll", () => {
+    const { focus } = mount();
+    focus("lib");
+
+    const event = new window.KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.activeElement.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("leaves keys it does not handle alone", () => {
+    const { focus } = mount();
+    focus("lib");
+
+    const event = new window.KeyboardEvent("keydown", {
+      key: "a",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.activeElement.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("stops listening once destroyed", () => {
+    const { hook, el, focus, activeId } = mount();
+    focus("lib");
+
+    hook.destroyed();
+    mounted.splice(mounted.indexOf(hook), 1);
+
+    el.querySelector('[data-node-id="lib"]').dispatchEvent(
+      new window.KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }),
+    );
+
+    expect(activeId()).toBe("lib");
+  });
+
+  it("does nothing on an empty tree", () => {
+    const el = document.createElement("ul");
+    el.id = "empty";
+    el.setAttribute("role", "tree");
+    document.body.appendChild(el);
+
+    const hook = Object.create(hooks.PetalTree);
+    hook.el = el;
+
+    expect(() => hook.mounted()).not.toThrow();
+    expect(() =>
+      el.dispatchEvent(new window.KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })),
+    ).not.toThrow();
+
+    hook.destroyed();
+  });
+});

--- a/test/petal/tree_test.exs
+++ b/test/petal/tree_test.exs
@@ -1,0 +1,566 @@
+defmodule PetalComponents.TreeTest do
+  use ComponentCase
+
+  import PetalComponents.Tree
+
+  # Four levels deep on purpose: recursion is the whole trick in this component,
+  # so every structural assertion below runs against a tree that actually nests.
+  defp deep_items do
+    [
+      %{
+        id: "lib",
+        label: "lib",
+        children: [
+          %{
+            id: "petal",
+            label: "petal",
+            children: [
+              %{
+                id: "components",
+                label: "components",
+                children: [%{id: "button.ex", label: "button.ex"}]
+              }
+            ]
+          },
+          %{id: "petal.ex", label: "petal.ex"}
+        ]
+      },
+      %{id: "mix.exs", label: "mix.exs"},
+      %{id: "README.md", label: "README.md"}
+    ]
+  end
+
+  defp nodes(html), do: html |> parse_html() |> LazyHTML.query("[data-pc-tree-node]")
+
+  defp node_by_id(html, id) do
+    html |> parse_html() |> LazyHTML.query(~s|[data-node-id="#{id}"]|)
+  end
+
+  defp at(lazy, name), do: lazy |> LazyHTML.attribute(name) |> List.first()
+
+  describe "structure and recursion" do
+    test "renders nested items to four levels with DOM nesting matching the data" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" label="Files" items={@items} default_expanded={:all} />
+        """)
+
+      assert html =~ ~s|role="tree"|
+      assert html =~ ~s|aria-label="Files"|
+      assert Enum.count(nodes(html)) == 7
+
+      # the deepest leaf is reachable only through three nested role="group" lists
+      deepest =
+        html
+        |> parse_html()
+        |> LazyHTML.query(
+          ~s|[data-node-id="lib"] [role="group"] [data-node-id="petal"] [role="group"] | <>
+            ~s|[data-node-id="components"] [role="group"] [data-node-id="button.ex"]|
+        )
+
+      assert Enum.count(deepest) == 1
+    end
+
+    test "renders a single node" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={[%{id: "only", label: "Only"}]} />
+        """)
+
+      assert Enum.count(nodes(html)) == 1
+      assert html =~ "Only"
+    end
+
+    test "an empty children list makes a leaf, not an empty branch" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={[%{id: "a", label: "A", children: []}]} />
+        """)
+
+      assert html =~ "pc-tree__chevron--leaf"
+      refute html =~ ~s|role="group"|
+      refute html =~ "aria-expanded"
+    end
+
+    test "groups are role=group and only branches have them" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} default_expanded={:all} />
+        """)
+
+      groups = html |> parse_html() |> LazyHTML.query(~s|[role="group"]|)
+      assert Enum.count(groups) == 3
+    end
+  end
+
+  describe "aria-level, aria-setsize and aria-posinset" do
+    test "are exact across siblings and depths" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} default_expanded={:all} />
+        """)
+
+      # three roots
+      assert at(node_by_id(html, "lib"), "aria-level") == "1"
+      assert at(node_by_id(html, "lib"), "aria-posinset") == "1"
+      assert at(node_by_id(html, "lib"), "aria-setsize") == "3"
+
+      assert at(node_by_id(html, "mix.exs"), "aria-posinset") == "2"
+      assert at(node_by_id(html, "README.md"), "aria-posinset") == "3"
+      assert at(node_by_id(html, "README.md"), "aria-setsize") == "3"
+
+      # two children under lib
+      assert at(node_by_id(html, "petal"), "aria-level") == "2"
+      assert at(node_by_id(html, "petal"), "aria-posinset") == "1"
+      assert at(node_by_id(html, "petal"), "aria-setsize") == "2"
+      assert at(node_by_id(html, "petal.ex"), "aria-posinset") == "2"
+
+      # one child each the rest of the way down
+      assert at(node_by_id(html, "components"), "aria-level") == "3"
+      assert at(node_by_id(html, "components"), "aria-setsize") == "1"
+      assert at(node_by_id(html, "button.ex"), "aria-level") == "4"
+      assert at(node_by_id(html, "button.ex"), "aria-posinset") == "1"
+      assert at(node_by_id(html, "button.ex"), "aria-setsize") == "1"
+    end
+  end
+
+  describe "aria-expanded" do
+    test "branches carry it, leaves omit it entirely" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} default_expanded={["lib"]} />
+        """)
+
+      assert at(node_by_id(html, "lib"), "aria-expanded") == "true"
+      assert at(node_by_id(html, "petal"), "aria-expanded") == "false"
+      assert at(node_by_id(html, "mix.exs"), "aria-expanded") == nil
+      assert at(node_by_id(html, "petal.ex"), "aria-expanded") == nil
+    end
+
+    test "default_expanded: :all expands every branch" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} default_expanded={:all} />
+        """)
+
+      for id <- ~w(lib petal components) do
+        assert at(node_by_id(html, id), "aria-expanded") == "true"
+        assert at(node_by_id(html, id), "data-expanded") == "true"
+      end
+    end
+
+    test "default_expanded: [] leaves everything collapsed" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} />
+        """)
+
+      assert at(node_by_id(html, "lib"), "aria-expanded") == "false"
+      assert at(node_by_id(html, "petal"), "aria-expanded") == "false"
+    end
+
+    test "server-controlled :expanded overrides default_expanded and takes a MapSet" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree
+          id="t"
+          items={@items}
+          default_expanded={:all}
+          expanded={MapSet.new(["lib"])}
+          on_expand="toggle"
+        />
+        """)
+
+      assert at(node_by_id(html, "lib"), "aria-expanded") == "true"
+      assert at(node_by_id(html, "petal"), "aria-expanded") == "false"
+    end
+  end
+
+  describe "expansion wiring" do
+    test "client-side mode toggles both attributes with LiveView.JS" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} />
+        """)
+
+      chevron =
+        html |> parse_html() |> LazyHTML.query("[data-pc-tree-chevron]") |> Enum.at(0)
+
+      click = at(chevron, "phx-click")
+      assert click =~ "toggle_attr"
+      assert click =~ "aria-expanded"
+      assert click =~ "data-expanded"
+      assert click =~ "#t-node-lib"
+    end
+
+    test "server-controlled mode pushes the event name with the node id" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} expanded={["lib"]} on_expand="toggle" target="#panel" />
+        """)
+
+      chevron =
+        html |> parse_html() |> LazyHTML.query("[data-pc-tree-chevron]") |> Enum.at(0)
+
+      assert at(chevron, "phx-click") == "toggle"
+      assert at(chevron, "phx-value-id") == "lib"
+      assert at(chevron, "phx-target") == "#panel"
+    end
+  end
+
+  describe "selection" do
+    test "the selected id gets aria-selected=true and the class, others false" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} selected="mix.exs" />
+        """)
+
+      assert at(node_by_id(html, "mix.exs"), "aria-selected") == "true"
+      assert at(node_by_id(html, "mix.exs"), "class") =~ "pc-tree__item--selected"
+      assert at(node_by_id(html, "lib"), "aria-selected") == "false"
+      refute at(node_by_id(html, "lib"), "class") =~ "pc-tree__item--selected"
+      assert count_substring(html, ~s|aria-selected="true"|) == 1
+    end
+
+    test "select_event pushes with the node id in phx-value-id" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} select_event="pick" target="#panel" />
+        """)
+
+      label = html |> parse_html() |> LazyHTML.query("[data-pc-tree-select]") |> Enum.at(0)
+
+      assert at(label, "phx-value-id") == "lib"
+      assert at(label, "phx-target") == "#panel"
+
+      click = at(label, "phx-click")
+      assert click =~ "\"push\""
+      assert click =~ "pick"
+    end
+
+    test "on_select JS is composed onto the built-in selection behaviour" do
+      assigns = %{items: deep_items(), on_select: Phoenix.LiveView.JS.dispatch("my:event")}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} on_select={@on_select} />
+        """)
+
+      label = html |> parse_html() |> LazyHTML.query("[data-pc-tree-select]") |> Enum.at(0)
+      click = at(label, "phx-click")
+
+      assert click =~ "my:event"
+      # the built-in highlight move rides along
+      assert click =~ "aria-selected"
+      assert click =~ "pc-tree__item--selected"
+    end
+  end
+
+  describe "guides" do
+    test "show_guides renders guide elements, one per ancestor level, aria-hidden" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} default_expanded={:all} show_guides />
+        """)
+
+      assert html =~ "pc-tree--guides"
+
+      guide_layers = html |> parse_html() |> LazyHTML.query(".pc-tree__guides")
+      # one layer per node below the roots: petal, petal.ex, components, button.ex
+      assert Enum.count(guide_layers) == 4
+      assert Enum.all?(guide_layers, &(at(&1, "aria-hidden") == "true"))
+
+      # depth 4 node draws three guide columns
+      deep_guides =
+        html
+        |> parse_html()
+        |> LazyHTML.query(~s|[data-node-id="button.ex"] > .pc-tree__row > .pc-tree__guides|)
+        |> LazyHTML.query(".pc-tree__guide")
+
+      assert Enum.count(deep_guides) == 3
+    end
+
+    test "guides are off by default" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} default_expanded={:all} />
+        """)
+
+      refute html =~ "pc-tree--guides"
+      refute html =~ "pc-tree__guide"
+    end
+  end
+
+  describe "icons" do
+    test "default folder/document icons, flipping open when expanded" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} default_expanded={["lib"]} />
+        """)
+
+      assert html =~ "hero-folder-open"
+      assert html =~ "hero-document"
+      assert html =~ "hero-chevron-right-mini"
+    end
+
+    test "a node's :icon key overrides the default" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={[%{id: "a", label: "A", icon: "hero-cog-6-tooth"}]} />
+        """)
+
+      assert html =~ "hero-cog-6-tooth"
+      refute html =~ "hero-document"
+    end
+  end
+
+  describe "slots" do
+    test ":item renders custom content while the ARIA wiring stays intact" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} default_expanded={:all}>
+          <:item :let={node}>
+            <span class="custom-row">{node.label} custom</span>
+          </:item>
+        </.tree>
+        """)
+
+      assert html =~ "custom-row"
+      assert html =~ "lib custom"
+      assert html =~ "button.ex custom"
+      # the component keeps the chevron, the roles and the level maths
+      assert html =~ "pc-tree__chevron"
+      assert at(node_by_id(html, "button.ex"), "aria-level") == "4"
+      assert at(node_by_id(html, "button.ex"), "role") == "treeitem"
+    end
+
+    test ":empty renders when items is empty" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={[]}>
+          <:empty>No files here.</:empty>
+        </.tree>
+        """)
+
+      assert html =~ "No files here."
+      assert html =~ "pc-tree__empty"
+      assert Enum.empty?(nodes(html))
+    end
+
+    test "an empty tree falls back to a default empty row" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={[]} />
+        """)
+
+      assert html =~ "pc-tree__empty"
+      assert html =~ "Nothing here yet."
+    end
+
+    test ":loading renders inside an expanded :lazy branch with no children yet" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree
+          id="t"
+          items={[%{id: "remote", label: "remote", lazy: true}]}
+          expanded={["remote"]}
+          on_expand="toggle"
+        >
+          <:loading>Fetching...</:loading>
+        </.tree>
+        """)
+
+      assert html =~ "pc-tree__loading"
+      assert html =~ "Fetching..."
+      # a lazy node is a branch even with no children loaded
+      assert at(node_by_id(html, "remote"), "aria-expanded") == "true"
+      assert html =~ ~s|role="group"|
+    end
+
+    test "a lazy branch defaults to a spinner row and drops it once children arrive" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree
+          id="t"
+          items={[%{id: "remote", label: "remote", lazy: true}]}
+          expanded={["remote"]}
+          on_expand="toggle"
+        />
+        """)
+
+      assert html =~ "pc-tree__spinner"
+
+      html =
+        rendered_to_string(~H"""
+        <.tree
+          id="t"
+          items={[%{id: "remote", label: "remote", lazy: true, children: [%{id: "x", label: "x"}]}]}
+          expanded={["remote"]}
+          on_expand="toggle"
+        />
+        """)
+
+      refute html =~ "pc-tree__loading"
+      assert html =~ ~s|data-node-id="x"|
+    end
+  end
+
+  describe "disabled nodes" do
+    test "carry aria-disabled and no selection binding, but stay focusable" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree
+          id="t"
+          items={[%{id: "a", label: "A", disabled: true}, %{id: "b", label: "B"}]}
+          select_event="pick"
+        />
+        """)
+
+      disabled = node_by_id(html, "a")
+      assert at(disabled, "aria-disabled") == "true"
+      assert at(disabled, "class") =~ "pc-tree__item--disabled"
+      # still in the roving order per the APG
+      assert at(disabled, "tabindex") == "0"
+
+      label_a =
+        html |> parse_html() |> LazyHTML.query(~s|#t-label-a|) |> Enum.at(0)
+
+      label_b =
+        html |> parse_html() |> LazyHTML.query(~s|#t-label-b|) |> Enum.at(0)
+
+      assert at(label_a, "phx-click") == nil
+      assert at(label_b, "phx-click") =~ "pick"
+      assert at(node_by_id(html, "b"), "aria-disabled") == nil
+    end
+  end
+
+  describe "roving tabindex" do
+    test "exactly one node has tabindex=0 at render" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} default_expanded={:all} />
+        """)
+
+      assert count_substring(html, ~s|tabindex="0"|) == 1
+      assert count_substring(html, ~s|tabindex="-1"|) == 6
+      # first visible node when nothing is selected
+      assert at(node_by_id(html, "lib"), "tabindex") == "0"
+    end
+
+    test "the selected node holds the tab stop when it is visible" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} default_expanded={:all} selected="components" />
+        """)
+
+      assert count_substring(html, ~s|tabindex="0"|) == 1
+      assert at(node_by_id(html, "components"), "tabindex") == "0"
+    end
+
+    test "a selected node hidden inside a collapsed branch does not steal the tab stop" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} selected="button.ex" />
+        """)
+
+      assert count_substring(html, ~s|tabindex="0"|) == 1
+      assert at(node_by_id(html, "lib"), "tabindex") == "0"
+      assert at(node_by_id(html, "button.ex"), "tabindex") == "-1"
+    end
+  end
+
+  describe "container" do
+    test "mounts the hook and marks itself for the hook's queries" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} />
+        """)
+
+      assert html =~ ~s|phx-hook="PetalTree"|
+      assert html =~ "data-pc-tree"
+      assert html =~ ~s|id="t"|
+    end
+
+    test "class and rest pass through" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} class="my-tree" data-testid="files" aria-describedby="hint" />
+        """)
+
+      root = html |> parse_html() |> LazyHTML.query("#t") |> Enum.at(0)
+
+      assert at(root, "class") =~ "my-tree"
+      assert at(root, "class") =~ "pc-tree"
+      assert at(root, "data-testid") == "files"
+      assert at(root, "aria-describedby") == "hint"
+    end
+
+    test "each node is labelled by its own row, not the whole subtree" do
+      assigns = %{items: deep_items()}
+
+      html =
+        rendered_to_string(~H"""
+        <.tree id="t" items={@items} default_expanded={:all} />
+        """)
+
+      assert at(node_by_id(html, "lib"), "aria-labelledby") == "t-label-lib"
+      assert html =~ ~s|id="t-label-lib"|
+    end
+  end
+end


### PR DESCRIPTION
Closes #611

## Summary

`<.tree>` renders a nested list of maps to arbitrary depth: expand/collapse, single selection, connecting indent guides, and the WAI-ARIA TreeView pattern in full. Five parts per CONTRIBUTING.md, plus a `PetalTree` hook and a `### Unreleased` changelog entry.

1. **Module** `lib/petal_components/tree.ex`, exported from `lib/petal_components.ex` (`tree` was free). Every attr has a `doc:`; the moduledoc carries the node-map reference, both expansion models, the keyboard table and usage examples.
2. **Styles** - a `pc-tree` section appended to `assets/default.css` in its own `@layer components` block, nothing reflowed. `--pc-radius` with the nested-child formula, gray ramp neutrals, `dark:` pairs, soft primary selection, `focus-visible` only, reduced-motion safe.
3. **Tests** - `test/petal/tree_test.exs` (30 specs) and `test/js/tree.test.js` (24 specs, vitest + jsdom).
4. **Showcase** - `lib/petal_components/showcase/tree.ex` plus its registry entry.
5. **Playground** - nav entry under Navigation, slug `tree`, dials plus three scenarios at `/c/tree`. Verified rendering.

## How recursion is handled

A private `tree_node/1` function component renders its own row and, when it is an expanded branch, a `role="group"` list that calls straight back into `tree_node/1`. Depth is whatever the data has - no level cap, no per-level code.

Shared context (the expanded set, selection, the slots, the tree id, guides on/off) is bundled into one `ctx` map built once in `tree/1` and threaded down, so a node carries only what is genuinely per-node: the node map, its level, and its position in its sibling group. `aria-level`, `aria-setsize` and `aria-posinset` fall out of that on the way down.

Indentation is one custom property per row (`--pc-tree-depth`) times a fixed step. The guides are a separate `aria-hidden` absolutely-positioned layer holding one 1px column per ancestor level, offset half a step so each line falls through its parent's chevron - which is why they line up at any depth without per-level rules.

## Both expansion models

Both render identical markup and identical ARIA; only the chevron's `phx-click` differs.

**Client-side (default).** `default_expanded` seeds it; the chevron toggles `data-expanded` and `aria-expanded` with `JS.toggle_attribute`, and the `0fr -> 1fr` grid technique animates the height. `visibility` rides along on that transition so a collapsed branch leaves the accessibility tree rather than sitting there clipped but exposed. No round-trips.

**Server-controlled.** Passing `:expanded` switches modes: the chevron pushes `:on_expand` with the node id in `phx-value-id`. Required for `:lazy` branches, whose children only exist once the server has been asked, and for trees that must survive a patch.

The moduledoc states the trade plainly, including that client-side state is lost on a patch. I deliberately did **not** reach for `phx-update="ignore"` (the accordion's approach): the issue's own wording describes the state as "lost on patch unless the server mirrors it", and ignoring updates would break any tree whose *data* changes.

## Roving tabindex, and why there is a hook

The APG allows either roving tabindex or `aria-activedescendant`; I went with roving tabindex, which the issue names as the recommended default for tree views. `PetalCommand` uses `aria-activedescendant` because its virtual highlight lives in a listbox the user never leaves - focus stays in the text input while the highlight moves, which is the whole point of a combobox. A tree has no input. Its nodes *are* the interactive elements the user is on, so real DOM focus on the `treeitem` is what screen readers and `focus-visible` both expect, and it keeps "which node am I on" in one place (the document) rather than mirrored in an attribute. Exactly one node carries `tabindex="0"` at render - the selected node when it is reachable without expanding anything, otherwise the first visible node - so the tree is one Tab stop.

**The hook is justified by exactly that.** Moving DOM focus between arbitrary nodes on an arrow key is not something CSS or `Phoenix.LiveView.JS` can do: `JS.focus/2` cannot pick "the next node that is visible given which ancestors happen to be expanded". So `PetalTree` does the keyboard map and the tabindex bookkeeping, and **nothing else** - to expand or select it clicks the chevron or the label the component already wired. Consequences:

- Expansion and selection stay in JS commands and server events, so a pointer-only user gets a fully working tree if the hook never mounts.
- The hook is identical under both expansion models; it never needs to know which one is in play.
- It re-establishes the tab stop in `updated()`, since a server patch re-renders `tabindex` from the server's guess, and hands it back to the first visible node if the branch above it closed underneath.

Keyboard map implemented: Down/Up through visible nodes, Right to expand a collapsed branch or descend into an open one, Left to collapse or ascend, Home/End, Enter/Space to select, `*` to expand the focused node's sibling branches. Typeahead is out, per the issue's non-goals.

## Deviations from the issue's API sketch

All small, all deliberate:

1. **`select_event` added.** The sketch has `on_select` (a `JS` struct) and says the node "also emits a phx-click style event carrying the node id", but names no attr for it. `select_event` is that name; the id rides in `phx-value-id` as the test checklist specifies. `on_select` still composes user JS onto the built-in selection behaviour, exactly as sketched.
2. **`expanded` and `on_expand` added.** The "Expansion model" section requires both but does not list them as attrs. `:expanded` being non-nil is what switches the tree to the server-controlled model.
3. **`label` added.** The issue asked for "an `:aria_label`-friendly path via `rest` or a dedicated attr". `label` sets `aria-label`; `rest` still works if you prefer `aria-labelledby`.
4. **`target` added.** `phx-target`, so a tree inside a LiveComponent can route its events.
5. **Selection also fires client-side.** The component flips `aria-selected` and the selected class on click before the server replies, so the highlight is not a round-trip behind. Not in the sketch; it makes selection feel native and degrades cleanly.
6. **The chevron is a `<span>`, not a `<button>`.** A button inside the tree would be a second Tab stop and break the one-Tab-stop requirement. It is `aria-hidden`, and keyboard users reach expansion through Left/Right per the APG. Chevron and label are siblings inside the row, so a chevron click never bubbles into selection.
7. **`aria-labelledby` on each `treeitem`**, pointing at its own label span. Without it, a branch's accessible name is computed from its entire subtree.
8. **Guides render per row rather than per branch**, for the alignment reason above. Behaviour matches the spec: `show_guides` toggles them and they are `aria-hidden`.

## No new dependencies

None added, npm or hex.

## Test counts

| Suite | Before (`origin/main` @ 871b2cf) | After |
|---|---|---|
| `mix test` | 913 tests, 0 failures, 1 skipped | **943 tests, 0 failures, 1 skipped** |
| `npm test` | 157 passing | **181 passing** |

`mix format --check-formatted` clean, `mix compile --force --warnings-as-errors` clean, and `mix credo` is **unchanged** against `origin/main` (14 refactoring opportunities, 31 readability issues on both).

## Verified by hand

In the playground at `/c/tree`, light and dark, on the real page rather than in jsdom:

- **Every key in the map.** Down/Up walk visible nodes and skip collapsed subtrees; Right descends into an open branch and expands a closed one; Left collapses, then ascends; Home/End hit the ends; `*` expanded the focused node's collapsed siblings and left the already-open one alone; Enter selected the focused node and cleared the previous `aria-selected`. Confirmed by reading `tabindex` / `aria-expanded` / `aria-selected` off the live DOM after each keystroke - including across the server round-trip in the explorer scenario, where the collapse and the selection both went through `handle_event` and the hook put the tab stop back afterwards.
- **Pointer expand/collapse in both models**, and the `:lazy` branch: clicking `deps/` showed the loading row, then its children landed 900ms later with their custom icons.
- Guides, selection fill, the disabled node, the folder icon flip on expand, and label alignment all check out in both themes.

## Screenshots

Captured light and dark at 1280x2200 with branches expanded 3-4 levels deep, so the nesting and the guide lines are actually visible rather than a row of collapsed roots. Not committed to the repo (no image files, no `pr-assets`) - I will attach them here before taking this out of draft.
