### PR TITLE
feat(alert_dialog): the confirm/cancel gate before destructive actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,37 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **New `alert_dialog` component: the confirm/cancel question you ask
+  before something irreversible.** `<.modal>` is the general-purpose
+  overlay, and it lets you out cheaply - close button, click away, done.
+  That is the wrong behaviour when the next click deletes an account, so
+  `alert_dialog` inverts it. It carries `role="alertdialog"` so assistive
+  tech announces it as an interruption that wants a decision, opens with
+  focus on the **cancel** button rather than the first focusable, cancels
+  on Escape, and ignores backdrop clicks entirely. The friction is the
+  feature: there are two answers and you have to pick one. A `default`
+  variant renders the primary confirm treatment; `destructive` moves the
+  confirm button to the danger ramp and adds a danger icon accent, which
+  the `:icon` slot overrides. `description` is the one-line consequence
+  and wires itself to `aria-describedby`; the body slot composes live
+  data underneath it, so "you are about to delete 14 invoices" reads off
+  an assign instead of a hardcoded string. Long bodies scroll inside the
+  panel while the title and the action row stay put. Open it from
+  anywhere with `open_alert_dialog/2`, or drop an opener in the
+  `:trigger` slot and skip repeating the id.
+
+  Built on the native `<dialog>`, the same call `command_dialog` makes:
+  `showModal()` supplies the top layer, focus containment and focus
+  restoration to the opener for free, and a native modal dialog already
+  ignores backdrop clicks, which is exactly what this pattern wants. The
+  hook is small and only covers what `Phoenix.LiveView.JS` cannot reach -
+  `showModal()`/`close()` are DOM methods with no JS-command equivalent,
+  and Escape's native `cancel` event has to be intercepted so it runs
+  your `on_cancel` instead of quietly closing. The surface, the
+  transitions and the reduced-motion behaviour are all CSS.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,114 @@
       transition-duration: 1ms;
     }
   }
+
+/* Alert dialog - the two-answer decision before something destructive.
+   Built on the native <dialog>, so the top layer, focus containment and
+   ::backdrop come from the element. Deliberately narrower than the modal:
+   one question, one accent icon, one action row that stays put while a long
+   body scrolls under it. */
+
+@layer components {
+  .pc-alert-dialog {
+    /* The panel needs a DEFINITE height to bound its scrolling body: a
+       percentage max-height on the panel would resolve against the dialog's
+       auto height and be ignored, so the panel would overflow and clip its
+       own header. Both carry the same explicit cap instead. */
+    --pc-alert-dialog-max-h: min(32rem, calc(100dvh - 4rem));
+    @apply fixed p-0 overflow-hidden shadow-lg;
+    inset: 0;
+    margin: auto;
+    width: min(30rem, calc(100vw - 2rem));
+    max-height: var(--pc-alert-dialog-max-h);
+    color: inherit;
+    border: 1px solid var(--color-gray-200);
+    background: var(--color-white, #fff);
+    border-radius: min(var(--pc-radius, 0.625rem), 1rem);
+  }
+
+  .dark .pc-alert-dialog {
+    border-color: color-mix(in srgb, white 15%, transparent);
+    background: var(--color-gray-900);
+  }
+
+  .pc-alert-dialog::backdrop {
+    background: rgb(0 0 0 / 0.5);
+  }
+
+  .pc-alert-dialog__panel {
+    @apply flex flex-col;
+    max-height: var(--pc-alert-dialog-max-h);
+  }
+
+  .pc-alert-dialog__header {
+    @apply flex items-start gap-3 shrink-0 px-6 pt-6;
+  }
+
+  .pc-alert-dialog__icon {
+    @apply flex items-center justify-center shrink-0 w-9 h-9 text-gray-500 dark:text-gray-400;
+    background: var(--color-gray-100);
+    border-radius: min(calc(var(--pc-radius, 0.625rem) * 0.8), 0.625rem);
+  }
+
+  .dark .pc-alert-dialog__icon {
+    background: color-mix(in srgb, white 8%, transparent);
+  }
+
+  .pc-alert-dialog--destructive .pc-alert-dialog__icon {
+    @apply text-danger-600 dark:text-danger-400;
+    background: color-mix(in srgb, var(--color-danger-500) 12%, transparent);
+  }
+
+  .pc-alert-dialog__icon-svg {
+    @apply w-5 h-5;
+  }
+
+  .pc-alert-dialog__title {
+    @apply self-center text-base font-semibold text-gray-900 dark:text-gray-100;
+  }
+
+  .pc-alert-dialog__body {
+    @apply flex-1 min-h-0 overflow-y-auto px-6 pt-2;
+  }
+
+  .pc-alert-dialog__description {
+    @apply text-sm text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-alert-dialog__content {
+    @apply mt-3 text-sm text-gray-600 dark:text-gray-300;
+  }
+
+  .pc-alert-dialog__actions {
+    @apply flex flex-col-reverse gap-2 shrink-0 px-6 pt-5 pb-6;
+    @apply sm:flex-row sm:justify-end;
+  }
+
+  .pc-alert-dialog__actions .pc-alert-dialog__cancel,
+  .pc-alert-dialog__actions .pc-alert-dialog__confirm {
+    @apply justify-center sm:w-auto w-full;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .pc-alert-dialog[open] {
+      animation: pc-alert-dialog-in 0.15s ease-out;
+    }
+
+    .pc-alert-dialog[open]::backdrop {
+      animation: pc-alert-dialog-backdrop-in 0.15s ease-out;
+    }
+  }
+
+  @keyframes pc-alert-dialog-in {
+    from {
+      opacity: 0;
+      transform: scale(0.96);
+    }
+  }
+
+  @keyframes pc-alert-dialog-backdrop-in {
+    from {
+      opacity: 0;
+    }
+  }
+}

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -1909,6 +1909,81 @@ export const PetalCommandDialog = {
   },
 };
 
+// The alertdialog: a native <dialog> asking one question with two answers.
+//
+// The hook exists for the three things CSS and Phoenix.LiveView.JS cannot do:
+// showModal()/close() are DOM methods with no JS-command equivalent; initial
+// focus has to land on cancel (the least destructive action) rather than the
+// first focusable; and Escape's native `cancel` event must be intercepted so
+// it runs the component's on_cancel JS instead of quietly closing.
+//
+// Note what is deliberately absent: there is NO backdrop click handler. A
+// native modal dialog ignores backdrop clicks, so click-away does nothing -
+// which is the behaviour the WAI-ARIA alertdialog pattern asks for. Focus
+// containment and focus restoration to the opener also come from the native
+// element, not from here.
+export const PetalAlertDialog = {
+  mounted() {
+    this.onOpen = () => this.open();
+    // Escape. Swallow the native close and route through the cancel button so
+    // Escape and a Cancel click run the exact same on_cancel JS - one path.
+    this.onCancel = (e) => {
+      e.preventDefault();
+      const cancel = this.cancelButton();
+      cancel ? cancel.click() : this.close();
+    };
+    // Both actions close the dialog after their phx-click JS has run.
+    this.onAction = (e) => {
+      if (e.target.closest("[data-pc-alert-dialog-close]")) this.close();
+    };
+
+    this.el.addEventListener("pc:alert-dialog-open", this.onOpen);
+    this.el.addEventListener("cancel", this.onCancel);
+    this.el.addEventListener("click", this.onAction);
+  },
+
+  destroyed() {
+    this.el.removeEventListener("pc:alert-dialog-open", this.onOpen);
+    this.el.removeEventListener("cancel", this.onCancel);
+    this.el.removeEventListener("click", this.onAction);
+  },
+
+  cancelButton() {
+    return this.el.querySelector("[data-pc-alert-dialog-cancel]");
+  },
+
+  open() {
+    if (this.el.open) return;
+    this.el.showModal();
+    // showModal() focuses the first focusable (or [autofocus]); pin it to
+    // cancel explicitly so the least destructive action is always the default,
+    // whatever a consumer's body content puts above it.
+    const cancel = this.cancelButton();
+    if (cancel) cancel.focus();
+  },
+
+  close() {
+    if (this.el.open) this.el.close();
+  },
+};
+
+// Opens the alert dialog named in data-dialog. A hook rather than a phx-click
+// JS command for the same reason as PetalCommandTrigger: hooks mount on dead
+// views, phx-click JS commands only run inside a LiveView.
+export const PetalAlertDialogTrigger = {
+  mounted() {
+    this.onClick = () => {
+      const dialog = document.getElementById(this.el.dataset.dialog);
+      if (dialog) dialog.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+    };
+    this.el.addEventListener("click", this.onClick);
+  },
+
+  destroyed() {
+    this.el.removeEventListener("click", this.onClick);
+  },
+};
+
 // Opens the command dialog named in data-dialog. A hook rather than a
 // phx-click JS command: hooks mount on dead views (LiveView 1.1+), phx-click
 // JS commands only execute inside a LiveView - so the trigger works on
@@ -5452,6 +5527,8 @@ export default {
   PetalAurora,
   PetalNavMenu,
   PetalCommandDialog,
+  PetalAlertDialog,
+  PetalAlertDialogTrigger,
   PetalComboBox,
   PetalDataTable,
 };

--- a/dev.exs
+++ b/dev.exs
@@ -304,6 +304,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "tooltip", name: "Tooltip", ready: true},
         %{slug: "popover", name: "Popover", ready: true},
         %{slug: "modal", name: "Modal", ready: true},
+        %{slug: "alert-dialog", name: "Alert dialog", ready: true},
         %{slug: "dropdown", name: "Dropdown", ready: true},
         %{slug: "command", name: "Command", ready: true},
         %{slug: "slide-over", name: "Slide over", ready: true}
@@ -733,6 +734,8 @@ defmodule Dev.PlaygroundLive do
        tg_device: "desktop",
        tg_variant: "solid",
        tg_size: "md",
+       alert_dialog: %{variant: "destructive", description: "with", length: "short"},
+       alert_dialog_result: nil,
        chat: %{
          turns: [
            %{id: "m-today", role: :marker, text: "Today"},
@@ -1051,6 +1054,21 @@ defmodule Dev.PlaygroundLive do
 
   def handle_event("ctl_plasma", %{"k" => "width", "v" => v}, socket) when v in ~w(1px 2px 4px),
     do: {:noreply, update(socket, :plasma, &%{&1 | width: v})}
+
+  def handle_event("ctl_alert_dialog", %{"k" => "variant", "v" => v}, socket)
+      when v in ~w(default destructive),
+      do: {:noreply, update(socket, :alert_dialog, &%{&1 | variant: v})}
+
+  def handle_event("ctl_alert_dialog", %{"k" => "description", "v" => v}, socket)
+      when v in ~w(with without),
+      do: {:noreply, update(socket, :alert_dialog, &%{&1 | description: v})}
+
+  def handle_event("ctl_alert_dialog", %{"k" => "length", "v" => v}, socket)
+      when v in ~w(short long),
+      do: {:noreply, update(socket, :alert_dialog, &%{&1 | length: v})}
+
+  def handle_event("alert_dialog_answer", %{"answer" => answer}, socket),
+    do: {:noreply, assign(socket, :alert_dialog_result, answer)}
 
   def handle_event("ctl_beam", %{"k" => "glow"}, socket),
     do: {:noreply, update(socket, :beam, &%{&1 | glow: !&1.glow})}
@@ -2981,6 +2999,164 @@ defmodule Dev.PlaygroundLive do
         registry - the same source petal.build renders, so the playground and the marketing
         docs can't drift. Select, checkbox, radio and switch are the same field surface;
         their pages render the rest of the registry.
+      </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "alert-dialog"} = assigns) do
+    ~H"""
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">Alert dialog</h1>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        The two-answer question you ask before something irreversible. Unlike
+        the modal, focus opens on Cancel, Escape cancels, and clicking the
+        backdrop does nothing - the friction is deliberate. Built on the native
+        &lt;dialog&gt;, so the top layer and the focus trap come from the browser.
+      </p>
+
+      <div class="mt-8 overflow-hidden border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="flex flex-col items-center justify-center gap-3 px-6 py-14">
+          <.button
+            color={if @alert_dialog.variant == "destructive", do: "danger", else: "primary"}
+            phx-click={PetalComponents.AlertDialog.open_alert_dialog("pg-alert-dialog")}
+          >
+            Open alert dialog
+          </.button>
+
+          <p :if={@alert_dialog_result} class="text-sm text-gray-500 dark:text-gray-400">
+            You chose <span class="font-semibold">{@alert_dialog_result}</span>.
+          </p>
+          <p :if={!@alert_dialog_result} class="text-sm text-gray-400 dark:text-gray-500">
+            Open it, then Tab between the actions and hit Escape.
+          </p>
+
+          <.alert_dialog
+            id="pg-alert-dialog"
+            variant={@alert_dialog.variant}
+            title={
+              if @alert_dialog.variant == "destructive",
+                do: "Delete this workspace?",
+                else: "Publish these changes?"
+            }
+            description={
+              if @alert_dialog.description == "with",
+                do:
+                  "Everyone on the team loses access straight away, and the deployment history goes with it.",
+                else: nil
+            }
+            confirm_label={
+              if @alert_dialog.variant == "destructive", do: "Delete workspace", else: "Publish"
+            }
+            on_confirm={JS.push("alert_dialog_answer", value: %{answer: "confirm"})}
+            on_cancel={JS.push("alert_dialog_answer", value: %{answer: "cancel"})}
+          >
+            <div :if={@alert_dialog.length == "long"} class="space-y-3">
+              <p>Deleting this workspace also removes:</p>
+              <ul class="pl-4 space-y-1 list-disc marker:text-gray-400">
+                <li :for={n <- 1..12}>Project {n} and its {n * 3} deployments</li>
+              </ul>
+              <p>
+                Billing stops at the end of the current period. Invoices already
+                issued stay in your records and are not refunded automatically.
+              </p>
+            </div>
+          </.alert_dialog>
+        </div>
+
+        <div class="flex flex-wrap items-end gap-x-8 gap-y-4 px-4 sm:px-6 py-4 border-t border-gray-200 dark:border-gray-800">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">variant</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Variant"
+              value={@alert_dialog.variant}
+              on_change="ctl_alert_dialog"
+            >
+              <:item
+                :for={v <- ~w(default destructive)}
+                value={v}
+                phx-value-k="variant"
+                phx-value-v={v}
+              >
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">description</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Description"
+              value={@alert_dialog.description}
+              on_change="ctl_alert_dialog"
+            >
+              <:item
+                :for={d <- ~w(with without)}
+                value={d}
+                phx-value-k="description"
+                phx-value-v={d}
+              >
+                {d}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">content length</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Content length"
+              value={@alert_dialog.length}
+              on_change="ctl_alert_dialog"
+            >
+              <:item :for={l <- ~w(short long)} value={l} phx-value-k="length" phx-value-v={l}>
+                {l}
+              </:item>
+            </.toggle_group>
+          </div>
+        </div>
+        <p class="px-6 pb-3 -mt-1 text-xs text-gray-400 dark:text-gray-500">
+          long proves the overflow: the body scrolls, the title and the action row stay put, and the page behind never moves
+        </p>
+      </div>
+
+      <div class="p-4 mt-6 text-sm border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="font-semibold text-gray-900 dark:text-gray-100">Keyboard</div>
+        <ul class="mt-2 space-y-1 text-gray-500 dark:text-gray-400">
+          <li>
+            Open it and focus lands on <span class="font-medium">Cancel</span>, not the confirm button.
+          </li>
+          <li>
+            <span class="font-medium">Tab</span>
+            / <span class="font-medium">Shift+Tab</span>
+            cycle the two actions and never leave the dialog.
+          </li>
+          <li>
+            <span class="font-medium">Escape</span>
+            cancels, running the same on_cancel as the Cancel button.
+          </li>
+          <li>Clicking the backdrop does nothing at all.</li>
+        </ul>
+      </div>
+
+      <div :for={ex <- PetalComponents.Showcase.AlertDialog.examples()} class="mt-10">
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
+      <.showcase_props component={PetalComponents.AlertDialog} function={:alert_dialog} />
+
+      <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        These examples render from the shared <code>PetalComponents.Showcase.AlertDialog</code>
+        registry - the same source petal.build renders, so the playground and the marketing
+        docs can't drift.
       </div>
     </div>
     """

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -21,6 +21,7 @@ defmodule PetalComponents do
       import PetalComponents.{
         Accordion,
         Alert,
+        AlertDialog,
         Avatar,
         Badge,
         Aurora,

--- a/lib/petal_components/alert_dialog.ex
+++ b/lib/petal_components/alert_dialog.ex
@@ -1,0 +1,229 @@
+defmodule PetalComponents.AlertDialog do
+  @moduledoc """
+  The confirm/cancel decision dialog you reach for before a destructive or
+  irreversible action: "Delete this account?", "Discard unsaved changes?".
+
+  ## alert_dialog vs modal
+
+  `PetalComponents.Modal` is the general-purpose overlay - it holds forms,
+  detail panes, anything. It has a close button, and clicking away closes it,
+  because getting out cheaply is the right behaviour for a container.
+
+  `alert_dialog/1` is the opposite. It asks one question with two answers, and
+  it will not let you leave without answering:
+
+    * `role="alertdialog"` rather than `role="dialog"`, so assistive tech
+      announces it as an interruption that needs a decision.
+    * Initial focus lands on the **cancel** button - the least destructive
+      action - not on confirm.
+    * Escape cancels.
+    * Clicking the backdrop does **nothing**. The friction is the point.
+
+  Reach for `modal/1` when the user needs to fill something in. Reach for
+  `alert_dialog/1` when the user needs to choose.
+
+  ## Usage
+
+  Render the dialog anywhere in the template and open it from any element with
+  `open_alert_dialog/2`:
+
+      <.button color="danger" phx-click={PetalComponents.AlertDialog.open_alert_dialog("delete-account")}>
+        Delete account
+      </.button>
+
+      <.alert_dialog
+        id="delete-account"
+        variant="destructive"
+        title="Delete your account?"
+        description="This permanently removes your account and every project in it. This cannot be undone."
+        confirm_label="Delete account"
+        on_confirm={JS.push("delete_account")}
+      />
+
+  The default variant is the neutral confirm - same shape, primary button, no
+  danger icon:
+
+      <.alert_dialog
+        id="discard-changes"
+        title="Discard unsaved changes?"
+        description="Your edits since the last save will be lost."
+        confirm_label="Discard"
+        cancel_label="Keep editing"
+        on_confirm={JS.push("discard")}
+      />
+
+  The `:trigger` slot renders the opener next to the dialog and wires it up for
+  you, so you never repeat the id:
+
+      <.alert_dialog id="revoke-key" variant="destructive" title="Revoke this API key?">
+        <:trigger>
+          <.button color="danger" variant="outline">Revoke</.button>
+        </:trigger>
+      </.alert_dialog>
+
+  The `:inner_block` composes live data into the body, below the description:
+
+      <.alert_dialog id="bulk-delete" variant="destructive" title="Delete selected invoices?">
+        <p>You are about to delete <strong>{@selected_count} invoices</strong>.</p>
+      </.alert_dialog>
+
+  ## Implementation
+
+  Built on the native `<dialog>` element (same approach as
+  `PetalComponents.Command.command_dialog/1`). `showModal()` supplies the top
+  layer, focus containment, the `::backdrop`, focus restoration to the opener
+  on close, and - crucially for this component - **no light dismiss**: a native
+  modal dialog ignores backdrop clicks, which is exactly the behaviour the
+  WAI-ARIA alertdialog pattern wants.
+
+  Two small hooks carry the parts `Phoenix.LiveView.JS` cannot reach:
+  `showModal()`/`close()` are DOM methods with no JS-command equivalent, and
+  Escape's native `cancel` event has to be intercepted so it runs `on_cancel`
+  instead of silently closing. Everything else - the surface, the transitions,
+  reduced motion - is CSS.
+  """
+  use Phoenix.Component
+
+  alias Phoenix.LiveView.JS
+
+  import PetalComponents.Button
+  import PetalComponents.Icon
+
+  attr :id, :string, required: true, doc: "unique id; open the dialog with open_alert_dialog/2"
+
+  attr :title, :string,
+    required: true,
+    doc: "the question being asked. Becomes the dialog's accessible name via aria-labelledby"
+
+  attr :description, :string,
+    default: nil,
+    doc:
+      "supporting copy explaining the consequence; wired to aria-describedby. Omit it when the inner_block carries the body"
+
+  attr :variant, :string,
+    default: "default",
+    values: ["default", "destructive"],
+    doc:
+      "destructive styles the confirm button on the danger ramp and adds a danger icon accent; default uses the primary button treatment and no icon"
+
+  attr :confirm_label, :string, default: "Continue", doc: "confirm button text"
+  attr :cancel_label, :string, default: "Cancel", doc: "cancel button text"
+
+  attr :on_confirm, JS,
+    default: %JS{},
+    doc:
+      ~s|JS commands run when the user confirms, e.g. JS.push("delete_account"). The dialog closes afterwards|
+
+  attr :on_cancel, JS,
+    default: %JS{},
+    doc:
+      "JS commands run when the user cancels, via the cancel button or Escape. The dialog closes afterwards"
+
+  attr :class, :any, default: nil, doc: "extra classes for the dialog element"
+  attr :rest, :global
+
+  slot :inner_block,
+    required: false,
+    doc: "custom body content rendered below the description"
+
+  slot :icon,
+    required: false,
+    doc:
+      "icon rendered in the accent slot. The destructive variant supplies a danger icon when this is empty; the default variant renders no icon unless you pass one"
+
+  slot :trigger,
+    required: false,
+    doc: "an opener rendered next to the dialog, pre-wired to open it"
+
+  @doc """
+  Renders an alert dialog. See the module docs for when to use this over
+  `PetalComponents.Modal.modal/1`.
+  """
+  def alert_dialog(assigns) do
+    assigns = assign(assigns, :show_icon?, assigns.icon != [] or assigns.variant == "destructive")
+
+    ~H"""
+    <div
+      :if={@trigger != []}
+      id={"#{@id}-trigger"}
+      class="pc-alert-dialog__trigger"
+      phx-hook="PetalAlertDialogTrigger"
+      data-dialog={@id}
+    >
+      {render_slot(@trigger)}
+    </div>
+    <dialog
+      id={@id}
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby={"#{@id}-title"}
+      aria-describedby={@description && "#{@id}-description"}
+      phx-hook="PetalAlertDialog"
+      class={[
+        "pc-alert-dialog",
+        @variant == "destructive" && "pc-alert-dialog--destructive",
+        @class
+      ]}
+      {@rest}
+    >
+      <div class="pc-alert-dialog__panel">
+        <div class="pc-alert-dialog__header">
+          <div :if={@show_icon?} class="pc-alert-dialog__icon" aria-hidden="true">
+            <%= if @icon != [] do %>
+              {render_slot(@icon)}
+            <% else %>
+              <.icon name="hero-exclamation-triangle" class="pc-alert-dialog__icon-svg" />
+            <% end %>
+          </div>
+          <h2 id={"#{@id}-title"} class="pc-alert-dialog__title">{@title}</h2>
+        </div>
+
+        <div class="pc-alert-dialog__body">
+          <p :if={@description} id={"#{@id}-description"} class="pc-alert-dialog__description">
+            {@description}
+          </p>
+          <div :if={@inner_block != []} class="pc-alert-dialog__content">
+            {render_slot(@inner_block)}
+          </div>
+        </div>
+
+        <div class="pc-alert-dialog__actions">
+          <.button
+            type="button"
+            color="gray"
+            variant="outline"
+            autofocus
+            phx-click={@on_cancel}
+            data-pc-alert-dialog-cancel
+            data-pc-alert-dialog-close
+            class="pc-alert-dialog__cancel"
+          >
+            {@cancel_label}
+          </.button>
+          <.button
+            type="button"
+            color={confirm_color(@variant)}
+            phx-click={@on_confirm}
+            data-pc-alert-dialog-confirm
+            data-pc-alert-dialog-close
+            class="pc-alert-dialog__confirm"
+          >
+            {@confirm_label}
+          </.button>
+        </div>
+      </div>
+    </dialog>
+    """
+  end
+
+  defp confirm_color("destructive"), do: "danger"
+  defp confirm_color(_), do: "primary"
+
+  @doc """
+  Returns a `JS` command that opens the alert dialog with the given id.
+  Compose it onto any element: `phx-click={open_alert_dialog("delete-account")}`.
+  """
+  def open_alert_dialog(js \\ %JS{}, id) when is_binary(id) do
+    JS.dispatch(js, "pc:alert-dialog-open", to: "##{id}")
+  end
+end

--- a/lib/petal_components/showcase/alert_dialog.ex
+++ b/lib/petal_components/showcase/alert_dialog.ex
@@ -1,0 +1,90 @@
+defmodule PetalComponents.Showcase.AlertDialog do
+  @moduledoc false
+  use PetalComponents.Showcase,
+    component: PetalComponents.AlertDialog,
+    title: "Alert dialog",
+    functions: [:alert_dialog]
+
+  example :delete_account, "Delete account",
+    description:
+      "The destructive variant: danger icon, danger confirm button, and a description that spells out what is about to be lost. Focus lands on Cancel when it opens, Escape cancels, and clicking the backdrop does nothing." do
+    ~H"""
+    <.alert_dialog
+      id="showcase-delete-account"
+      variant="destructive"
+      title="Delete your account?"
+      description="This permanently removes your account, your projects and every deployment attached to them. This cannot be undone."
+      confirm_label="Delete account"
+    >
+      <:trigger>
+        <.button color="danger">Delete account</.button>
+      </:trigger>
+    </.alert_dialog>
+    """
+  end
+
+  example :unsaved_changes, "Unsaved changes",
+    description:
+      "The default variant: no icon, primary confirm. Relabel both buttons so each one names its outcome - Keep editing and Discard beat OK and Cancel every time." do
+    ~H"""
+    <.alert_dialog
+      id="showcase-unsaved-changes"
+      title="Discard unsaved changes?"
+      description="Your edits since the last save will be lost."
+      confirm_label="Discard"
+      cancel_label="Keep editing"
+    >
+      <:trigger>
+        <.button color="gray" variant="outline">
+          <.icon name="hero-arrow-left" class="w-4 h-4 mr-1" /> Back to posts
+        </.button>
+      </:trigger>
+    </.alert_dialog>
+    """
+  end
+
+  example :bulk_delete, "Bulk delete with a summary",
+    description:
+      "The body slot composes anything under the description - here a count and the invoice list, so the user can see exactly what the confirm button is going to take." do
+    ~H"""
+    <.alert_dialog
+      id="showcase-bulk-delete"
+      variant="destructive"
+      title="Delete 14 invoices?"
+      description="These invoices leave your records immediately. Paid invoices stay in your Stripe account."
+      confirm_label="Delete 14 invoices"
+    >
+      <:trigger>
+        <.button color="danger" variant="outline">
+          <.icon name="hero-trash" class="w-4 h-4 mr-1" /> Delete selected
+        </.button>
+      </:trigger>
+      <ul class="pl-4 mt-1 space-y-1 list-disc marker:text-gray-400">
+        <li>INV-2041 through INV-2054</li>
+        <li>3 are already marked paid</li>
+        <li>Total value $18,420.00</li>
+      </ul>
+    </.alert_dialog>
+    """
+  end
+
+  example :custom_icon, "Your own icon",
+    description:
+      "The destructive variant ships a danger icon; the icon slot replaces it, and it works on the default variant too when the question wants a visual anchor." do
+    ~H"""
+    <.alert_dialog
+      id="showcase-custom-icon"
+      title="Sign out of every device?"
+      description="You will need to sign in again on your phone, your tablet and any browser you have used this month."
+      confirm_label="Sign out everywhere"
+    >
+      <:icon>
+        <.icon name="hero-arrow-right-start-on-rectangle" class="pc-alert-dialog__icon-svg" />
+      </:icon>
+      <:trigger>
+        <.button color="gray" variant="outline">Sign out everywhere</.button>
+      </:trigger>
+    </.alert_dialog>
+    """
+  end
+end

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -11,6 +11,7 @@ defmodule PetalComponents.Showcase.Registry do
   @modules [
     PetalComponents.Showcase.Accordion,
     PetalComponents.Showcase.Alert,
+    PetalComponents.Showcase.AlertDialog,
     PetalComponents.Showcase.Aurora,
     PetalComponents.Showcase.Avatar,
     PetalComponents.Showcase.Badge,

--- a/test/js/alert_dialog.test.js
+++ b/test/js/alert_dialog.test.js
@@ -1,0 +1,254 @@
+// PetalAlertDialog / PetalAlertDialogTrigger hooks.
+//
+// The component's whole point is friction: the dialog opens focused on the
+// least destructive action, Escape runs the same cancel path as the Cancel
+// button, and clicking the backdrop does nothing at all. Every spec here
+// guards one of those.
+import { afterEach, describe, expect, it } from "vitest";
+
+import hooks from "../../assets/js/petal_components.js";
+
+const mounted = [];
+
+// jsdom has no <dialog> behaviour: showModal()/close() are not implemented,
+// and the `open` property is not wired to them. Stub the parts the hook
+// touches so the specs test the hook's decisions, not jsdom's gaps.
+function stubDialog(el) {
+  el.showModal = () => {
+    el.open = true;
+    el.showModalCalls = (el.showModalCalls || 0) + 1;
+  };
+  el.close = () => {
+    el.open = false;
+    el.closeCalls = (el.closeCalls || 0) + 1;
+  };
+  el.open = false;
+  el.showModalCalls = 0;
+  el.closeCalls = 0;
+  return el;
+}
+
+function mount({ withTrigger = false } = {}) {
+  const wrap = document.createElement("div");
+  wrap.innerHTML = `
+    ${
+      withTrigger
+        ? `<div id="d-trigger" data-dialog="d"><button type="button" id="opener">Delete</button></div>`
+        : ""
+    }
+    <dialog id="d" class="pc-alert-dialog" role="alertdialog">
+      <div class="pc-alert-dialog__panel">
+        <div class="pc-alert-dialog__actions">
+          <button type="button" class="pc-alert-dialog__cancel"
+                  data-pc-alert-dialog-cancel data-pc-alert-dialog-close>Cancel</button>
+          <button type="button" class="pc-alert-dialog__confirm"
+                  data-pc-alert-dialog-confirm data-pc-alert-dialog-close>Continue</button>
+        </div>
+      </div>
+    </dialog>
+  `;
+  document.body.appendChild(wrap);
+
+  const el = stubDialog(wrap.querySelector("#d"));
+  const hook = Object.create(hooks.PetalAlertDialog);
+  hook.el = el;
+  hook.mounted();
+
+  const entry = { hooks: [hook], wrap };
+
+  let trigger = null;
+  if (withTrigger) {
+    trigger = wrap.querySelector("#d-trigger");
+    const triggerHook = Object.create(hooks.PetalAlertDialogTrigger);
+    triggerHook.el = trigger;
+    triggerHook.mounted();
+    entry.hooks.push(triggerHook);
+  }
+
+  mounted.push(entry);
+
+  return {
+    hook,
+    el,
+    wrap,
+    trigger,
+    cancel: wrap.querySelector(".pc-alert-dialog__cancel"),
+    confirm: wrap.querySelector(".pc-alert-dialog__confirm"),
+  };
+}
+
+function click(el) {
+  el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}
+
+describe("PetalAlertDialog", () => {
+  afterEach(() => {
+    mounted.splice(0).forEach(({ hooks, wrap }) => {
+      hooks.forEach((h) => h.destroyed());
+      wrap.remove();
+    });
+  });
+
+  it("opens as a modal on the open event", () => {
+    const { el } = mount();
+
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+
+    expect(el.showModalCalls).toBe(1);
+    expect(el.open).toBe(true);
+  });
+
+  it("focuses the cancel button on open, never confirm", () => {
+    const { el, cancel } = mount();
+
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+
+    expect(document.activeElement).toBe(cancel);
+  });
+
+  it("ignores a second open while already open", () => {
+    const { el } = mount();
+
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+
+    expect(el.showModalCalls).toBe(1);
+  });
+
+  it("closes when the cancel button is clicked", () => {
+    const { el, cancel } = mount();
+
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+    click(cancel);
+
+    expect(el.closeCalls).toBe(1);
+    expect(el.open).toBe(false);
+  });
+
+  it("closes when the confirm button is clicked", () => {
+    const { el, confirm } = mount();
+
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+    click(confirm);
+
+    expect(el.closeCalls).toBe(1);
+    expect(el.open).toBe(false);
+  });
+
+  it("closes when a click lands on a child of an action button", () => {
+    const { el, confirm } = mount();
+    const span = document.createElement("span");
+    confirm.appendChild(span);
+
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+    click(span);
+
+    expect(el.closeCalls).toBe(1);
+  });
+
+  it("does NOT close on a backdrop click - the friction is the point", () => {
+    const { el } = mount();
+
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+    // a backdrop click is a click whose target is the dialog element itself
+    click(el);
+
+    expect(el.closeCalls).toBe(0);
+    expect(el.open).toBe(true);
+  });
+
+  it("does NOT close on a click inside the panel but outside the actions", () => {
+    const { el, wrap } = mount();
+
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+    click(wrap.querySelector(".pc-alert-dialog__panel"));
+
+    expect(el.closeCalls).toBe(0);
+    expect(el.open).toBe(true);
+  });
+
+  it("routes Escape through the cancel button so it runs the same cancel path", () => {
+    const { el, cancel } = mount();
+    const clicked = [];
+    cancel.addEventListener("click", () => clicked.push("cancel"));
+
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+    const cancelEvent = new Event("cancel", { cancelable: true });
+    el.dispatchEvent(cancelEvent);
+
+    // native close is swallowed; the cancel button drives the close instead
+    expect(cancelEvent.defaultPrevented).toBe(true);
+    expect(clicked).toEqual(["cancel"]);
+    expect(el.open).toBe(false);
+    expect(el.closeCalls).toBe(1);
+  });
+
+  it("still closes on Escape when there is no cancel button to route through", () => {
+    const { el, cancel } = mount();
+    cancel.remove();
+
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+    el.dispatchEvent(new Event("cancel", { cancelable: true }));
+
+    expect(el.open).toBe(false);
+    expect(el.closeCalls).toBe(1);
+  });
+
+  it("close is a no-op when the dialog is already closed", () => {
+    const { el, confirm } = mount();
+
+    click(confirm);
+
+    expect(el.closeCalls).toBe(0);
+  });
+
+  it("removes every listener on destroy so a reused node cannot close a torn-down dialog", () => {
+    const { hook, el, confirm } = mount();
+
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+    hook.destroyed();
+
+    el.showModalCalls = 0;
+    el.dispatchEvent(new CustomEvent("pc:alert-dialog-open"));
+    click(confirm);
+    el.dispatchEvent(new Event("cancel", { cancelable: true }));
+
+    expect(el.showModalCalls).toBe(0);
+    expect(el.closeCalls).toBe(0);
+  });
+});
+
+describe("PetalAlertDialogTrigger", () => {
+  afterEach(() => {
+    mounted.splice(0).forEach(({ hooks, wrap }) => {
+      hooks.forEach((h) => h.destroyed());
+      wrap.remove();
+    });
+  });
+
+  it("opens the dialog named in data-dialog", () => {
+    const { el, wrap } = mount({ withTrigger: true });
+
+    click(wrap.querySelector("#opener"));
+
+    expect(el.showModalCalls).toBe(1);
+    expect(el.open).toBe(true);
+  });
+
+  it("does nothing when data-dialog points at no element", () => {
+    const { el, trigger, wrap } = mount({ withTrigger: true });
+    trigger.dataset.dialog = "not-here";
+
+    expect(() => click(wrap.querySelector("#opener"))).not.toThrow();
+    expect(el.showModalCalls).toBe(0);
+  });
+
+  it("stops opening the dialog once destroyed", () => {
+    const { el, wrap, hooks: _ } = mount({ withTrigger: true });
+    mounted[mounted.length - 1].hooks[1].destroyed();
+
+    click(wrap.querySelector("#opener"));
+
+    expect(el.showModalCalls).toBe(0);
+  });
+});

--- a/test/petal/alert_dialog_test.exs
+++ b/test/petal/alert_dialog_test.exs
@@ -1,0 +1,520 @@
+defmodule PetalComponents.AlertDialogTest do
+  use ComponentCase
+
+  import PetalComponents.AlertDialog
+  import PetalComponents.Icon
+
+  alias Phoenix.LiveView.JS
+
+  defp doc(html), do: LazyHTML.from_fragment(html)
+
+  defp attr_of(html, selector, attribute) do
+    html
+    |> doc()
+    |> LazyHTML.query(selector)
+    |> LazyHTML.attribute(attribute)
+    |> List.first()
+  end
+
+  describe "alert_dialog/1 - ARIA" do
+    test "renders a native dialog with the alertdialog role and aria-modal" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete this project?" />
+        """)
+
+      assert attr_of(html, "dialog#confirm", "role") == "alertdialog"
+      assert attr_of(html, "dialog#confirm", "aria-modal") == "true"
+    end
+
+    test "aria-labelledby resolves to the rendered title id, and the title text renders" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete this project?" />
+        """)
+
+      labelledby = attr_of(html, "dialog#confirm", "aria-labelledby")
+      assert labelledby == "confirm-title"
+
+      title = html |> doc() |> LazyHTML.query("##{labelledby}")
+      assert LazyHTML.text(title) =~ "Delete this project?"
+      assert attr_of(html, "##{labelledby}", "class") =~ "pc-alert-dialog__title"
+    end
+
+    test "aria-describedby resolves to the description id when description is set" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete?" description="This cannot be undone." />
+        """)
+
+      describedby = attr_of(html, "dialog#confirm", "aria-describedby")
+      assert describedby == "confirm-description"
+
+      description = html |> doc() |> LazyHTML.query("##{describedby}")
+      assert LazyHTML.text(description) =~ "This cannot be undone."
+    end
+
+    test "aria-describedby is absent when no description is given" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete?" />
+        """)
+
+      assert attr_of(html, "dialog#confirm", "aria-describedby") == nil
+      refute_attribute(html, "aria-describedby")
+      assert html |> doc() |> LazyHTML.query(".pc-alert-dialog__description") |> Enum.empty?()
+    end
+
+    test "the decorative icon accent is hidden from assistive tech" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" variant="destructive" title="Delete?" />
+        """)
+
+      assert attr_of(html, ".pc-alert-dialog__icon", "aria-hidden") == "true"
+    end
+  end
+
+  describe "alert_dialog/1 - variants" do
+    test "default variant renders the primary confirm treatment" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Continue?" />
+        """)
+
+      assert attr_of(html, ".pc-alert-dialog__confirm", "class") =~ "pc-button--primary"
+      refute_has_class(html, "pc-alert-dialog--destructive")
+    end
+
+    test "destructive variant renders the danger confirm and the modifier class" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" variant="destructive" title="Delete?" />
+        """)
+
+      assert_has_class(html, "pc-alert-dialog--destructive")
+      assert attr_of(html, ".pc-alert-dialog__confirm", "class") =~ "pc-button--danger"
+    end
+
+    test "destructive variant supplies a default danger icon" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" variant="destructive" title="Delete?" />
+        """)
+
+      assert has_icon?(html, "hero-exclamation-triangle")
+      assert attr_of(html, ".pc-alert-dialog__icon-svg", "class") =~ "hero-exclamation-triangle"
+    end
+
+    test "default variant renders no icon without the icon slot" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Continue?" />
+        """)
+
+      assert html |> doc() |> LazyHTML.query(".pc-alert-dialog__icon") |> Enum.empty?()
+      refute has_icon?(html)
+    end
+
+    test "the cancel button always rides the neutral ramp, in both variants" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="a" title="Continue?" />
+        <.alert_dialog id="b" variant="destructive" title="Delete?" />
+        """)
+
+      classes =
+        html |> doc() |> LazyHTML.query(".pc-alert-dialog__cancel") |> LazyHTML.attribute("class")
+
+      assert length(classes) == 2
+      assert Enum.all?(classes, &(&1 =~ "pc-button--gray-outline"))
+    end
+  end
+
+  describe "alert_dialog/1 - slots" do
+    test "the icon slot overrides the destructive variant's default icon" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" variant="destructive" title="Delete?">
+          <:icon>
+            <.icon name="hero-fire" class="pc-alert-dialog__icon-svg" />
+          </:icon>
+        </.alert_dialog>
+        """)
+
+      assert has_icon?(html, "hero-fire")
+      refute has_icon?(html, "hero-exclamation-triangle")
+    end
+
+    test "the icon slot renders an icon on the default variant too" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Sign out?">
+          <:icon>
+            <.icon name="hero-key" class="pc-alert-dialog__icon-svg" />
+          </:icon>
+        </.alert_dialog>
+        """)
+
+      assert has_icon?(html, "hero-key")
+      refute html |> doc() |> LazyHTML.query(".pc-alert-dialog__icon") |> Enum.empty?()
+    end
+
+    test "inner_block content renders inside the body, below the description" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete invoices?" description="14 selected.">
+          <p class="my-body">You are about to delete 14 invoices.</p>
+        </.alert_dialog>
+        """)
+
+      body = html |> doc() |> LazyHTML.query(".pc-alert-dialog__body .pc-alert-dialog__content")
+      assert LazyHTML.text(body) =~ "You are about to delete 14 invoices."
+
+      assert html |> doc() |> LazyHTML.query(".pc-alert-dialog__body .my-body") |> Enum.count() ==
+               1
+    end
+
+    test "no content wrapper renders without an inner_block" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete?" />
+        """)
+
+      assert html |> doc() |> LazyHTML.query(".pc-alert-dialog__content") |> Enum.empty?()
+    end
+
+    test "the trigger slot renders and is wired to open the dialog" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="revoke-key" title="Revoke this key?">
+          <:trigger>
+            <button type="button" class="my-trigger">Revoke</button>
+          </:trigger>
+        </.alert_dialog>
+        """)
+
+      assert attr_of(html, "#revoke-key-trigger", "phx-hook") == "PetalAlertDialogTrigger"
+      assert attr_of(html, "#revoke-key-trigger", "data-dialog") == "revoke-key"
+
+      assert html |> doc() |> LazyHTML.query("#revoke-key-trigger .my-trigger") |> Enum.count() ==
+               1
+    end
+
+    test "no trigger wrapper renders without the trigger slot" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="revoke-key" title="Revoke this key?" />
+        """)
+
+      assert html |> doc() |> LazyHTML.query(".pc-alert-dialog__trigger") |> Enum.empty?()
+      refute html =~ "PetalAlertDialogTrigger"
+    end
+  end
+
+  describe "alert_dialog/1 - labels" do
+    test "confirm_label and cancel_label default to Continue and Cancel" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Continue?" />
+        """)
+
+      assert html |> doc() |> LazyHTML.query(".pc-alert-dialog__confirm") |> LazyHTML.text() =~
+               "Continue"
+
+      assert html |> doc() |> LazyHTML.query(".pc-alert-dialog__cancel") |> LazyHTML.text() =~
+               "Cancel"
+    end
+
+    test "confirm_label and cancel_label overrides render" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog
+          id="confirm"
+          title="Discard unsaved changes?"
+          confirm_label="Discard"
+          cancel_label="Keep editing"
+        />
+        """)
+
+      assert html |> doc() |> LazyHTML.query(".pc-alert-dialog__confirm") |> LazyHTML.text() =~
+               "Discard"
+
+      assert html |> doc() |> LazyHTML.query(".pc-alert-dialog__cancel") |> LazyHTML.text() =~
+               "Keep editing"
+
+      refute html |> doc() |> LazyHTML.query(".pc-alert-dialog__cancel") |> LazyHTML.text() =~
+               "Cancel"
+    end
+  end
+
+  describe "alert_dialog/1 - JS wiring" do
+    test "on_confirm is attached to the confirm button, on_cancel to the cancel button" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog
+          id="confirm"
+          title="Delete?"
+          on_confirm={JS.push("delete_account")}
+          on_cancel={JS.push("keep_account")}
+        />
+        """)
+
+      confirm = attr_of(html, ".pc-alert-dialog__confirm", "phx-click")
+      cancel = attr_of(html, ".pc-alert-dialog__cancel", "phx-click")
+
+      assert confirm == ~s|[["push",{"event":"delete_account"}]]|
+      assert cancel == ~s|[["push",{"event":"keep_account"}]]|
+    end
+
+    test "both actions carry the close marker the hook closes the dialog on" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete?" />
+        """)
+
+      assert html
+             |> doc()
+             |> LazyHTML.query("[data-pc-alert-dialog-close]")
+             |> Enum.count() == 2
+
+      assert html
+             |> doc()
+             |> LazyHTML.query(".pc-alert-dialog__cancel[data-pc-alert-dialog-cancel]")
+             |> Enum.count() == 1
+
+      assert html
+             |> doc()
+             |> LazyHTML.query(".pc-alert-dialog__confirm[data-pc-alert-dialog-confirm]")
+             |> Enum.count() == 1
+    end
+
+    test "initial focus is pinned to the cancel button, the least destructive action" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" variant="destructive" title="Delete?" />
+        """)
+
+      # showModal() honours [autofocus]; the hook also focuses this button
+      # explicitly. Either way it must be cancel, never confirm.
+      assert html
+             |> doc()
+             |> LazyHTML.query(".pc-alert-dialog__cancel[autofocus]")
+             |> Enum.count() == 1
+
+      assert html
+             |> doc()
+             |> LazyHTML.query(".pc-alert-dialog__confirm[autofocus]")
+             |> Enum.empty?()
+    end
+
+    test "the dialog mounts the PetalAlertDialog hook that owns Escape and closing" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete?" />
+        """)
+
+      assert attr_of(html, "dialog#confirm", "phx-hook") == "PetalAlertDialog"
+    end
+
+    test "no light-dismiss wiring exists - click-away must not close the dialog" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete?" description="Careful." />
+        """)
+
+      # A native modal <dialog> ignores backdrop clicks; nothing here may add
+      # it back. No phx-click-away, and no closedby="any" opt-in either.
+      refute html =~ "phx-click-away"
+      refute html =~ "click_away"
+      refute html =~ ~s|closedby="any"|
+      assert html |> doc() |> LazyHTML.query("[phx-click-away]") |> Enum.empty?()
+    end
+
+    test "no overlay div is rendered - the native ::backdrop does that job" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete?" />
+        """)
+
+      refute html =~ "pc-modal__overlay"
+      assert html |> doc() |> LazyHTML.query("dialog") |> Enum.count() == 1
+    end
+
+    test "open_alert_dialog/2 dispatches the open event at the dialog" do
+      assert [["dispatch", opts]] = open_alert_dialog("delete-account").ops
+      assert opts.event == "pc:alert-dialog-open"
+      assert opts.to == "#delete-account"
+    end
+
+    test "open_alert_dialog/2 composes onto an existing JS chain" do
+      js = JS.push("track") |> open_alert_dialog("delete-account")
+
+      assert [["push", %{event: "track"}], ["dispatch", opts]] = js.ops
+      assert opts.event == "pc:alert-dialog-open"
+      assert opts.to == "#delete-account"
+    end
+  end
+
+  describe "alert_dialog/1 - pass-through" do
+    test "class is appended to the dialog element's classes" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete?" class="max-w-xs my-custom" />
+        """)
+
+      class = attr_of(html, "dialog#confirm", "class")
+      assert class =~ "pc-alert-dialog"
+      assert class =~ "max-w-xs"
+      assert class =~ "my-custom"
+    end
+
+    test "rest attributes land on the dialog element" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete?" data-testid="danger-zone" data-role="gate" />
+        """)
+
+      assert attr_of(html, "dialog#confirm", "data-testid") == "danger-zone"
+      assert attr_of(html, "dialog#confirm", "data-role") == "gate"
+    end
+
+    test "ids are namespaced per dialog so two can coexist" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="one" title="First?" description="One." />
+        <.alert_dialog id="two" title="Second?" description="Two." />
+        """)
+
+      assert attr_of(html, "dialog#one", "aria-labelledby") == "one-title"
+      assert attr_of(html, "dialog#two", "aria-labelledby") == "two-title"
+      assert attr_of(html, "dialog#one", "aria-describedby") == "one-description"
+      assert attr_of(html, "dialog#two", "aria-describedby") == "two-description"
+    end
+  end
+
+  describe "alert_dialog/1 - structure" do
+    test "the panel keeps the header and action row outside the scrolling body" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" variant="destructive" title="Delete?" description="Careful." />
+        """)
+
+      d = doc(html)
+
+      assert d
+             |> LazyHTML.query(".pc-alert-dialog__panel > .pc-alert-dialog__header")
+             |> Enum.count() ==
+               1
+
+      assert d
+             |> LazyHTML.query(".pc-alert-dialog__panel > .pc-alert-dialog__body")
+             |> Enum.count() ==
+               1
+
+      assert d
+             |> LazyHTML.query(".pc-alert-dialog__panel > .pc-alert-dialog__actions")
+             |> Enum.count() == 1
+
+      assert d
+             |> LazyHTML.query(".pc-alert-dialog__header > .pc-alert-dialog__icon")
+             |> Enum.count() == 1
+
+      assert d
+             |> LazyHTML.query(".pc-alert-dialog__header > .pc-alert-dialog__title")
+             |> Enum.count() == 1
+    end
+
+    test "cancel is rendered before confirm so Tab order reaches the safe action first" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete?" />
+        """)
+
+      classes =
+        html
+        |> doc()
+        |> LazyHTML.query(".pc-alert-dialog__actions button")
+        |> LazyHTML.attribute("class")
+
+      assert [cancel, confirm] = classes
+      assert cancel =~ "pc-alert-dialog__cancel"
+      assert confirm =~ "pc-alert-dialog__confirm"
+    end
+
+    test "both actions are type=button so they never submit a surrounding form" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.alert_dialog id="confirm" title="Delete?" />
+        """)
+
+      types =
+        html
+        |> doc()
+        |> LazyHTML.query(".pc-alert-dialog__actions button")
+        |> LazyHTML.attribute("type")
+
+      assert types == ["button", "button"]
+    end
+  end
+end


### PR DESCRIPTION
Closes #600

## Summary

`<.alert_dialog>` is the two-answer question you ask before something irreversible. `<.modal>` is the general-purpose overlay and it lets you out cheaply, which is the wrong behaviour when the next click deletes an account, so this inverts it: `role="alertdialog"`, focus opens on cancel, Escape cancels, backdrop clicks do nothing.

What shipped:

- `lib/petal_components/alert_dialog.ex` - `alert_dialog/1` plus the `open_alert_dialog/2` helper, exported via `use PetalComponents`. Every attr carries a `doc:`; the moduledoc covers alert_dialog vs modal and both variants.
- `pc-alert-dialog` section appended to `assets/default.css`, inside `@layer components`. Nothing above it moved.
- `test/petal/alert_dialog_test.exs` - 32 tests.
- `test/js/alert_dialog.test.js` - 15 tests for the two hooks.
- `PetalComponents.Showcase.AlertDialog` with four examples, registered in `showcase/registry.ex`.
- Playground page at `/c/alert-dialog` with the three dials, a keyboard map, and the showcase examples.
- `### Unreleased` / `#### Added` entry at the top of `CHANGELOG.md`.

## Native `<dialog>` vs the modal's overlay machinery

**Native `<dialog>`**, the same call `command_dialog/1` made. Reasoning:

- `showModal()` gives the top layer, **focus containment**, and **focus restoration to the opener** on close. The WAI-ARIA alertdialog pattern requires all three, and `<.modal>` does not actually contain focus today. Hand-rolling a focus trap in an overlay div would have been the largest and least reliable part of this component.
- The suppression the issue flagged turned out not to be needed. A native modal dialog **already ignores backdrop clicks** - light dismiss is opt-in via `closedby="any"`, which this component simply never sets. So "click-away does not close" is the default rather than something fought for. The only native behaviour intercepted is Escape, and only so it runs your `on_cancel` rather than closing silently.
- `::backdrop` replaces the overlay div and the `body { overflow: hidden }` juggling entirely.

## Focus, Escape and backdrop

- **Focus**: cancel carries `autofocus` (which `showModal()` honours) *and* the hook focuses it explicitly on open, so the least destructive action is the default however a consumer's body content is composed. Cancel is also rendered before confirm, so Tab order reaches the safe action first. Focus restores to the opener via the native element.
- **Escape**: the hook listens for the native `cancel` event, calls `preventDefault()`, and clicks the cancel button. Escape and a Cancel click therefore run the identical `on_cancel` path - one code path, not two that can drift.
- **Backdrop**: nothing is wired. No `phx-click-away`, no click handler on the dialog element, no `closedby`. A test asserts the absence rather than trusting it stays absent.

## The hook, and why

House rule is CSS-first, so naming what forced it: `showModal()` and `close()` are DOM methods with no `Phoenix.LiveView.JS` equivalent - there is no JS command that invokes a DOM method - and the native `cancel` event has to be intercepted in JS to reroute Escape through `on_cancel`. Everything else (surface, radius token, transitions, `prefers-reduced-motion`, dark mode) is CSS.

`PetalAlertDialogTrigger` is a second ~10-line hook backing the `:trigger` slot, mirroring `PetalCommandTrigger` for the same documented reason: hooks mount on dead views, `phx-click` JS commands only run inside a LiveView.

Both are unit-tested in `test/js/alert_dialog.test.js`. **No new dependencies**, hex or npm.

## Deviations from the issue's API sketch

**None** on the public surface - every attr, slot, default and the `open_alert_dialog/2` signature match the sketch as written.

Two additions the sketch did not spell out, both internal:

- The CSS section grew `pc-alert-dialog__panel`, `__header`, `__body`, `__content`, `__icon`, `__icon-svg`, `__cancel`, `__confirm` and `__trigger` alongside the names the issue listed. The header/body/actions split is what keeps the title and the action row visible while a long body scrolls.
- `data-pc-alert-dialog-close` / `-cancel` / `-confirm` markers on the action buttons are how the hook finds them.

One thing worth a maintainer's eye: the confirm and cancel buttons are `<.button>` (`color="danger"`/`"primary"` and `color="gray" variant="outline"`) rather than bespoke `pc-alert-dialog` button styles, so they inherit the theme rail and the radius rules for free. Say the word if you would rather they were standalone.

## Verification

| Check | Result |
|---|---|
| `mix format --check-formatted` | pass |
| `mix compile --force --warnings-as-errors` | pass |
| `mix credo` | **zero** new entries vs `origin/main` (diffed `--all --format=oneline`) |
| `mix test` | 913 -> **945**, 0 failures, 1 skipped |
| `npm test` | 157 -> **172** passing |

Verified by hand in the playground, light and dark, at `/c/alert-dialog`:

- **Initial focus lands on Cancel** - opened the dialog and pressed Enter without touching anything else; the page acknowledged `cancel`, not `confirm`.
- **Escape cancels** - closes the dialog and acknowledges `cancel`, i.e. it runs `on_cancel` rather than closing silently.
- **Backdrop click does not close** - with the dialog open the rest of the page is inert (the a11y tree contains only the dialog's own heading and two buttons) and the dialog stays up.
- **Tab** moves from Cancel to the confirm button with a visible `focus-visible` ring, and does not escape the dialog.
- **Long content** scrolls inside the body while the title and the action row stay fixed.

One bug found and fixed during that pass: a percentage `max-height` on the panel resolved against the dialog's `auto` height and was ignored, so a long body overflowed and clipped its own header. Both now carry the same explicit `--pc-alert-dialog-max-h`.

Light and dark screenshots of the playground page were captured during that pass and are available on request - I have not pushed image assets to the repo.
