### PR TITLE
feat(slider): single and dual range slider on native inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,39 @@
 # Changelog
+
+### Unreleased
+
+#### Added
+
+- **New `slider` component: a range slider with one thumb or two, marks, a
+  value readout, sizes and vertical orientation.** It is a native
+  `<input type="range">` underneath, so the arrow / Home / End / PageUp /
+  PageDown keyboard map, the `role="slider"` and `aria-valuemin`/`valuemax`/
+  `valuenow` announcement, touch handling and form posting all come from the
+  browser rather than being re-implemented. What the library adds is paint: a
+  track and fill that ride the gray and primary ramps in both schemes, tick
+  marks that invert once the fill swallows them, and a value bubble or inline
+  readout with a prefix and suffix.
+
+  Dual mode is two overlaid inputs posting two form fields, so a price filter
+  is a plain `phx-change` with no JavaScript in your app:
+
+  ```heex
+  <.slider min_field={@form[:min]} max_field={@form[:max]} min={0} max={1000} step={50} label="Price" value_prefix="$" show_value="inline" />
+  ```
+
+  Geometry rides CSS custom properties that the server renders inline, so the
+  control paints correctly before the `PetalSlider` hook connects and with JS
+  off entirely. The hook only does what the client alone can know: keeping
+  those percentages live while you drag, enforcing the thumb ordering two
+  native inputs cannot enforce themselves, and emitting a bubbling
+  `petal:slider-change` event for apps that want the value without a form.
+
+#### Deprecated
+
+- `<.field type="range">` and `<.field type="range-dual">` are superseded by
+  `<.slider>`. Both still work and nothing is being removed in this release -
+  the docs now point at the slider for new code.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,294 @@
       transition-duration: 1ms;
     }
   }
+
+@layer components {
+  /* ---- Slider ---------------------------------------------------------- */
+  /* A native <input type="range"> doing all the work (keyboard, ARIA, form
+     posting) with its own track and thumb painted out, and our track, fill,
+     marks and tooltip drawn as real elements underneath it. Real elements are
+     the point: `dark:` and `--pc-radius` resolve on them, which they cannot on
+     ::-webkit-slider-runnable-track (a `dark:` variant compiles to a trailing
+     :where(.dark, ...) ancestor test that a pseudo-element can never satisfy -
+     the bug that used to leave .pc-range-input's track light in dark mode).
+
+     Geometry rides three custom properties so nothing needs measuring in JS:
+       --pc-slider-track  track thickness
+       --pc-slider-thumb  thumb diameter
+       --pc-slider-pct    thumb position (single), or -min / -max (dual)
+     The server renders the initial percentages inline, so the control paints
+     correctly with JS off; the PetalSlider hook keeps them live while dragging. */
+  .pc-slider {
+    @apply relative select-none;
+    --pc-slider-track: 0.375rem;
+    --pc-slider-thumb: 1.25rem;
+    --pc-slider-length: 11rem;
+    --pc-slider-surface: var(--color-gray-200);
+  }
+
+  .pc-slider:where(.dark, .dark *) {
+    --pc-slider-surface: color-mix(in oklab, var(--color-gray-400) 17%, transparent);
+  }
+
+  .pc-slider--sm {
+    --pc-slider-track: 0.25rem;
+    --pc-slider-thumb: 1rem;
+  }
+
+  .pc-slider--lg {
+    --pc-slider-track: 0.5rem;
+    --pc-slider-thumb: 1.5rem;
+  }
+
+  .pc-slider--disabled {
+    @apply opacity-50 pointer-events-none;
+  }
+
+  /* Label row: name on the left, inline readout on the right. */
+  .pc-slider__header {
+    @apply flex items-baseline justify-between gap-3 mb-1.5;
+  }
+
+  .pc-slider__label {
+    @apply mb-0;
+  }
+
+  .pc-slider__value {
+    @apply text-sm font-medium text-gray-700 tabular-nums dark:text-gray-200;
+  }
+
+  /* Stacking context for track, fill, marks and the input(s). */
+  .pc-slider__track-wrapper {
+    @apply relative flex items-center;
+    min-height: var(--pc-slider-thumb);
+  }
+
+  .pc-slider__track {
+    @apply absolute inset-x-0 rounded-full;
+    height: var(--pc-slider-track);
+    background-color: var(--pc-slider-surface);
+  }
+
+  /* Single fills from the start to the thumb; dual spans between the thumbs. */
+  .pc-slider__fill {
+    @apply absolute rounded-full bg-primary-500;
+    height: var(--pc-slider-track);
+    left: 0;
+    right: calc(100% - var(--pc-slider-pct, 0%));
+  }
+
+  .pc-slider--dual .pc-slider__fill {
+    left: var(--pc-slider-pct-min, 0%);
+    right: calc(100% - var(--pc-slider-pct-max, 100%));
+  }
+
+  /* Ticks sit above the fill so a mark inside the filled span can invert. */
+  .pc-slider__marks {
+    @apply absolute inset-x-0 pointer-events-none;
+    height: var(--pc-slider-track);
+  }
+
+  .pc-slider__mark {
+    @apply absolute top-1/2 rounded-full;
+    left: var(--pc-slider-mark, 0%);
+    width: 0.25rem;
+    height: 0.25rem;
+    transform: translate(-50%, -50%);
+    background-color: color-mix(in oklab, var(--color-gray-500) 55%, transparent);
+  }
+
+  /* On-primary treatment once the fill has swallowed the tick. */
+  .pc-slider__mark--filled {
+    background-color: color-mix(in oklab, white 70%, transparent);
+  }
+
+  .pc-slider__mark-labels {
+    @apply relative h-5 mt-1.5;
+  }
+
+  .pc-slider__mark-label {
+    @apply absolute text-xs text-gray-500 whitespace-nowrap dark:text-gray-400 tabular-nums;
+    left: var(--pc-slider-mark, 0%);
+    transform: translateX(-50%);
+  }
+
+  /* The native input: its own track and thumb are painted out, everything
+     visible comes from the elements above. */
+  .pc-slider__input {
+    @apply w-full bg-transparent appearance-none cursor-pointer focus:outline-hidden disabled:cursor-not-allowed;
+    height: var(--pc-slider-thumb);
+    margin: 0;
+  }
+
+  .pc-slider__input::-webkit-slider-runnable-track {
+    @apply bg-transparent;
+    height: var(--pc-slider-track);
+  }
+
+  .pc-slider__input::-moz-range-track {
+    @apply bg-transparent;
+    height: var(--pc-slider-track);
+  }
+
+  /* box-border is load-bearing: preflight's border-box reset cannot reach a
+     pseudo-element (the universal selector does not match one) and the UA
+     defaults disagree - WebKit sizes range thumbs border-box, Firefox
+     content-box - so without it Firefox draws the ring outside the diameter. */
+  .pc-slider__input::-webkit-slider-thumb {
+    @apply relative appearance-none rounded-full cursor-pointer bg-primary-500 border-[3px] border-white box-border shadow shadow-black/25 transition-transform duration-100 ease-out dark:border-gray-900;
+    width: var(--pc-slider-thumb);
+    height: var(--pc-slider-thumb);
+    margin-top: calc((var(--pc-slider-track) - var(--pc-slider-thumb)) / 2);
+  }
+
+  .pc-slider__input::-moz-range-thumb {
+    @apply rounded-full cursor-pointer bg-primary-500 border-[3px] border-white box-border shadow shadow-black/25 transition-transform duration-100 ease-out dark:border-gray-900;
+    width: var(--pc-slider-thumb);
+    height: var(--pc-slider-thumb);
+  }
+
+  .pc-slider__input:hover::-webkit-slider-thumb {
+    @apply scale-110;
+  }
+
+  /* focus-visible only - a persistent :focus ring would sit on the thumb for
+     the whole of a mouse drag. */
+  .pc-slider__input:focus-visible::-webkit-slider-thumb {
+    @apply scale-110 ring-2 ring-primary-500/50;
+  }
+
+  .pc-slider__input:hover::-moz-range-thumb {
+    transform: scale(1.1);
+  }
+
+  .pc-slider__input:focus-visible::-moz-range-thumb {
+    transform: scale(1.1);
+    outline: none;
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--color-primary-500) 50%, transparent);
+  }
+
+  /* Dual: two zero-height inputs stacked over the shared track. Only the
+     thumbs take pointer events, so each one stays independently draggable
+     where they overlap. Zero height plus `top: auto` means the flex parent's
+     align-items: center resolves their static position for us. */
+  .pc-slider--dual .pc-slider__input {
+    @apply absolute w-full outline-none pointer-events-none;
+    height: 0;
+  }
+
+  .pc-slider--dual .pc-slider__input::-webkit-slider-thumb {
+    @apply pointer-events-auto;
+    margin-top: 0;
+  }
+
+  .pc-slider--dual .pc-slider__input::-moz-range-thumb {
+    @apply pointer-events-auto;
+  }
+
+  /* Value bubble. Anchored off the same percentage the fill uses, so there is
+     no measurement JS - --pc-slider-at is aliased to the relevant percentage
+     on the element itself. */
+  .pc-slider__tooltip {
+    @apply absolute bottom-full z-10 mb-2 px-1.5 py-0.5 text-xs font-medium text-white pointer-events-none opacity-0 bg-gray-900 tabular-nums whitespace-nowrap transition-opacity duration-150 ease-out dark:bg-gray-700;
+    left: var(--pc-slider-at, 0%);
+    transform: translateX(-50%);
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.375rem), 0.125rem);
+  }
+
+  .pc-slider:hover .pc-slider__tooltip,
+  .pc-slider:has(.pc-slider__input:focus-visible) .pc-slider__tooltip,
+  .pc-slider:has(.pc-slider__input:active) .pc-slider__tooltip {
+    @apply opacity-100;
+  }
+
+  /* Vertical. writing-mode is the standards-track way to stand a range up
+     (Chrome 111+, Firefox 108+, Safari 15.4+); direction: rtl puts the
+     minimum at the bottom where it belongs. appearance: slider-vertical is
+     the deprecated fallback for older WebKit and is ignored elsewhere. */
+  .pc-slider--vertical .pc-slider__track-wrapper {
+    @apply flex-col justify-center w-auto;
+    height: var(--pc-slider-length);
+    min-height: 0;
+    width: var(--pc-slider-thumb);
+  }
+
+  .pc-slider--vertical .pc-slider__input {
+    writing-mode: vertical-lr;
+    direction: rtl;
+    appearance: slider-vertical;
+    width: var(--pc-slider-thumb);
+    height: 100%;
+  }
+
+  .pc-slider--vertical.pc-slider--dual .pc-slider__input {
+    @apply absolute h-full;
+    width: 0;
+  }
+
+  .pc-slider--vertical .pc-slider__track,
+  .pc-slider--vertical .pc-slider__fill,
+  .pc-slider--vertical .pc-slider__marks {
+    @apply inset-x-auto left-1/2 h-auto;
+    width: var(--pc-slider-track);
+    transform: translateX(-50%);
+  }
+
+  .pc-slider--vertical .pc-slider__track {
+    @apply inset-y-0;
+  }
+
+  .pc-slider--vertical .pc-slider__fill {
+    @apply right-auto;
+    bottom: 0;
+    top: calc(100% - var(--pc-slider-pct, 0%));
+  }
+
+  .pc-slider--vertical.pc-slider--dual .pc-slider__fill {
+    @apply left-1/2;
+    bottom: var(--pc-slider-pct-min, 0%);
+    top: calc(100% - var(--pc-slider-pct-max, 100%));
+  }
+
+  .pc-slider--vertical .pc-slider__marks {
+    @apply inset-y-0;
+  }
+
+  .pc-slider--vertical .pc-slider__mark {
+    @apply top-auto left-1/2;
+    bottom: var(--pc-slider-mark, 0%);
+    transform: translate(-50%, 50%);
+  }
+
+  /* Vertical mark labels run beside the track rather than under it. */
+  .pc-slider--vertical .pc-slider__mark-labels {
+    @apply absolute top-0 h-full mt-0;
+    left: calc(50% + var(--pc-slider-thumb));
+  }
+
+  .pc-slider--vertical .pc-slider__mark-label {
+    @apply left-0;
+    bottom: var(--pc-slider-mark, 0%);
+    transform: translateY(50%);
+  }
+
+  .pc-slider--vertical .pc-slider__tooltip {
+    @apply bottom-auto left-full mb-0 ml-2;
+    top: calc(100% - var(--pc-slider-at, 0%));
+    transform: translateY(-50%);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pc-slider__input::-webkit-slider-thumb,
+    .pc-slider__input::-moz-range-thumb,
+    .pc-slider__tooltip {
+      transition-duration: 1ms;
+    }
+
+    .pc-slider__input:hover::-webkit-slider-thumb,
+    .pc-slider__input:focus-visible::-webkit-slider-thumb,
+    .pc-slider__input:hover::-moz-range-thumb,
+    .pc-slider__input:focus-visible::-moz-range-thumb {
+      transform: none;
+    }
+  }
+}

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -444,6 +444,167 @@ export const PetalDualRangeSlider = {
   },
 };
 
+// Slider: keeps the geometry custom properties on the <.slider> wrapper in
+// sync while you drag, and in dual mode enforces the ordering invariant the
+// two overlaid native inputs cannot enforce themselves.
+//
+// The server renders --pc-slider-pct* inline, so the control is already
+// correct before this hook connects and stays correct with JS off; everything
+// here is the live update. Positioning stays pure CSS (fill, tooltip and every
+// tick read the same properties), so nothing is measured.
+//
+// Read from the wrapper (set server-side in slider.ex):
+//   data-pc-slider-min / data-pc-slider-max  — absolute bounds
+//   data-pc-slider-mode                      — "single" | "dual"
+//   data-value-prefix / data-value-suffix    — readout formatting
+//
+// Inner elements found by marker attributes:
+//   [data-pc-slider-input]        — the single input
+//   [data-pc-slider-input-min]    — dual lower input
+//   [data-pc-slider-input-max]    — dual upper input
+//   [data-pc-slider-display]      — inline readout / single tooltip
+//   [data-pc-slider-display-min]  — dual lower tooltip
+//   [data-pc-slider-display-max]  — dual upper tooltip
+//   [data-pc-slider-mark]         — a tick, its percentage as the value
+export const PetalSlider = {
+  mounted() {
+    this.dual = this.el.dataset.pcSliderMode === "dual";
+    this.lo = parseFloat(this.el.dataset.pcSliderMin);
+    this.hi = parseFloat(this.el.dataset.pcSliderMax);
+    if (Number.isNaN(this.lo)) this.lo = 0;
+    if (Number.isNaN(this.hi)) this.hi = 100;
+    this.prefix = this.el.dataset.valuePrefix || "";
+    this.suffix = this.el.dataset.valueSuffix || "";
+    this.marks = Array.from(this.el.querySelectorAll("[data-pc-slider-mark]"));
+
+    if (this.dual) {
+      this.minInput = this.el.querySelector("[data-pc-slider-input-min]");
+      this.maxInput = this.el.querySelector("[data-pc-slider-input-max]");
+      this.inputs = [this.minInput, this.maxInput].filter(Boolean);
+    } else {
+      this.input = this.el.querySelector("[data-pc-slider-input]");
+      this.inputs = this.input ? [this.input] : [];
+    }
+
+    this.onInput = (event) => this.handleInput(event);
+    this.inputs.forEach((el) => el.addEventListener("input", this.onInput));
+    this.sync();
+  },
+
+  updated() {
+    // The server re-rendered: its --pc-slider-pct* are authoritative again,
+    // but the marks and readout still need reconciling against the new values.
+    this.marks = Array.from(this.el.querySelectorAll("[data-pc-slider-mark]"));
+    this.sync({ emit: false });
+  },
+
+  destroyed() {
+    (this.inputs || []).forEach((el) =>
+      el.removeEventListener("input", this.onInput),
+    );
+  },
+
+  handleInput(event) {
+    if (this.dual) this.enforceOrder(event && event.target);
+    this.sync();
+  },
+
+  // Two overlaid inputs can cross each other. Clamp the one being dragged to
+  // the other, then lift its z-index so that when the thumbs meet the user can
+  // still drag back out - without the lift the stacking order decides which
+  // thumb answers the pointer, and one of them becomes stuck.
+  enforceOrder(target) {
+    if (!this.minInput || !this.maxInput) return;
+    let min = parseFloat(this.minInput.value);
+    let max = parseFloat(this.maxInput.value);
+    if (Number.isNaN(min) || Number.isNaN(max)) return;
+
+    if (target === this.maxInput) {
+      if (max < min) {
+        max = min;
+        this.maxInput.value = String(max);
+      }
+      this.maxInput.style.zIndex = max <= min ? "20" : "";
+      this.minInput.style.zIndex = "";
+    } else {
+      if (min > max) {
+        min = max;
+        this.minInput.value = String(min);
+      }
+      this.minInput.style.zIndex = min >= max ? "20" : "";
+      this.maxInput.style.zIndex = "";
+    }
+  },
+
+  values() {
+    if (this.dual) {
+      return [
+        this.numberFrom(this.minInput, this.lo),
+        this.numberFrom(this.maxInput, this.hi),
+      ];
+    }
+    return [this.numberFrom(this.input, this.lo)];
+  },
+
+  numberFrom(el, fallback) {
+    if (!el) return fallback;
+    const n = parseFloat(el.value);
+    return Number.isNaN(n) ? fallback : n;
+  },
+
+  pct(value) {
+    const span = this.hi - this.lo;
+    if (span === 0) return 0;
+    return Math.max(0, Math.min(100, ((value - this.lo) / span) * 100));
+  },
+
+  sync({ emit = true } = {}) {
+    const values = this.values();
+
+    if (this.dual) {
+      const [min, max] = values;
+      this.el.style.setProperty("--pc-slider-pct-min", `${this.pct(min)}%`);
+      this.el.style.setProperty("--pc-slider-pct-max", `${this.pct(max)}%`);
+      this.setText("[data-pc-slider-display]", `${this.fmt(min)} – ${this.fmt(max)}`);
+      this.setText("[data-pc-slider-display-min]", this.fmt(min));
+      this.setText("[data-pc-slider-display-max]", this.fmt(max));
+      this.syncMarks((p) => p >= this.pct(min) && p <= this.pct(max));
+      if (emit) this.emit({ values: [min, max] });
+    } else {
+      const [value] = values;
+      this.el.style.setProperty("--pc-slider-pct", `${this.pct(value)}%`);
+      this.setText("[data-pc-slider-display]", this.fmt(value));
+      this.syncMarks((p) => p <= this.pct(value));
+      if (emit) this.emit({ value });
+    }
+  },
+
+  syncMarks(filled) {
+    this.marks.forEach((mark) => {
+      const p = parseFloat(mark.dataset.pcSliderMark);
+      if (Number.isNaN(p)) return;
+      mark.classList.toggle("pc-slider__mark--filled", filled(p));
+    });
+  },
+
+  setText(selector, text) {
+    const el = this.el.querySelector(selector);
+    if (el) el.textContent = text;
+  },
+
+  // parseFloat strips trailing zeros (50.0 -> "50"), matching the server's
+  // formatter so the readout does not jump on the first drag.
+  fmt(value) {
+    return `${this.prefix}${parseFloat(value.toFixed(10))}${this.suffix}`;
+  },
+
+  emit(detail) {
+    this.el.dispatchEvent(
+      new CustomEvent("petal:slider-change", { detail, bubbles: true }),
+    );
+  },
+};
+
 // Number ticker: counts up to data-value when the element scrolls into view,
 // and re-animates from the previous value whenever data-value changes (so a
 // LiveView assign update animates the delta). Formatting via Intl.NumberFormat.
@@ -5440,6 +5601,7 @@ export default {
   PetalClearableInput,
   PetalRangeFill,
   PetalDualRangeSlider,
+  PetalSlider,
   PetalNumberTicker,
   PetalConfetti,
   PetalSpotlight,

--- a/dev.exs
+++ b/dev.exs
@@ -782,8 +782,18 @@ defmodule Dev.PlaygroundLive do
          disabled: false
        },
        switch: %{size: "md", disabled: false, error: false},
-       slider: %{thumbs: "dual", format: "money", disabled: false, fill: true},
-       slider_form: slider_form("money"),
+       slider: %{
+         mode: "single",
+         show_value: "inline",
+         orientation: "horizontal",
+         step: 1,
+         size: "md",
+         marks: false,
+         disabled: false
+       },
+       slider_price: to_form(%{"min" => "250", "max" => "750"}, as: :pg_price),
+       slider_volume: 60,
+       slider_year: 2010,
        otp: %{length: 6, grouped: false, pattern: "numeric", disabled: false},
        progress: %{
          value: 0,
@@ -1457,23 +1467,40 @@ defmodule Dev.PlaygroundLive do
       {:noreply,
        update(socket, :switch, &Map.update!(&1, String.to_existing_atom(k), fn v -> !v end))}
 
-  def handle_event("ctl_slider", %{"k" => "format", "v" => v}, socket)
-      when v in ~w(money percent plain),
-      do:
-        {:noreply,
-         socket
-         |> update(:slider, &%{&1 | format: v})
-         |> assign(:slider_form, slider_form(v))}
-
-  def handle_event("ctl_slider", %{"k" => "disabled"}, socket),
-    do: {:noreply, update(socket, :slider, &%{&1 | disabled: !&1.disabled})}
-
-  def handle_event("ctl_slider", %{"k" => "fill"}, socket),
-    do: {:noreply, update(socket, :slider, &%{&1 | fill: !&1.fill})}
-
-  def handle_event("ctl_slider", %{"k" => "thumbs", "v" => v}, socket)
+  def handle_event("ctl_slider", %{"k" => "mode", "v" => v}, socket)
       when v in ~w(single dual),
-      do: {:noreply, update(socket, :slider, &%{&1 | thumbs: v})}
+      do: {:noreply, update(socket, :slider, &%{&1 | mode: v})}
+
+  def handle_event("ctl_slider", %{"k" => "show_value", "v" => v}, socket)
+      when v in ~w(none tooltip inline),
+      do: {:noreply, update(socket, :slider, &%{&1 | show_value: v})}
+
+  def handle_event("ctl_slider", %{"k" => "orientation", "v" => v}, socket)
+      when v in ~w(horizontal vertical),
+      do: {:noreply, update(socket, :slider, &%{&1 | orientation: v})}
+
+  def handle_event("ctl_slider", %{"k" => "step", "v" => v}, socket)
+      when v in ~w(1 5 25),
+      do: {:noreply, update(socket, :slider, &%{&1 | step: String.to_integer(v)})}
+
+  def handle_event("ctl_slider", %{"k" => "size", "v" => v}, socket)
+      when v in ~w(sm md lg),
+      do: {:noreply, update(socket, :slider, &%{&1 | size: v})}
+
+  def handle_event("ctl_slider", %{"k" => k}, socket) when k in ~w(marks disabled),
+    do:
+      {:noreply,
+       update(socket, :slider, &Map.update!(&1, String.to_existing_atom(k), fn v -> !v end))}
+
+  # The price filter is an ordinary form change - the two thumbs post two fields.
+  def handle_event("slider_price", %{"pg_price" => params}, socket),
+    do: {:noreply, assign(socket, :slider_price, to_form(params, as: :pg_price))}
+
+  def handle_event("slider_volume", %{"volume" => v}, socket),
+    do: {:noreply, assign(socket, :slider_volume, String.to_integer(v))}
+
+  def handle_event("slider_year", %{"year" => v}, socket),
+    do: {:noreply, assign(socket, :slider_year, String.to_integer(v))}
 
   def handle_event("ctl_radio", %{"k" => "style", "v" => v}, socket)
       when v in ~w(cards plain),
@@ -2137,50 +2164,56 @@ defmodule Dev.PlaygroundLive do
     "<.input_otp #{Enum.join(attrs, " ")} />"
   end
 
-  defp slider_form("money"), do: to_form(%{"min" => "250", "max" => "750"}, as: :pg_range)
-  defp slider_form("percent"), do: to_form(%{"min" => "20", "max" => "80"}, as: :pg_range)
-  defp slider_form("plain"), do: to_form(%{"min" => "25", "max" => "75"}, as: :pg_range)
+  defp slider_preview_marks,
+    do: [
+      %{value: 0, label: "0"},
+      %{value: 25, label: ""},
+      %{value: 50, label: "50"},
+      %{value: 75, label: ""},
+      %{value: 100, label: "100"}
+    ]
 
-  defp slider_bounds("money"),
-    do: %{bound_min: 0, bound_max: 1000, step: 25, prefix: "$", suffix: "", label: "Price range"}
+  defp slider_year_marks,
+    do:
+      for(
+        y <- 1990..2030//5,
+        do: %{value: y, label: if(rem(y, 10) == 0, do: to_string(y), else: "")}
+      )
 
-  defp slider_bounds("percent"),
-    do: %{bound_min: 0, bound_max: 100, step: 5, prefix: "", suffix: "%", label: "Discount range"}
+  # A stand-in catalogue so the price filter has something real to count.
+  defp slider_catalogue,
+    do: [40, 75, 120, 180, 240, 310, 380, 450, 520, 600, 680, 740, 810, 880, 950]
 
-  defp slider_bounds("plain"),
-    do: %{bound_min: 0, bound_max: 100, step: 1, prefix: "", suffix: "", label: "Value range"}
-
-  defp slider_snippet(%{thumbs: "single"} = s) do
-    attrs =
-      [
-        ~s(type="range"),
-        ~s(name="volume"),
-        ~s(label="Volume"),
-        ~s(value="60"),
-        ~s(min="0"),
-        ~s(max="100"),
-        s.fill && "fill",
-        s.disabled && "disabled"
-      ]
-      |> Enum.filter(& &1)
-
-    "<.field #{Enum.join(attrs, " ")} />"
+  defp slider_price_count(form) do
+    lo = slider_param(form, :min, 0)
+    hi = slider_param(form, :max, 1000)
+    Enum.count(slider_catalogue(), &(&1 >= lo and &1 <= hi))
   end
 
-  defp slider_snippet(s) do
-    b = slider_bounds(s.format)
+  defp slider_param(form, key, default) do
+    case Integer.parse(to_string(form[key].value || "")) do
+      {n, _} -> n
+      :error -> default
+    end
+  end
 
+  defp slider_volume_icon(v) when v == 0, do: "hero-speaker-x-mark"
+  defp slider_volume_icon(v) when v < 50, do: "hero-speaker-wave"
+  defp slider_volume_icon(_), do: "hero-speaker-wave"
+
+  defp slider_snippet(%{mode: "dual"} = s) do
     attrs =
       [
-        ~s(type="range-dual"),
         ~s(min_field={@form[:min]}),
         ~s(max_field={@form[:max]}),
-        ~s(range_min={#{b.bound_min}}),
-        ~s(range_max={#{b.bound_max}}),
-        b.step != 1 && ~s(step={#{b.step}}),
-        b.prefix != "" && ~s(value_prefix="#{b.prefix}"),
-        b.suffix != "" && ~s(value_suffix="#{b.suffix}"),
-        ~s(label="#{b.label}"),
+        ~s(min={0}),
+        ~s(max={100}),
+        s.step != 1 && ~s(step={#{s.step}}),
+        ~s(label="Budget"),
+        s.size != "md" && ~s(size="#{s.size}"),
+        s.orientation != "horizontal" && ~s(orientation="#{s.orientation}"),
+        s.show_value != "none" && ~s(show_value="#{s.show_value}"),
+        s.marks && ~s(marks={[%{value: 0, label: "0"}, %{value: 50, label: "50"}]}),
         s.disabled && "disabled"
       ]
       |> Enum.filter(& &1)
@@ -2188,10 +2221,35 @@ defmodule Dev.PlaygroundLive do
 
     """
     <.form for={@form} phx-change="filter">
-      <.field
+      <.slider
     #{Enum.join(attrs, "\n")}
       />
     </.form>\
+    """
+  end
+
+  defp slider_snippet(s) do
+    attrs =
+      [
+        ~s(name="budget"),
+        ~s(label="Budget"),
+        ~s(value={60}),
+        ~s(min={0}),
+        ~s(max={100}),
+        s.step != 1 && ~s(step={#{s.step}}),
+        s.size != "md" && ~s(size="#{s.size}"),
+        s.orientation != "horizontal" && ~s(orientation="#{s.orientation}"),
+        s.show_value != "none" && ~s(show_value="#{s.show_value}"),
+        s.marks && ~s(marks={[%{value: 0, label: "0"}, %{value: 50, label: "50"}]}),
+        s.disabled && "disabled"
+      ]
+      |> Enum.filter(& &1)
+      |> Enum.map(&("  " <> &1))
+
+    """
+    <.slider
+    #{Enum.join(attrs, "\n")}
+    />\
     """
   end
 
@@ -7211,83 +7269,118 @@ defmodule Dev.PlaygroundLive do
   end
 
   defp render_page(%{active: "slider"} = assigns) do
-    assigns = assign(assigns, :sb, slider_bounds(assigns.slider.format))
-
     ~H"""
     <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
       <h1 class="text-3xl font-bold tracking-tight">Slider</h1>
       <p class="mt-2 text-gray-500 dark:text-gray-400">
-        One thumb or two, one grammar: the same track, thumb and focus ring
-        whether you render a single range (pure CSS on the native input) or the
-        dual range (two thumbs and a hook for min/max filtering).
+        One thumb or two, on a native range input. The browser gives the keyboard
+        map, the ARIA and the form posting; the library paints the track, the fill,
+        the marks and the value bubble on top.
       </p>
 
       <div class="mt-8 overflow-hidden border border-gray-200 rounded-xl dark:border-gray-800">
-        <div class="flex items-center justify-center px-6 py-12">
-          <div class="w-full max-w-sm">
-            <.field
-              :if={@slider.thumbs == "dual"}
-              id={"pg-slider-#{@slider.format}-#{@slider.disabled}"}
-              type="range-dual"
-              min_field={@slider_form[:min]}
-              max_field={@slider_form[:max]}
-              range_min={@sb.bound_min}
-              range_max={@sb.bound_max}
-              step={@sb.step}
-              value_prefix={@sb.prefix}
-              value_suffix={@sb.suffix}
-              label={@sb.label}
+        <div class="flex items-center justify-center px-6 py-16">
+          <div class={if @slider.orientation == "vertical", do: "", else: "w-full max-w-sm"}>
+            <.slider
+              id="pg-slider-preview"
+              name="pg_slider"
+              label="Budget"
+              value={60}
+              values={if @slider.mode == "dual", do: [25, 75]}
+              min={0}
+              max={100}
+              step={@slider.step}
+              size={@slider.size}
+              orientation={@slider.orientation}
+              show_value={@slider.show_value}
               disabled={@slider.disabled}
-              no_margin
-            />
-            <.field
-              :if={@slider.thumbs == "single"}
-              id={"pg-single-#{@slider.fill}-#{@slider.disabled}"}
-              type="range"
-              name="pg_flag_volume"
-              label="Volume"
-              value="60"
-              min="0"
-              max="100"
-              fill={@slider.fill}
-              disabled={@slider.disabled}
-              no_margin
+              marks={if @slider.marks, do: slider_preview_marks(), else: []}
             />
           </div>
         </div>
         <div class="flex flex-wrap items-end gap-x-8 gap-y-4 px-4 sm:px-6 py-4 [&>div]:min-w-0 [&>div]:max-w-full border-t border-gray-200 dark:border-gray-800">
           <div>
-            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">thumbs</div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">mode</div>
             <.toggle_group
               variant="outline"
               size="sm"
-              aria_label="Thumbs"
-              value={@slider.thumbs}
+              aria_label="Mode"
+              value={@slider.mode}
               on_change="ctl_slider"
               class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             >
-              <:item :for={t <- ~w(single dual)} value={t} phx-value-k="thumbs" phx-value-v={t}>
-                {t}
+              <:item :for={m <- ~w(single dual)} value={m} phx-value-k="mode" phx-value-v={m}>
+                {m}
               </:item>
             </.toggle_group>
           </div>
-          <div :if={@slider.thumbs == "dual"}>
-            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">format</div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">show_value</div>
             <.toggle_group
               variant="outline"
               size="sm"
-              aria_label="Format"
-              value={@slider.format}
+              aria_label="Show value"
+              value={@slider.show_value}
               on_change="ctl_slider"
               class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             >
               <:item
-                :for={f <- ~w(money percent plain)}
-                value={f}
-                phx-value-k="format"
-                phx-value-v={f}
+                :for={v <- ~w(none tooltip inline)}
+                value={v}
+                phx-value-k="show_value"
+                phx-value-v={v}
               >
-                {f}
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">orientation</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Orientation"
+              value={@slider.orientation}
+              on_change="ctl_slider"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={o <- ~w(horizontal vertical)}
+                value={o}
+                phx-value-k="orientation"
+                phx-value-v={o}
+              >
+                {o}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">step</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Step"
+              value={to_string(@slider.step)}
+              on_change="ctl_slider"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item :for={s <- ~w(1 5 25)} value={s} phx-value-k="step" phx-value-v={s}>
+                {s}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">size</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Size"
+              value={@slider.size}
+              on_change="ctl_slider"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item :for={z <- ~w(sm md lg)} value={z} phx-value-k="size" phx-value-v={z}>
+                {z}
               </:item>
             </.toggle_group>
           </div>
@@ -7299,12 +7392,14 @@ defmodule Dev.PlaygroundLive do
               size="sm"
               aria_label="State"
               value={
-                for {k, on} <- [{"fill", @slider.fill}, {"disabled", @slider.disabled}], on, do: k
+                for {k, on} <- [{"marks", @slider.marks}, {"disabled", @slider.disabled}],
+                    on,
+                    do: k
               }
               on_change="ctl_slider"
               class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             >
-              <:item :if={@slider.thumbs == "single"} value="fill" phx-value-k="fill">fill</:item>
+              <:item value="marks" phx-value-k="marks">marks</:item>
               <:item value="disabled" phx-value-k="disabled">disabled</:item>
             </.toggle_group>
           </div>
@@ -7324,10 +7419,97 @@ defmodule Dev.PlaygroundLive do
         class="p-4 mt-2 overflow-x-auto text-sm text-gray-100 bg-gray-900 rounded-xl dark:border dark:border-gray-800"
       ><code>{slider_snippet(@slider)}</code></pre>
 
-      <div
-        :for={ex <- examples_for(PetalComponents.Showcase.Field, ~w(sliders slider_dual)a)}
-        class="mt-10"
-      >
+      <div class="flex items-start gap-2 p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        <.icon name="hero-command-line" class="w-4 h-4 mt-0.5 shrink-0" />
+        <div>
+          <span class="font-medium text-gray-700 dark:text-gray-200">Keyboard:</span>
+          tab to a thumb, then arrows to nudge one step, PageUp / PageDown for a
+          bigger jump, Home / End for the bounds. All of it is the native input -
+          none of it is re-implemented here.
+        </div>
+      </div>
+
+      <h2 class="mt-12 mb-1 text-lg font-semibold">Price range filter</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        Two thumbs posting two form fields, so filtering is a plain <code>phx-change</code>
+        on the form. The result count below updates as you drag - no JavaScript in
+        the app, and the values survive a reconnect because the server holds them.
+      </p>
+      <div class="p-6 border border-gray-200 rounded-xl dark:border-gray-800">
+        <.form for={@slider_price} phx-change="slider_price">
+          <.slider
+            id="pg-slider-price"
+            min_field={@slider_price[:min]}
+            max_field={@slider_price[:max]}
+            min={0}
+            max={1000}
+            step={50}
+            label="Price"
+            value_prefix="$"
+            show_value="inline"
+            marks={[
+              %{value: 0, label: "$0"},
+              %{value: 500, label: "$500"},
+              %{value: 1000, label: "$1,000"}
+            ]}
+          />
+        </.form>
+        <div class="pt-4 mt-6 text-sm border-t border-gray-200 dark:border-gray-800">
+          <span class="font-semibold text-gray-900 dark:text-white">
+            {slider_price_count(@slider_price)}
+          </span>
+          <span class="text-gray-500 dark:text-gray-400">
+            of {length(slider_catalogue())} products in range
+          </span>
+        </div>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Volume</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        The everyday single-thumb case: an icon that reacts to the level, the
+        value inline in the label row, and a suffix so the number carries a unit.
+      </p>
+      <div class="p-6 border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="flex items-center gap-4">
+          <.icon name={slider_volume_icon(@slider_volume)} class="w-5 h-5 text-gray-400 shrink-0" />
+          <form phx-change="slider_volume" class="flex-1">
+            <.slider
+              id="pg-slider-volume"
+              name="volume"
+              label="Output volume"
+              value={@slider_volume}
+              min={0}
+              max={100}
+              value_suffix="%"
+              show_value="inline"
+            />
+          </form>
+        </div>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Model year</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        A coarse scale where every stop matters: <code>step</code>
+        of 5 snaps the thumb, a mark sits on each stop, and the tooltip carries the
+        number so no row is spent on a readout.
+      </p>
+      <div class="p-6 border border-gray-200 rounded-xl dark:border-gray-800">
+        <form phx-change="slider_year">
+          <.slider
+            id="pg-slider-year"
+            name="year"
+            label="Model year"
+            value={@slider_year}
+            min={1990}
+            max={2030}
+            step={5}
+            show_value="tooltip"
+            marks={slider_year_marks()}
+          />
+        </form>
+      </div>
+
+      <div :for={ex <- PetalComponents.Showcase.Slider.examples()} class="mt-10">
         <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
         <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
           {ex.description}
@@ -7336,13 +7518,14 @@ defmodule Dev.PlaygroundLive do
       </div>
 
       <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
-      <.showcase_props component={PetalComponents.Field} function={:field} />
+      <.showcase_props component={PetalComponents.Slider} function={:slider} />
 
       <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
-        These examples render from the shared <code>PetalComponents.Showcase.Field</code>
-        registry - the same source petal.build renders, so the playground and the marketing
-        docs can't drift. Sliders are field types (range / range-dual), so they live in the
-        field registry with the rest of the form surface.
+        <code>&lt;.field type="range"&gt;</code>
+        and <code>type="range-dual"</code>
+        still work and are not going anywhere in this release, but <code>&lt;.slider&gt;</code>
+        supersedes them - same native machinery, with marks, a value readout,
+        vertical orientation and sizes on top. Reach for the slider in new code.
       </div>
     </div>
     """

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -60,6 +60,7 @@ defmodule PetalComponents do
         Progress,
         Rating,
         Skeleton,
+        Slider,
         SlideOver,
         SocialButton,
         Sparkline,

--- a/lib/petal_components/field.ex
+++ b/lib/petal_components/field.ex
@@ -13,6 +13,14 @@ defmodule PetalComponents.Field do
 
       <.field field={@form[:email]} type="email" />
       <.field label="Name" value="" name="name" errors={["oh no!"]} />
+
+  > #### Sliders have moved {: .info}
+  >
+  > `type="range"` and `type="range-dual"` still work and are not going
+  > anywhere in this release, but `PetalComponents.Slider.slider/1` supersedes
+  > them. It is the same native `<input type="range">` machinery with marks, a
+  > value readout, vertical orientation and sizes on top, so reach for
+  > `<.slider>` in new code.
   """
   attr :id, :any,
     default: nil,

--- a/lib/petal_components/input.ex
+++ b/lib/petal_components/input.ex
@@ -4,6 +4,14 @@ defmodule PetalComponents.Input do
 
   @moduledoc """
   Renders pure inputs (no label or errors).
+
+  > #### Sliders have moved {: .info}
+  >
+  > `type="range"` and `type="range-dual"` still work and are not going
+  > anywhere in this release, but `PetalComponents.Slider.slider/1` supersedes
+  > them. It is the same native `<input type="range">` machinery with marks, a
+  > value readout, vertical orientation and sizes on top, so reach for
+  > `<.slider>` in new code.
   """
 
   attr :id, :any, default: nil

--- a/lib/petal_components/showcase/field.ex
+++ b/lib/petal_components/showcase/field.ex
@@ -330,7 +330,7 @@ defmodule PetalComponents.Showcase.Field do
 
   example :sliders, "Sliders",
     description:
-      "type=\"range\" is the native input on the shared field surface - no JavaScript when plain. fill paints the track primary up to the thumb (Firefox natively, a tiny hook for webkit); leave it off for balance and pan controls, where a fill would imply a wrong zero point. step snaps the scale." do
+      "type=\"range\" is the native input on the shared field surface - no JavaScript when plain. fill paints the track primary up to the thumb (Firefox natively, a tiny hook for webkit); leave it off for balance and pan controls, where a fill would imply a wrong zero point. step snaps the scale. Superseded by <.slider>, which adds marks, a value readout, vertical orientation and sizes; this type still works and is not going anywhere in this release." do
     ~H"""
     <div class="grid w-full gap-x-10 gap-y-6 sm:grid-cols-2">
       <.field type="range" name="volume" label="Volume" value="60" min="0" max="100" fill no_margin />
@@ -353,7 +353,7 @@ defmodule PetalComponents.Showcase.Field do
 
   example :slider_dual, "Dual range",
     description:
-      "type=\"range-dual\" is two thumbs and a hook for min/max filtering - same track, thumb and focus ring as the single. min_field and max_field take form fields (in your app, @form[:min] and @form[:max]); value_prefix formats the readout and range_max_label caps the scale as open-ended." do
+      "type=\"range-dual\" is two thumbs and a hook for min/max filtering - same track, thumb and focus ring as the single. min_field and max_field take form fields (in your app, @form[:min] and @form[:max]); value_prefix formats the readout and range_max_label caps the scale as open-ended. Superseded by <.slider>, which takes the same two form fields and adds marks, a value readout, vertical orientation and sizes; this type still works and is not going anywhere in this release." do
     ~H"""
     <div class="w-full max-w-sm">
       <.field

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -46,6 +46,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.Rating,
     PetalComponents.Showcase.ShineBorder,
     PetalComponents.Showcase.Skeleton,
+    PetalComponents.Showcase.Slider,
     PetalComponents.Showcase.SlideOver,
     PetalComponents.Showcase.Sparkline,
     PetalComponents.Showcase.SpotlightCard,

--- a/lib/petal_components/showcase/slider.ex
+++ b/lib/petal_components/showcase/slider.ex
@@ -1,0 +1,90 @@
+defmodule PetalComponents.Showcase.Slider do
+  @moduledoc false
+  use PetalComponents.Showcase, component: PetalComponents.Slider, title: "Slider"
+
+  example :basic, "Single thumb",
+    description:
+      "A native range input with the track, fill and thumb painted by the library, so it looks the same on every browser and OS. label names it for screen readers and prints above the track; show_value=\"inline\" puts the live readout in that same row, with value_prefix and value_suffix formatting it." do
+    ~H"""
+    <div class="w-full max-w-sm space-y-8">
+      <.slider name="volume" label="Volume" value={60} value_suffix="%" show_value="inline" />
+      <.slider name="quality" label="Quality" value={3} min={1} max={5} />
+    </div>
+    """
+  end
+
+  example :dual, "Dual thumb",
+    description:
+      "min_field and max_field make it a range: two thumbs, two form values, one fill spanning between them. Each thumb posts its own name, so a price filter is a plain form change event with no JavaScript of your own. Reversed or out-of-bounds values are clamped and ordered server-side, so the fill can never paint backwards." do
+    ~H"""
+    <div class="w-full max-w-sm">
+      <.slider
+        min_field={to_form(%{"min" => "250"}, as: :price)[:min]}
+        max_field={to_form(%{"max" => "750"}, as: :price)[:max]}
+        min={0}
+        max={1000}
+        step={50}
+        label="Price"
+        value_prefix="$"
+        show_value="inline"
+      />
+    </div>
+    """
+  end
+
+  example :marks, "Marks and tooltip",
+    description:
+      "marks are labelled stops under the track. An empty label renders a tick only, so you can mark every step and label the ones that carry meaning; ticks the fill has swallowed flip to the on-primary treatment. show_value=\"tooltip\" floats the value in a bubble over the thumb while you drag or tab to it, rather than taking up a row." do
+    ~H"""
+    <div class="w-full max-w-sm">
+      <.slider
+        name="year"
+        label="Model year"
+        value={2010}
+        min={1990}
+        max={2030}
+        step={5}
+        show_value="tooltip"
+        marks={[
+          %{value: 1990, label: "1990"},
+          %{value: 2000, label: ""},
+          %{value: 2010, label: "2010"},
+          %{value: 2020, label: ""},
+          %{value: 2030, label: "2030"}
+        ]}
+      />
+    </div>
+    """
+  end
+
+  example :sizes_states, "Sizes and states",
+    description:
+      "size runs sm, md, lg - track thickness and thumb diameter move together, so the proportions hold. disabled dims the whole control and takes the native inputs out of the tab order." do
+    ~H"""
+    <div class="w-full max-w-sm space-y-6">
+      <.slider name="s" label="Small" value={30} size="sm" />
+      <.slider name="m" label="Medium" value={50} size="md" />
+      <.slider name="l" label="Large" value={70} size="lg" />
+      <.slider name="d" label="Disabled" value={40} disabled />
+    </div>
+    """
+  end
+
+  example :vertical, "Vertical",
+    description:
+      "orientation=\"vertical\" stands the track up and fills from the bottom. It is the same native input turned with writing-mode, so the keyboard map and the screen reader announcement are unchanged - useful for a mixer strip or a level control that sits beside content rather than under it." do
+    ~H"""
+    <div class="flex items-end gap-10">
+      <.slider name="bass" label="Bass" value={70} orientation="vertical" show_value="tooltip" />
+      <.slider name="mid" label="Mid" value={45} orientation="vertical" show_value="tooltip" />
+      <.slider
+        name="treble"
+        label="Treble"
+        value={55}
+        orientation="vertical"
+        show_value="tooltip"
+      />
+    </div>
+    """
+  end
+end

--- a/lib/petal_components/slider.ex
+++ b/lib/petal_components/slider.ex
@@ -1,0 +1,524 @@
+defmodule PetalComponents.Slider do
+  @moduledoc """
+  A styled range slider, in single-thumb and dual-thumb (range) forms.
+
+  Built on native `<input type="range">`. That is the whole accessibility
+  story: the browser gives us `role="slider"`, `aria-valuemin`/`valuemax`/
+  `valuenow`, the full arrow/Home/End/PageUp/PageDown keyboard map, touch
+  and pointer handling, and form posting. None of it is re-implemented here.
+  Everything this module adds is paint: a custom track, a primary fill, tick
+  marks, and an optional value readout.
+
+  ## Single thumb
+
+      <.slider name="volume" label="Volume" value={60} value_suffix="%" show_value="inline" />
+
+  ## Dual thumb (a range)
+
+  Pass `min_field` and `max_field` (or `values` with `min_name`/`max_name`).
+  Two overlaid native inputs post both names, and the fill spans between them.
+
+      <.form for={@form} phx-change="filter">
+        <.slider
+          min_field={@form[:min]}
+          max_field={@form[:max]}
+          min={0}
+          max={1000}
+          step={50}
+          label="Price"
+          value_prefix="$"
+          show_value="inline"
+        />
+      </.form>
+
+  ## Marks
+
+  `marks` renders labelled stops under the track. An empty label renders a
+  tick only, so you can mark every step and label a few.
+
+      <.slider
+        name="year"
+        label="Year"
+        value={2010}
+        min={1990}
+        max={2030}
+        step={5}
+        show_value="tooltip"
+        marks={[
+          %{value: 1990, label: "1990"},
+          %{value: 2010, label: "2010"},
+          %{value: 2030, label: "2030"}
+        ]}
+      />
+
+  ## Listening for changes without a form
+
+  The `PetalSlider` hook emits a bubbling `petal:slider-change` CustomEvent on
+  the wrapper, with `detail: %{value: v}` (single) or `detail: %{values: [min, max]}`
+  (dual), so a plain `JS.dispatch`-free listener can pick it up.
+
+  ## Relationship to the `range` field types
+
+  `<.field type="range">` and `<.field type="range-dual">` still work and are
+  not going anywhere in this release, but `<.slider>` supersedes them: it is
+  the same native machinery with marks, a value readout, vertical orientation
+  and sizes on top. Reach for `<.slider>` in new code.
+  """
+  use Phoenix.Component
+
+  alias PetalComponents.Field
+  alias Phoenix.HTML.FormField
+
+  attr :field, :any,
+    default: nil,
+    doc: "a Phoenix.HTML.FormField for single-thumb use; sets name, id and value"
+
+  attr :min_field, :any,
+    default: nil,
+    doc: "FormField for the lower value; dual-thumb mode when set with max_field"
+
+  attr :max_field, :any,
+    default: nil,
+    doc: "FormField for the upper value; dual-thumb mode when set with min_field"
+
+  attr :name, :string, default: nil, doc: "input name when not using field"
+
+  attr :min_name, :string,
+    default: nil,
+    doc: ~s|lower input name in dual mode when not using min_field; defaults to "\#{name}_min"|
+
+  attr :max_name, :string,
+    default: nil,
+    doc: ~s|upper input name in dual mode when not using max_field; defaults to "\#{name}_max"|
+
+  attr :id, :string, default: nil, doc: "wrapper id; the inputs derive theirs from it"
+  attr :value, :any, default: nil, doc: "current value (single-thumb)"
+
+  attr :values, :list,
+    default: nil,
+    doc: "[min, max] current values (dual-thumb, when not using min_field/max_field)"
+
+  attr :min, :any, default: 0, doc: "lower bound"
+  attr :max, :any, default: 100, doc: "upper bound"
+  attr :step, :any, default: 1, doc: "step increment; values snap to it natively"
+
+  attr :marks, :list,
+    default: [],
+    doc:
+      ~s|labelled stops rendered under the track, e.g. [%{value: 0, label: "Min"}, %{value: 50, label: ""}]; an empty label renders a tick only|
+
+  attr :show_value, :string,
+    default: "none",
+    values: ["tooltip", "inline", "none"],
+    doc:
+      "tooltip shows the value in a bubble above the thumb while dragging or focus-visible; inline renders it in the label row beside the track"
+
+  attr :value_prefix, :string, default: "", doc: ~s|prepended to displayed values, e.g. "$"|
+  attr :value_suffix, :string, default: "", doc: ~s|appended to displayed values, e.g. "%"|
+
+  attr :label, :string,
+    default: nil,
+    doc:
+      "visible label above the track, and the base for each input's accessible name (dual thumbs become \"<label> minimum\" and \"<label> maximum\"); defaults to the humanised field name"
+
+  attr :orientation, :string,
+    default: "horizontal",
+    values: ["horizontal", "vertical"],
+    doc: "vertical stands the track up, filling from the bottom"
+
+  attr :size, :string,
+    default: "md",
+    values: ["sm", "md", "lg"],
+    doc: "track thickness and thumb diameter"
+
+  attr :disabled, :boolean, default: false, doc: "disables every input and dims the control"
+  attr :class, :any, default: nil, doc: "CSS class for the outer wrapper"
+  attr :rest, :global, doc: "any other HTML attributes, applied to the wrapper"
+
+  @doc """
+  Renders a slider.
+
+  Single vs dual mode is inferred: `min_field`/`max_field` or `values` means
+  dual, otherwise single. Mixing the two raises `ArgumentError`.
+  """
+  def slider(assigns) do
+    assigns
+    |> normalise()
+    |> render_slider()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Mode inference and normalisation
+  # ---------------------------------------------------------------------------
+
+  defp normalise(assigns) do
+    dual? = dual?(assigns)
+    validate!(assigns, dual?)
+
+    lo = to_number(assigns.min, 0)
+    hi = to_number(assigns.max, 100)
+
+    assigns
+    |> assign(:dual, dual?)
+    |> assign(:lo, lo)
+    |> assign(:hi, hi)
+    |> assign(:id, assigns.id || default_id(assigns))
+    |> assign_label()
+    |> assign_values(dual?, lo, hi)
+    |> assign_errors(dual?)
+    |> assign_marks(lo, hi)
+  end
+
+  defp dual?(%{min_field: mf, max_field: xf, values: v}),
+    do: not is_nil(mf) or not is_nil(xf) or not is_nil(v)
+
+  defp validate!(assigns, true) do
+    if assigns.field do
+      raise ArgumentError,
+            "<.slider> got both a single-thumb `field` and dual-thumb attrs " <>
+              "(min_field/max_field/values). Pass one or the other, not both."
+    end
+
+    if is_nil(assigns.min_field) != is_nil(assigns.max_field) do
+      raise ArgumentError,
+            "<.slider> needs both `min_field` and `max_field` for dual-thumb mode, got only one."
+    end
+
+    if assigns.values && (assigns.min_field || assigns.max_field) do
+      raise ArgumentError,
+            "<.slider> got both `values` and min_field/max_field. Pass one or the other."
+    end
+
+    :ok
+  end
+
+  defp validate!(_assigns, false), do: :ok
+
+  defp default_id(%{field: %FormField{id: id}}), do: id
+  defp default_id(%{min_field: %FormField{id: id}}), do: id
+  defp default_id(_), do: "pc-slider-#{Ecto.UUID.generate()}"
+
+  defp assign_label(assigns) do
+    assign(assigns, :label, assigns.label || derived_label(assigns))
+  end
+
+  defp derived_label(%{field: %FormField{field: f}}), do: humanize(f)
+  defp derived_label(%{min_field: %FormField{field: f}}), do: humanize(f)
+  defp derived_label(_), do: nil
+
+  defp humanize(field), do: PhoenixHTMLHelpers.Form.humanize(field)
+
+  # Accessible name for the inputs. Falls back through label, field name, raw
+  # name, then a generic - an input must never be nameless.
+  defp a11y_name(assigns) do
+    assigns.label || assigns.name || "Value"
+  end
+
+  defp assign_values(assigns, true, lo, hi) do
+    raw_min = dual_raw(assigns, :min)
+    raw_max = dual_raw(assigns, :max)
+
+    min_value = clamp(to_number(raw_min, lo), lo, hi)
+    max_value = clamp(to_number(raw_max, hi), lo, hi)
+
+    # Order invariant: a reversed pair renders in order rather than painting a
+    # negative fill.
+    {min_value, max_value} =
+      if min_value > max_value, do: {max_value, min_value}, else: {min_value, max_value}
+
+    assigns
+    |> assign(:min_value, min_value)
+    |> assign(:max_value, max_value)
+    |> assign(:min_pct, pct(min_value, lo, hi))
+    |> assign(:max_pct, pct(max_value, lo, hi))
+    |> assign(:min_input_name, dual_name(assigns, :min))
+    |> assign(:max_input_name, dual_name(assigns, :max))
+  end
+
+  defp assign_values(assigns, false, lo, hi) do
+    raw = if assigns.field, do: assigns.field.value, else: assigns.value
+    value = clamp(to_number(raw, lo), lo, hi)
+
+    assigns
+    |> assign(:single_value, value)
+    |> assign(:single_pct, pct(value, lo, hi))
+    |> assign(:single_name, assigns.name || (assigns.field && assigns.field.name))
+  end
+
+  defp dual_raw(%{min_field: %FormField{value: v}}, :min), do: v
+  defp dual_raw(%{max_field: %FormField{value: v}}, :max), do: v
+  defp dual_raw(%{values: [v, _]}, :min), do: v
+  defp dual_raw(%{values: [_, v]}, :max), do: v
+  defp dual_raw(_, _), do: nil
+
+  defp dual_name(%{min_field: %FormField{name: n}}, :min), do: n
+  defp dual_name(%{max_field: %FormField{name: n}}, :max), do: n
+  defp dual_name(%{min_name: n}, :min) when is_binary(n), do: n
+  defp dual_name(%{max_name: n}, :max) when is_binary(n), do: n
+  defp dual_name(%{name: n}, :min) when is_binary(n), do: n <> "_min"
+  defp dual_name(%{name: n}, :max) when is_binary(n), do: n <> "_max"
+  defp dual_name(_, _), do: nil
+
+  # Errors come out of the form field(s) and render through the standard field
+  # error markup, merged and de-duplicated across both thumbs in dual mode.
+  defp assign_errors(assigns, true) do
+    assign(
+      assigns,
+      :errors,
+      Enum.uniq(errors_for(assigns.min_field) ++ errors_for(assigns.max_field))
+    )
+  end
+
+  defp assign_errors(assigns, false) do
+    assign(assigns, :errors, errors_for(assigns.field))
+  end
+
+  defp errors_for(%FormField{} = field) do
+    if Phoenix.Component.used_input?(field) do
+      Enum.map(field.errors, &translate_error/1)
+    else
+      []
+    end
+  end
+
+  defp errors_for(_), do: []
+
+  defp translate_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
+  end
+
+  defp translate_error(msg) when is_binary(msg), do: msg
+
+  defp assign_marks(assigns, lo, hi) do
+    marks =
+      Enum.map(assigns.marks, fn mark ->
+        value = to_number(Map.get(mark, :value), lo)
+        %{value: value, label: Map.get(mark, :label) || "", pct: pct(value, lo, hi)}
+      end)
+
+    assigns
+    |> assign(:marks, marks)
+    |> assign(:has_mark_labels, Enum.any?(marks, &(&1.label != "")))
+  end
+
+  # ---------------------------------------------------------------------------
+  # Render
+  # ---------------------------------------------------------------------------
+
+  defp render_slider(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      class={[
+        "pc-slider",
+        "pc-slider--#{@size}",
+        "pc-slider--#{@orientation}",
+        @dual && "pc-slider--dual",
+        @disabled && "pc-slider--disabled",
+        @marks != [] && "pc-slider--marked",
+        @class
+      ]}
+      phx-hook="PetalSlider"
+      data-pc-slider-min={@lo}
+      data-pc-slider-max={@hi}
+      data-pc-slider-mode={if @dual, do: "dual", else: "single"}
+      data-value-prefix={@value_prefix}
+      data-value-suffix={@value_suffix}
+      style={wrapper_style(assigns)}
+      {@rest}
+    >
+      <div :if={@label || @show_value == "inline"} class="pc-slider__header">
+        <Field.field_label :if={@label} for={primary_input_id(assigns)} class="pc-slider__label">
+          {@label}
+        </Field.field_label>
+        <span
+          :if={@show_value == "inline"}
+          class="pc-slider__value"
+          data-pc-slider-display
+        >
+          {display_text(assigns)}
+        </span>
+      </div>
+
+      <div class="pc-slider__track-wrapper">
+        <div class="pc-slider__track"></div>
+        <div class="pc-slider__fill" data-pc-slider-fill></div>
+
+        <div :if={@marks != []} class="pc-slider__marks" aria-hidden="true">
+          <span
+            :for={mark <- @marks}
+            class={["pc-slider__mark", mark_filled?(assigns, mark) && "pc-slider__mark--filled"]}
+            style={"--pc-slider-mark: #{mark.pct}%"}
+            data-pc-slider-mark={mark.pct}
+          ></span>
+        </div>
+
+        <.slider_inputs {assigns} />
+
+        <div
+          :if={@show_value == "tooltip" and not @dual}
+          class="pc-slider__tooltip"
+          style="--pc-slider-at: var(--pc-slider-pct)"
+          data-pc-slider-display
+          aria-hidden="true"
+        >
+          {display_text(assigns)}
+        </div>
+        <div
+          :if={@show_value == "tooltip" and @dual}
+          class="pc-slider__tooltip pc-slider__tooltip--min"
+          style="--pc-slider-at: var(--pc-slider-pct-min)"
+          data-pc-slider-display-min
+          aria-hidden="true"
+        >
+          {format_value(assigns, @min_value)}
+        </div>
+        <div
+          :if={@show_value == "tooltip" and @dual}
+          class="pc-slider__tooltip pc-slider__tooltip--max"
+          style="--pc-slider-at: var(--pc-slider-pct-max)"
+          data-pc-slider-display-max
+          aria-hidden="true"
+        >
+          {format_value(assigns, @max_value)}
+        </div>
+      </div>
+
+      <div :if={@has_mark_labels} class="pc-slider__mark-labels" aria-hidden="true">
+        <span
+          :for={mark <- @marks}
+          :if={mark.label != ""}
+          class="pc-slider__mark-label"
+          style={"--pc-slider-mark: #{mark.pct}%"}
+        >
+          {mark.label}
+        </span>
+      </div>
+
+      <Field.field_error :for={msg <- @errors}>{msg}</Field.field_error>
+    </div>
+    """
+  end
+
+  # Private function component: the whole assigns map is forwarded from
+  # render_slider/1, so no attr declarations (they would reject the pass-through).
+  defp slider_inputs(%{dual: false} = assigns) do
+    ~H"""
+    <input
+      type="range"
+      id={@id <> "_input"}
+      name={@single_name}
+      value={@single_value}
+      min={@lo}
+      max={@hi}
+      step={@step}
+      disabled={@disabled}
+      aria-label={a11y_name(assigns)}
+      class="pc-slider__input"
+      data-pc-slider-input
+    />
+    """
+  end
+
+  defp slider_inputs(%{dual: true} = assigns) do
+    ~H"""
+    <input
+      type="range"
+      id={@id <> "_min"}
+      name={@min_input_name}
+      value={@min_value}
+      min={@lo}
+      max={@hi}
+      step={@step}
+      disabled={@disabled}
+      aria-label={a11y_name(assigns) <> " minimum"}
+      class="pc-slider__input pc-slider__input--min"
+      data-pc-slider-input-min
+    />
+    <input
+      type="range"
+      id={@id <> "_max"}
+      name={@max_input_name}
+      value={@max_value}
+      min={@lo}
+      max={@hi}
+      step={@step}
+      disabled={@disabled}
+      aria-label={a11y_name(assigns) <> " maximum"}
+      class="pc-slider__input pc-slider__input--max"
+      data-pc-slider-input-max
+    />
+    """
+  end
+
+  defp primary_input_id(%{dual: true, id: id}), do: id <> "_min"
+  defp primary_input_id(%{id: id}), do: id <> "_input"
+
+  # The fill, the tooltip and every mark anchor off these custom properties, so
+  # positioning is pure CSS. Server-rendered here so the control paints
+  # correctly before the hook connects (and with JS off entirely); the hook
+  # keeps them in sync while dragging.
+  defp wrapper_style(%{dual: true} = assigns) do
+    "--pc-slider-pct-min: #{assigns.min_pct}%; --pc-slider-pct-max: #{assigns.max_pct}%"
+  end
+
+  defp wrapper_style(assigns) do
+    "--pc-slider-pct: #{assigns.single_pct}%"
+  end
+
+  defp mark_filled?(%{dual: true} = assigns, mark),
+    do: mark.value >= assigns.min_value and mark.value <= assigns.max_value
+
+  defp mark_filled?(assigns, mark), do: mark.value <= assigns.single_value
+
+  defp display_text(%{dual: true} = assigns) do
+    format_value(assigns, assigns.min_value) <> " – " <> format_value(assigns, assigns.max_value)
+  end
+
+  defp display_text(assigns), do: format_value(assigns, assigns.single_value)
+
+  defp format_value(assigns, value) do
+    "#{assigns.value_prefix}#{trim_zeros(value)}#{assigns.value_suffix}"
+  end
+
+  # 50.0 reads as "50". Mirrors the hook's formatter so server and client agree.
+  defp trim_zeros(value) when is_float(value) do
+    if value == Float.round(value), do: to_string(round(value)), else: to_string(value)
+  end
+
+  defp trim_zeros(value), do: to_string(value)
+
+  # ---------------------------------------------------------------------------
+  # Numbers
+  # ---------------------------------------------------------------------------
+
+  defp to_number(nil, default), do: default
+  defp to_number(v, _default) when is_integer(v) or is_float(v), do: v
+
+  defp to_number(v, default) when is_binary(v) do
+    case Integer.parse(v) do
+      {int, ""} ->
+        int
+
+      _ ->
+        case Float.parse(v) do
+          {float, ""} -> float
+          _ -> default
+        end
+    end
+  end
+
+  defp to_number(_, default), do: default
+
+  defp clamp(value, lo, hi) when lo > hi, do: clamp(value, hi, lo)
+  defp clamp(value, lo, _hi) when value < lo, do: lo
+  defp clamp(value, _lo, hi) when value > hi, do: hi
+  defp clamp(value, _lo, _hi), do: value
+
+  # Percentage position of `value` within [lo, hi], to 2dp so marks at awkward
+  # steps (1990..2030 by 5) land exactly rather than drifting off the tick.
+  defp pct(_value, lo, hi) when lo == hi, do: 0
+  defp pct(value, lo, hi), do: Float.round((value - lo) / (hi - lo) * 100, 2)
+end

--- a/test/js/slider.test.js
+++ b/test/js/slider.test.js
@@ -1,0 +1,237 @@
+// PetalSlider hook: the live half of <.slider>.
+//
+// The server already renders correct geometry, so every spec here is about
+// what only the client can know - where the thumb has been dragged to. That
+// splits three ways: the percentage custom properties the CSS reads, the
+// ordering invariant two overlaid native inputs cannot enforce themselves,
+// and the petal:slider-change event an app listens to without a form.
+import { afterEach, describe, expect, it } from "vitest";
+
+import hooks from "../../assets/js/petal_components.js";
+
+const mounted = [];
+
+function mount({
+  mode = "single",
+  min = 0,
+  max = 100,
+  value = 50,
+  values = [20, 80],
+  prefix = "",
+  suffix = "",
+  display = false,
+  marks = [],
+} = {}) {
+  const wrap = document.createElement("div");
+
+  const inputs =
+    mode === "dual"
+      ? `<input type="range" data-pc-slider-input-min min="${min}" max="${max}" value="${values[0]}" />
+         <input type="range" data-pc-slider-input-max min="${min}" max="${max}" value="${values[1]}" />`
+      : `<input type="range" data-pc-slider-input min="${min}" max="${max}" value="${value}" />`;
+
+  const markEls = marks
+    .map(
+      (p) =>
+        `<span class="pc-slider__mark" data-pc-slider-mark="${p}"></span>`,
+    )
+    .join("");
+
+  wrap.innerHTML = `
+    <div id="s" class="pc-slider"
+         data-pc-slider-mode="${mode}"
+         data-pc-slider-min="${min}"
+         data-pc-slider-max="${max}"
+         data-value-prefix="${prefix}"
+         data-value-suffix="${suffix}">
+      ${inputs}
+      ${markEls}
+      ${display ? '<span data-pc-slider-display></span>' : ""}
+    </div>
+  `;
+  document.body.appendChild(wrap);
+
+  const el = wrap.querySelector("#s");
+  const hook = Object.create(hooks.PetalSlider);
+  hook.el = el;
+
+  const events = [];
+  el.addEventListener("petal:slider-change", (e) => events.push(e));
+
+  hook.mounted();
+  mounted.push({ hook, wrap });
+  return { hook, el, events, wrap };
+}
+
+function fire(input) {
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+afterEach(() => {
+  mounted.splice(0).forEach(({ hook, wrap }) => {
+    hook.destroyed();
+    wrap.remove();
+  });
+});
+
+describe("PetalSlider single", () => {
+  it("sets --pc-slider-pct from the value on mount", () => {
+    const { el } = mount({ value: 25 });
+    expect(el.style.getPropertyValue("--pc-slider-pct")).toBe("25%");
+  });
+
+  it("computes the percentage against the declared bounds", () => {
+    const { el } = mount({ min: 1990, max: 2030, value: 2010 });
+    expect(el.style.getPropertyValue("--pc-slider-pct")).toBe("50%");
+  });
+
+  it("re-syncs the percentage as the thumb moves", () => {
+    const { el } = mount({ value: 10 });
+    const input = el.querySelector("[data-pc-slider-input]");
+    input.value = "90";
+    fire(input);
+    expect(el.style.getPropertyValue("--pc-slider-pct")).toBe("90%");
+  });
+
+  it("clamps the painted percentage when a value escapes the bounds", () => {
+    const { el } = mount({ value: 50 });
+    const input = el.querySelector("[data-pc-slider-input]");
+    // jsdom does not clamp input.value the way a browser does.
+    input.value = "500";
+    fire(input);
+    expect(el.style.getPropertyValue("--pc-slider-pct")).toBe("100%");
+  });
+
+  it("paints 0% rather than dividing by zero on a collapsed range", () => {
+    const { el } = mount({ min: 5, max: 5, value: 5 });
+    expect(el.style.getPropertyValue("--pc-slider-pct")).toBe("0%");
+  });
+
+  it("writes the formatted readout with prefix and suffix", () => {
+    const { el } = mount({ value: 40, prefix: "$", suffix: "k", display: true });
+    expect(el.querySelector("[data-pc-slider-display]").textContent).toBe("$40k");
+  });
+
+  it("strips trailing zeros from the readout", () => {
+    const { el } = mount({ value: 50, display: true });
+    const input = el.querySelector("[data-pc-slider-input]");
+    input.value = "50.0";
+    fire(input);
+    expect(el.querySelector("[data-pc-slider-display]").textContent).toBe("50");
+  });
+
+  it("emits petal:slider-change with the value, bubbling", () => {
+    const { el, events } = mount({ value: 10 });
+    const input = el.querySelector("[data-pc-slider-input]");
+    input.value = "70";
+    fire(input);
+
+    const last = events[events.length - 1];
+    expect(last.detail).toEqual({ value: 70 });
+    expect(last.bubbles).toBe(true);
+  });
+
+  it("toggles the filled treatment on marks the fill has swallowed", () => {
+    const { el } = mount({ value: 50, marks: [25, 75] });
+    const [low, high] = el.querySelectorAll(".pc-slider__mark");
+    expect(low.classList.contains("pc-slider__mark--filled")).toBe(true);
+    expect(high.classList.contains("pc-slider__mark--filled")).toBe(false);
+
+    const input = el.querySelector("[data-pc-slider-input]");
+    input.value = "80";
+    fire(input);
+    expect(high.classList.contains("pc-slider__mark--filled")).toBe(true);
+  });
+
+  it("stops listening once destroyed", () => {
+    const { hook, el, events } = mount({ value: 10 });
+    const input = el.querySelector("[data-pc-slider-input]");
+    hook.destroyed();
+    const before = events.length;
+    input.value = "70";
+    fire(input);
+    expect(events.length).toBe(before);
+    mounted.length = 0;
+  });
+});
+
+describe("PetalSlider dual", () => {
+  it("sets both percentage properties on mount", () => {
+    const { el } = mount({ mode: "dual", values: [20, 80] });
+    expect(el.style.getPropertyValue("--pc-slider-pct-min")).toBe("20%");
+    expect(el.style.getPropertyValue("--pc-slider-pct-max")).toBe("80%");
+  });
+
+  it("clamps the lower thumb to the upper one when dragged past it", () => {
+    const { el } = mount({ mode: "dual", values: [20, 60] });
+    const minInput = el.querySelector("[data-pc-slider-input-min]");
+    minInput.value = "90";
+    fire(minInput);
+
+    expect(minInput.value).toBe("60");
+    expect(el.style.getPropertyValue("--pc-slider-pct-min")).toBe("60%");
+  });
+
+  it("clamps the upper thumb to the lower one when dragged past it", () => {
+    const { el } = mount({ mode: "dual", values: [40, 80] });
+    const maxInput = el.querySelector("[data-pc-slider-input-max]");
+    maxInput.value = "10";
+    fire(maxInput);
+
+    expect(maxInput.value).toBe("40");
+    expect(el.style.getPropertyValue("--pc-slider-pct-max")).toBe("40%");
+  });
+
+  it("lifts the dragged thumb when the two meet, so it can be dragged back out", () => {
+    const { el } = mount({ mode: "dual", values: [20, 60] });
+    const minInput = el.querySelector("[data-pc-slider-input-min]");
+    const maxInput = el.querySelector("[data-pc-slider-input-max]");
+
+    minInput.value = "60";
+    fire(minInput);
+    expect(minInput.style.zIndex).toBe("20");
+    expect(maxInput.style.zIndex).toBe("");
+
+    // Now drag the other one: the lift follows whichever thumb is moving.
+    maxInput.value = "60";
+    fire(maxInput);
+    expect(maxInput.style.zIndex).toBe("20");
+    expect(minInput.style.zIndex).toBe("");
+  });
+
+  it("drops the lift once the thumbs separate again", () => {
+    const { el } = mount({ mode: "dual", values: [60, 60] });
+    const minInput = el.querySelector("[data-pc-slider-input-min]");
+    minInput.value = "20";
+    fire(minInput);
+    expect(minInput.style.zIndex).toBe("");
+  });
+
+  it("writes a min to max readout", () => {
+    const { el } = mount({
+      mode: "dual",
+      values: [100, 600],
+      max: 1000,
+      prefix: "$",
+      display: true,
+    });
+    expect(el.querySelector("[data-pc-slider-display]").textContent).toBe("$100 – $600");
+  });
+
+  it("emits petal:slider-change with both values", () => {
+    const { el, events } = mount({ mode: "dual", values: [20, 80] });
+    const maxInput = el.querySelector("[data-pc-slider-input-max]");
+    maxInput.value = "70";
+    fire(maxInput);
+
+    expect(events[events.length - 1].detail).toEqual({ values: [20, 70] });
+  });
+
+  it("marks between the thumbs are filled, marks outside are not", () => {
+    const { el } = mount({ mode: "dual", values: [30, 70], marks: [10, 50, 90] });
+    const [a, b, c] = el.querySelectorAll(".pc-slider__mark");
+    expect(a.classList.contains("pc-slider__mark--filled")).toBe(false);
+    expect(b.classList.contains("pc-slider__mark--filled")).toBe(true);
+    expect(c.classList.contains("pc-slider__mark--filled")).toBe(false);
+  });
+});

--- a/test/petal/slider_test.exs
+++ b/test/petal/slider_test.exs
@@ -1,0 +1,497 @@
+defmodule PetalComponents.SliderTest do
+  use ComponentCase
+
+  import PetalComponents.Slider
+
+  # LazyHTML helpers. The interesting assertions here are structural (how many
+  # inputs, what each one posts, which element carries which percentage), so
+  # everything goes through the parsed DOM rather than substring matching.
+  defp inputs(html), do: html |> parse_html() |> LazyHTML.query("input[type=range]")
+
+  defp attrs(html, selector, name) do
+    html
+    |> parse_html()
+    |> LazyHTML.query(selector)
+    |> LazyHTML.attribute(name)
+  end
+
+  defp attr_at(html, selector, name), do: html |> attrs(selector, name) |> List.first()
+
+  describe "single thumb" do
+    test "renders one native range input carrying name, id, bounds and value" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider id="vol" name="volume" value={60} min={0} max={100} step={5} />
+        """)
+
+      assert Enum.count(inputs(html)) == 1
+      assert attr_at(html, "input[type=range]", "name") == "volume"
+      assert attr_at(html, "input[type=range]", "id") == "vol_input"
+      assert attr_at(html, "input[type=range]", "min") == "0"
+      assert attr_at(html, "input[type=range]", "max") == "100"
+      assert attr_at(html, "input[type=range]", "step") == "5"
+      assert attr_at(html, "input[type=range]", "value") == "60"
+      assert_has_class(html, "pc-slider__input")
+    end
+
+    test "the wrapper carries the server-rendered fill percentage" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider id="s" name="v" value={25} min={0} max={100} />
+        """)
+
+      assert attr_at(html, "#s", "style") =~ "--pc-slider-pct: 25.0%"
+      refute html =~ "pc-slider--dual"
+    end
+
+    test "a percentage is computed against the given bounds, not assumed 0..100" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider id="s" name="year" value={2010} min={1990} max={2030} />
+        """)
+
+      assert attr_at(html, "#s", "style") =~ "--pc-slider-pct: 50.0%"
+    end
+
+    test "a value outside the bounds is clamped server-side" do
+      assigns = %{}
+
+      high =
+        rendered_to_string(~H"""
+        <.slider id="s" name="v" value={500} min={0} max={100} />
+        """)
+
+      low =
+        rendered_to_string(~H"""
+        <.slider id="s" name="v" value={-40} min={0} max={100} />
+        """)
+
+      assert attr_at(high, "input[type=range]", "value") == "100"
+      assert attr_at(low, "input[type=range]", "value") == "0"
+    end
+
+    test "takes name, id and value from a form field" do
+      assigns = %{field: to_form(%{"volume" => "35"}, as: :mix)[:volume]}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider field={@field} min={0} max={100} />
+        """)
+
+      assert attr_at(html, "input[type=range]", "name") == "mix[volume]"
+      assert attr_at(html, "input[type=range]", "value") == "35"
+      # The label defaults to the humanised field name.
+      assert html =~ "Volume"
+    end
+  end
+
+  describe "dual thumb" do
+    test "renders two inputs posting both form field names, in order" do
+      assigns = %{
+        min_field: to_form(%{"min" => "200"}, as: :price)[:min],
+        max_field: to_form(%{"max" => "800"}, as: :price)[:max]
+      }
+
+      html =
+        rendered_to_string(~H"""
+        <.slider id="p" min_field={@min_field} max_field={@max_field} min={0} max={1000} />
+        """)
+
+      assert Enum.count(inputs(html)) == 2
+      assert attrs(html, "input[type=range]", "name") == ["price[min]", "price[max]"]
+      assert attrs(html, "input[type=range]", "value") == ["200", "800"]
+      assert attr_at(html, "input[type=range]", "id") == "p_min"
+      assert_has_class(html, "pc-slider--dual")
+    end
+
+    test "values plus a name derive both input names" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider id="p" name="price" values={[10, 90]} min={0} max={100} />
+        """)
+
+      assert attrs(html, "input[type=range]", "name") == ["price_min", "price_max"]
+      assert attrs(html, "input[type=range]", "value") == ["10", "90"]
+    end
+
+    test "min_name and max_name override the derived names" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider values={[10, 90]} min_name="from" max_name="to" />
+        """)
+
+      assert attrs(html, "input[type=range]", "name") == ["from", "to"]
+    end
+
+    test "reversed values render in order rather than painting a negative fill" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider id="p" name="p" values={[90, 10]} min={0} max={100} />
+        """)
+
+      assert attrs(html, "input[type=range]", "value") == ["10", "90"]
+      assert attr_at(html, "#p", "style") =~ "--pc-slider-pct-min: 10.0%"
+      assert attr_at(html, "#p", "style") =~ "--pc-slider-pct-max: 90.0%"
+    end
+
+    test "out-of-bounds values are clamped on both thumbs" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="p" values={[-10, 400]} min={0} max={100} />
+        """)
+
+      assert attrs(html, "input[type=range]", "value") == ["0", "100"]
+    end
+
+    test "raises when single and dual attrs are mixed" do
+      assigns = %{field: to_form(%{"a" => "1"}, as: :f)[:a]}
+
+      assert_raise ArgumentError, ~r/single-thumb `field` and dual-thumb/, fn ->
+        rendered_to_string(~H"""
+        <.slider field={@field} values={[1, 2]} />
+        """)
+      end
+    end
+
+    test "raises when only one of min_field/max_field is given" do
+      assigns = %{field: to_form(%{"a" => "1"}, as: :f)[:a]}
+
+      assert_raise ArgumentError, ~r/needs both `min_field` and `max_field`/, fn ->
+        rendered_to_string(~H"""
+        <.slider min_field={@field} />
+        """)
+      end
+    end
+  end
+
+  describe "marks" do
+    test "renders one tick per mark, positioned by percentage" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider
+          name="v"
+          value={50}
+          min={0}
+          max={100}
+          marks={[%{value: 0, label: "Min"}, %{value: 50, label: ""}, %{value: 100, label: "Max"}]}
+        />
+        """)
+
+      assert html |> parse_html() |> LazyHTML.query(".pc-slider__mark") |> Enum.count() == 3
+      assert attrs(html, ".pc-slider__mark", "data-pc-slider-mark") == ["0.0", "50.0", "100.0"]
+      assert_has_class(html, "pc-slider--marked")
+    end
+
+    test "only non-empty labels render, and the tick layer is hidden from AT" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider
+          name="v"
+          value={50}
+          marks={[%{value: 0, label: "Min"}, %{value: 50, label: ""}, %{value: 100, label: "Max"}]}
+        />
+        """)
+
+      labels = html |> parse_html() |> LazyHTML.query(".pc-slider__mark-label") |> LazyHTML.text()
+
+      assert labels =~ "Min"
+      assert labels =~ "Max"
+      assert attr_at(html, ".pc-slider__marks", "aria-hidden") == "true"
+      assert attr_at(html, ".pc-slider__mark-labels", "aria-hidden") == "true"
+    end
+
+    test "marks inside the filled region take the on-primary treatment" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider
+          name="v"
+          value={50}
+          min={0}
+          max={100}
+          marks={[%{value: 25, label: ""}, %{value: 75, label: ""}]}
+        />
+        """)
+
+      classes = attrs(html, ".pc-slider__mark", "class")
+      assert Enum.at(classes, 0) =~ "pc-slider__mark--filled"
+      refute Enum.at(classes, 1) =~ "pc-slider__mark--filled"
+    end
+
+    test "no marks means no mark layer at all" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="v" value={50} />
+        """)
+
+      refute html =~ "pc-slider__mark"
+      refute html =~ "pc-slider--marked"
+    end
+  end
+
+  describe "show_value" do
+    test "inline renders the readout in the header row with prefix and suffix" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="v" label="Discount" value={20} show_value="inline" value_suffix="%" />
+        """)
+
+      value = html |> parse_html() |> LazyHTML.query(".pc-slider__value") |> LazyHTML.text()
+      assert String.trim(value) == "20%"
+      refute html =~ "pc-slider__tooltip"
+    end
+
+    test "tooltip renders a bubble anchored to the thumb percentage" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="v" value={40} show_value="tooltip" value_prefix="$" />
+        """)
+
+      assert attr_at(html, ".pc-slider__tooltip", "style") =~
+               "--pc-slider-at: var(--pc-slider-pct)"
+
+      assert attr_at(html, ".pc-slider__tooltip", "aria-hidden") == "true"
+
+      text = html |> parse_html() |> LazyHTML.query(".pc-slider__tooltip") |> LazyHTML.text()
+      assert String.trim(text) == "$40"
+      refute html =~ "pc-slider__value"
+    end
+
+    test "dual tooltip renders one bubble per thumb" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="p" values={[10, 90]} show_value="tooltip" value_prefix="$" />
+        """)
+
+      assert html |> parse_html() |> LazyHTML.query(".pc-slider__tooltip") |> Enum.count() == 2
+      assert attr_at(html, ".pc-slider__tooltip--min", "style") =~ "var(--pc-slider-pct-min)"
+      assert attr_at(html, ".pc-slider__tooltip--max", "style") =~ "var(--pc-slider-pct-max)"
+    end
+
+    test "dual inline renders a single min to max readout" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="p" values={[10, 90]} show_value="inline" value_prefix="$" />
+        """)
+
+      value = html |> parse_html() |> LazyHTML.query(".pc-slider__value") |> LazyHTML.text()
+      assert String.trim(value) == "$10 – $90"
+    end
+
+    test "none renders neither readout" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="v" value={40} />
+        """)
+
+      refute html =~ "pc-slider__tooltip"
+      refute html =~ "pc-slider__value"
+    end
+  end
+
+  describe "orientation, size, state and class" do
+    test "orientation and size add their modifier classes" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="v" value={10} size="sm" orientation="vertical" />
+        """)
+
+      assert_has_class(html, "pc-slider--sm")
+      assert_has_class(html, "pc-slider--vertical")
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="v" value={10} size="lg" />
+        """)
+
+      assert_has_class(html, "pc-slider--lg")
+      assert_has_class(html, "pc-slider--horizontal")
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="v" value={10} />
+        """)
+
+      assert_has_class(html, "pc-slider--md")
+    end
+
+    test "disabled disables every input and dims the wrapper" do
+      assigns = %{}
+
+      single =
+        rendered_to_string(~H"""
+        <.slider name="v" value={10} disabled />
+        """)
+
+      dual =
+        rendered_to_string(~H"""
+        <.slider name="p" values={[10, 90]} disabled />
+        """)
+
+      assert_has_class(single, "pc-slider--disabled")
+      assert attrs(single, "input[type=range]", "disabled") == [""]
+      assert attrs(dual, "input[type=range]", "disabled") == ["", ""]
+
+      # And the attribute is absent, not empty, when enabled.
+      enabled =
+        rendered_to_string(~H"""
+        <.slider name="v" value={10} />
+        """)
+
+      assert attrs(enabled, "input[type=range]", "disabled") == []
+    end
+
+    test "class lands on the wrapper and rest passes through" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider id="s" name="v" value={10} class="mt-4" data-testid="vol" />
+        """)
+
+      assert attr_at(html, "#s", "class") =~ "mt-4"
+      assert attr_at(html, "#s", "data-testid") == "vol"
+    end
+
+    test "the wrapper carries the hook and the bounds the hook reads" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider id="s" name="v" value={10} min={5} max={45} value_prefix="$" value_suffix="k" />
+        """)
+
+      assert attr_at(html, "#s", "phx-hook") == "PetalSlider"
+      assert attr_at(html, "#s", "data-pc-slider-min") == "5"
+      assert attr_at(html, "#s", "data-pc-slider-max") == "45"
+      assert attr_at(html, "#s", "data-pc-slider-mode") == "single"
+      assert attr_at(html, "#s", "data-value-prefix") == "$"
+      assert attr_at(html, "#s", "data-value-suffix") == "k"
+    end
+  end
+
+  describe "accessibility" do
+    test "the native input exposes the value range without any ARIA of ours" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="v" label="Volume" value={60} min={0} max={100} />
+        """)
+
+      # role/aria-valuenow/valuemin/valuemax come from the native input, so the
+      # markup must NOT hand-roll them - min/max/value are what the browser maps.
+      assert attr_at(html, "input[type=range]", "min") == "0"
+      assert attr_at(html, "input[type=range]", "max") == "100"
+      assert attr_at(html, "input[type=range]", "value") == "60"
+      refute html =~ "aria-valuenow"
+      refute html =~ ~s(role="slider")
+    end
+
+    test "the single input gets an accessible name from the label" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="v" label="Volume" value={60} />
+        """)
+
+      assert attr_at(html, "input[type=range]", "aria-label") == "Volume"
+    end
+
+    test "each dual input gets a distinct accessible name" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="p" label="Price" values={[10, 90]} />
+        """)
+
+      assert attrs(html, "input[type=range]", "aria-label") == ["Price minimum", "Price maximum"]
+    end
+
+    test "an unlabelled slider still names its input" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider name="volume" value={10} />
+        """)
+
+      assert attr_at(html, "input[type=range]", "aria-label") == "volume"
+    end
+
+    test "the visible label points at the input it names" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider id="s" name="v" label="Volume" value={10} />
+        """)
+
+      assert attr_at(html, "label", "for") == "s_input"
+    end
+  end
+
+  describe "field integration" do
+    test "errors on a used field render as standard field errors" do
+      form = to_form(%{"v" => "90"}, as: :f)
+
+      assigns = %{
+        field: %{form[:v] | errors: [{"must be less than %{count}", [count: 50]}]}
+      }
+
+      html =
+        rendered_to_string(~H"""
+        <.slider field={@field} min={0} max={100} />
+        """)
+
+      error = html |> parse_html() |> LazyHTML.query(".pc-form-field-error") |> LazyHTML.text()
+      assert String.trim(error) == "must be less than 50"
+    end
+
+    test "no error markup when the field has none" do
+      assigns = %{field: to_form(%{"v" => "10"}, as: :f)[:v]}
+
+      html =
+        rendered_to_string(~H"""
+        <.slider field={@field} />
+        """)
+
+      refute html =~ "pc-form-field-error"
+    end
+  end
+end


### PR DESCRIPTION
Closes #608

## Summary

A first-class `<.slider>`: single and dual thumb, marks, a tooltip or inline value readout, sizes, vertical orientation and disabled. It absorbs the display work that lived in `field.ex`/`input.ex` and adds what those types could not carry.

Five parts per CONTRIBUTING.md:

- `lib/petal_components/slider.ex` (exported from `lib/petal_components.ex`)
- a `pc-slider` section in `assets/default.css`, appended as its own `@layer components` block, nothing reflowed
- `test/petal/slider_test.exs` (32 tests) and `test/js/slider.test.js` (18 tests)
- `lib/petal_components/showcase/slider.ex` + its `registry.ex` entry
- the `slider` playground page in `dev.exs`, rebuilt around `<.slider>`

Plus `### Unreleased` in `CHANGELOG.md` and deprecation notes on the `range` / `range-dual` docs.

## Native `<input type="range">`, not `role="slider"`

I went native, as the issue proposed, and the keyboard argument decided it on its own. The WAI-ARIA slider pattern's whole keyboard map — arrows, Home, End, PageUp, PageDown — plus `role="slider"`, `aria-valuemin`/`valuemax`/`valuenow`, touch and pointer handling, and form posting, all arrive for free and stay correct across browsers and assistive tech. A custom `role="slider"` implementation would mean re-implementing every one of those and getting them all right, in exchange for styling freedom I did not actually need: the track, fill, thumb, marks and tooltip are drawn as **real sibling elements** under the input, with the input's own track and thumb painted out. That sidesteps the usual native-styling ceiling, and it fixes a real bug class along the way — `dark:` and `--pc-radius` resolve on real elements but cannot on `::-webkit-slider-runnable-track` (a `dark:` variant compiles to a trailing `:where(.dark, …)` ancestor test a pseudo-element can never satisfy, which is why `.pc-range-input`'s track used to stay light in dark mode).

**On dual and native:** correct, one native input cannot carry two thumbs. Dual mode is two overlaid native inputs, each posting its own name — the technique the existing `pc-dual-range` already uses. That keeps both thumbs individually focusable and keyboard-operable, which a single custom two-thumb widget makes materially harder. It did not push me toward a custom implementation; it is the one place a hook is genuinely required (see below).

I verified the keyboard map by hand in the playground rather than assuming it: on the volume slider, 60 → 62 (two ArrowRights), → 72 (PageUp), → 0 (Home), → 100 (End).

## CSS-first, and the one thing the hook is for

Geometry rides `--pc-slider-pct` (and `-min`/`-max`) custom properties that the **server renders inline**, so the control paints correctly before any JS connects and with JS off entirely. The fill, both tooltips and every tick anchor off those same properties, so positioning is pure CSS with nothing measured.

`PetalSlider` does only what the client alone can know:

1. keeping the percentages live while you drag
2. the ordering invariant two overlaid inputs cannot enforce themselves, including the z-index lift when the thumbs meet (without it, one thumb becomes unreachable once they overlap)
3. emitting a bubbling `petal:slider-change` CustomEvent for apps that want the value without a form

`JS.dispatch` and CSS cannot do (1) or (2) — there is no declarative hook for "the user is dragging a native range thumb". Everything else is CSS.

## Deviations from the issue's API sketch

Three additions, no removals. Everything in the sketch is present with the sketched names and defaults.

1. **`label` added.** The sketch has no attr that can name the inputs, but an input must never be nameless. `label` is the accessible-name base *and* a visible label above the track; it defaults to the humanised field name. Dual thumbs become `"<label> minimum"` / `"<label> maximum"`, which is the naming the issue's a11y section asks for.
2. **`min_name` / `max_name` added.** The test checklist asks for dual names "from `values` + explicit names", but a single `name` cannot express two. `values` + `name` derives `"<name>_min"` / `"<name>_max"`; these two override it.
3. **`rest` applies to the wrapper, not the inputs.** The issue suggests overriding the dual thumbs' `aria-label` via `rest`, but `rest` is one bag of attributes and dual mode needs two *different* labels, so it cannot express that. `label` is the override instead. Wrapper is also where `phx-hook` and the geometry properties live, so it is the natural target.

Also: errors from the form field(s) render through `PetalComponents.Field.field_error` (merged and de-duplicated across both thumbs, matching how `field.ex` merges min/max errors), so `<.slider>` is usable directly in a form without wrapping it in `<.field>`.

**Not done from the issue:** the vertical orientation is verified in Chrome only (screenshot below). The issue asks for a VoiceOver pass, which I could not run; `writing-mode: vertical-lr` + `direction: rtl` is the standards-track approach with `appearance: slider-vertical` as the legacy WebKit fallback, and the input is unchanged otherwise, so the announcement should be identical — but that is reasoning, not a test. Firefox was likewise not exercised; the CSS carries both the `::-webkit-*` and `::-moz-*` branches, following the existing split.

## The pre-existing slider situation

Worth reporting, since it was ambiguous going in:

- **There was no `Slider` module and no slider commit history.** `git log --all -- '*slider*'` is empty, and `lib/petal_components.ex` had `slider` free, as the issue said.
- **The playground nav entry was not stale.** `main` already had a full, working `slider` page — but it demoed `<.field type="range">` and `type="range-dual"`, pulling its examples from the *Field* showcase (`~w(sliders slider_dual)a`). So the slug was real and occupied, not a placeholder.
- **Given the strict one-slug-per-component rule, I replaced that page rather than adding a second one.** The new page keeps the `slider` slug and is built entirely on `<.slider>`, with the six dials the issue specifies (mode, marks, show_value, orientation, step, size — plus disabled) and the three scenarios (price-range filter, volume, year picker), a keyboard hint line, and a closing note pointing at the deprecated field types. Verified it renders and does not fall back to the Button page.
- **`origin/dual-range-slider` is stale and superseded.** Its 10 commits are not reachable from `main`, but the feature they built *is* on `main` (squash-merged), so the branch is history, not pending work. I did not build on it; the issue's brief supersedes it.
- The Field showcase keeps its `sliders` / `slider_dual` examples so the deprecated types stay documented on petal.build; both descriptions now say they are superseded by `<.slider>`.

## Verification

| Gate | Result |
|---|---|
| `mix format --check-formatted` | clean |
| `mix compile --force --warnings-as-errors` | clean |
| `mix credo` | **zero new entries** (44 issues before and after, diffed line-for-line vs `origin/main`) |
| `mix test` | 913 → **945**, 0 failures, 1 skipped (+32) |
| `npm test` | 157 → **175** (+18) |

No test was weakened or deleted. No new dependencies — no npm package, no hex dep.

Exercised in the playground on :4023: every dial, light and dark, dual, marks, vertical, tooltip-on-hover, and keyboard-only.

## Screenshots

Light and dark of the playground page, thumbs at non-default positions so the fill/track relationship is visible.

<!-- light.png -->
<!-- dark.png -->

Also captured while verifying (happy to attach if useful): dual + vertical, marks with the tick inversion inside the fill, and the tooltip bubble anchored to the thumb.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
