### PR TITLE
feat(slide_over): bottom-sheet drawer mode for origin="bottom"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,38 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **`slide_over` gains a bottom-sheet drawer mode.** `origin="bottom"`
+  already existed, but it slid a plain full-width panel up with the same
+  chrome as a side sheet. It is now a proper mobile drawer: rounded top
+  corners on the large-panel radius rule, a grab-handle pill, a border,
+  `env(safe-area-inset-bottom)` padding under the body and footer, and
+  drag-to-dismiss. Pull the sheet down past about a quarter of its height,
+  or flick it, and it closes - through the same `hide_slide_over` path and
+  the same single `"close_slide_over"` event as escape, click-away and the
+  close button, `close_slide_over_target` included.
+
+  Five new attrs, all on the existing `slide_over/1`: `handle` (defaults to
+  `nil`, which resolves to on for bottom sheets and off everywhere else, so
+  `<.slide_over origin="bottom">` gets the pill for free), `drag_to_dismiss`,
+  `snap_points` (viewport-height fractions the drawer can rest at, e.g.
+  `[0.4, 0.9]`), `initial_snap`, and `scale_background` (off by default -
+  it transforms the page wrapper, which re-parents `position: fixed`
+  descendants; see the moduledoc).
+
+  The drag is a pointer-only enhancement layered on the dialog. Keyboard and
+  screen-reader users get exactly what they had: `role="dialog"`,
+  `aria-modal`, focus into the panel, escape to close. The handle is
+  `aria-hidden` because it is decorative, snap changes are not announced, and
+  under `prefers-reduced-motion` the sheet settles instantly instead of
+  springing. The new `PetalDrawer` hook only attaches to bottom sheets that
+  are actually draggable, snapped or scaling their background - a plain
+  bottom sheet stays CSS and `LiveView.JS` only.
+
+  Left, right and top sheets are unchanged: no handle, no hook, no new
+  markup, and every existing attr default is the same.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,84 @@
       transition-duration: 1ms;
     }
   }
+
+@layer components {
+  /* Slideover - bottom-sheet drawer mode (origin="bottom").
+     Everything here is scoped to .pc-slideover__box--drawer, a class only the
+     bottom origin gets, so left/right/top sheets are untouched. */
+
+  /* The large-panel radius rule: token x 1.2, capped, and top corners only -
+     the sheet is anchored to the bottom edge, so its bottom corners sit
+     off-screen and rounding them would just expose a sliver of overlay. */
+  .pc-slideover__box--drawer {
+    border-top-left-radius: min(calc(var(--pc-radius, 0.625rem) * 1.2), 20px);
+    border-top-right-radius: min(calc(var(--pc-radius, 0.625rem) * 1.2), 20px);
+    max-height: 92dvh;
+    /* the sheet is the drag surface and its body is the scroller; letting the
+       sheet itself scroll would put a second scroller under the finger */
+    overflow: hidden;
+    will-change: transform;
+  }
+
+  /* The pill is decorative (aria-hidden) - the drag is the interaction, not
+     this element. The hook captures pointerdown across the whole sheet head,
+     so the real drag target is far larger than the 40x4 pill. touch-action
+     stops the browser claiming the gesture as a page scroll. */
+  .pc-slideover__handle {
+    @apply flex flex-none items-center justify-center pt-3 pb-2;
+    min-height: 1.75rem;
+    touch-action: none;
+    cursor: grab;
+  }
+
+  .pc-slideover__handle__pill {
+    @apply block w-10 rounded-full bg-gray-300 dark:bg-gray-600;
+    height: 0.25rem;
+  }
+
+  .pc-slideover__box--dragging {
+    @apply select-none;
+  }
+
+  .pc-slideover__box--dragging .pc-slideover__handle {
+    cursor: grabbing;
+  }
+
+  /* Home-indicator clearance on phones. env() resolves to 0 everywhere else,
+     so this costs nothing on desktop. */
+  .pc-slideover__box--drawer .pc-slideover__content {
+    padding-bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+  }
+
+  .pc-slideover__box--drawer .pc-slideover__footer {
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+  }
+
+  /* A drawer with a footer already clears the home indicator there; doubling
+     it on the body would leave a dead gap above the action row. */
+  .pc-slideover__box--drawer:has(.pc-slideover__footer) .pc-slideover__content {
+    padding-bottom: 1.25rem;
+  }
+
+  /* scale_background: the hook toggles .pc-drawer-scaled on the consumer's
+     [data-pc-drawer-wrapper] while the drawer is open. Opt-in only - see the
+     moduledoc for why a transformed ancestor re-parents fixed descendants. */
+  [data-pc-drawer-wrapper] {
+    transition:
+      transform 300ms cubic-bezier(0.32, 0.72, 0, 1),
+      border-radius 300ms cubic-bezier(0.32, 0.72, 0, 1);
+  }
+
+  .pc-drawer-scaled {
+    transform: scale(0.96);
+    transform-origin: top center;
+    border-radius: min(calc(var(--pc-radius, 0.625rem) * 1.2), 20px);
+    overflow: hidden;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-pc-drawer-wrapper] {
+      transition-duration: 1ms;
+    }
+  }
+}

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -5424,6 +5424,283 @@ export const PetalDataTable = {
   },
 };
 
+// Bottom-sheet drag layer for <.slide_over origin="bottom">.
+//
+// Pointer physics is the one thing CSS and LiveView.JS genuinely cannot do:
+// following a finger 1:1 and then deciding, from distance AND release
+// velocity, whether the sheet springs back or closes. Everything else about
+// the drawer (radius, safe area, handle, open/close transitions) stays in CSS
+// and JS commands, and this hook is only attached when a bottom sheet is
+// actually draggable, snapped or scaling its background.
+//
+// The maths lives in pure functions below so it can be tested without a DOM.
+// Offsets are pixels DOWN from the drawer's tallest resting position: 0 is
+// fully open, larger is further off-screen.
+
+// Above the top snap the sheet should feel anchored rather than detached, so
+// overshoot is admitted at a fraction of its real size.
+export const drawerResistance = (offset, minOffset = 0, factor = 0.15) =>
+  offset < minOffset ? minOffset + (offset - minOffset) * factor : offset;
+
+// px/ms across the last few samples. A single frame pair is too noisy to tell
+// a flick from a slow drag that happened to end with one fast frame.
+export const drawerVelocity = (samples, sampleCount = 5) => {
+  if (!Array.isArray(samples) || samples.length < 2) return 0;
+  const recent = samples.slice(-sampleCount);
+  const first = recent[0];
+  const last = recent[recent.length - 1];
+  const elapsed = last.time - first.time;
+  if (elapsed <= 0) return 0;
+  return (last.y - first.y) / elapsed;
+};
+
+// Where a release lands: dismiss, or the snap offset to settle on.
+export const drawerSettle = ({
+  offset,
+  velocity = 0,
+  height = Infinity,
+  snapOffsets = [0],
+  dismissThreshold = 0.25,
+  velocityThreshold = 0.5,
+  dismissible = true,
+}) => {
+  const points = [...snapOffsets].sort((a, b) => a - b);
+  // largest offset is the LOWEST resting position - the one you fall off
+  const lowest = points[points.length - 1];
+  const travelled = offset - lowest;
+  const flickDown = velocity >= velocityThreshold;
+  const flickUp = velocity <= -velocityThreshold;
+
+  // Only a release below the lowest snap can dismiss. Between snaps a flick
+  // just moves to the next point, which is what keeps a snapped drawer from
+  // closing every time someone shoves it downward.
+  if (
+    dismissible &&
+    travelled > 0 &&
+    (flickDown || travelled >= height * dismissThreshold)
+  ) {
+    return { type: "dismiss" };
+  }
+
+  if (points.length > 1 && (flickDown || flickUp)) {
+    const ahead = points.filter((p) => (flickDown ? p > offset : p < offset));
+    if (ahead.length) {
+      return {
+        type: "settle",
+        offset: flickDown ? Math.min(...ahead) : Math.max(...ahead),
+      };
+    }
+  }
+
+  const nearest = points.reduce(
+    (best, p) => (Math.abs(p - offset) < Math.abs(best - offset) ? p : best),
+    points[0],
+  );
+  return { type: "settle", offset: nearest };
+};
+
+export const PetalDrawer = {
+  mounted() {
+    this.dragging = false;
+    this.pointerId = null;
+    this.samples = [];
+    this.offset = 0;
+    this.height = 0;
+
+    this.readConfig();
+
+    this.onPointerDown = this.onPointerDown.bind(this);
+    this.onPointerMove = this.onPointerMove.bind(this);
+    this.onPointerUp = this.onPointerUp.bind(this);
+    this.onResize = this.onResize.bind(this);
+
+    this.el.addEventListener("pointerdown", this.onPointerDown);
+    // move/up on the window, not the sheet: a fast flick outruns the element
+    // and we still need the release that happens past its edge
+    window.addEventListener("pointermove", this.onPointerMove);
+    window.addEventListener("pointerup", this.onPointerUp);
+    window.addEventListener("pointercancel", this.onPointerUp);
+    window.addEventListener("resize", this.onResize);
+
+    // scale_background has to track the panel opening and closing, which the
+    // JS commands drive by writing inline display on this element.
+    if (this.wrapper) {
+      this.observer = new MutationObserver(() => this.syncBackground());
+      this.observer.observe(this.el, {
+        attributes: true,
+        attributeFilter: ["style"],
+      });
+      this.syncBackground();
+    }
+
+    this.reset();
+  },
+
+  updated() {
+    const previous = this.el.dataset.snapPoints + this.el.dataset.initialSnap;
+    this.readConfig();
+    // a re-render mid-drag must not yank the sheet out from under the finger
+    if (!this.dragging && previous !== this.configKey) this.reset();
+  },
+
+  destroyed() {
+    this.el.removeEventListener("pointerdown", this.onPointerDown);
+    window.removeEventListener("pointermove", this.onPointerMove);
+    window.removeEventListener("pointerup", this.onPointerUp);
+    window.removeEventListener("pointercancel", this.onPointerUp);
+    window.removeEventListener("resize", this.onResize);
+    if (this.observer) this.observer.disconnect();
+    if (this.wrapper) this.wrapper.classList.remove("pc-drawer-scaled");
+    clearTimeout(this.timer);
+  },
+
+  readConfig() {
+    this.snapPoints = (this.el.dataset.snapPoints || "")
+      .split(",")
+      .map((n) => parseFloat(n))
+      .filter((n) => !Number.isNaN(n))
+      .sort((a, b) => a - b);
+    this.initialSnap = parseFloat(this.el.dataset.initialSnap);
+    this.dismissible = this.el.dataset.dragDismiss === "true";
+    this.configKey = this.el.dataset.snapPoints + this.el.dataset.initialSnap;
+    this.scroller = this.el.querySelector(".pc-slideover__content");
+    this.wrapper =
+      this.el.dataset.scaleBackground === "true"
+        ? document.querySelector("[data-pc-drawer-wrapper]")
+        : null;
+  },
+
+  // The sheet is sized to its tallest snap, so a point p rests (max - p) of a
+  // viewport down from the top. No snaps means one rest position at 0.
+  snapOffsets() {
+    if (!this.snapPoints.length) return [0];
+    const max = this.snapPoints[this.snapPoints.length - 1];
+    return this.snapPoints.map((p) => (max - p) * window.innerHeight);
+  },
+
+  reset() {
+    const offsets = this.snapOffsets();
+    const max = this.snapPoints[this.snapPoints.length - 1];
+    this.offset =
+      this.snapPoints.length && !Number.isNaN(this.initialSnap)
+        ? (max - this.initialSnap) * window.innerHeight
+        : offsets[0];
+    this.el.style.transition = "";
+    this.apply(this.offset);
+  },
+
+  onResize() {
+    if (!this.dragging) this.reset();
+  },
+
+  apply(offset) {
+    // An inline transform composes with the translate utility the open/close
+    // commands animate, so the drag offset and the slide can coexist.
+    this.el.style.transform = offset ? `translate3d(0, ${offset}px, 0)` : "";
+  },
+
+  isOpen() {
+    const display = this.el.style.display;
+    return display !== "" && display !== "none";
+  },
+
+  syncBackground() {
+    if (!this.wrapper) return;
+    this.wrapper.classList.toggle("pc-drawer-scaled", this.isOpen());
+  },
+
+  reducedMotion() {
+    return (
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    );
+  },
+
+  onPointerDown(e) {
+    if (this.dragging || e.isPrimary === false || e.button > 0) return;
+    const target = e.target;
+    if (!target || typeof target.closest !== "function") return;
+    // never swallow a tap meant for a control inside the sheet
+    if (target.closest("input, textarea, select, button, a, [contenteditable]"))
+      return;
+
+    // The vaul rule: claim the gesture only from the handle, or when the body
+    // has nothing left to scroll up. Otherwise inner scrolling stops working.
+    const onHandle = !!target.closest("[data-pc-drawer-handle]");
+    if (!onHandle && this.scroller && this.scroller.scrollTop > 0) return;
+
+    this.dragging = true;
+    this.pointerId = e.pointerId;
+    this.startY = e.clientY;
+    this.startOffset = this.offset;
+    this.height = this.el.offsetHeight || window.innerHeight;
+    this.samples = [{ y: e.clientY, time: e.timeStamp }];
+    clearTimeout(this.timer);
+    this.el.style.transition = "none";
+    this.el.classList.add("pc-slideover__box--dragging");
+  },
+
+  onPointerMove(e) {
+    if (!this.dragging || e.pointerId !== this.pointerId) return;
+    if (e.cancelable) e.preventDefault();
+
+    this.samples.push({ y: e.clientY, time: e.timeStamp });
+    if (this.samples.length > 8) this.samples.shift();
+
+    const raw = this.startOffset + (e.clientY - this.startY);
+    this.offset = drawerResistance(raw, Math.min(...this.snapOffsets()));
+    this.apply(this.offset);
+  },
+
+  onPointerUp(e) {
+    if (!this.dragging || e.pointerId !== this.pointerId) return;
+    this.dragging = false;
+    this.pointerId = null;
+    this.el.classList.remove("pc-slideover__box--dragging");
+
+    const result = drawerSettle({
+      offset: this.offset,
+      velocity: drawerVelocity(this.samples),
+      height: this.height,
+      snapOffsets: this.snapOffsets(),
+      dismissible: this.dismissible,
+    });
+    this.samples = [];
+
+    if (result.type === "dismiss") this.dismiss();
+    else this.settle(result.offset);
+  },
+
+  settle(offset) {
+    this.offset = offset;
+    if (this.reducedMotion()) {
+      this.apply(offset);
+      this.el.style.transition = "";
+      return;
+    }
+    this.el.style.transition = "transform 320ms cubic-bezier(0.32, 0.72, 0, 1)";
+    this.apply(offset);
+    clearTimeout(this.timer);
+    // hand the transition back to the open/close classes once parked
+    this.timer = setTimeout(() => {
+      this.el.style.transition = "";
+    }, 340);
+  },
+
+  dismiss() {
+    // Leave the drag offset where it is with no inline transition: the hide
+    // command animates the translate utility 0 -> 100% on top of it, so the
+    // sheet carries on from exactly where the finger let go. Routing through
+    // data-pc-drawer-hide means a drag closes by the same path as Escape, the
+    // close button and click-away - one "close_slide_over" event either way.
+    this.el.style.transition = "";
+    const command = this.el.getAttribute("data-pc-drawer-hide");
+    if (command && this.liveSocket) this.liveSocket.execJS(this.el, command);
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => this.reset(), 400);
+  },
+};
+
 export default {
   PetalChart,
   PetalColorScheme,
@@ -5454,4 +5731,5 @@ export default {
   PetalCommandDialog,
   PetalComboBox,
   PetalDataTable,
+  PetalDrawer,
 };

--- a/dev.exs
+++ b/dev.exs
@@ -821,6 +821,7 @@ defmodule Dev.PlaygroundLive do
          step: "whole"
        },
        slideover: %{origin: "right", width: "md"},
+       drawer: %{handle: true, drag: true, snaps: "off", scale: false},
        tabs: %{variant: "segmented", active: "overview", number: true},
        table: %{
          sort_by: "name",
@@ -1138,6 +1139,13 @@ defmodule Dev.PlaygroundLive do
 
   def handle_event("ctl_slideover", %{"k" => "width", "v" => v}, socket) when v in ~w(sm md lg),
     do: {:noreply, update(socket, :slideover, &%{&1 | width: v})}
+
+  def handle_event("ctl_drawer", %{"k" => "snaps", "v" => v}, socket) when v in ~w(off 0.4-0.9),
+    do: {:noreply, update(socket, :drawer, &%{&1 | snaps: v})}
+
+  def handle_event("ctl_drawer", %{"k" => k, "v" => v}, socket)
+      when k in ~w(handle drag scale) and v in ~w(on off),
+      do: {:noreply, update(socket, :drawer, &Map.put(&1, String.to_existing_atom(k), v == "on"))}
 
   def handle_event("close_slide_over", _, socket), do: {:noreply, socket}
 
@@ -5159,7 +5167,7 @@ defmodule Dev.PlaygroundLive do
 
   defp render_page(%{active: "slide-over"} = assigns) do
     ~H"""
-    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10" data-pc-drawer-wrapper>
       <h1 class="text-3xl font-bold tracking-tight">Slide over</h1>
       <p class="mt-2 text-gray-500 dark:text-gray-400">
         An edge-attached panel (a "sheet") for forms and detail views that don't warrant a
@@ -5247,8 +5255,148 @@ defmodule Dev.PlaygroundLive do
         </:footer>
       </.slide_over>
 
+      <h2 class="mt-12 text-lg font-semibold">Bottom-sheet drawer</h2>
+      <p class="mt-1 mb-3 text-sm text-gray-500 dark:text-gray-400">
+        <code>origin="bottom"</code>
+        is a mobile drawer: rounded top corners, a grab handle, safe-area padding, and
+        drag-to-dismiss. Grab the sheet anywhere its body is scrolled to the top and pull it
+        down, or flick it. Escape, click-away and the close button work exactly as they always
+        did - dragging routes through the same close event. Judge this one at phone width.
+      </p>
+
+      <div class="border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="flex items-center justify-center px-6 py-16">
+          <.button
+            color="gray"
+            variant="outline"
+            phx-click={PetalComponents.SlideOver.show_slide_over("bottom", "pg-drawer")}
+          >
+            <.icon name="hero-adjustments-horizontal" class="w-4 h-4 mr-1" /> Open drawer
+          </.button>
+        </div>
+
+        <div class="grid gap-5 px-6 py-5 border-t border-gray-100 md:grid-cols-2 dark:border-gray-800/80">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">handle</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Handle"
+              value={(@drawer.handle && "on") || "off"}
+              on_change="ctl_drawer"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item value="on" phx-value-k="handle" phx-value-v="on">on</:item>
+              <:item value="off" phx-value-k="handle" phx-value-v="off">off</:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">
+              drag to dismiss
+            </div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Drag to dismiss"
+              value={(@drawer.drag && "on") || "off"}
+              on_change="ctl_drawer"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item value="on" phx-value-k="drag" phx-value-v="on">on</:item>
+              <:item value="off" phx-value-k="drag" phx-value-v="off">off</:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">snap points</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Snap points"
+              value={@drawer.snaps}
+              on_change="ctl_drawer"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item value="off" phx-value-k="snaps" phx-value-v="off">off</:item>
+              <:item value="0.4-0.9" phx-value-k="snaps" phx-value-v="0.4-0.9">
+                [0.4, 0.9]
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">
+              scale background
+            </div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Scale background"
+              value={(@drawer.scale && "on") || "off"}
+              on_change="ctl_drawer"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item value="on" phx-value-k="scale" phx-value-v="on">on</:item>
+              <:item value="off" phx-value-k="scale" phx-value-v="off">off</:item>
+            </.toggle_group>
+          </div>
+        </div>
+      </div>
+
+      <.slide_over
+        id="pg-drawer"
+        hide
+        origin="bottom"
+        handle={@drawer.handle}
+        drag_to_dismiss={@drawer.drag}
+        snap_points={(@drawer.snaps == "0.4-0.9" && [0.4, 0.9]) || nil}
+        initial_snap={(@drawer.snaps == "0.4-0.9" && 0.4) || nil}
+        scale_background={@drawer.scale}
+        title="Filters"
+        description="Narrow the list down"
+      >
+        <div class="flex flex-col gap-3">
+          <.field
+            :for={
+              {name, label, checked} <- [
+                {"pg_stock", "In stock", true},
+                {"pg_preorder", "Available to pre-order", false},
+                {"pg_soon", "Back in soon", false},
+                {"pg_under_50", "Under $50", true},
+                {"pg_50_150", "$50 to $150", false},
+                {"pg_over_150", "Over $150", false},
+                {"pg_free_ship", "Free shipping", false},
+                {"pg_rated", "Rated 4 stars and up", false}
+              ]
+            }
+            type="checkbox"
+            name={name}
+            value={checked}
+            label={label}
+          />
+        </div>
+        <:footer>
+          <div class="flex items-center justify-between w-full gap-4">
+            <.button
+              color="gray"
+              variant="ghost"
+              phx-click={PetalComponents.SlideOver.hide_slide_over("bottom", "pg-drawer")}
+            >
+              Clear all
+            </.button>
+            <.button phx-click={PetalComponents.SlideOver.hide_slide_over("bottom", "pg-drawer")}>
+              Show 42 results
+            </.button>
+          </div>
+        </:footer>
+      </.slide_over>
+
       <div
-        :for={ex <- examples_for(PetalComponents.Showcase.SlideOver, ~w(cart)a)}
+        :for={
+          ex <-
+            examples_for(
+              PetalComponents.Showcase.SlideOver,
+              ~w(cart filter_drawer queue_drawer action_drawer)a
+            )
+        }
         class="mt-10"
       >
         <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>

--- a/lib/petal_components/showcase/slide_over.ex
+++ b/lib/petal_components/showcase/slide_over.ex
@@ -107,4 +107,192 @@ defmodule PetalComponents.Showcase.SlideOver do
     </.slide_over>
     """
   end
+
+  example :filter_drawer, "Mobile filter sheet",
+    description:
+      "origin=\"bottom\" is a drawer, not just a sheet that happens to come from below: rounded top corners, a grab handle, safe-area padding under the action row. Drag it down past about a quarter of its height, or flick it, and it closes - through the same close_slide_over event as escape or the button." do
+    ~H"""
+    <.button
+      color="gray"
+      variant="outline"
+      phx-click={show_slide_over("bottom", "showcase-sheet-filters")}
+    >
+      <.icon name="hero-adjustments-horizontal" class="w-4 h-4 mr-1" /> Filters
+      <.badge color="primary" size="sm" label="2" class="ml-2" />
+    </.button>
+
+    <.slide_over
+      id="showcase-sheet-filters"
+      hide
+      origin="bottom"
+      title="Filters"
+      description="Narrow the list down"
+    >
+      <div class="flex flex-col gap-5">
+        <div>
+          <p class="mb-2 text-xs font-medium tracking-wide text-gray-400 uppercase">Availability</p>
+          <div class="flex flex-col gap-2">
+            <.field
+              :for={
+                {name, label, checked} <- [
+                  {"filter_stock", "In stock", true},
+                  {"filter_preorder", "Available to pre-order", false},
+                  {"filter_soon", "Back in soon", false}
+                ]
+              }
+              type="checkbox"
+              name={name}
+              value={checked}
+              label={label}
+            />
+          </div>
+        </div>
+        <div>
+          <p class="mb-2 text-xs font-medium tracking-wide text-gray-400 uppercase">Price</p>
+          <div class="flex flex-col gap-2">
+            <.field
+              :for={
+                {name, label, checked} <- [
+                  {"filter_under_50", "Under $50", true},
+                  {"filter_50_150", "$50 to $150", false},
+                  {"filter_over_150", "Over $150", false}
+                ]
+              }
+              type="checkbox"
+              name={name}
+              value={checked}
+              label={label}
+            />
+          </div>
+        </div>
+      </div>
+      <:footer>
+        <div class="flex items-center justify-between w-full gap-4">
+          <.button
+            color="gray"
+            variant="ghost"
+            phx-click={hide_slide_over("bottom", "showcase-sheet-filters")}
+          >
+            Clear all
+          </.button>
+          <.button phx-click={hide_slide_over("bottom", "showcase-sheet-filters")}>
+            Show 42 results
+          </.button>
+        </div>
+      </:footer>
+    </.slide_over>
+    """
+  end
+
+  example :queue_drawer, "Queue sheet with snap points",
+    description:
+      "snap_points are viewport-height fractions the drawer can rest at, and initial_snap picks the one it opens on. This one peeks at 0.4 with the current track, then drags up to 0.9 for the whole queue. A flick skips to the next point in the direction you threw it; only a downward release below the lowest point closes it." do
+    ~H"""
+    <.button
+      color="gray"
+      variant="outline"
+      phx-click={show_slide_over("bottom", "showcase-sheet-queue")}
+    >
+      <.icon name="hero-queue-list" class="w-4 h-4 mr-1" /> Open queue
+    </.button>
+
+    <.slide_over
+      id="showcase-sheet-queue"
+      hide
+      origin="bottom"
+      snap_points={[0.4, 0.9]}
+      initial_snap={0.4}
+      title="Up next"
+      description="Drag the sheet up for the full queue"
+    >
+      <div class="flex items-center gap-3 pb-4 mb-2 border-b border-gray-100 dark:border-white/10">
+        <div class="flex items-center justify-center flex-none w-14 h-14 rounded-lg bg-primary-500/10">
+          <.icon name="hero-musical-note" class="w-6 h-6 text-primary-500" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-xs tracking-wide text-gray-400 uppercase">Now playing</p>
+          <p class="text-sm font-medium text-gray-900 truncate dark:text-gray-100">
+            Midnight in the Garden
+          </p>
+          <p class="text-xs text-gray-500 truncate dark:text-gray-400">Marlowe Hart</p>
+        </div>
+        <.icon name="hero-pause-circle" class="flex-none w-8 h-8 text-gray-400" />
+      </div>
+
+      <div class="flex flex-col divide-y divide-gray-100 dark:divide-white/10">
+        <div
+          :for={
+            {track, artist, length} <- [
+              {"Slow Tide", "Marlowe Hart", "3:41"},
+              {"Paper Lanterns", "The Wilder Sons", "4:12"},
+              {"Coastline", "Ivy Kane", "2:58"},
+              {"Halfway Home", "Marlowe Hart", "5:03"},
+              {"Blue Hour", "Ivy Kane", "3:22"},
+              {"Northbound", "The Wilder Sons", "4:47"},
+              {"Little Fires", "Ada Vance", "3:09"},
+              {"Weather Report", "Ivy Kane", "3:55"}
+            ]
+          }
+          class="flex items-center gap-3 py-3"
+        >
+          <.icon name="hero-bars-3" class="flex-none w-4 h-4 text-gray-300 dark:text-gray-600" />
+          <div class="flex-1 min-w-0">
+            <p class="text-sm text-gray-900 truncate dark:text-gray-100">{track}</p>
+            <p class="text-xs text-gray-500 truncate dark:text-gray-400">{artist}</p>
+          </div>
+          <p class="text-xs tabular-nums text-gray-400">{length}</p>
+        </div>
+      </div>
+    </.slide_over>
+    """
+  end
+
+  example :action_drawer, "Action sheet",
+    description:
+      "The classic phone pattern: a short list of actions and a cancel row. The sheet is content-height with no snap points, so it sits exactly as tall as it needs to be. Drag works from anywhere on it, not just the pill - the handle is decorative and aria-hidden." do
+    ~H"""
+    <.button
+      color="gray"
+      variant="outline"
+      phx-click={show_slide_over("bottom", "showcase-sheet-share")}
+    >
+      <.icon name="hero-share" class="w-4 h-4 mr-1" /> Share
+    </.button>
+
+    <.slide_over id="showcase-sheet-share" hide origin="bottom" title="Share this page">
+      <div class="flex flex-col -mx-2">
+        <button
+          :for={
+            {icon, label, hint} <- [
+              {"hero-link", "Copy link", "petal.build/components"},
+              {"hero-envelope", "Email a colleague", "Opens your mail client"},
+              {"hero-chat-bubble-left-right", "Post to Slack", "#design-system"},
+              {"hero-bookmark", "Save for later", "Adds to your reading list"}
+            ]
+          }
+          type="button"
+          class="flex items-center gap-3 px-2 py-3 text-left transition-colors rounded-lg cursor-pointer hover:bg-gray-50 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:hover:bg-white/5"
+        >
+          <div class="flex items-center justify-center flex-none w-9 h-9 rounded-full bg-gray-100 dark:bg-white/10">
+            <.icon name={icon} class="w-4 h-4 text-gray-500 dark:text-gray-400" />
+          </div>
+          <div class="min-w-0">
+            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">{label}</p>
+            <p class="text-xs text-gray-500 truncate dark:text-gray-400">{hint}</p>
+          </div>
+        </button>
+      </div>
+      <:footer>
+        <.button
+          color="gray"
+          variant="outline"
+          class="w-full"
+          phx-click={hide_slide_over("bottom", "showcase-sheet-share")}
+        >
+          Cancel
+        </.button>
+      </:footer>
+    </.slide_over>
+    """
+  end
 end

--- a/lib/petal_components/slide_over.ex
+++ b/lib/petal_components/slide_over.ex
@@ -1,4 +1,67 @@
 defmodule PetalComponents.SlideOver do
+  @moduledoc """
+  An edge-attached panel - a "sheet" - for forms and detail views that don't warrant a
+  full page. `origin` decides which edge it slides from.
+
+      <.slide_over id="profile" origin="right" title="Edit profile">
+        Body
+        <:footer>
+          <button>Save</button>
+        </:footer>
+      </.slide_over>
+
+  ## Bottom-sheet drawer mode
+
+  `origin="bottom"` is a first-class mobile drawer rather than a plain full-width panel:
+  rounded top corners, a border, `env(safe-area-inset-bottom)` padding, and a grab-handle
+  pill. The handle appears automatically - `handle` defaults to `nil`, which resolves to
+  `true` for `origin="bottom"` and `false` everywhere else. Pass it explicitly to override
+  in either direction.
+
+      <.slide_over id="filters" origin="bottom" title="Filters">
+        Body
+      </.slide_over>
+
+  Drag-to-dismiss is on by default for bottom sheets. Drag the sheet down past roughly a
+  quarter of its height, or flick it down, and it closes through the exact same path as
+  Escape, the close button and click-away - the server still receives one
+  `"close_slide_over"` event.
+
+      <.slide_over id="queue" origin="bottom" snap_points={[0.4, 0.9]} initial_snap={0.4}>
+        Body
+      </.slide_over>
+
+  `snap_points` are viewport-height fractions the drawer can rest at. It opens at
+  `initial_snap` (the first point when unset), drags between the points, and only a
+  downward release below the lowest point dismisses.
+
+  Dragging is a pointer-only enhancement layered over the dialog. Keyboard and
+  screen-reader users get exactly the behaviour they had before: `role="dialog"`,
+  `aria-modal`, focus moved into the panel on open, Escape to close. The handle is
+  `aria-hidden` because it is decorative - the drag is the interaction, not the element.
+  Snap changes are visual only and are not announced. Under `prefers-reduced-motion` the
+  drawer settles instantly instead of springing.
+
+  ## The `scale_background` trade-off
+
+  `scale_background` shrinks and rounds the page behind an open drawer. It is off by
+  default because it puts a `transform` on the page wrapper, and a transformed ancestor
+  becomes the containing block for every `position: fixed` descendant - sticky headers and
+  fixed toolbars inside the page will move with it. It also forces a full-page repaint on
+  open and close. Turn it on only when the page behind the drawer is simple, and mark the
+  wrapper it should scale:
+
+      <div data-pc-drawer-wrapper>
+        <%!-- page content --%>
+      </div>
+
+      <.slide_over id="share" origin="bottom" scale_background title="Share">
+        Body
+      </.slide_over>
+
+  Left, right and top sheets are unchanged by all of the above: no handle, no drag, no
+  hook.
+  """
   use Phoenix.Component
   alias Phoenix.LiveView.JS
   import PetalComponents.Helpers, only: [compose_js: 2]
@@ -49,6 +112,36 @@ defmodule PetalComponents.SlideOver do
     default: %JS{},
     doc: "additional JS commands to run when the slide over closes"
 
+  attr(:handle, :boolean,
+    default: nil,
+    doc:
+      ~s|show the grab-handle pill. Defaults to true when origin="bottom", false otherwise. Set explicitly to override.|
+  )
+
+  attr(:drag_to_dismiss, :boolean,
+    default: true,
+    doc:
+      ~s|for origin="bottom": drag the sheet down past a threshold (or flick with enough velocity) to dismiss. Pointer-only; Escape and the close button always work regardless. Ignored for other origins.|
+  )
+
+  attr(:snap_points, :list,
+    default: nil,
+    doc:
+      "optional list of viewport-height fractions the drawer can rest at, e.g. [0.4, 0.9]. Drag between them; a fast flick skips to the next point in the flick direction. nil means content-height with a single rest position."
+  )
+
+  attr(:initial_snap, :float,
+    default: nil,
+    doc:
+      "which snap point the drawer opens at. Must be a member of snap_points. Defaults to the first entry."
+  )
+
+  attr(:scale_background, :boolean,
+    default: false,
+    doc:
+      "scales and rounds the page behind the drawer while it is open. Off by default because it transforms the whole page (see the moduledoc for the trade-offs). Requires the consumer to mark the page wrapper with data-pc-drawer-wrapper."
+  )
+
   attr(:class, :any, default: nil, doc: "CSS class")
   attr(:hide, :boolean, default: false, doc: "slideover is hidden")
   attr(:rest, :global)
@@ -60,6 +153,8 @@ defmodule PetalComponents.SlideOver do
   )
 
   def slide_over(assigns) do
+    assigns = assign_drawer(assigns)
+
     ~H"""
     <div
       {@rest}
@@ -80,7 +175,17 @@ defmodule PetalComponents.SlideOver do
       >
         <div
           id={"#{@id}-content"}
-          class={get_classes(@max_width, @origin, @class)}
+          class={[get_classes(@max_width, @origin, @class), @drawer? && "pc-slideover__box--drawer"]}
+          style={@drawer_height}
+          phx-hook={@drawer_hook}
+          data-pc-drawer-hide={
+            @drawer_hook &&
+              compose_js(@on_close, hide_slide_over(@origin, @id, @close_slide_over_target))
+          }
+          data-drag-dismiss={@drawer? && @drag_to_dismiss && "true"}
+          data-snap-points={@snap_points_attr}
+          data-initial-snap={@initial_snap_attr}
+          data-scale-background={@drawer? && @scale_background && "true"}
           phx-click-away={
             @close_on_click_away &&
               compose_js(@on_close, hide_slide_over(@origin, @id, @close_slide_over_target))
@@ -91,6 +196,14 @@ defmodule PetalComponents.SlideOver do
           }
           phx-key="escape"
         >
+          <div
+            :if={@show_handle?}
+            class="pc-slideover__handle"
+            data-pc-drawer-handle
+            aria-hidden="true"
+          >
+            <span class="pc-slideover__handle__pill"></span>
+          </div>
           <!-- Header -->
           <div class="pc-slideover__header">
             <div class="pc-slideover__header__container">
@@ -220,6 +333,56 @@ defmodule PetalComponents.SlideOver do
 
     [slide_over_classes, max_width_class, base_classes, custom_classes]
   end
+
+  # Bottom sheets are the only origin with a drag layer, so everything the hook
+  # needs is resolved here and emitted as data attributes. Side sheets fall
+  # through with every drawer assign nil - no handle, no hook, no new markup.
+  defp assign_drawer(assigns) do
+    drawer? = assigns.origin == "bottom"
+    snaps = drawer? && normalize_snap_points(assigns.snap_points)
+
+    assigns
+    |> assign(:drawer?, drawer?)
+    |> assign(:show_handle?, resolve_handle(assigns.handle, drawer?))
+    |> assign(:drawer_hook, drawer_hook(assigns, drawer?, snaps))
+    |> assign(:snap_points_attr, snaps && Enum.map_join(snaps, ",", &to_string/1))
+    |> assign(:initial_snap_attr, snaps && to_string(resolve_initial_snap(assigns, snaps)))
+    |> assign(:drawer_height, snaps && "height: #{Enum.max(snaps) * 100}dvh")
+  end
+
+  # nil means "whatever suits this origin"; an explicit boolean always wins.
+  defp resolve_handle(nil, drawer?), do: drawer?
+  defp resolve_handle(handle, _drawer?), do: handle
+
+  # Only bottom sheets that actually do something pointer-driven pay for a hook.
+  # A plain non-draggable bottom sheet stays CSS + LiveView.JS only.
+  defp drawer_hook(_assigns, false, _snaps), do: nil
+
+  defp drawer_hook(assigns, true, snaps) do
+    if assigns.drag_to_dismiss || snaps || assigns.scale_background do
+      "PetalDrawer"
+    end
+  end
+
+  defp normalize_snap_points(points) when is_list(points) and points != [] do
+    points
+    |> Enum.filter(&is_number/1)
+    |> Enum.sort()
+    |> case do
+      [] -> nil
+      sorted -> sorted
+    end
+  end
+
+  defp normalize_snap_points(_points), do: nil
+
+  # An initial_snap that isn't one of the points would leave the hook resting at a
+  # position the user can never drag back to, so fall back to the lowest point.
+  defp resolve_initial_snap(%{initial_snap: initial}, snaps) when is_number(initial) do
+    if initial in snaps, do: initial, else: List.first(snaps)
+  end
+
+  defp resolve_initial_snap(_assigns, snaps), do: List.first(snaps)
 
   defp get_margin_classes(margin) do
     case margin do

--- a/test/js/drawer.test.js
+++ b/test/js/drawer.test.js
@@ -1,0 +1,352 @@
+// PetalDrawer hook: the bottom-sheet drag layer.
+//
+// The physics is pure - offsets are pixels DOWN from the drawer's tallest
+// resting position, so 0 is fully open and larger is further off-screen. The
+// specs below pin the two decisions that matter on release: did this drag go
+// far enough, or fast enough, to mean "close".
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import hooks, {
+  drawerResistance,
+  drawerSettle,
+  drawerVelocity,
+  PetalDrawer,
+} from "../../assets/js/petal_components.js";
+
+// a viewport-sized sheet: 800px tall drawer in an 800px viewport
+const HEIGHT = 800;
+
+describe("drawerResistance", () => {
+  it("passes ordinary downward drag through untouched", () => {
+    expect(drawerResistance(120, 0)).toBe(120);
+    expect(drawerResistance(0, 0)).toBe(0);
+  });
+
+  it("rubber-bands above the top snap so the sheet feels anchored", () => {
+    // 100px of pull above the top only buys 15px of travel
+    expect(drawerResistance(-100, 0)).toBeCloseTo(-15);
+    expect(drawerResistance(-100, 0, 0.5)).toBeCloseTo(-50);
+  });
+
+  it("measures resistance from the top snap, not from zero", () => {
+    // top snap is 200px down; pulling to 100 is 100px of overshoot
+    expect(drawerResistance(100, 200)).toBeCloseTo(185);
+    expect(drawerResistance(250, 200)).toBe(250);
+  });
+});
+
+describe("drawerVelocity", () => {
+  it("is zero without at least two samples", () => {
+    expect(drawerVelocity([])).toBe(0);
+    expect(drawerVelocity([{ y: 10, time: 1 }])).toBe(0);
+    expect(drawerVelocity(undefined)).toBe(0);
+  });
+
+  it("reports px/ms, signed downward-positive", () => {
+    expect(
+      drawerVelocity([
+        { y: 0, time: 0 },
+        { y: 100, time: 100 },
+      ]),
+    ).toBeCloseTo(1);
+
+    expect(
+      drawerVelocity([
+        { y: 100, time: 0 },
+        { y: 0, time: 50 },
+      ]),
+    ).toBeCloseTo(-2);
+  });
+
+  it("averages over a window, so one fast frame cannot fake a flick", () => {
+    const slowDragEndingFast = [
+      { y: 0, time: 0 },
+      { y: 10, time: 100 },
+      { y: 20, time: 200 },
+      { y: 30, time: 300 },
+      { y: 60, time: 320 },
+    ];
+    // the last pair alone reads 1.5px/ms; across the window it is ~0.19
+    expect(drawerVelocity(slowDragEndingFast)).toBeCloseTo(0.1875);
+  });
+
+  it("cannot divide by a zero time delta", () => {
+    expect(
+      drawerVelocity([
+        { y: 0, time: 5 },
+        { y: 90, time: 5 },
+      ]),
+    ).toBe(0);
+  });
+});
+
+describe("drawerSettle without snap points", () => {
+  const release = (offset, velocity = 0, extra = {}) =>
+    drawerSettle({ offset, velocity, height: HEIGHT, ...extra });
+
+  it("springs back from a short, slow drag", () => {
+    // 25% of 800 is 200px; 120px with no flick is not a dismiss
+    expect(release(120)).toEqual({ type: "settle", offset: 0 });
+  });
+
+  it("dismisses once the drag passes the distance threshold", () => {
+    expect(release(220)).toEqual({ type: "dismiss" });
+  });
+
+  it("dismisses a short flick that clears the velocity threshold", () => {
+    // 60px is well under the 200px threshold, but 0.9px/ms is a flick
+    expect(release(60, 0.9)).toEqual({ type: "dismiss" });
+  });
+
+  it("keeps a short, gentle drag even when it ends moving", () => {
+    expect(release(60, 0.2)).toEqual({ type: "settle", offset: 0 });
+  });
+
+  it("never dismisses on an upward flick", () => {
+    expect(release(150, -2)).toEqual({ type: "settle", offset: 0 });
+  });
+
+  it("never dismisses from rest, however hard the flick", () => {
+    expect(release(0, 5)).toEqual({ type: "settle", offset: 0 });
+  });
+
+  it("springs back instead of closing when dismissal is off", () => {
+    expect(release(500, 3, { dismissible: false })).toEqual({
+      type: "settle",
+      offset: 0,
+    });
+  });
+});
+
+describe("drawerSettle with snap points", () => {
+  // snaps [0.4, 0.9] in an 800px viewport: the sheet is 720px tall, so 0.9
+  // rests at offset 0 and 0.4 rests 400px down
+  const snapOffsets = [0, 400];
+  const height = 720;
+  const release = (offset, velocity = 0, extra = {}) =>
+    drawerSettle({ offset, velocity, height, snapOffsets, ...extra });
+
+  it("settles on the nearest point when released slowly", () => {
+    expect(release(120)).toEqual({ type: "settle", offset: 0 });
+    expect(release(300)).toEqual({ type: "settle", offset: 400 });
+  });
+
+  it("lets a downward flick skip to the next point down", () => {
+    // nearest is 0, but the flick direction wins
+    expect(release(100, 1.2)).toEqual({ type: "settle", offset: 400 });
+  });
+
+  it("lets an upward flick skip to the next point up", () => {
+    expect(release(340, -1.2)).toEqual({ type: "settle", offset: 0 });
+  });
+
+  it("falls back to nearest when a flick has nowhere left to go", () => {
+    // already at the top point and still flicking up
+    expect(release(0, -1.5)).toEqual({ type: "settle", offset: 0 });
+  });
+
+  it("holds a drag between points that has not passed the lowest one", () => {
+    // 180px below the lowest snap is under the 25% (180px) threshold
+    expect(release(560)).toEqual({ type: "settle", offset: 400 });
+  });
+
+  it("dismisses only below the lowest snap, past the threshold", () => {
+    expect(release(600)).toEqual({ type: "dismiss" });
+  });
+
+  it("dismisses on a flick below the lowest snap", () => {
+    expect(release(430, 1.2)).toEqual({ type: "dismiss" });
+  });
+
+  it("does not dismiss on a flick that is still above the lowest snap", () => {
+    expect(release(200, 1.2)).toEqual({ type: "settle", offset: 400 });
+  });
+
+  it("accepts snap offsets in any order", () => {
+    expect(
+      drawerSettle({ offset: 300, height, snapOffsets: [400, 0] }),
+    ).toEqual({ type: "settle", offset: 400 });
+  });
+});
+
+// A thin harness over the hook lifecycle - enough of `this` for mounted() to
+// run, and a liveSocket that records the JS command a dismiss fires.
+const mounted = [];
+
+function mount({
+  snapPoints = "",
+  initialSnap = "",
+  dragDismiss = "true",
+  scaleBackground = "",
+  scrollTop = 0,
+} = {}) {
+  const wrap = document.createElement("div");
+  wrap.innerHTML = `
+    <div data-pc-drawer-wrapper></div>
+    <div id="sheet-content" class="pc-slideover__box pc-slideover__box--drawer"
+         data-drag-dismiss="${dragDismiss}"
+         data-snap-points="${snapPoints}"
+         data-initial-snap="${initialSnap}"
+         data-scale-background="${scaleBackground}"
+         data-pc-drawer-hide='[["push",{"event":"close_slide_over"}]]'>
+      <div class="pc-slideover__handle" data-pc-drawer-handle></div>
+      <div class="pc-slideover__content"></div>
+    </div>
+  `;
+  document.body.appendChild(wrap);
+
+  const el = wrap.querySelector("#sheet-content");
+  Object.defineProperty(el.querySelector(".pc-slideover__content"), "scrollTop", {
+    value: scrollTop,
+    writable: true,
+  });
+
+  const executed = [];
+  const hook = Object.create(PetalDrawer);
+  hook.el = el;
+  hook.liveSocket = { execJS: (_el, cmd) => executed.push(cmd) };
+  hook.mounted();
+
+  mounted.push({ hook, wrap });
+  return { hook, el, wrap, executed };
+}
+
+// the hook binds pointer handlers to the window, so drive them directly -
+// jsdom has no PointerEvent and the maths is what these specs are about
+const down = (hook, target, y) =>
+  hook.onPointerDown({
+    isPrimary: true,
+    button: 0,
+    pointerId: 1,
+    clientY: y,
+    timeStamp: 0,
+    target,
+  });
+
+const move = (hook, y, time) =>
+  hook.onPointerMove({ pointerId: 1, clientY: y, timeStamp: time });
+
+const up = (hook) => hook.onPointerUp({ pointerId: 1 });
+
+describe("PetalDrawer", () => {
+  afterEach(() => {
+    mounted.splice(0).forEach(({ hook, wrap }) => {
+      hook.destroyed();
+      wrap.remove();
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("is exported on the hooks object under the name the component asks for", () => {
+    expect(hooks.PetalDrawer).toBe(PetalDrawer);
+  });
+
+  it("opens a snapped drawer at its initial snap", () => {
+    const { hook, el } = mount({ snapPoints: "0.4,0.9", initialSnap: "0.4" });
+    // (0.9 - 0.4) of the viewport down from the top of a 0.9-tall sheet
+    expect(hook.offset).toBeCloseTo(0.5 * window.innerHeight);
+    expect(el.style.transform).toContain("translate3d");
+  });
+
+  it("leaves an unsnapped drawer at rest with no transform", () => {
+    const { hook, el } = mount();
+    expect(hook.offset).toBe(0);
+    expect(el.style.transform).toBe("");
+  });
+
+  it("follows the finger downward and springs back from a short drag", () => {
+    const { hook, el } = mount();
+    const handle = el.querySelector("[data-pc-drawer-handle]");
+
+    down(hook, handle, 500);
+    // slowly - 40px over 300ms is a nudge, not a flick
+    move(hook, 540, 300);
+    expect(hook.offset).toBeCloseTo(40);
+    expect(el.classList.contains("pc-slideover__box--dragging")).toBe(true);
+
+    up(hook);
+    expect(hook.offset).toBe(0);
+    expect(el.classList.contains("pc-slideover__box--dragging")).toBe(false);
+  });
+
+  it("routes a dismissing drag through the shared hide command", () => {
+    const { hook, el, executed } = mount();
+    const handle = el.querySelector("[data-pc-drawer-handle]");
+
+    down(hook, handle, 100);
+    // a decisive flick down
+    move(hook, 200, 20);
+    move(hook, 400, 60);
+    up(hook);
+
+    expect(executed).toHaveLength(1);
+    expect(executed[0]).toContain("close_slide_over");
+  });
+
+  it("does not dismiss when drag_to_dismiss is off", () => {
+    const { hook, el, executed } = mount({ dragDismiss: "false" });
+    const handle = el.querySelector("[data-pc-drawer-handle]");
+
+    down(hook, handle, 100);
+    move(hook, 400, 60);
+    up(hook);
+
+    expect(executed).toHaveLength(0);
+    expect(hook.offset).toBe(0);
+  });
+
+  it("ignores a pointer landing on a control inside the sheet", () => {
+    const { hook, el } = mount();
+    const button = document.createElement("button");
+    el.querySelector(".pc-slideover__content").appendChild(button);
+
+    down(hook, button, 500);
+    expect(hook.dragging).toBe(false);
+  });
+
+  it("leaves the drag to the body while its content is scrolled", () => {
+    const { hook, el } = mount({ scrollTop: 120 });
+
+    down(hook, el.querySelector(".pc-slideover__content"), 500);
+    expect(hook.dragging).toBe(false);
+  });
+
+  it("still drags from the handle when the body is scrolled", () => {
+    const { hook, el } = mount({ scrollTop: 120 });
+
+    down(hook, el.querySelector("[data-pc-drawer-handle]"), 500);
+    expect(hook.dragging).toBe(true);
+  });
+
+  it("scales the page wrapper only while the drawer is open", () => {
+    const { hook, el, wrap } = mount({ scaleBackground: "true" });
+    const page = wrap.querySelector("[data-pc-drawer-wrapper]");
+
+    expect(page.classList.contains("pc-drawer-scaled")).toBe(false);
+
+    el.style.display = "flex";
+    hook.syncBackground();
+    expect(page.classList.contains("pc-drawer-scaled")).toBe(true);
+
+    el.style.display = "none";
+    hook.syncBackground();
+    expect(page.classList.contains("pc-drawer-scaled")).toBe(false);
+  });
+
+  it("settles instantly under prefers-reduced-motion", () => {
+    vi.spyOn(window, "matchMedia").mockImplementation(() => ({
+      matches: true,
+      addEventListener() {},
+      removeEventListener() {},
+    }));
+
+    const { hook, el } = mount();
+    const handle = el.querySelector("[data-pc-drawer-handle]");
+
+    down(hook, handle, 500);
+    move(hook, 540, 300);
+    up(hook);
+
+    expect(el.style.transition).toBe("");
+  });
+});

--- a/test/petal/slide_over_test.exs
+++ b/test/petal/slide_over_test.exs
@@ -219,4 +219,290 @@ defmodule PetalComponents.SlideOverTest do
     assert html =~ "pc-slideover__footer"
     assert html =~ "Save"
   end
+
+  describe "bottom-sheet drawer mode" do
+    test "origin=bottom shows the grab handle by default" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" title="Filters">Body</.slide_over>
+        """)
+
+      assert html =~ "pc-slideover__handle"
+      assert html =~ "pc-slideover__handle__pill"
+      assert html =~ "data-pc-drawer-handle"
+    end
+
+    test "the handle is decorative - aria-hidden and carrying the handle class" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" title="Filters">Body</.slide_over>
+        """)
+
+      handle =
+        html
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query(".pc-slideover__handle")
+
+      assert Enum.count(handle) == 1
+      assert LazyHTML.attribute(handle, "aria-hidden") == ["true"]
+    end
+
+    test "handle={false} removes the handle from a bottom sheet" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" handle={false} title="Filters">Body</.slide_over>
+        """)
+
+      refute html =~ "pc-slideover__handle"
+    end
+
+    test "an explicit handle={true} wins on a side sheet" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="right" handle title="Filters">Body</.slide_over>
+        """)
+
+      assert html =~ "pc-slideover__handle"
+    end
+
+    test "side and top origins get no handle by default" do
+      assigns = %{}
+
+      for origin <- ~w(left right top) do
+        assigns = Map.put(assigns, :origin, origin)
+
+        html =
+          rendered_to_string(~H"""
+          <.slide_over id="sheet" origin={@origin} title="Filters">Body</.slide_over>
+          """)
+
+        refute html =~ "pc-slideover__handle"
+      end
+    end
+
+    test "only the bottom origin gets the drawer box modifier" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" title="Filters">Body</.slide_over>
+        """)
+
+      assert html =~ "pc-slideover__box--drawer"
+
+      for origin <- ~w(left right top) do
+        assigns = Map.put(assigns, :origin, origin)
+
+        html =
+          rendered_to_string(~H"""
+          <.slide_over id="sheet" origin={@origin} title="Filters">Body</.slide_over>
+          """)
+
+        refute html =~ "pc-slideover__box--drawer"
+      end
+    end
+
+    test "a draggable bottom sheet attaches the hook and its dismiss command" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" title="Filters">Body</.slide_over>
+        """)
+
+      content = html |> LazyHTML.from_fragment() |> LazyHTML.query("#sheet-content")
+
+      assert LazyHTML.attribute(content, "phx-hook") == ["PetalDrawer"]
+      assert LazyHTML.attribute(content, "data-drag-dismiss") == ["true"]
+      # dragging closes through the same command as escape and the close button
+      assert [command] = LazyHTML.attribute(content, "data-pc-drawer-hide")
+      assert command =~ "close_slide_over"
+    end
+
+    test "the drag dismiss command carries close_slide_over_target" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" close_slide_over_target="#lc" title="Filters">
+          Body
+        </.slide_over>
+        """)
+
+      content = html |> LazyHTML.from_fragment() |> LazyHTML.query("#sheet-content")
+      assert [command] = LazyHTML.attribute(content, "data-pc-drawer-hide")
+      assert command =~ "#lc"
+    end
+
+    test "snap_points and initial_snap emit the hook config" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" snap_points={[0.4, 0.9]} initial_snap={0.4}>
+          Body
+        </.slide_over>
+        """)
+
+      content = html |> LazyHTML.from_fragment() |> LazyHTML.query("#sheet-content")
+
+      assert LazyHTML.attribute(content, "phx-hook") == ["PetalDrawer"]
+      assert LazyHTML.attribute(content, "data-snap-points") == ["0.4,0.9"]
+      assert LazyHTML.attribute(content, "data-initial-snap") == ["0.4"]
+      # the sheet is sized to its tallest snap so the hook only ever translates
+      assert [style] = LazyHTML.attribute(content, "style")
+      assert style =~ "90"
+      assert style =~ "dvh"
+    end
+
+    test "snap points are sorted and initial_snap defaults to the lowest" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" snap_points={[0.9, 0.35]}>Body</.slide_over>
+        """)
+
+      content = html |> LazyHTML.from_fragment() |> LazyHTML.query("#sheet-content")
+
+      assert LazyHTML.attribute(content, "data-snap-points") == ["0.35,0.9"]
+      assert LazyHTML.attribute(content, "data-initial-snap") == ["0.35"]
+    end
+
+    test "an initial_snap outside snap_points falls back to the lowest point" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" snap_points={[0.4, 0.9]} initial_snap={0.7}>
+          Body
+        </.slide_over>
+        """)
+
+      content = html |> LazyHTML.from_fragment() |> LazyHTML.query("#sheet-content")
+      assert LazyHTML.attribute(content, "data-initial-snap") == ["0.4"]
+    end
+
+    test "a plain bottom sheet with nothing pointer-driven attaches no hook" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" drag_to_dismiss={false} title="Filters">
+          Body
+        </.slide_over>
+        """)
+
+      content = html |> LazyHTML.from_fragment() |> LazyHTML.query("#sheet-content")
+
+      assert LazyHTML.attribute(content, "phx-hook") == []
+      assert LazyHTML.attribute(content, "data-drag-dismiss") == []
+      assert LazyHTML.attribute(content, "data-pc-drawer-hide") == []
+      # it is still a drawer visually - just not a draggable one
+      assert html =~ "pc-slideover__box--drawer"
+      assert html =~ "pc-slideover__handle"
+    end
+
+    test "snap points alone attach the hook even with drag_to_dismiss off" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" drag_to_dismiss={false} snap_points={[0.4, 0.9]}>
+          Body
+        </.slide_over>
+        """)
+
+      content = html |> LazyHTML.from_fragment() |> LazyHTML.query("#sheet-content")
+
+      assert LazyHTML.attribute(content, "phx-hook") == ["PetalDrawer"]
+      assert LazyHTML.attribute(content, "data-drag-dismiss") == []
+    end
+
+    test "scale_background opts in through a data attribute" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" scale_background title="Share">Body</.slide_over>
+        """)
+
+      content = html |> LazyHTML.from_fragment() |> LazyHTML.query("#sheet-content")
+
+      assert LazyHTML.attribute(content, "data-scale-background") == ["true"]
+      assert LazyHTML.attribute(content, "phx-hook") == ["PetalDrawer"]
+    end
+
+    test "scale_background is off by default" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" title="Share">Body</.slide_over>
+        """)
+
+      content = html |> LazyHTML.from_fragment() |> LazyHTML.query("#sheet-content")
+      assert LazyHTML.attribute(content, "data-scale-background") == []
+    end
+
+    test "side origins never attach the hook, whatever the drawer attrs say" do
+      assigns = %{}
+
+      for origin <- ~w(left right top) do
+        assigns = Map.put(assigns, :origin, origin)
+
+        html =
+          rendered_to_string(~H"""
+          <.slide_over
+            id="sheet"
+            origin={@origin}
+            snap_points={[0.4, 0.9]}
+            initial_snap={0.4}
+            scale_background
+          >
+            Body
+          </.slide_over>
+          """)
+
+        content = html |> LazyHTML.from_fragment() |> LazyHTML.query("#sheet-content")
+
+        assert LazyHTML.attribute(content, "phx-hook") == []
+        assert LazyHTML.attribute(content, "data-snap-points") == []
+        assert LazyHTML.attribute(content, "data-initial-snap") == []
+        assert LazyHTML.attribute(content, "data-scale-background") == []
+        assert LazyHTML.attribute(content, "data-drag-dismiss") == []
+      end
+    end
+
+    test "the drawer leaves the dialog semantics exactly as they were" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.slide_over id="sheet" origin="bottom" title="Filters" description="Narrow the list">
+          Body
+          <:footer>
+            <button>Apply</button>
+          </:footer>
+        </.slide_over>
+        """)
+
+      dialog = html |> LazyHTML.from_fragment() |> LazyHTML.query("[role=dialog]")
+
+      assert LazyHTML.attribute(dialog, "aria-modal") == ["true"]
+      assert LazyHTML.attribute(dialog, "aria-labelledby") == ["sheet-title"]
+      assert LazyHTML.attribute(dialog, "aria-describedby") == ["sheet-description"]
+      assert html =~ "phx-window-keydown"
+      assert html =~ "phx-click-away"
+      assert html =~ "pc-slideover__footer"
+    end
+  end
 end


### PR DESCRIPTION
Closes #614

## Summary

`origin="bottom"` already existed, but it slid a plain full-width panel up with the same chrome as a side sheet. This turns it into a proper mobile drawer.

- Rounded top corners on the large-panel radius rule (`min(calc(var(--pc-radius) * 1.2), 20px)`), top corners only since the bottom two are off-screen
- Grab-handle pill, `aria-hidden` because it is decorative
- `env(safe-area-inset-bottom)` padding on the body and footer
- `max-height: 92dvh` with the body scrolling inside it
- Drag-to-dismiss: distance threshold (25% of sheet height) **or** release velocity, with rubber-band resistance above the top snap
- Optional `snap_points` as viewport-height fractions, opening at `initial_snap`. A flick skips to the next point in its direction; only a downward release below the lowest point dismisses
- Opt-in `scale_background` for the vaul-style page shrink

Five new attrs, all on the existing `slide_over/1`: `handle`, `drag_to_dismiss`, `snap_points`, `initial_snap`, `scale_background`. `handle` defaults to `nil`, which resolves to on for bottom sheets and off elsewhere, so a bare `<.slide_over origin="bottom">` gets the pill with no configuration.

Dismissal always routes through `hide_slide_over/3` via a `data-pc-drawer-hide` attribute the hook `execJS`'s, so the server sees one `"close_slide_over"` event with the same `close_slide_over_target` whether the user drags, taps away, presses escape or clicks the close button.

Accessibility is unchanged. The drag is a pointer-only enhancement layered over the existing dialog: `role="dialog"`, `aria-modal`, `focus_first` on open, escape and click-away all behave exactly as before. No new keyboard bindings, no ARIA on the drag mechanics, snap changes not announced, `prefers-reduced-motion` settles instantly instead of springing.

## Backward compatibility

**No existing attr default changed and no existing test was modified.** The diff on `test/petal/slide_over_test.exs` is additions only — `git diff` shows zero deleted lines in that file, which is the compatibility proof. All 913 pre-existing tests pass untouched.

Left, right and top sheets emit byte-identical markup: no handle, no hook, no data attributes, no new classes. A test asserts this explicitly for all three origins even when every drawer attr is passed. Verified visually too — the side sheet renders exactly as it did on `main`.

The only changed lines outside additions are three, all additive in effect:
- `class={get_classes(...)}` became `class={[get_classes(...), @drawer? && "pc-slideover__box--drawer"]}` — the modifier is `false` (dropped) for every non-bottom origin
- the playground page root gained `data-pc-drawer-wrapper` (for the `scale_background` demo)
- the playground's showcase list gained the three new example ids

`assets/default.css` is appended to in a fresh `@layer components { }` block; nothing existing was reflowed.

## Did you ship a hook, and why

Yes — `PetalDrawer`. Pointer-driven drag physics is the one thing CSS and `Phoenix.LiveView.JS` genuinely cannot do: following a finger 1:1 and then deciding, from distance **and** release velocity, whether the sheet springs back or closes. The specific failure without it is that there is no way to express "translate follows pointerY, and on pointerup dismiss if travelled > 25% of height OR |velocity| > 0.5px/ms" declaratively.

Kept minimal:
- The physics is three exported pure functions — `drawerResistance`, `drawerVelocity`, `drawerSettle` — unit-tested with no DOM.
- The Elixir side renders configuration only, as `data-*` attributes.
- **The hook attaches only when a bottom sheet is actually draggable, snapped or scaling its background.** A plain `drag_to_dismiss={false}` bottom sheet stays CSS + `LiveView.JS` only, and side origins never get it. There is a test for each of those.
- No new dependencies, npm or hex. The hook is hand-rolled in `assets/js/petal_components.js` like every other one.

## Deviations from the issue's sketch

1. **Handle hit target.** The issue asks for a min 44px tall touch area on the pill. A 44px block above the header pushed the title down noticeably, and faking it with a `::before` overlay would have covered the close button. Instead the handle is ~28px visually and **the hook captures pointerdown across the whole sheet head**, not just the pill — so the real drag target is the full sheet width by everything above the scrolled content, far larger than 44px. Happy to change this if you'd rather have the literal 44px pill.

2. **`initial_snap` validation.** The issue says it "must be a member of `snap_points`". Rather than raise, a value outside the list falls back to the lowest point — an `initial_snap` you can never drag back to would be a worse failure mode than a silent correction. There is a test for it. Say the word if you'd prefer it to raise.

3. **`snap_points` normalisation.** They are sorted ascending on render regardless of the order passed, so `[0.9, 0.4]` and `[0.4, 0.9]` behave identically.

4. **`scale_background` needs the hook.** It is not pointer-driven, but it has to follow the panel opening and closing, and the open/close is driven by JS commands that write inline `display` on the content element. The hook watches that with a `MutationObserver` and toggles `.pc-drawer-scaled` on `[data-pc-drawer-wrapper]`. I could not find a CSS-only way to reach a sibling page wrapper from the sheet's open state; if there's a house pattern for this I've missed, I'll switch to it.

5. **Overlay does not fade with drag position** — matching the issue's "keep it simple" instruction.

## Tests

| Suite | Before | After |
|---|---|---|
| `mix test` | 913, 0 failures, 1 skipped | **930, 0 failures, 1 skipped** |
| `npm test` | 157 | **191** |

- 17 new ExUnit tests covering handle resolution per origin, the `aria-hidden` handle, drawer-only box classes, hook attachment and non-attachment, the emitted `data-*` config, snap sorting and `initial_snap` fallback, `close_slide_over_target` in the drag command, and that dialog semantics are untouched in drawer mode.
- 34 new vitest specs in `test/js/drawer.test.js`: the threshold and velocity maths, nearest-snap resolution with and without velocity bias, rubber-band resistance, plus hook-level specs for initial snap offset, spring-back, dismiss routing through the shared hide command, ignoring taps on controls, the scroll-top capture rule, `scale_background` toggling, and reduced-motion settling.

`mix format --check-formatted`, `mix compile --force --warnings-as-errors` clean. **Credo: one entry fewer than `main`, zero new** — `SlideOver` picked up a moduledoc, which closed the existing `Modules should have a @moduledoc tag` finding.

## Verified by hand in the playground

- **Escape closes** the drawer.
- **Focus management**: pressing Enter immediately after opening activates the close button, i.e. `focus_first` still lands inside the panel and the handle does not steal focus.
- **The hook runs**: the snapped queue drawer opens at `translate3d(0px, 422px, 0px)` on a `90dvh` sheet in an 844px viewport, which is exactly the `initial_snap={0.4}` peek.
- **Side sheets visibly unchanged.**

**What I could not verify:** an end-to-end pointer drag in the browser. The automation tool's coordinate resolution mishandles `position: fixed` elements and its `eval` was unavailable, so every scripted drag landed on the page header instead of the sheet. The drag path is covered at the unit level (including dismiss routing through `data-pc-drawer-hide` with a stubbed `liveSocket`), but **it has not been exercised on a real touch device or with real pointer events** — worth a manual pass on a phone before merge.

## Screenshots

Light and dark playground pages, the drawer open at desktop and phone width, and the snapped queue drawer peeking at 0.4 — attached separately.
