### PR TITLE
feat(file_upload): the dropzone family over LiveView uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 # Changelog
+
+### Unreleased
+
+#### Added
+
+- **New `file_upload` component: the whole upload surface for a Phoenix
+  LiveView upload.** Hand it an `@uploads.<name>` from `allow_upload/3`
+  and it renders the drop zone, the file list with thumbnails and type
+  icons, per-entry progress, cancel buttons and the errors from
+  `upload_errors/1` and `upload_errors/2` in plain English. It sits on
+  top of LiveView's upload machinery rather than beside it: drag and
+  drop is `phx-drop-target`, previews are `live_img_preview`, progress
+  is `entry.progress`. No hook, no JS, no new dependencies.
+  Four variants - `dropzone`, `compact`, `avatar` and `gallery` - plus
+  an `:entry` slot when you want to render the rows yourself. The hint
+  line ("PNG or JPG, up to 8 MB, max 4 files") is derived from the
+  config, so it cannot drift from what the server will actually accept.
+  Requires a LiveView; `<.field type="file">` is still the static
+  option and is unchanged.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,267 @@
       transition-duration: 1ms;
     }
   }
+
+/* File upload - the dropzone family over Phoenix.LiveView uploads. Drag-over
+ * is LiveView's own `phx-drop-target-active` class, so the highlight is plain
+ * CSS and the component ships no hook. The native input stays in the tab
+ * order (clipped, never display:none), and because it is invisible the zone
+ * that labels it draws the focus ring on its behalf via :has(). */
+@layer components {
+  .pc-file-upload {
+    @apply flex flex-col w-full gap-3;
+  }
+
+  /* Clipped to nothing but still focusable: keyboard users tab to the input
+     and Enter/Space opens the native picker. `display: none` or `hidden`
+     would drop it out of the tab order and strand them. */
+  .pc-file-upload__input {
+    @apply absolute w-px h-px p-0 -m-px overflow-hidden whitespace-nowrap border-0;
+    clip-path: inset(50%);
+  }
+
+  /* The drop surface: a label, so clicking anywhere on it opens the picker
+     and LiveView's phx-drop-target lands on the same element. */
+  .pc-file-upload__zone {
+    @apply relative flex flex-col items-center justify-center w-full gap-1 px-6 py-10 text-center cursor-pointer;
+    @apply bg-transparent border border-dashed border-gray-300 shadow-xs;
+    @apply transition-[color,background-color,border-color,box-shadow] duration-200 ease-out;
+    @apply hover:border-gray-400 hover:bg-gray-50;
+    @apply dark:bg-gray-400/8 dark:border-gray-400/25 dark:hover:border-gray-400/40 dark:hover:bg-gray-400/12;
+    border-radius: var(--pc-radius, 0.625rem);
+  }
+
+  .pc-file-upload__zone:has(.pc-file-upload__input:focus-visible) {
+    @apply outline-hidden border-primary-500 ring-2 ring-primary-500/50;
+  }
+
+  .pc-file-upload__zone.phx-drop-target-active {
+    @apply border-primary-500 bg-primary-500/8 dark:bg-primary-500/12;
+  }
+
+  .pc-file-upload__heading {
+    @apply flex flex-col gap-0.5;
+  }
+
+  .pc-file-upload__glyph {
+    @apply w-8 h-8 text-gray-400 dark:text-gray-500;
+  }
+
+  .pc-file-upload__label {
+    @apply text-sm font-medium text-gray-900 dark:text-gray-100;
+  }
+
+  .pc-file-upload__description {
+    @apply text-sm text-gray-500 dark:text-gray-400;
+  }
+
+  /* The drag hint doubles as the polite live region, so it is faded rather
+     than removed - a live region has to stay in the accessibility tree. */
+  .pc-file-upload__live {
+    @apply absolute inset-x-0 bottom-2 text-xs font-medium opacity-0 pointer-events-none;
+    @apply text-primary-600 transition-opacity duration-150 dark:text-primary-400;
+  }
+
+  .pc-file-upload__zone.phx-drop-target-active .pc-file-upload__live {
+    @apply opacity-100;
+  }
+
+  /* File upload - entries */
+
+  .pc-file-upload__entries {
+    @apply flex flex-col gap-2 p-0 m-0 list-none;
+  }
+
+  .pc-file-upload__entry {
+    @apply list-none;
+  }
+
+  .pc-file-upload__entry-inner {
+    @apply flex items-center w-full gap-3 px-3 py-2 bg-transparent border border-gray-200;
+    @apply dark:border-gray-400/20 dark:bg-gray-400/8;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-file-upload__entry-inner--invalid {
+    @apply border-danger-500 dark:border-danger-500/70;
+  }
+
+  .pc-file-upload__media {
+    @apply flex items-center justify-center w-10 h-10 overflow-hidden shrink-0;
+    @apply bg-gray-100 dark:bg-gray-400/12;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-file-upload__thumb {
+    @apply object-cover w-full h-full;
+  }
+
+  .pc-file-upload__type-icon {
+    @apply w-5 h-5 text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-file-upload__entry-body {
+    @apply flex flex-col min-w-0 gap-1 grow;
+  }
+
+  .pc-file-upload__entry-name {
+    @apply block text-sm font-medium truncate text-gray-900 dark:text-gray-100;
+  }
+
+  .pc-file-upload__entry-meta {
+    @apply block text-xs tabular-nums text-gray-500 dark:text-gray-400;
+  }
+
+  /* File upload - progress. Mirrors pc-progress: washed track, solid fill,
+     width driven inline from entry.progress. The width transition is
+     informative, so reduced motion leaves it alone. */
+
+  .pc-file-upload__progress {
+    @apply relative flex w-full h-1 overflow-hidden rounded-full bg-primary-500/15;
+  }
+
+  .pc-file-upload__progress-bar {
+    @apply relative z-[1] block h-full rounded-full bg-primary-600;
+    @apply transition-[width] duration-500 ease-out;
+  }
+
+  .pc-file-upload__entry-inner--invalid .pc-file-upload__progress {
+    @apply bg-danger-500/15;
+  }
+
+  .pc-file-upload__entry-inner--invalid .pc-file-upload__progress-bar {
+    @apply bg-danger-600;
+  }
+
+  /* File upload - errors, matching the pc-form-field-error treatment */
+
+  .pc-file-upload__error {
+    @apply flex items-center gap-1.5 text-sm text-danger-600 dark:text-danger-400;
+  }
+
+  .pc-file-upload__error--entry {
+    @apply mt-1.5 text-xs;
+  }
+
+  .pc-file-upload__error-icon {
+    @apply w-4 h-4 shrink-0;
+  }
+
+  /* File upload - cancel */
+
+  .pc-file-upload__cancel {
+    @apply flex items-center justify-center w-7 h-7 shrink-0 cursor-pointer;
+    @apply text-gray-400 transition-colors duration-150 hover:text-gray-700;
+    @apply dark:text-gray-500 dark:hover:text-gray-200;
+    @apply focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500/50;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-file-upload__cancel-icon {
+    @apply w-4 h-4;
+  }
+
+  /* File upload - compact: a browse button, no zone */
+
+  .pc-file-upload__bar {
+    @apply flex flex-wrap items-center gap-3;
+  }
+
+  .pc-file-upload--compact .pc-file-upload__zone {
+    @apply flex-row w-auto gap-2 px-4 py-2 border-solid;
+    @apply text-sm font-medium text-gray-700 dark:text-gray-200;
+  }
+
+  .pc-file-upload--compact .pc-file-upload__glyph {
+    @apply w-4 h-4;
+  }
+
+  /* File upload - avatar: one circular preview with a replace overlay */
+
+  .pc-file-upload--avatar .pc-file-upload__zone {
+    @apply relative w-24 h-24 p-0 overflow-hidden rounded-full shrink-0;
+  }
+
+  .pc-file-upload__avatar-img {
+    @apply object-cover w-full h-full;
+  }
+
+  .pc-file-upload--avatar .pc-file-upload__glyph {
+    @apply w-10 h-10;
+  }
+
+  .pc-file-upload__overlay {
+    @apply absolute inset-0 flex items-center justify-center text-white opacity-0;
+    @apply bg-gray-900/60 transition-opacity duration-150;
+  }
+
+  .pc-file-upload--avatar .pc-file-upload__zone:hover .pc-file-upload__overlay,
+  .pc-file-upload--avatar
+    .pc-file-upload__zone:has(.pc-file-upload__input:focus-visible)
+    .pc-file-upload__overlay {
+    @apply opacity-100;
+  }
+
+  .pc-file-upload__overlay-icon {
+    @apply w-6 h-6;
+  }
+
+  /* File upload - gallery: preview tiles plus an add tile under max_entries */
+
+  .pc-file-upload__grid {
+    @apply grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4;
+  }
+
+  .pc-file-upload__tile {
+    @apply relative overflow-hidden aspect-square;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-file-upload--gallery .pc-file-upload__tile--add {
+    @apply flex flex-col items-center justify-center w-full h-full gap-1 px-2 py-2 text-center;
+  }
+
+  .pc-file-upload__tile-label {
+    @apply text-xs font-medium text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-file-upload--gallery .pc-file-upload__glyph {
+    @apply w-6 h-6;
+  }
+
+  .pc-file-upload--gallery .pc-file-upload__entry-inner {
+    @apply relative flex-col items-stretch h-full gap-0 p-0;
+  }
+
+  .pc-file-upload--gallery .pc-file-upload__media {
+    @apply w-full h-full rounded-none;
+  }
+
+  .pc-file-upload--gallery .pc-file-upload__entry-body {
+    @apply absolute inset-x-0 bottom-0 gap-1 p-2 bg-gray-900/70;
+  }
+
+  .pc-file-upload--gallery .pc-file-upload__entry-name {
+    @apply text-xs text-white;
+  }
+
+  .pc-file-upload--gallery .pc-file-upload__entry-meta {
+    @apply text-[10px] text-gray-300;
+  }
+
+  .pc-file-upload--gallery .pc-file-upload__cancel {
+    @apply absolute w-6 h-6 text-white top-1 right-1 bg-gray-900/70;
+    @apply hover:text-white hover:bg-gray-900/90 dark:text-white dark:hover:text-white;
+  }
+
+  /* Decorative fades only; the progress width transition stays, matching
+     pc-progress - it reports state rather than decorating it. */
+  @media (prefers-reduced-motion: reduce) {
+    .pc-file-upload__zone,
+    .pc-file-upload__overlay,
+    .pc-file-upload__live,
+    .pc-file-upload__cancel {
+      transition-duration: 1ms;
+    }
+  }
+}

--- a/dev.exs
+++ b/dev.exs
@@ -250,6 +250,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "switch", name: "Switch", ready: true},
         %{slug: "slider", name: "Slider", ready: true},
         %{slug: "input-otp", name: "Input OTP", ready: true},
+        %{slug: "file-upload", name: "File upload", ready: true},
         %{slug: "color-scheme", name: "Color scheme", ready: true}
       ]
     },
@@ -709,7 +710,8 @@ defmodule Dev.PlaygroundLive do
 
   def mount(_params, _session, socket) do
     {:ok,
-     assign(socket,
+     socket
+     |> assign(
        nav: @nav,
        primaries: @primaries,
        grays: @grays,
@@ -862,8 +864,44 @@ defmodule Dev.PlaygroundLive do
          two_series: false,
          gap: "cozy",
          points: 14
-       }
-     )}
+       },
+       file_upload: %{variant: "dropzone", max_entries: 4, saved: []}
+     )
+     |> allow_pg_uploads(4)}
+  end
+
+  # The file-upload page runs on real LiveView uploads, not a mock. Drag and
+  # drop, progress and cancel only exist because allow_upload/3 is wired here.
+  @pg_hero_accept ~w(.png .jpg .jpeg .gif .pdf)
+
+  defp allow_pg_uploads(socket, max_entries) do
+    socket
+    |> allow_upload(:pg_files,
+      accept: @pg_hero_accept,
+      max_entries: max_entries,
+      max_file_size: 8_000_000,
+      auto_upload: true
+    )
+    |> allow_upload(:pg_auto, accept: :any, max_entries: 3, auto_upload: true)
+    |> allow_upload(:pg_manual, accept: :any, max_entries: 3)
+    |> allow_upload(:pg_avatar,
+      accept: ~w(.png .jpg .jpeg),
+      max_entries: 1,
+      max_file_size: 2_000_000,
+      auto_upload: true
+    )
+    |> allow_upload(:pg_gallery,
+      accept: ~w(.png .jpg .jpeg .webp),
+      max_entries: 6,
+      auto_upload: true
+    )
+    # A deliberately tiny cap so visitors can trip :too_large on purpose.
+    |> allow_upload(:pg_small,
+      accept: ~w(.pdf .png .jpg),
+      max_entries: 3,
+      max_file_size: 20_000,
+      auto_upload: true
+    )
   end
 
   # Theme state lives in the URL, so any look is shareable / screenshotable.
@@ -991,6 +1029,51 @@ defmodule Dev.PlaygroundLive do
 
   def handle_event("ctl_icon", %{"v" => v}, socket) when v in ~w(left right),
     do: {:noreply, assign(socket, :icon, v)}
+
+  def handle_event("ctl_file_upload", %{"k" => "variant", "v" => v}, socket)
+      when v in ~w(dropzone compact avatar gallery),
+      do: {:noreply, update(socket, :file_upload, &%{&1 | variant: v})}
+
+  # max_entries is baked into the config at allow_upload/3 time, so changing
+  # it means dropping the config and re-allowing it.
+  def handle_event("ctl_file_upload", %{"k" => "max", "v" => v}, socket)
+      when v in ~w(1 4 8) do
+    n = String.to_integer(v)
+
+    socket =
+      socket
+      |> disallow_upload(:pg_files)
+      |> allow_upload(:pg_files,
+        accept: @pg_hero_accept,
+        max_entries: n,
+        max_file_size: 8_000_000,
+        auto_upload: true
+      )
+      |> update(:file_upload, &%{&1 | max_entries: n, saved: []})
+
+    {:noreply, socket}
+  end
+
+  # Every upload form on the page posts here; entries only reach the server
+  # because the form carries phx-change.
+  def handle_event("pg_upload_validate", _params, socket), do: {:noreply, socket}
+
+  # One cancel handler for all six demo configs. The suffix names the config
+  # and the guard keeps the atom lookup bounded to what mount already allowed.
+  def handle_event("pg_upload_cancel_" <> which, %{"ref" => ref}, socket)
+      when which in ~w(files auto manual avatar gallery small),
+      do: {:noreply, cancel_upload(socket, String.to_existing_atom("pg_" <> which), ref)}
+
+  def handle_event("pg_upload_save", _params, socket) do
+    names =
+      consume_uploaded_entries(socket, :pg_files, fn _meta, entry ->
+        # Nothing is written to disk - the playground only proves the entries
+        # made the round trip and were consumed.
+        {:ok, entry.client_name}
+      end)
+
+    {:noreply, update(socket, :file_upload, &%{&1 | saved: names})}
+  end
 
   def handle_event("flip", %{"k" => "loading"}, socket),
     do: {:noreply, update(socket, :loading, &(!&1))}
@@ -4846,6 +4929,183 @@ defmodule Dev.PlaygroundLive do
         These examples render from the shared <code>PetalComponents.Showcase.Modal</code>
         registry - the same source petal.build renders, so the playground and the marketing
         docs can't drift.
+      </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "file-upload"} = assigns) do
+    ~H"""
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">File upload</h1>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        A dropzone over Phoenix.LiveView uploads. Every upload on this page is
+        real: drag a file in, watch the progress, cancel it mid-flight. The
+        component renders the UploadConfig it is handed, so the validation and
+        the progress are the server's, not the browser's.
+      </p>
+
+      <div class="mt-8 overflow-hidden border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="px-6 py-10">
+          <form id="pg-upload-form" phx-change="pg_upload_validate" phx-submit="pg_upload_save">
+            <.file_upload
+              upload={@uploads.pg_files}
+              variant={@file_upload.variant}
+              label="Drop images or PDFs here"
+              cancel_event="pg_upload_cancel_files"
+            />
+            <div class="flex flex-wrap items-center gap-3 mt-4">
+              <.button type="submit" size="sm" disabled={@uploads.pg_files.entries == []}>
+                Save
+              </.button>
+              <span
+                :if={@file_upload.saved != []}
+                class="text-sm text-gray-500 dark:text-gray-400"
+              >
+                consumed: {Enum.join(@file_upload.saved, ", ")}
+              </span>
+            </div>
+          </form>
+        </div>
+        <div class="flex flex-wrap items-end px-4 py-4 border-t border-gray-200 gap-x-8 gap-y-4 sm:px-6 dark:border-gray-800">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">variant</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Variant"
+              value={@file_upload.variant}
+              on_change="ctl_file_upload"
+            >
+              <:item
+                :for={v <- ~w(dropzone compact avatar gallery)}
+                value={v}
+                phx-value-k="variant"
+                phx-value-v={v}
+              >
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">max_entries</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Max entries"
+              value={to_string(@file_upload.max_entries)}
+              on_change="ctl_file_upload"
+            >
+              <:item :for={v <- ~w(1 4 8)} value={v} phx-value-k="max" phx-value-v={v}>
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-4 mt-4 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        <span class="font-medium text-gray-700 dark:text-gray-200">Keyboard only:</span>
+        tab into the zone (the native input is clipped, not hidden, so it stays
+        in the tab order and the zone shows its focus ring), press Enter or
+        Space to open the picker, then tab on to each file's cancel button -
+        every one is named after its file.
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">auto_upload, both ways</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        With auto_upload the bytes start moving the moment you pick a file.
+        Without it the entries sit at 0% until the form is submitted, which is
+        why the row still has to read sensibly at zero.
+      </p>
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div class="p-4 border border-gray-200 rounded-xl dark:border-gray-800">
+          <div class="mb-3 font-mono text-xs text-gray-400">auto_upload: true</div>
+          <form id="pg-upload-auto" phx-change="pg_upload_validate">
+            <.file_upload
+              upload={@uploads.pg_auto}
+              label="Uploads on pick"
+              cancel_event="pg_upload_cancel_auto"
+            />
+          </form>
+        </div>
+        <div class="p-4 border border-gray-200 rounded-xl dark:border-gray-800">
+          <div class="mb-3 font-mono text-xs text-gray-400">auto_upload: false</div>
+          <form id="pg-upload-manual" phx-change="pg_upload_validate">
+            <.file_upload
+              upload={@uploads.pg_manual}
+              label="Waits for submit"
+              cancel_event="pg_upload_cancel_manual"
+            />
+          </form>
+        </div>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Profile photo</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        One circular target, one file. Hover or tab to it for the replace
+        overlay; pick an image and the preview takes over the circle.
+      </p>
+      <div class="p-6 border border-gray-200 rounded-xl dark:border-gray-800">
+        <form id="pg-upload-avatar" phx-change="pg_upload_validate">
+          <.file_upload
+            upload={@uploads.pg_avatar}
+            variant="avatar"
+            label="Profile photo"
+            cancel_event="pg_upload_cancel_avatar"
+          />
+        </form>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Listing photos</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        The gallery grid, six photos deep. Each tile carries its own progress
+        and cancel; the add tile bows out once the config is full.
+      </p>
+      <div class="p-6 border border-gray-200 rounded-xl dark:border-gray-800">
+        <form id="pg-upload-gallery" phx-change="pg_upload_validate">
+          <.file_upload
+            upload={@uploads.pg_gallery}
+            variant="gallery"
+            label="Listing photos"
+            cancel_event="pg_upload_cancel_gallery"
+          />
+        </form>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Documents, with a cap you can trip</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        max_file_size is set to 20 KB here on purpose. Drop anything bigger and
+        the row turns and says why, with the message tied to the file so a
+        screen reader reads the two together.
+      </p>
+      <div class="p-6 border border-gray-200 rounded-xl dark:border-gray-800">
+        <form id="pg-upload-small" phx-change="pg_upload_validate">
+          <.file_upload
+            upload={@uploads.pg_small}
+            label="Attach supporting documents"
+            cancel_event="pg_upload_cancel_small"
+          />
+        </form>
+      </div>
+
+      <div :for={ex <- PetalComponents.Showcase.FileUpload.examples()} class="mt-10">
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
+      <.showcase_props component={PetalComponents.FileUpload} function={:file_upload} />
+
+      <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        The examples above render statically from the shared
+        <code>PetalComponents.Showcase.FileUpload</code>
+        registry, so their thumbnails stay blank - <code>live_img_preview</code>
+        needs a running LiveView. The live sections at the top of this page are
+        the real thing.
       </div>
     </div>
     """

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -38,6 +38,7 @@ defmodule PetalComponents do
         Container,
         Dropdown,
         Field,
+        FileUpload,
         Form,
         Icon,
         Input,

--- a/lib/petal_components/file_upload.ex
+++ b/lib/petal_components/file_upload.ex
@@ -1,0 +1,564 @@
+defmodule PetalComponents.FileUpload do
+  @moduledoc ~S"""
+  A dropzone family that renders a `Phoenix.LiveView` upload end to end: the
+  drop surface, the file list with previews and progress, cancel buttons, and
+  human-readable errors.
+
+  **This component requires a LiveView.** It renders the state held in a
+  `Phoenix.LiveView.UploadConfig` - it does not upload anything itself. All the
+  machinery (validation, chunking, progress, previews) comes from
+  `Phoenix.LiveView.allow_upload/3`. If you only need a plain styled file input
+  in a static form, use `PetalComponents.Field` with `<.field type="file">`
+  instead; this component does not replace it.
+
+  ## Wiring it up
+
+  Three pieces: `allow_upload/3` in `mount`, the component inside a form, and
+  `consume_uploaded_entries/3` when the form is submitted.
+
+      defmodule MyAppWeb.ProfileLive do
+        use MyAppWeb, :live_view
+
+        @impl true
+        def mount(_params, _session, socket) do
+          {:ok,
+           socket
+           |> assign(:uploaded_files, [])
+           |> allow_upload(:avatar,
+             accept: ~w(.png .jpg .jpeg),
+             max_entries: 4,
+             max_file_size: 8_000_000
+           )}
+        end
+
+        @impl true
+        def render(assigns) do
+          ~H\"\"\"
+          <form id="upload-form" phx-change="validate" phx-submit="save">
+            <.file_upload upload={@uploads.avatar} label="Drop your photos here" />
+            <.button type="submit">Save</.button>
+          </form>
+          \"\"\"
+        end
+
+        # phx-change is required for the entries to reach the server at all.
+        @impl true
+        def handle_event("validate", _params, socket), do: {:noreply, socket}
+
+        # The cancel button in each entry row pushes this event with the ref.
+        @impl true
+        def handle_event("cancel-upload", %{"ref" => ref}, socket) do
+          {:noreply, cancel_upload(socket, :avatar, ref)}
+        end
+
+        @impl true
+        def handle_event("save", _params, socket) do
+          uploaded =
+            consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->
+              dest = Path.join("priv/static/uploads", entry.client_name)
+              File.cp!(path, dest)
+              {:ok, ~p"/uploads/#{entry.client_name}"}
+            end)
+
+          {:noreply, update(socket, :uploaded_files, &(&1 ++ uploaded))}
+        end
+      end
+
+  The `phx-change` form binding is not optional. Without it LiveView never
+  receives the selected entries, so the list stays empty and nothing uploads.
+
+  ## Variants
+
+      <.file_upload upload={@uploads.docs} />
+      <.file_upload upload={@uploads.docs} variant="compact" />
+      <.file_upload upload={@uploads.avatar} variant="avatar" label="Profile photo" />
+      <.file_upload upload={@uploads.photos} variant="gallery" label="Listing photos" />
+
+    * `dropzone` - a full dashed zone with a label, a hint line and the entry
+      list underneath. The default.
+    * `compact` - a browse button plus the entry list, no zone.
+    * `avatar` - a single circular preview with a replace overlay; a dashed
+      circle when empty.
+    * `gallery` - a responsive grid of preview tiles with an "add more" tile
+      while the config is under `max_entries`.
+
+  ## Drag and drop
+
+  Drag and drop is LiveView's, not ours: the drop surface carries
+  `phx-drop-target={@upload.ref}` and LiveView adds a
+  `phx-drop-target-active` class while files hover it. The highlight is plain
+  CSS keyed off that class, so there is no hook and no JS in this component.
+
+  ## The description line
+
+  With no `description`, one is derived from the config - accepted types from
+  `:accept`, the size cap from `:max_file_size`, the count from `:max_entries`:
+
+      allow_upload(:photos, accept: ~w(.png .jpg), max_entries: 4, max_file_size: 8_000_000)
+      #=> "PNG or JPG, up to 8 MB, max 4 files"
+
+  Sizes are rendered in SI units (1 KB = 1000 bytes), matching how
+  `:max_file_size` is conventionally written. Pass `description` to override,
+  or `description=""` to drop the line entirely.
+
+  ## Errors
+
+  Config-level errors (`:too_many_files`) render above the entry list;
+  entry-level errors (`:too_large`, `:not_accepted`) render inside the entry
+  row and are associated with it via `aria-describedby`. Messages are plain
+  English and live in this module - there is no i18n hook. To translate them,
+  render your own rows through the `:entry` slot.
+
+  ## Custom entry rows
+
+      <.file_upload upload={@uploads.docs}>
+        <:entry :let={entry}>
+          <span>{entry.client_name} - {entry.progress}%</span>
+        </:entry>
+      </.file_upload>
+
+  The slot replaces the whole default row, including the progress bar and the
+  cancel button, so re-add whatever you still need. `upload_errors/2` is yours
+  to render too.
+  """
+  use Phoenix.Component
+
+  import PetalComponents.Icon
+
+  @doc """
+  Renders an upload surface for a `Phoenix.LiveView.UploadConfig`.
+
+  See the module documentation for the full `allow_upload/3` wiring.
+  """
+  attr :upload, Phoenix.LiveView.UploadConfig,
+    required: true,
+    doc: "the upload config from `allow_upload/3`, e.g. `@uploads.avatar`"
+
+  attr :id, :string,
+    default: nil,
+    doc:
+      "id for the wrapper; the ARIA relationships are derived from it. Defaults to the upload ref."
+
+  attr :label, :string, default: nil, doc: "heading text inside the drop zone"
+
+  attr :description, :string,
+    default: nil,
+    doc:
+      "hint line under the label. When nil it is derived from the config - accepted " <>
+        "extensions from `:accept`, the cap from `:max_file_size`, the count from " <>
+        ~s|`:max_entries` (e.g. "PNG or JPG, up to 8 MB, max 4 files"). Pass "" for no line.|
+
+  attr :variant, :string,
+    default: "dropzone",
+    values: ["dropzone", "compact", "avatar", "gallery"],
+    doc:
+      "dropzone = full dashed zone; compact = browse button + list, no zone; " <>
+        "avatar = single circular image with a replace overlay; gallery = grid of preview tiles"
+
+  attr :cancel_event, :string,
+    default: "cancel-upload",
+    doc:
+      "phx-click event name emitted by each entry's cancel button. The parent LiveView " <>
+        "handles it and calls `cancel_upload/3` with the entry ref, sent as `phx-value-ref`."
+
+  attr :cancel_label, :string,
+    default: "Cancel upload of",
+    doc: "prefix for each cancel button's accessible name, joined with the file name"
+
+  attr :cancel_target, :any,
+    default: nil,
+    doc: "phx-target for the cancel event when used inside a LiveComponent"
+
+  attr :class, :any, default: nil, doc: "CSS class for the outer wrapper"
+  attr :rest, :global
+
+  slot :entry,
+    doc:
+      "optional custom rendering for each entry; receives the " <>
+        "`%Phoenix.LiveView.UploadEntry{}` and replaces the default entry row"
+
+  def file_upload(assigns) do
+    assigns = normalize(assigns)
+
+    ~H"""
+    <div
+      id={@id}
+      class={["pc-file-upload", "pc-file-upload--#{@variant}", @class]}
+      role="group"
+      aria-labelledby={@label && "#{@id}-label"}
+      aria-label={is_nil(@label) && "File upload"}
+      {@rest}
+    >
+      <.surface {assigns} />
+      <.config_errors upload={@upload} id={@id} />
+      <.entry_list {assigns} />
+    </div>
+    """
+  end
+
+  # The drop surface. Every variant hands the same `label` element to
+  # LiveView: it wraps the (focusable) file input, carries the drop target and
+  # acts as the click surface. Only the contents change.
+  defp surface(%{variant: "gallery"} = assigns) do
+    # The gallery's add-tile lives inside the grid, next to the entry tiles.
+    ~H"""
+    <div :if={@label || @description != ""} class="pc-file-upload__heading">
+      <span :if={@label} id={"#{@id}-label"} class="pc-file-upload__label">{@label}</span>
+      <span :if={@description != ""} class="pc-file-upload__description">{@description}</span>
+    </div>
+    """
+  end
+
+  defp surface(%{variant: "avatar"} = assigns) do
+    ~H"""
+    <div :if={@label || @description != ""} class="pc-file-upload__heading">
+      <span :if={@label} id={"#{@id}-label"} class="pc-file-upload__label">{@label}</span>
+      <span :if={@description != ""} class="pc-file-upload__description">{@description}</span>
+    </div>
+
+    <label for={@upload.ref} phx-drop-target={@upload.ref} class="pc-file-upload__zone">
+      <.live_file_input upload={@upload} class="pc-file-upload__input" />
+      <.live_img_preview
+        :if={@avatar_entry}
+        entry={@avatar_entry}
+        id={"#{@id}-avatar-preview"}
+        class="pc-file-upload__avatar-img"
+        alt={@avatar_entry.client_name}
+      />
+      <.icon
+        :if={is_nil(@avatar_entry)}
+        name="hero-user-circle"
+        class="pc-file-upload__glyph"
+        aria-hidden="true"
+      />
+      <span class="pc-file-upload__overlay" aria-hidden="true">
+        <.icon name="hero-arrow-up-tray" class="pc-file-upload__overlay-icon" />
+      </span>
+      <span class="pc-file-upload__live" aria-live="polite">{@drop_hint}</span>
+    </label>
+    """
+  end
+
+  defp surface(%{variant: "compact"} = assigns) do
+    ~H"""
+    <div class="pc-file-upload__bar">
+      <label for={@upload.ref} phx-drop-target={@upload.ref} class="pc-file-upload__zone">
+        <.live_file_input upload={@upload} class="pc-file-upload__input" />
+        <.icon name="hero-arrow-up-tray" class="pc-file-upload__glyph" aria-hidden="true" />
+        <span :if={@label} id={"#{@id}-label"} class="pc-file-upload__label">{@label}</span>
+        <span :if={is_nil(@label)} class="pc-file-upload__label">Choose files</span>
+        <span class="pc-file-upload__live" aria-live="polite">{@drop_hint}</span>
+      </label>
+      <span :if={@description != ""} class="pc-file-upload__description">{@description}</span>
+    </div>
+    """
+  end
+
+  defp surface(assigns) do
+    ~H"""
+    <label for={@upload.ref} phx-drop-target={@upload.ref} class="pc-file-upload__zone">
+      <.live_file_input upload={@upload} class="pc-file-upload__input" />
+      <.icon name="hero-cloud-arrow-up" class="pc-file-upload__glyph" aria-hidden="true" />
+      <span :if={@label} id={"#{@id}-label"} class="pc-file-upload__label">{@label}</span>
+      <span :if={is_nil(@label)} class="pc-file-upload__label">
+        Drop files here, or click to browse
+      </span>
+      <span :if={@description != ""} class="pc-file-upload__description">{@description}</span>
+      <span class="pc-file-upload__live" aria-live="polite">{@drop_hint}</span>
+    </label>
+    """
+  end
+
+  attr :upload, Phoenix.LiveView.UploadConfig, required: true
+  attr :id, :string, required: true
+
+  defp config_errors(assigns) do
+    ~H"""
+    <p
+      :for={{error, i} <- Enum.with_index(upload_errors(@upload))}
+      id={"#{@id}-error-#{i}"}
+      class="pc-file-upload__error pc-file-upload__error--config"
+    >
+      <.icon name="hero-exclamation-circle" class="pc-file-upload__error-icon" aria-hidden="true" />
+      {error_to_string(error)}
+    </p>
+    """
+  end
+
+  # The entry list. Gallery renders tiles in a grid alongside the add-tile;
+  # every other variant renders rows.
+  defp entry_list(%{variant: "gallery"} = assigns) do
+    ~H"""
+    <div class="pc-file-upload__grid">
+      <div :for={entry <- @upload.entries} class="pc-file-upload__tile">
+        <.entry_cell
+          e={entry}
+          id={@id}
+          upload={@upload}
+          custom={@entry}
+          cancel_event={@cancel_event}
+          cancel_target={@cancel_target}
+          cancel_label={@cancel_label}
+        />
+      </div>
+      <label
+        :if={length(@upload.entries) < @upload.max_entries}
+        for={@upload.ref}
+        phx-drop-target={@upload.ref}
+        class="pc-file-upload__zone pc-file-upload__tile pc-file-upload__tile--add"
+      >
+        <.live_file_input upload={@upload} class="pc-file-upload__input" />
+        <.icon name="hero-plus" class="pc-file-upload__glyph" aria-hidden="true" />
+        <span class="pc-file-upload__tile-label">Add files</span>
+        <span class="pc-file-upload__live" aria-live="polite">{@drop_hint}</span>
+      </label>
+    </div>
+    """
+  end
+
+  defp entry_list(%{variant: "avatar"} = assigns) do
+    # The avatar surface IS the preview, so only progress and errors are left
+    # to report for the single entry it holds.
+    ~H"""
+    <div :if={@avatar_entry} class="pc-file-upload__entries">
+      <div class="pc-file-upload__entry">
+        <.entry_cell
+          e={@avatar_entry}
+          id={@id}
+          upload={@upload}
+          custom={@entry}
+          cancel_event={@cancel_event}
+          cancel_target={@cancel_target}
+          cancel_label={@cancel_label}
+        />
+      </div>
+    </div>
+    """
+  end
+
+  defp entry_list(assigns) do
+    ~H"""
+    <ul :if={@upload.entries != []} class="pc-file-upload__entries">
+      <li :for={entry <- @upload.entries} class="pc-file-upload__entry">
+        <.entry_cell
+          e={entry}
+          id={@id}
+          upload={@upload}
+          custom={@entry}
+          cancel_event={@cancel_event}
+          cancel_target={@cancel_target}
+          cancel_label={@cancel_label}
+        />
+      </li>
+    </ul>
+    """
+  end
+
+  attr :e, Phoenix.LiveView.UploadEntry, required: true
+  attr :id, :string, required: true
+  attr :upload, Phoenix.LiveView.UploadConfig, required: true
+  attr :custom, :any, required: true
+  attr :cancel_event, :string, required: true
+  attr :cancel_target, :any, required: true
+  attr :cancel_label, :string, required: true
+
+  # A non-empty :entry slot replaces the whole default row.
+  defp entry_cell(%{custom: [_ | _]} = assigns) do
+    ~H"""
+    {render_slot(@custom, @e)}
+    """
+  end
+
+  defp entry_cell(assigns) do
+    assigns = assign(assigns, :entry_errors, upload_errors(assigns.upload, assigns.e))
+
+    ~H"""
+    <div
+      class={[
+        "pc-file-upload__entry-inner",
+        @entry_errors != [] && "pc-file-upload__entry-inner--invalid"
+      ]}
+      aria-describedby={@entry_errors != [] && "#{@id}-#{@e.ref}-error"}
+    >
+      <span class="pc-file-upload__media">
+        <.live_img_preview
+          :if={image?(@e)}
+          entry={@e}
+          id={"#{@id}-preview-#{@e.ref}"}
+          class="pc-file-upload__thumb"
+          alt={@e.client_name}
+        />
+        <.icon
+          :if={not image?(@e)}
+          name={type_icon(@e.client_type)}
+          class="pc-file-upload__type-icon"
+          aria-hidden="true"
+        />
+      </span>
+
+      <span class="pc-file-upload__entry-body">
+        <span class="pc-file-upload__entry-name" title={@e.client_name}>{@e.client_name}</span>
+        <span class="pc-file-upload__entry-meta">{format_bytes(@e.client_size)}</span>
+
+        <span
+          class="pc-file-upload__progress"
+          role="progressbar"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-valuenow={@e.progress}
+          aria-valuetext={"#{@e.progress}%"}
+          aria-label={"Upload progress for #{@e.client_name}"}
+        >
+          <span class="pc-file-upload__progress-bar" style={"width: #{@e.progress}%"}></span>
+        </span>
+
+        <span
+          :if={@entry_errors != []}
+          id={"#{@id}-#{@e.ref}-error"}
+          class="pc-file-upload__error pc-file-upload__error--entry"
+        >
+          <.icon
+            name="hero-exclamation-circle"
+            class="pc-file-upload__error-icon"
+            aria-hidden="true"
+          />
+          {@entry_errors |> Enum.map(&error_to_string/1) |> Enum.join(". ")}
+        </span>
+      </span>
+
+      <button
+        type="button"
+        class="pc-file-upload__cancel"
+        phx-click={@cancel_event}
+        phx-value-ref={@e.ref}
+        phx-target={@cancel_target}
+        aria-label={"#{@cancel_label} #{@e.client_name}"}
+      >
+        <.icon name="hero-x-mark" class="pc-file-upload__cancel-icon" aria-hidden="true" />
+      </button>
+    </div>
+    """
+  end
+
+  # -- assigns ---------------------------------------------------------------
+
+  defp normalize(assigns) do
+    upload = assigns.upload
+
+    assigns
+    |> assign_new(:id, fn -> nil end)
+    |> then(&assign(&1, :id, &1.id || "pc-file-upload-#{upload.ref}"))
+    |> assign(:description, assigns.description || derive_description(upload))
+    |> assign(:avatar_entry, List.first(upload.entries))
+    |> assign(:drop_hint, "Drop files to upload")
+  end
+
+  # -- copy ------------------------------------------------------------------
+
+  defp error_to_string(:too_many_files), do: "You have selected too many files"
+  defp error_to_string(:too_large), do: "This file is too large"
+  defp error_to_string(:not_accepted), do: "This file type is not accepted"
+  # Anything else - :external_client_failure, {:writer_failure, reason}, or a
+  # custom validator's reason - degrades to a generic line rather than
+  # crashing the render on an atom we have no copy for.
+  defp error_to_string(_other), do: "Upload failed, please try again"
+
+  @doc false
+  # Derives the hint line from the config: accepted types, size cap, count.
+  def derive_description(%Phoenix.LiveView.UploadConfig{} = upload) do
+    [
+      accept_phrase(upload.accept),
+      size_phrase(upload.max_file_size),
+      entries_phrase(upload.max_entries)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(", ")
+  end
+
+  defp accept_phrase(:any), do: nil
+  defp accept_phrase([]), do: nil
+  defp accept_phrase(""), do: nil
+
+  # allow_upload/3 stores :accept comma-joined, ready for the input's accept
+  # attribute, so that is what a real config hands us. The list form is the
+  # struct's own default and what hand-built configs tend to carry.
+  defp accept_phrase(accept) when is_binary(accept) do
+    accept |> String.split(",") |> Enum.map(&String.trim/1) |> accept_phrase()
+  end
+
+  defp accept_phrase(accept) when is_list(accept) do
+    accept
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.map(&accept_label/1)
+    |> Enum.uniq()
+    |> case do
+      [] -> nil
+      labels -> to_sentence(labels)
+    end
+  end
+
+  defp accept_phrase(_other), do: nil
+
+  defp accept_label("." <> ext), do: String.upcase(ext)
+
+  defp accept_label(type) do
+    case String.split(type, "/") do
+      [group, "*"] -> group <> "s"
+      [_group, sub] -> sub |> String.split("+") |> hd() |> String.upcase()
+      _ -> type
+    end
+  end
+
+  defp to_sentence([one]), do: one
+  defp to_sentence([a, b]), do: "#{a} or #{b}"
+
+  defp to_sentence(list) do
+    {rest, [last]} = Enum.split(list, -1)
+    "#{Enum.join(rest, ", ")} or #{last}"
+  end
+
+  defp size_phrase(nil), do: nil
+  defp size_phrase(bytes) when is_integer(bytes), do: "up to #{format_bytes(bytes)}"
+  defp size_phrase(_other), do: nil
+
+  defp entries_phrase(n) when is_integer(n) and n > 1, do: "max #{n} files"
+  defp entries_phrase(_other), do: nil
+
+  # -- formatting ------------------------------------------------------------
+
+  @doc false
+  # SI units, matching how :max_file_size is conventionally written
+  # (the LiveView default of 8_000_000 reads as "8 MB", not "7.6 MB").
+  def format_bytes(nil), do: ""
+  def format_bytes(bytes) when is_integer(bytes) and bytes < 1_000, do: "#{bytes} B"
+
+  def format_bytes(bytes) when is_integer(bytes) and bytes < 1_000_000,
+    do: "#{trim_float(bytes / 1_000)} KB"
+
+  def format_bytes(bytes) when is_integer(bytes) and bytes < 1_000_000_000,
+    do: "#{trim_float(bytes / 1_000_000)} MB"
+
+  def format_bytes(bytes) when is_integer(bytes), do: "#{trim_float(bytes / 1_000_000_000)} GB"
+  def format_bytes(_other), do: ""
+
+  defp trim_float(number) do
+    rounded = Float.round(number, 1)
+
+    if rounded == Float.round(rounded, 0) do
+      rounded |> trunc() |> Integer.to_string()
+    else
+      Float.to_string(rounded)
+    end
+  end
+
+  defp image?(%{client_type: "image/" <> _}), do: true
+  defp image?(_entry), do: false
+
+  defp type_icon("image/" <> _), do: "hero-photo"
+  defp type_icon("video/" <> _), do: "hero-film"
+  defp type_icon("audio/" <> _), do: "hero-musical-note"
+  defp type_icon("application/pdf"), do: "hero-document-text"
+  defp type_icon("text/" <> _), do: "hero-document-text"
+  defp type_icon("application/zip"), do: "hero-archive-box"
+  defp type_icon(_other), do: "hero-document"
+end

--- a/lib/petal_components/showcase/file_upload.ex
+++ b/lib/petal_components/showcase/file_upload.ex
@@ -1,0 +1,169 @@
+defmodule PetalComponents.Showcase.FileUpload do
+  @moduledoc false
+  use PetalComponents.Showcase,
+    component: PetalComponents.FileUpload,
+    title: "File upload"
+
+  alias Phoenix.LiveView.UploadConfig
+  alias Phoenix.LiveView.UploadEntry
+
+  # The examples render statically, so they hand the component hand-built
+  # configs rather than an @uploads assign. In your app these come from
+  # allow_upload/3 and nothing else changes.
+
+  @doc false
+  def config(ref, opts) do
+    %UploadConfig{
+      name: Keyword.get(opts, :name, :docs),
+      ref: ref,
+      accept: Keyword.get(opts, :accept, ~w(.pdf .docx)),
+      max_entries: Keyword.get(opts, :max_entries, 4),
+      max_file_size: Keyword.get(opts, :max_file_size, 8_000_000),
+      entries: Keyword.get(opts, :entries, []),
+      errors: Keyword.get(opts, :errors, [])
+    }
+  end
+
+  @doc false
+  def entry(upload_ref, ref, name, size, type, progress) do
+    %UploadEntry{
+      upload_ref: upload_ref,
+      ref: ref,
+      client_name: name,
+      client_size: size,
+      client_type: type,
+      progress: progress,
+      valid?: true,
+      done?: progress == 100
+    }
+  end
+
+  @doc false
+  def uploading_config do
+    config("sxfu1",
+      entries: [
+        entry("sxfu1", "0", "q3-forecast.pdf", 2_400_000, "application/pdf", 100),
+        entry("sxfu1", "1", "board-notes.docx", 486_000, "application/msword", 42)
+      ]
+    )
+  end
+
+  @doc false
+  def error_config do
+    config("sxfu2",
+      max_entries: 2,
+      entries: [
+        entry("sxfu2", "0", "raw-scan.pdf", 61_200_000, "application/pdf", 0),
+        entry("sxfu2", "1", "cover-letter.pdf", 94_000, "application/pdf", 100)
+      ],
+      errors: [{"sxfu2", :too_many_files}, {"0", :too_large}]
+    )
+  end
+
+  @doc false
+  def gallery_config do
+    config("sxfu4",
+      name: :photos,
+      accept: ~w(.png .jpg),
+      max_entries: 6,
+      entries: [
+        entry("sxfu4", "0", "kitchen.jpg", 1_800_000, "image/jpeg", 100),
+        entry("sxfu4", "1", "balcony.jpg", 2_100_000, "image/jpeg", 63)
+      ]
+    )
+  end
+
+  example :dropzone, "The dropzone",
+    description:
+      "Hand it an @uploads.<name> from allow_upload/3 and it renders the whole surface. The hint line is derived from the config, so the accepted types, the size cap and the file count stay true without you repeating them." do
+    ~H"""
+    <.file_upload
+      upload={PetalComponents.Showcase.FileUpload.config("sxfu0", [])}
+      label="Drop your documents here"
+    />
+    """
+  end
+
+  example :uploading, "Files in flight",
+    description:
+      "Each entry gets a type icon, its humanised size, a progress bar carrying role=progressbar, and a cancel button named after the file. Progress comes straight from entry.progress, so the bar moves as LiveView reports chunks." do
+    ~H"""
+    <.file_upload
+      upload={PetalComponents.Showcase.FileUpload.uploading_config()}
+      label="Drop your documents here"
+    />
+    """
+  end
+
+  example :errors, "Errors, config level and per entry",
+    description:
+      "upload_errors/1 and upload_errors/2 are rendered as plain English. The config-level message sits above the list, the per-entry one inside its row, tied to it with aria-describedby so a screen reader reads the file and the problem together." do
+    ~H"""
+    <.file_upload
+      upload={PetalComponents.Showcase.FileUpload.error_config()}
+      label="Attach up to two files"
+    />
+    """
+  end
+
+  example :compact, "Compact",
+    description:
+      "A browse button and the list, no zone. For forms where a full dashed rectangle would shout too loudly. Drag and drop still works, the button is the drop target." do
+    ~H"""
+    <.file_upload
+      upload={PetalComponents.Showcase.FileUpload.config("sxfu3", max_entries: 1)}
+      variant="compact"
+      label="Attach a file"
+    />
+    """
+  end
+
+  example :gallery, "Gallery",
+    description:
+      "A grid of preview tiles with the cancel button and progress on the tile itself, plus an add tile that disappears once the config hits max_entries. Thumbnails come from live_img_preview, which needs a running LiveView, so they fill in on the playground rather than here." do
+    ~H"""
+    <.file_upload
+      upload={PetalComponents.Showcase.FileUpload.gallery_config()}
+      variant="gallery"
+      label="Listing photos"
+    />
+    """
+  end
+
+  example :avatar, "Avatar",
+    description:
+      "One circular target with a replace overlay on hover and on keyboard focus. Empty here; pick a file and the preview takes over the circle." do
+    ~H"""
+    <.file_upload
+      upload={
+        PetalComponents.Showcase.FileUpload.config("sxfu5",
+          name: :avatar,
+          accept: ~w(.png .jpg),
+          max_entries: 1,
+          max_file_size: 2_000_000
+        )
+      }
+      variant="avatar"
+      label="Profile photo"
+    />
+    """
+  end
+
+  example :custom_entry, "Your own entry row",
+    description:
+      "The :entry slot hands you the %Phoenix.LiveView.UploadEntry{} and replaces the default row outright, so translated copy or a different layout costs one slot. You own the progress and cancel affordances once you take it over." do
+    ~H"""
+    <.file_upload
+      upload={PetalComponents.Showcase.FileUpload.uploading_config()}
+      label="Drop your documents here"
+    >
+      <:entry :let={entry}>
+        <div class="flex items-center justify-between w-full gap-3 text-sm">
+          <span class="font-medium truncate">{entry.client_name}</span>
+          <span class="text-gray-500 tabular-nums dark:text-gray-400">{entry.progress}%</span>
+        </div>
+      </:entry>
+    </.file_upload>
+    """
+  end
+end

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -32,6 +32,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.LanguageSelect,
     PetalComponents.Showcase.SocialButton,
     PetalComponents.Showcase.Field,
+    PetalComponents.Showcase.FileUpload,
     PetalComponents.Showcase.InputGroup,
     PetalComponents.Showcase.InputOtp,
     PetalComponents.Showcase.Loading,

--- a/test/petal/file_upload_test.exs
+++ b/test/petal/file_upload_test.exs
@@ -1,0 +1,605 @@
+defmodule PetalComponents.FileUploadTest do
+  use ComponentCase
+
+  import PetalComponents.FileUpload
+
+  alias Phoenix.LiveView.UploadConfig
+  alias Phoenix.LiveView.UploadEntry
+
+  # The render layer only reads the structs LiveView hands it, so the whole
+  # suite runs against hand-built configs - no live upload required.
+  defp config(opts \\ []) do
+    %UploadConfig{
+      name: Keyword.get(opts, :name, :docs),
+      ref: Keyword.get(opts, :ref, "phx-ref-1"),
+      accept: Keyword.get(opts, :accept, ~w(.pdf)),
+      max_entries: Keyword.get(opts, :max_entries, 3),
+      max_file_size: Keyword.get(opts, :max_file_size, 8_000_000),
+      entries: Keyword.get(opts, :entries, []),
+      errors: Keyword.get(opts, :errors, []),
+      auto_upload?: Keyword.get(opts, :auto_upload?, false)
+    }
+  end
+
+  defp entry(opts \\ []) do
+    %UploadEntry{
+      upload_ref: Keyword.get(opts, :upload_ref, "phx-ref-1"),
+      ref: Keyword.get(opts, :ref, "0"),
+      client_name: Keyword.get(opts, :client_name, "report.pdf"),
+      client_size: Keyword.get(opts, :client_size, 2_400_000),
+      client_type: Keyword.get(opts, :client_type, "application/pdf"),
+      progress: Keyword.get(opts, :progress, 40),
+      valid?: true,
+      done?: Keyword.get(opts, :progress, 40) == 100
+    }
+  end
+
+  defp query(html, selector) do
+    html |> LazyHTML.from_fragment() |> LazyHTML.query(selector)
+  end
+
+  defp attr_of(html, selector, attribute) do
+    html |> query(selector) |> LazyHTML.attribute(attribute) |> List.first()
+  end
+
+  describe "variants" do
+    test "dropzone is the default and renders the zone" do
+      assigns = %{upload: config()}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert_has_class(html, "pc-file-upload")
+      assert_has_class(html, "pc-file-upload--dropzone")
+      assert Enum.count(query(html, ".pc-file-upload__zone")) == 1
+      assert html =~ "Drop files here, or click to browse"
+    end
+
+    test "compact renders a browse bar and no dashed zone body" do
+      assigns = %{upload: config()}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} variant=\"compact\" />")
+
+      assert_has_class(html, "pc-file-upload--compact")
+      assert Enum.count(query(html, ".pc-file-upload__bar")) == 1
+      assert html =~ "Choose files"
+    end
+
+    test "avatar renders the circular target with a replace overlay" do
+      assigns = %{upload: config(max_entries: 1)}
+
+      html =
+        rendered_to_string(
+          ~H"<.file_upload upload={@upload} variant=\"avatar\" label=\"Photo\" />"
+        )
+
+      assert_has_class(html, "pc-file-upload--avatar")
+      assert Enum.count(query(html, ".pc-file-upload__overlay")) == 1
+      # empty state falls back to the placeholder glyph
+      assert has_icon?(html, "hero-user-circle")
+    end
+
+    test "avatar swaps the placeholder for a preview once an entry exists" do
+      assigns = %{upload: config(entries: [entry(client_type: "image/png")])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} variant=\"avatar\" />")
+
+      assert Enum.count(query(html, ".pc-file-upload__avatar-img")) == 1
+      refute has_icon?(html, "hero-user-circle")
+    end
+
+    test "gallery renders a tile per entry plus an add tile under max_entries" do
+      entries = [entry(ref: "0"), entry(ref: "1", client_name: "b.pdf")]
+      assigns = %{upload: config(max_entries: 6, entries: entries)}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} variant=\"gallery\" />")
+
+      assert_has_class(html, "pc-file-upload--gallery")
+      assert Enum.count(query(html, ".pc-file-upload__grid")) == 1
+      # two entry tiles + the add tile
+      assert Enum.count(query(html, ".pc-file-upload__tile")) == 3
+      assert Enum.count(query(html, ".pc-file-upload__tile--add")) == 1
+    end
+
+    test "gallery drops the add tile once max_entries is reached" do
+      entries = [entry(ref: "0"), entry(ref: "1", client_name: "b.pdf")]
+      assigns = %{upload: config(max_entries: 2, entries: entries)}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} variant=\"gallery\" />")
+
+      assert Enum.empty?(query(html, ".pc-file-upload__tile--add"))
+    end
+  end
+
+  describe "LiveView upload wiring" do
+    test "the drop target is the config ref" do
+      assigns = %{upload: config(ref: "phx-F123")}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert attr_of(html, ".pc-file-upload__zone", "phx-drop-target") == "phx-F123"
+    end
+
+    test "every variant sets phx-drop-target" do
+      for variant <- ~w(dropzone compact avatar gallery) do
+        assigns = %{upload: config(ref: "phx-F9"), variant: variant}
+        html = rendered_to_string(~H"<.file_upload upload={@upload} variant={@variant} />")
+
+        assert attr_of(html, "[phx-drop-target]", "phx-drop-target") == "phx-F9",
+               "#{variant} did not set phx-drop-target"
+      end
+    end
+
+    test "the live_file_input is rendered, keyed to the ref, and stays focusable" do
+      assigns = %{upload: config(ref: "phx-F123")}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      input = query(html, "input[type=file]")
+      assert Enum.count(input) == 1
+      assert attr_of(html, "input[type=file]", "id") == "phx-F123"
+      assert attr_of(html, "input[type=file]", "data-phx-upload-ref") == "phx-F123"
+
+      # Clipped by CSS, never removed from the tab order.
+      assert_has_class(html, "pc-file-upload__input")
+      assert LazyHTML.attribute(input, "hidden") == []
+      assert LazyHTML.attribute(input, "tabindex") == []
+      assert LazyHTML.attribute(input, "disabled") == []
+    end
+
+    test "the zone labels the input via for=" do
+      assigns = %{upload: config(ref: "phx-F123")}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert attr_of(html, "label.pc-file-upload__zone", "for") == "phx-F123"
+    end
+
+    test "multiple is set by live_file_input when max_entries > 1" do
+      assigns = %{upload: config(max_entries: 4)}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+      assert LazyHTML.attribute(query(html, "input[type=file]"), "multiple") == [""]
+
+      assigns = %{upload: config(max_entries: 1)}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+      assert LazyHTML.attribute(query(html, "input[type=file]"), "multiple") == []
+    end
+  end
+
+  describe "entry rows" do
+    test "renders the file name and a humanised size" do
+      assigns = %{upload: config(entries: [entry(client_name: "q3.pdf", client_size: 2_400_000)])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert html =~ "q3.pdf"
+      assert html =~ "2.4 MB"
+    end
+
+    test "renders one row per entry" do
+      entries = [entry(ref: "0"), entry(ref: "1", client_name: "b.pdf")]
+      assigns = %{upload: config(entries: entries)}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert Enum.count(query(html, ".pc-file-upload__entry")) == 2
+    end
+
+    test "no entry list is rendered when there are no entries" do
+      assigns = %{upload: config()}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert Enum.empty?(query(html, ".pc-file-upload__entries"))
+    end
+
+    test "the cancel button carries the event, the ref and no target by default" do
+      assigns = %{upload: config(entries: [entry(ref: "7")])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert attr_of(html, ".pc-file-upload__cancel", "phx-click") == "cancel-upload"
+      assert attr_of(html, ".pc-file-upload__cancel", "phx-value-ref") == "7"
+      assert attr_of(html, ".pc-file-upload__cancel", "type") == "button"
+      assert LazyHTML.attribute(query(html, ".pc-file-upload__cancel"), "phx-target") == []
+    end
+
+    test "cancel_event and cancel_target override the defaults" do
+      assigns = %{upload: config(entries: [entry(ref: "7")])}
+
+      html =
+        rendered_to_string(
+          ~H"<.file_upload upload={@upload} cancel_event=\"drop-it\" cancel_target=\"#me\" />"
+        )
+
+      assert attr_of(html, ".pc-file-upload__cancel", "phx-click") == "drop-it"
+      assert attr_of(html, ".pc-file-upload__cancel", "phx-target") == "#me"
+    end
+
+    test "auto_upload false still reads sensibly at 0%" do
+      assigns = %{upload: config(auto_upload?: false, entries: [entry(progress: 0)])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert html =~ "report.pdf"
+      assert attr_of(html, "[role=progressbar]", "aria-valuenow") == "0"
+      assert attr_of(html, "[role=progressbar]", "aria-valuetext") == "0%"
+    end
+  end
+
+  describe "previews and type icons" do
+    test "image entries render a live preview element, not the type icon" do
+      assigns = %{upload: config(entries: [entry(client_type: "image/png", ref: "3")])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      preview = query(html, "img.pc-file-upload__thumb")
+      assert Enum.count(preview) == 1
+      assert LazyHTML.attribute(preview, "data-phx-hook") == ["Phoenix.LiveImgPreview"]
+      assert LazyHTML.attribute(preview, "data-phx-entry-ref") == ["3"]
+      assert Enum.empty?(query(html, ".pc-file-upload__type-icon"))
+    end
+
+    test "non-image entries render a type icon and no preview" do
+      assigns = %{upload: config(entries: [entry(client_type: "application/pdf")])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert Enum.empty?(query(html, "img.pc-file-upload__thumb"))
+      assert has_icon?(html, "hero-document-text")
+    end
+
+    test "the type icon follows the MIME family" do
+      for {type, icon} <- [
+            {"video/mp4", "hero-film"},
+            {"audio/mpeg", "hero-musical-note"},
+            {"application/pdf", "hero-document-text"},
+            {"text/csv", "hero-document-text"},
+            {"application/zip", "hero-archive-box"},
+            {"application/octet-stream", "hero-document"}
+          ] do
+        assigns = %{upload: config(entries: [entry(client_type: type)])}
+        html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+        assert has_icon?(html, icon), "#{type} did not render #{icon}"
+      end
+    end
+
+    test "a nil client_type falls back to the generic document icon" do
+      assigns = %{upload: config(entries: [entry(client_type: nil)])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert has_icon?(html, "hero-document")
+    end
+  end
+
+  describe "progress" do
+    test "aria-valuenow tracks entry.progress and the bar width follows" do
+      assigns = %{upload: config(entries: [entry(progress: 63)])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      bar = query(html, "[role=progressbar]")
+      assert Enum.count(bar) == 1
+      assert LazyHTML.attribute(bar, "aria-valuenow") == ["63"]
+      assert LazyHTML.attribute(bar, "aria-valuemin") == ["0"]
+      assert LazyHTML.attribute(bar, "aria-valuemax") == ["100"]
+      assert attr_of(html, ".pc-file-upload__progress-bar", "style") == "width: 63%"
+    end
+
+    test "the progress bar is named after its file" do
+      assigns = %{upload: config(entries: [entry(client_name: "q3.pdf")])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert attr_of(html, "[role=progressbar]", "aria-label") == "Upload progress for q3.pdf"
+    end
+
+    test "one progress bar per entry" do
+      entries = [entry(ref: "0"), entry(ref: "1", client_name: "b.pdf")]
+      assigns = %{upload: config(entries: entries)}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert Enum.count(query(html, "[role=progressbar]")) == 2
+    end
+  end
+
+  describe "errors" do
+    test "config-level :too_many_files renders above the list" do
+      assigns = %{upload: config(ref: "phx-F1", errors: [{"phx-F1", :too_many_files}])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert html =~ "You have selected too many files"
+      assert Enum.count(query(html, ".pc-file-upload__error--config")) == 1
+    end
+
+    test "entry-level :too_large renders inside the row" do
+      assigns = %{upload: config(entries: [entry(ref: "0")], errors: [{"0", :too_large}])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert html =~ "This file is too large"
+      assert Enum.count(query(html, ".pc-file-upload__error--entry")) == 1
+      assert_has_class(html, "pc-file-upload__entry-inner--invalid")
+    end
+
+    test "entry-level :not_accepted renders inside the row" do
+      assigns = %{upload: config(entries: [entry(ref: "0")], errors: [{"0", :not_accepted}])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert html =~ "This file type is not accepted"
+    end
+
+    test ":external_client_failure and unknown reasons degrade to a generic line" do
+      for reason <- [:external_client_failure, {:writer_failure, :enospc}, :some_custom_reason] do
+        assigns = %{upload: config(entries: [entry(ref: "0")], errors: [{"0", reason}])}
+        html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+        assert html =~ "Upload failed, please try again",
+               "#{inspect(reason)} did not degrade gracefully"
+      end
+    end
+
+    test "an error on one entry does not leak onto another" do
+      entries = [entry(ref: "0"), entry(ref: "1", client_name: "b.pdf")]
+      assigns = %{upload: config(entries: entries, errors: [{"0", :too_large}])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert Enum.count(query(html, ".pc-file-upload__error--entry")) == 1
+      assert Enum.count(query(html, ".pc-file-upload__entry-inner--invalid")) == 1
+    end
+
+    test "no error markup when the config is clean" do
+      assigns = %{upload: config(entries: [entry()])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert Enum.empty?(query(html, ".pc-file-upload__error"))
+    end
+  end
+
+  describe "description" do
+    test "is derived from accept, max_file_size and max_entries" do
+      assigns = %{
+        upload: config(accept: ~w(.png .jpg), max_file_size: 8_000_000, max_entries: 4)
+      }
+
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert html =~ "PNG or JPG, up to 8 MB, max 4 files"
+    end
+
+    test "drops the file count for a single-entry config" do
+      assigns = %{upload: config(accept: ~w(.pdf), max_file_size: 1_000_000, max_entries: 1)}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert html =~ "PDF, up to 1 MB"
+      refute html =~ "max 1 files"
+    end
+
+    # allow_upload/3 joins :accept into a comma-separated string for the
+    # input's accept attribute, so that - not the list - is what a real
+    # config carries. Missing this silently dropped the whole phrase.
+    test "reads the comma-joined accept a real allow_upload/3 config carries" do
+      assigns = %{
+        upload: config(accept: ".png,.jpg,.pdf", max_file_size: 8_000_000, max_entries: 4)
+      }
+
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert html =~ "PNG, JPG or PDF, up to 8 MB, max 4 files"
+    end
+
+    test "an empty accept string contributes nothing" do
+      assert derive_description(config(accept: "", max_entries: 1, max_file_size: 500)) ==
+               "up to 500 B"
+    end
+
+    test "handles MIME wildcards and three-or-more accept lists" do
+      assert derive_description(config(accept: ~w(image/*), max_entries: 1, max_file_size: nil)) ==
+               "images"
+
+      assert derive_description(
+               config(accept: ~w(.png .jpg .gif), max_entries: 1, max_file_size: nil)
+             ) == "PNG, JPG or GIF"
+
+      assert derive_description(
+               config(accept: ~w(application/pdf), max_entries: 1, max_file_size: nil)
+             ) == "PDF"
+    end
+
+    test "an :any accept contributes nothing" do
+      assert derive_description(config(accept: :any, max_entries: 1, max_file_size: 500)) ==
+               "up to 500 B"
+    end
+
+    test "an explicit description overrides the derivation" do
+      assigns = %{upload: config(accept: ~w(.png))}
+
+      html =
+        rendered_to_string(~H"<.file_upload upload={@upload} description=\"Anything goes\" />")
+
+      assert html =~ "Anything goes"
+      refute html =~ "up to 8 MB"
+    end
+
+    test "an empty description drops the line entirely" do
+      assigns = %{upload: config()}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} description=\"\" />")
+
+      assert Enum.empty?(query(html, ".pc-file-upload__description"))
+    end
+  end
+
+  describe "format_bytes/1" do
+    test "crosses the B / KB / MB / GB boundaries" do
+      assert format_bytes(0) == "0 B"
+      assert format_bytes(999) == "999 B"
+      assert format_bytes(1_000) == "1 KB"
+      assert format_bytes(1_500) == "1.5 KB"
+      assert format_bytes(999_999) == "1000 KB"
+      assert format_bytes(1_000_000) == "1 MB"
+      assert format_bytes(2_400_000) == "2.4 MB"
+      assert format_bytes(8_000_000) == "8 MB"
+      assert format_bytes(999_999_999) == "1000 MB"
+      assert format_bytes(1_000_000_000) == "1 GB"
+      assert format_bytes(2_500_000_000) == "2.5 GB"
+    end
+
+    test "a missing size renders nothing rather than crashing" do
+      assert format_bytes(nil) == ""
+    end
+  end
+
+  describe "the :entry slot" do
+    test "replaces the default row entirely" do
+      assigns = %{upload: config(entries: [entry(client_name: "q3.pdf")])}
+
+      html =
+        rendered_to_string(~H"""
+        <.file_upload upload={@upload}>
+          <:entry :let={entry}>
+            <span class="mine">{entry.client_name}</span>
+          </:entry>
+        </.file_upload>
+        """)
+
+      assert html =~ ~s(<span class="mine">q3.pdf</span>)
+      # the default row's furniture is gone
+      assert Enum.empty?(query(html, "[role=progressbar]"))
+      assert Enum.empty?(query(html, ".pc-file-upload__cancel"))
+    end
+
+    test "is invoked once per entry" do
+      entries = [entry(ref: "0"), entry(ref: "1", client_name: "b.pdf")]
+      assigns = %{upload: config(entries: entries)}
+
+      html =
+        rendered_to_string(~H"""
+        <.file_upload upload={@upload}>
+          <:entry :let={entry}><span class="mine">{entry.client_name}</span></:entry>
+        </.file_upload>
+        """)
+
+      assert Enum.count(query(html, "span.mine")) == 2
+    end
+
+    test "applies to gallery tiles too" do
+      assigns = %{upload: config(entries: [entry()], max_entries: 4)}
+
+      html =
+        rendered_to_string(~H"""
+        <.file_upload upload={@upload} variant="gallery">
+          <:entry :let={entry}><span class="mine">{entry.client_name}</span></:entry>
+        </.file_upload>
+        """)
+
+      assert Enum.count(query(html, "span.mine")) == 1
+    end
+  end
+
+  describe "accessibility" do
+    test "the wrapper is a group labelled by the label element" do
+      assigns = %{upload: config(ref: "phx-F1")}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} label=\"Receipts\" />")
+
+      assert attr_of(html, ".pc-file-upload", "role") == "group"
+      labelledby = attr_of(html, ".pc-file-upload", "aria-labelledby")
+      assert labelledby == "pc-file-upload-phx-F1-label"
+      assert attr_of(html, ".pc-file-upload__label", "id") == labelledby
+      assert LazyHTML.attribute(query(html, ".pc-file-upload"), "aria-label") == []
+    end
+
+    test "falls back to aria-label when no label is given" do
+      assigns = %{upload: config()}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert attr_of(html, ".pc-file-upload", "aria-label") == "File upload"
+      assert LazyHTML.attribute(query(html, ".pc-file-upload"), "aria-labelledby") == []
+    end
+
+    test "a polite live region carries the drag hint" do
+      assigns = %{upload: config()}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      region = query(html, ".pc-file-upload__live")
+      assert Enum.count(region) == 1
+      assert LazyHTML.attribute(region, "aria-live") == ["polite"]
+      assert html =~ "Drop files to upload"
+    end
+
+    test "cancel buttons are named after their file" do
+      assigns = %{upload: config(entries: [entry(client_name: "q3.pdf")])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert attr_of(html, ".pc-file-upload__cancel", "aria-label") == "Cancel upload of q3.pdf"
+    end
+
+    test "cancel_label customises the accessible name prefix" do
+      assigns = %{upload: config(entries: [entry(client_name: "q3.pdf")])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} cancel_label=\"Remove\" />")
+
+      assert attr_of(html, ".pc-file-upload__cancel", "aria-label") == "Remove q3.pdf"
+    end
+
+    test "entry errors are associated with their row" do
+      assigns = %{
+        upload: config(ref: "phx-F1", entries: [entry(ref: "9")], errors: [{"9", :too_large}])
+      }
+
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      described = attr_of(html, ".pc-file-upload__entry-inner", "aria-describedby")
+      assert described == "pc-file-upload-phx-F1-9-error"
+      assert attr_of(html, ".pc-file-upload__error--entry", "id") == described
+    end
+
+    test "a clean row carries no dangling aria-describedby" do
+      assigns = %{upload: config(entries: [entry()])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      assert LazyHTML.attribute(query(html, ".pc-file-upload__entry-inner"), "aria-describedby") ==
+               []
+    end
+
+    test "decorative icons are hidden from assistive tech" do
+      assigns = %{upload: config(entries: [entry()], errors: [{"0", :too_large}])}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} />")
+
+      for selector <- [
+            ".pc-file-upload__glyph",
+            ".pc-file-upload__type-icon",
+            ".pc-file-upload__cancel-icon",
+            ".pc-file-upload__error-icon"
+          ] do
+        nodes = query(html, selector)
+        refute Enum.empty?(nodes), "#{selector} was not rendered"
+
+        assert LazyHTML.attribute(nodes, "aria-hidden") |> Enum.uniq() == ["true"],
+               "#{selector} is not aria-hidden"
+      end
+    end
+
+    test "the avatar replace overlay is decorative" do
+      assigns = %{upload: config(max_entries: 1)}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} variant=\"avatar\" />")
+
+      assert attr_of(html, ".pc-file-upload__overlay", "aria-hidden") == "true"
+    end
+  end
+
+  describe "pass-through" do
+    test "class lands on the wrapper alongside the component classes" do
+      assigns = %{upload: config()}
+      html = rendered_to_string(~H"<.file_upload upload={@upload} class=\"mt-8 max-w-lg\" />")
+
+      classes = attr_of(html, ".pc-file-upload", "class")
+      assert classes =~ "pc-file-upload"
+      assert classes =~ "pc-file-upload--dropzone"
+      assert classes =~ "mt-8 max-w-lg"
+    end
+
+    test "rest attributes land on the wrapper" do
+      assigns = %{upload: config()}
+
+      html =
+        rendered_to_string(~H"<.file_upload upload={@upload} data-role=\"uploader\" hidden />")
+
+      assert attr_of(html, ".pc-file-upload", "data-role") == "uploader"
+      assert_attribute(html, "hidden")
+    end
+
+    test "id overrides the ref-derived default and drives the ARIA ids" do
+      assigns = %{upload: config(entries: [entry(ref: "9")], errors: [{"9", :too_large}])}
+
+      html =
+        rendered_to_string(
+          ~H"<.file_upload upload={@upload} id=\"my-uploader\" label=\"Docs\" />"
+        )
+
+      assert attr_of(html, ".pc-file-upload", "id") == "my-uploader"
+      assert attr_of(html, ".pc-file-upload", "aria-labelledby") == "my-uploader-label"
+      assert attr_of(html, ".pc-file-upload__error--entry", "id") == "my-uploader-9-error"
+    end
+  end
+end


### PR DESCRIPTION
Closes #605

## What this is

`<.file_upload>` renders the whole upload surface for a `%Phoenix.LiveView.UploadConfig{}`: the drop zone, the entry list with thumbnails and type icons, per-entry progress, cancel buttons, and human-readable errors.

Four variants (`dropzone`, `compact`, `avatar`, `gallery`), an `:entry` slot to replace the default row, and a hint line derived from the config so it cannot drift from what the server will actually accept.

## How it composes with `allow_upload/3`

It sits on top of LiveView's upload machinery rather than reimplementing any of it. Nothing here uploads bytes:

| Concern | Who does it |
|---|---|
| Drag and drop | `phx-drop-target={@upload.ref}` on the zone. LiveView adds `phx-drop-target-active`; the highlight is a plain CSS rule on that class. |
| Browse | `<.live_file_input>`, wrapped in the zone's `<label for={@upload.ref}>`, so the whole surface opens the picker. |
| Thumbnails | `<.live_img_preview>` for image entries; a MIME-sniffed type icon otherwise. |
| Progress | `entry.progress`, straight onto the bar's width and `aria-valuenow`. |
| Validation | `upload_errors/1` and `upload_errors/2`, mapped to English by a private `error_to_string/1`. |
| Cancel | A button pushing `cancel_event` with `phx-value-ref={entry.ref}`; the parent calls `cancel_upload/3`. |

The moduledoc carries a complete LiveView: `allow_upload/3` in `mount`, the component inside a `phx-change` form, the cancel `handle_event`, and `consume_uploaded_entries/3` on submit. It also says plainly that this needs a LiveView and does not replace `<.field type="file">`.

## Did you ship a hook?

**No.** No hook, no JS, no new hex or npm dependencies. LiveView's own upload machinery covered everything the issue asked for, and the two things that looked like they might need JS did not:

- **Drag-over highlight** - LiveView already adds `phx-drop-target-active` to the drop target, so it is one CSS rule.
- **Focus ring on a visually-hidden input** - the zone draws it with `:has(.pc-file-upload__input:focus-visible)`. The input is CSS-clipped (`clip-path: inset(50%)`), never `display: none`, so it stays in the tab order.

## Deviations from the issue's API sketch

1. **Added `attr :id`** (defaults to `pc-file-upload-<ref>`). The sketch had none, but the ARIA wiring needs stable ids - `aria-labelledby` on the group and `aria-describedby` from each entry row to its error. Callers can override it.
2. **Added `attr :cancel_label`** (default `"Cancel upload of"`). The issue requires named cancel buttons; since error copy is deliberately un-i18n'd, this is the one string worth letting callers swap without taking over the whole `:entry` slot.
3. **`description=""` drops the line**, rather than only `nil` auto-deriving. Needed a way to opt out of the hint entirely.
4. **Progress bar is a local `pc-file-upload__progress`, not `<.progress>`.** The issue offered either. A slim two-element bar avoids pulling Progress's size/colour matrix into an entry row, and it still mirrors `pc-progress`'s track/fill/transition idiom so they stay visually consistent.
5. **`format_bytes/1` is SI (1 KB = 1000 B)**, so LiveView's `8_000_000` default reads as "8 MB" rather than "7.6 MB". `format_bytes/1` and `derive_description/1` are `@doc false` public so the suite can assert them directly.
6. **The avatar variant renders the entry's progress and errors in a row under the circle**, since the circle itself is the preview and has nowhere to put a bar.

## One bug worth calling out

`allow_upload/3` stores `:accept` **comma-joined as a string** (`".png,.jpg"`), not as a list - it is built for the input's `accept` attribute. The struct's typespec says `list() | :any` and its default is `[]`, so a list-only implementation passes every unit test and then silently drops the whole accepted-types phrase against a real config. Caught it in the playground, not the suite. Both forms are handled now, with a regression test naming the reason.

## Accessibility

- The native input stays focusable and operable: Tab reaches it, Enter/Space opens the picker. The zone shows the focus ring on its behalf.
- Wrapper is `role="group"`, `aria-labelledby` the label (or `aria-label="File upload"` when there is none).
- Each bar is `role="progressbar"` with `aria-valuenow`/`min`/`max`/`valuetext` and an `aria-label` naming the file.
- Cancel buttons read "Cancel upload of q3.pdf", never icon-only silence.
- Entry errors are tied to their row via `aria-describedby`; decorative icons are `aria-hidden="true"`.
- Focus-visible ring in primary only, no persistent `:focus` fills. Reduced motion kills the decorative fades and leaves the progress width transition alone, matching `pc-progress`.

**One honest caveat:** the drag-over hint is an `aria-live="polite"` region that CSS fades in on `phx-drop-target-active`. A CSS visibility change is not a text mutation, so it will not reliably *announce* on dragenter - it would need a hook to swap the text. I did not add one: screen reader users reach this through the file input, not by dragging, and the house rule is to name the gap rather than reach for JS. Happy to add a hook if you want the announcement.

## Playground

`/c/file-upload`, wired to **six real `allow_upload/3` configs** (not static mocks):

- Hero dropzone with the `variant` and `max_entries` dials. `max_entries` is fixed at `allow_upload` time, so changing it does `disallow_upload` then `allow_upload` again.
- `auto_upload: true` and `false` side by side, labelled - the manual one shows the entry sitting at 0% until submit.
- Avatar, gallery, and a documents zone with `max_file_size: 20_000` so `:too_large` is trivially triggerable.
- Save consumes via `consume_uploaded_entries/3` (nothing is written to disk) and echoes the consumed names.

Verified in a real browser with real files: thumbnails render, progress runs to 100%, cancel works, the error row turns red with the message inside it, and the variant dial swaps all four. Light and dark both checked.

## Tests

| Suite | Before | After |
|---|---|---|
| Elixir | 913 (1 skipped) | **968** (1 skipped) |
| JS | 157 | **157** (no hook, so unchanged) |

56 new tests in `test/petal/file_upload_test.exs`, built against hand-constructed `UploadConfig`/`UploadEntry` structs - every variant, the drop target and input wiring, entry rows, `format_bytes/1` boundaries, previews vs type icons, progress ARIA, all four error classes, description derivation (both accept representations), the `:entry` slot, the full a11y surface, and `class`/`rest`/`id` pass-through.

`mix credo` shows **zero new entries** vs `origin/main` (diffed entry-by-entry, 45 both sides). `mix format --check-formatted` and `mix compile --force --warnings-as-errors` are clean. No test was weakened or removed.

## Screenshots

Light, dark, and a live upload in flight are attached below.
