### PR TITLE
feat(filters): standalone filter bar driven by DataTable.State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 # Changelog
+
+### Unreleased
+
+#### Added
+
+- **New `filters` component: a standalone filter bar driven by
+  `DataTable.State`.** Active filters render as removable chips (field,
+  humanised operator, formatted value) next to an "Add filter" popover
+  that walks field -> operator -> value in one panel, with no server
+  round trip. It speaks the same struct `<.data_table>` does, so pointing
+  both at one `State` composes with no glue: filter from the bar and the
+  table updates, filter from a column header and a chip appears. Six
+  registry types (`text`, `select`, `multi`, `number_range`,
+  `date_range`, `boolean`) each select a subset of `State.ops/0` - the
+  operator vocabulary is never forked. Both wiring modes ship: link mode
+  patches `State.to_params/1` URLs so filters are shareable and the back
+  button works, and event mode pushes the exact payloads
+  `State.handle_op/3` already parses, so a LiveView wired for an
+  event-mode data table gains a filter bar with zero new handler clauses.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,97 @@
       transition-duration: 1ms;
     }
   }
+
+  /* Filters: the standalone filter bar (chips + add-filter popover).
+     Shares the data table's editor form styling (pc-data-table__filter-*),
+     because the editor markup itself is shared - one home for the operator
+     select, the typed value inputs, and the JS-free :has rules that hide the
+     value for a valueless op and reveal the second bound for :between. */
+
+  .pc-filters {
+    @apply flex flex-wrap items-center gap-2;
+  }
+  .pc-filters__chips {
+    @apply flex flex-wrap items-center gap-2;
+  }
+  /* wins over pc-popover's inline-block: a chip is a row of parts */
+  .pc-filters__chip {
+    @apply relative inline-flex max-w-full items-center border border-gray-300 bg-white text-sm dark:border-gray-400/25 dark:bg-gray-400/8;
+    border-radius: min(var(--pc-radius, 0.625rem), 1rem);
+  }
+  .pc-filters__chip-body {
+    @apply flex min-w-0 items-center gap-1.5 py-1 pl-2.5 pr-1 text-left transition-colors duration-150 hover:bg-gray-50 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:hover:bg-gray-400/10;
+    border-start-start-radius: inherit;
+    border-end-start-radius: inherit;
+  }
+  .pc-filters__chip-field {
+    @apply shrink-0 font-medium text-gray-900 dark:text-gray-100;
+  }
+  .pc-filters__chip-op {
+    @apply shrink-0 text-gray-500 dark:text-gray-400;
+  }
+  .pc-filters__chip-value {
+    @apply min-w-0 truncate font-medium text-primary-700 dark:text-primary-300;
+    max-width: 12rem;
+  }
+  .pc-filters__chip-remove {
+    @apply mr-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors duration-150 hover:bg-gray-100 hover:text-gray-600 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:hover:bg-gray-400/10 dark:hover:text-gray-300;
+  }
+  /* Doubled selector + !important: icon sizing contract (see pagination chevrons). */
+  .pc-filters__chip-remove-icon.pc-filters__chip-remove-icon {
+    @apply w-4! h-4!;
+  }
+  .pc-filters__add-icon.pc-filters__add-icon {
+    @apply w-4! h-4! -ml-0.5;
+  }
+  .pc-filters__panel {
+    @apply w-60;
+  }
+  .pc-filters__editor {
+    @apply w-60;
+  }
+  .pc-filters__form.pc-filters__form {
+    @apply w-full;
+  }
+  .pc-filters__fields {
+    @apply flex max-h-72 flex-col gap-0.5 overflow-y-auto;
+  }
+  .pc-filters__fields--closed {
+    @apply hidden;
+  }
+  .pc-filters__field {
+    @apply flex w-full items-center rounded-md px-2 py-1.5 text-left text-sm text-gray-700 transition-colors duration-150 hover:bg-gray-100 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:text-gray-200 dark:hover:bg-gray-400/10;
+  }
+  .pc-filters__none {
+    @apply px-2 py-1.5 text-sm text-gray-500 dark:text-gray-400;
+  }
+  /* The add panel's second step. Display-only toggling, so there is a complete
+     rest state at both ends and nothing for reduced motion to sit through. */
+  .pc-filters__step {
+    @apply hidden;
+  }
+  .pc-filters__step--open {
+    @apply flex flex-col gap-2;
+  }
+  .pc-filters__back {
+    @apply -mt-1 inline-flex items-center gap-1 self-start text-xs text-gray-500 transition-colors duration-150 hover:text-gray-700 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:text-gray-400 dark:hover:text-gray-200;
+  }
+  /* Doubled selector + !important: icon sizing contract (see pagination chevrons). */
+  .pc-filters__back-icon.pc-filters__back-icon {
+    @apply w-3.5! h-3.5!;
+  }
+  .pc-filters__step-title {
+    @apply text-sm font-semibold text-gray-900 dark:text-gray-100;
+  }
+  .pc-filters__clear {
+    @apply rounded-md px-1 text-sm font-medium text-primary-600 hover:underline focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500/50 dark:text-primary-400;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .pc-filters__chip-body,
+    .pc-filters__chip-remove,
+    .pc-filters__field,
+    .pc-filters__back,
+    .pc-filters .pc-popover__panel[data-pc-menu] {
+      transition-duration: 1ms;
+    }
+  }

--- a/dev.exs
+++ b/dev.exs
@@ -284,6 +284,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "table", name: "Table", ready: true},
         %{slug: "data-table", name: "Data table", ready: true},
         %{slug: "data-table-link", name: "Data table · links", ready: true},
+        %{slug: "filters", name: "Filters", ready: true},
         %{slug: "chart", name: "Chart", ready: true},
         %{slug: "local-time", name: "Local time", ready: true}
       ]
@@ -333,6 +334,9 @@ defmodule Dev.PlaygroundLive do
   ]
 
   @slugs Enum.flat_map(@nav, fn g -> Enum.map(g.items, & &1.slug) end)
+  # the whitelist both filter-bar demos decode against - link mode's
+  # from_params and event mode's handle_op take the same list
+  @filters_fields [:name, :category, :price, :in_stock, :added_on]
   @locale_codes ~w(en fr de es pt)
   @playground_languages [
     %{locale: "en", flag: "🇬🇧", label: "English"},
@@ -772,6 +776,10 @@ defmodule Dev.PlaygroundLive do
        dt_hidden: [],
        dt_order: [],
        dt_refunded: [],
+       # the filter bar demo: one State shared with a data table (event mode),
+       # plus the registered field types the dials switch on and off
+       filters_state: PetalComponents.DataTable.State |> struct(page_size: 5) |> run_filters(),
+       filters_types: ~w(text select number_range boolean date_range),
        radio: %{
          style: "cards",
          variant: "outline",
@@ -881,6 +889,7 @@ defmodule Dev.PlaygroundLive do
       # mobile menu so picking a component reveals it immediately.
       |> assign(:nav_open, false)
       |> maybe_run_dt_link(params, uri)
+      |> maybe_run_filters_link(params, uri)
 
     {:noreply, maybe_start_progress_sim(socket)}
   end
@@ -906,6 +915,24 @@ defmodule Dev.PlaygroundLive do
   end
 
   defp maybe_run_dt_link(socket, _params, _uri), do: socket
+
+  # The filter page's third example: link mode, where the URL IS the filter
+  # state. Same decode as the data table's link page - the query string is
+  # the only place the filters live, so a shared or curled URL renders the
+  # right rows on first paint and the back button walks the history.
+  defp maybe_run_filters_link(%{assigns: %{active: "filters"}} = socket, params, uri) do
+    alias PetalComponents.DataTable.State
+
+    query = uri |> URI.parse() |> Map.get(:query) || ""
+    params = Map.merge(Plug.Conn.Query.decode(query), params)
+    state = State.from_params(params, fields: @filters_fields)
+
+    socket
+    |> assign(:filters_link, run_filters(state))
+    |> assign(:filters_query, query)
+  end
+
+  defp maybe_run_filters_link(socket, _params, _uri), do: socket
 
   # The progress flagship simulates a live upload while you watch. One
   # timer at a time; it dies quietly when you leave the page or take
@@ -1587,6 +1614,36 @@ defmodule Dev.PlaygroundLive do
      |> assign(:dt_hidden, hidden)
      |> assign(:dt_order, order)
      |> assign(:dt_refunded, refunded)}
+  end
+
+  # The filter bar's whole backend, event mode: State.handle_op speaks the
+  # payloads the chips and editors post, so this is one call plus a re-run
+  # through the free in-memory engine. The data table below it shares the
+  # same State, which is why filtering from either surface updates both.
+  def handle_event("pg_filters", params, socket) do
+    alias PetalComponents.DataTable.State
+
+    {state, _rows} = socket.assigns.filters_state
+    state = State.handle_op(state, params, fields: @filters_fields)
+
+    {:noreply, assign(socket, :filters_state, run_filters(state))}
+  end
+
+  def handle_event("pg_filters_types", %{"k" => type}, socket) do
+    types = socket.assigns.filters_types
+    types = if type in types, do: List.delete(types, type), else: types ++ [type]
+
+    {:noreply, assign(socket, :filters_types, types)}
+  end
+
+  defp run_filters(state) do
+    {rows, state} =
+      PetalComponents.DataTable.Engine.List.run(
+        PetalComponents.Showcase.Filters.products(),
+        state
+      )
+
+    {state, rows}
   end
 
   defp run_dt(state, refunded \\ []) do
@@ -7814,6 +7871,193 @@ defmodule Dev.PlaygroundLive do
         </p>
         <pre class="p-3 overflow-x-auto text-xs rounded-lg bg-gray-100 dark:bg-gray-800"><code>{inspect(elem(@dt_link, 0), pretty: true, width: 60)}</code></pre>
       </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "filters"} = assigns) do
+    ~H"""
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">Filters</h1>
+      <p class="mt-2 mb-6 text-gray-600 dark:text-gray-300">
+        A filter bar driven by the same State struct the data table uses. Chips carry field,
+        operator and value; the Add filter popover walks field &rarr; operator &rarr; value in
+        one panel, no round trip. Keyboard only: Tab to the trigger, Enter to open, Tab through
+        the field list, Enter to pick, Tab to the inputs, Enter to apply, Escape to back out.
+      </p>
+
+      <div class="border border-gray-200 dark:border-gray-400/20 rounded-xl overflow-hidden">
+        <div class="p-6">
+          <% {state, rows} = @filters_state %>
+          <.filters id="pg-filters" state={state} on_change="pg_filters">
+            <:field :if={"text" in @filters_types} field={:name} label="Name" type="text" />
+            <:field
+              :if={"select" in @filters_types}
+              field={:category}
+              label="Category"
+              type="select"
+              options={[{"Hand tools", "hand"}, {"Power tools", "power"}, {"Finishing", "finishing"}]}
+            />
+            <:field
+              :if={"number_range" in @filters_types}
+              field={:price}
+              label="Price"
+              type="number_range"
+            />
+            <:field
+              :if={"boolean" in @filters_types}
+              field={:in_stock}
+              label="In stock"
+              type="boolean"
+            />
+            <:field
+              :if={"date_range" in @filters_types}
+              field={:added_on}
+              label="Added"
+              type="date_range"
+            />
+          </.filters>
+
+          <ul class="grid gap-2 mt-5 sm:grid-cols-2">
+            <li
+              :for={p <- rows}
+              class="flex items-center justify-between gap-3 px-3 py-2 text-sm border border-gray-200 rounded-lg dark:border-gray-400/20"
+            >
+              <span class="font-medium">{p.name}</span>
+              <span class="flex items-center gap-2 text-gray-500 dark:text-gray-400">
+                <.badge size="sm" variant="soft" color="gray" label={p.category} />
+                <span>${p.price}</span>
+              </span>
+            </li>
+            <li
+              :if={rows == []}
+              class="py-6 text-sm text-center text-gray-500 sm:col-span-2 dark:text-gray-400"
+            >
+              Nothing matches these filters.
+            </li>
+          </ul>
+        </div>
+
+        <div class="flex flex-wrap items-end px-4 py-4 border-t border-gray-200 gap-x-8 gap-y-4 sm:px-6 dark:border-gray-800">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">
+              registered field types
+            </div>
+            <.toggle_group
+              multiple
+              variant="outline"
+              size="sm"
+              aria_label="Field types"
+              value={@filters_types}
+              on_change="pg_filters_types"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={t <- ~w(text select number_range boolean date_range)}
+                value={t}
+                phx-value-k={t}
+              >
+                {t}
+              </:item>
+            </.toggle_group>
+          </div>
+        </div>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">One State, bar and table</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        The composition proof. Both components read and write the same struct on the same event,
+        so a chip added here filters the table below, and a column header filter adds a chip up
+        here. Sorting and paging ride the same grammar.
+      </p>
+      <div class="p-6 border border-gray-200 dark:border-gray-400/20 rounded-xl">
+        <% {shared_state, shared_rows} = @filters_state %>
+        <.filters id="pg-filters-shared" state={shared_state} on_change="pg_filters">
+          <:field field={:name} label="Name" type="text" />
+          <:field
+            field={:category}
+            label="Category"
+            type="select"
+            options={[{"Hand tools", "hand"}, {"Power tools", "power"}, {"Finishing", "finishing"}]}
+          />
+          <:field field={:price} label="Price" type="number_range" />
+          <:field field={:in_stock} label="In stock" type="boolean" />
+        </.filters>
+        <div class="mt-4">
+          <.data_table
+            id="pg-filters-table"
+            rows={shared_rows}
+            state={shared_state}
+            on_change="pg_filters"
+            striped
+          >
+            <:col :let={p} field={:name} sortable>{p.name}</:col>
+            <:col
+              :let={p}
+              field={:category}
+              filterable="select"
+              options={[{"Hand tools", "hand"}, {"Power tools", "power"}, {"Finishing", "finishing"}]}
+            >
+              {p.category}
+            </:col>
+            <:col :let={p} field={:price} sortable align="right" filterable="number">${p.price}</:col>
+            <:col :let={p} field={:in_stock} align="center">
+              {if p.in_stock, do: "yes", else: "no"}
+            </:col>
+          </.data_table>
+        </div>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Link mode: the URL is the state</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        No events. Every chip removal, apply and clear-all is a patch URL built from
+        <code class="text-sm">State.to_params/1</code>
+        , and <code class="text-sm">handle_params</code>
+        decodes it back through the field whitelist. Apply a filter, then reload or hit back.
+      </p>
+      <div class="p-6 border border-gray-200 dark:border-gray-400/20 rounded-xl">
+        <% {link_state, link_rows} = @filters_link %>
+        <.filters
+          id="pg-filters-link"
+          state={link_state}
+          path={
+            theme_path(%{
+              active: "filters",
+              primary: @primary,
+              secondary: @secondary,
+              gray: @gray,
+              radius: @radius
+            })
+          }
+        >
+          <:field field={:name} label="Name" type="text" />
+          <:field
+            field={:category}
+            label="Category"
+            type="select"
+            options={[{"Hand tools", "hand"}, {"Power tools", "power"}, {"Finishing", "finishing"}]}
+          />
+          <:field field={:price} label="Price" type="number_range" />
+          <:field field={:added_on} label="Added" type="date_range" />
+        </.filters>
+        <p class="mt-4 mb-1 text-sm text-gray-500 dark:text-gray-400">
+          The query string this page decoded ({length(link_rows)} matching):
+        </p>
+        <pre class="p-3 overflow-x-auto text-xs rounded-lg bg-gray-100 dark:bg-gray-800"><code>{if @filters_query == "", do: "(none)", else: @filters_query}</code></pre>
+      </div>
+
+      <div
+        :for={ex <- examples_for(PetalComponents.Showcase.Filters, ~w(empty chips shared_state)a)}
+        class="mt-10"
+      >
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <.showcase_props component={PetalComponents.Filters} function={:filters} />
     </div>
     """
   end

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -38,6 +38,7 @@ defmodule PetalComponents do
         Container,
         Dropdown,
         Field,
+        Filters,
         Form,
         Icon,
         Input,

--- a/lib/petal_components/data_table.ex
+++ b/lib/petal_components/data_table.ex
@@ -55,6 +55,7 @@ defmodule PetalComponents.DataTable do
   import PetalComponents.Skeleton
   import PetalComponents.Table
 
+  alias PetalComponents.DataTable.FilterEditor
   alias PetalComponents.DataTable.State
   alias Phoenix.LiveView.JS
 
@@ -302,7 +303,7 @@ defmodule PetalComponents.DataTable do
       |> assign(:visible_cols, visible_cols)
       |> assign(:ordered_cols, ordered_cols)
       |> assign(:hidden, hidden)
-      |> assign(:op_labels, Map.merge(default_op_labels(), assigns.filter_op_labels))
+      |> assign(:op_labels, Map.merge(FilterEditor.default_op_labels(), assigns.filter_op_labels))
       |> assign(:ui_event, ui_event)
       |> selection_assigns()
       |> assign(:hooked?, hooked?)
@@ -662,10 +663,7 @@ defmodule PetalComponents.DataTable do
     end
   end
 
-  defp url_for(path, %State{} = state) do
-    query = state |> State.to_params() |> flatten_params() |> URI.encode_query()
-    join_query(path, query)
-  end
+  defp url_for(path, %State{} = state), do: FilterEditor.url_for(path, state)
 
   # pagination's :page placeholder must survive URL encoding, so the
   # template is assembled around the already-encoded rest of the query
@@ -711,37 +709,9 @@ defmodule PetalComponents.DataTable do
     join_query(path, query)
   end
 
-  # a base path may already carry a query string - join accordingly
-  defp join_query(path, ""), do: path
+  defp join_query(path, query), do: FilterEditor.join_query(path, query)
 
-  defp join_query(path, query) do
-    joiner = if String.contains?(path, "?"), do: "&", else: "?"
-    path <> joiner <> query
-  end
-
-  # filters encode as a list of maps - flatten to Phoenix-style indexed
-  # params so encode_query can carry them and from_params reads them
-  # back. Returns pairs, not a map: a list value (the :in op) needs the
-  # same key repeated ("...[value][]"), which a map cannot hold.
-  defp flatten_params(params) do
-    {filters, rest} = Map.pop(params, "filters")
-
-    Enum.sort(rest) ++
-      (filters
-       |> List.wrap()
-       |> Enum.with_index()
-       |> Enum.flat_map(fn {filter, i} ->
-         Enum.flat_map(filter, fn {k, v} -> filter_pairs("filters[#{i}][#{k}]", v) end)
-       end))
-  end
-
-  defp filter_pairs(key, values) when is_list(values),
-    do: Enum.map(values, &{"#{key}[]", &1})
-
-  defp filter_pairs(key, %{} = map),
-    do: Enum.map(map, fn {k, v} -> {"#{key}[#{k}]", v} end)
-
-  defp filter_pairs(key, value), do: [{key, value}]
+  defp flatten_params(params), do: FilterEditor.flatten_params(params)
 
   # -- selection -------------------------------------------------------------
 
@@ -896,38 +866,26 @@ defmodule PetalComponents.DataTable do
   @number_ops ~w(eq neq gt gte lt lte between is_empty is_not_empty)a
   @date_ops ~w(before on after is_empty is_not_empty)a
 
-  defp default_op_labels do
-    %{
-      contains: "contains",
-      eq: "is",
-      starts_with: "starts with",
-      not_contains: "does not contain",
-      neq: "is not",
-      gt: ">",
-      gte: "\u2265",
-      lt: "<",
-      lte: "\u2264",
-      not_in: "is none of",
-      is_empty: "is empty",
-      is_not_empty: "is not empty",
-      between: "between",
-      in: "is any of",
-      before: "before",
-      on: "on",
-      after: "after"
-    }
-  end
+  # the data table's own type vocabulary -> the shared editor's shapes
+  defp editor_shape("select"), do: {"options", [], :in}
+  defp editor_shape("number"), do: {"number", @number_ops, :eq}
+  defp editor_shape("date"), do: {"date", @date_ops, :on}
+  defp editor_shape(_text), do: {"text", @text_ops, :contains}
 
   defp filter_button(assigns) do
     col = assigns.col
     field_str = to_string(col.field)
     label = col[:label] || humanize(col.field)
     filter = Enum.find(assigns.state.filters, &(&1.field == col.field))
-    options = normalize_options(col[:options] || [])
+    options = FilterEditor.normalize_options(col[:options] || [])
     pop_id = "#{assigns.table_id}-filter-#{field_str}"
+    {shape, ops, default_op} = editor_shape(col[:filterable])
 
     assigns =
       assigns
+      |> assign(:shape, shape)
+      |> assign(:editor_ops, ops)
+      |> assign(:default_op, default_op)
       |> assign(:field_str, field_str)
       |> assign(:label, label)
       |> assign(:filter, filter)
@@ -956,7 +914,10 @@ defmodule PetalComponents.DataTable do
           ]}
         >
           <.icon :if={!@filter} name="hero-funnel" class="pc-data-table__filter-icon" />
-          <span>{(@filter && predicate_text(@label, @filter, @op_labels, @options)) || @label}</span>
+          <span>
+            {(@filter && FilterEditor.predicate_text(@label, @filter, @op_labels, @options)) ||
+              @label}
+          </span>
         </button>
         <div
           id={@pop_id}
@@ -973,8 +934,10 @@ defmodule PetalComponents.DataTable do
           >
             <input :if={@on_change} type="hidden" name="op" value="filter" />
             <input :if={@on_change} type="hidden" name="field" value={@field_str} />
-            <.filter_editor
-              type={@type}
+            <FilterEditor.filter_editor
+              type={@shape}
+              ops={@editor_ops}
+              default_op={@default_op}
               filter={@filter}
               options={@options}
               op_labels={@op_labels}
@@ -1013,185 +976,12 @@ defmodule PetalComponents.DataTable do
     """
   end
 
-  # eight or more options get a client-side filter box - a checkbox wall
-  # with no way to narrow it is where long lists go to die
-  @option_filter_threshold 8
-
-  defp filter_editor(%{type: "select"} = assigns) do
-    current = assigns.filter |> current_values() |> Enum.map(&to_string/1)
-
-    assigns =
-      assigns
-      |> assign(:current, current)
-      |> assign(:show_option_filter, length(assigns.options) >= @option_filter_threshold)
-
-    ~H"""
-    <input
-      :if={@show_option_filter}
-      type="text"
-      data-pc-dt-option-filter
-      autocomplete="off"
-      placeholder={@filter_options_placeholder}
-      aria-label={"#{@label} option filter"}
-      class="pc-text-input pc-data-table__filter-value pc-data-table__option-filter"
-    />
-    <div class="pc-data-table__filter-options" role="group" aria-label={"#{@label} options"}>
-      <label :for={{label, value} <- @options} class="pc-data-table__filter-option">
-        <input
-          type="checkbox"
-          name="values[]"
-          value={value}
-          checked={to_string(value) in @current}
-          class="pc-checkbox"
-        />
-        <span>{label}</span>
-      </label>
-    </div>
-    """
-  end
-
-  defp filter_editor(%{type: "number"} = assigns) do
-    {value, value2} = current_pair(assigns.filter)
-
-    assigns =
-      assigns
-      |> assign(:ops, @number_ops)
-      |> assign(:current_op, (assigns.filter && assigns.filter.op) || :eq)
-      |> assign(:value, value)
-      |> assign(:value2, value2)
-
-    ~H"""
-    <.filter_op_select ops={@ops} current_op={@current_op} op_labels={@op_labels} label={@label} />
-    <input
-      type="number"
-      step="any"
-      name="value"
-      value={@value}
-      aria-label={"#{@label} lower bound"}
-      class="pc-text-input pc-data-table__filter-value"
-    />
-    <input
-      type="number"
-      step="any"
-      name="value2"
-      value={@value2}
-      class="pc-text-input pc-data-table__filter-value pc-data-table__filter-value2"
-      aria-label={"#{@label} upper bound"}
-    />
-    """
-  end
-
-  defp filter_editor(%{type: "date"} = assigns) do
-    assigns =
-      assigns
-      |> assign(:ops, @date_ops)
-      |> assign(:current_op, (assigns.filter && assigns.filter.op) || :on)
-      |> assign(:value, (assigns.filter && to_string(assigns.filter.value)) || nil)
-
-    ~H"""
-    <.filter_op_select ops={@ops} current_op={@current_op} op_labels={@op_labels} label={@label} />
-    <input
-      type="date"
-      name="value"
-      value={@value}
-      aria-label={"#{@label} value"}
-      class="pc-text-input pc-data-table__filter-value"
-    />
-    """
-  end
-
-  defp filter_editor(assigns) do
-    assigns =
-      assigns
-      |> assign(:ops, @text_ops)
-      |> assign(:current_op, (assigns.filter && assigns.filter.op) || :contains)
-      |> assign(:value, (assigns.filter && to_string(assigns.filter.value)) || nil)
-
-    ~H"""
-    <.filter_op_select ops={@ops} current_op={@current_op} op_labels={@op_labels} label={@label} />
-    <input
-      type="text"
-      name="value"
-      value={@value}
-      aria-label={"#{@label} value"}
-      class="pc-text-input pc-data-table__filter-value"
-    />
-    """
-  end
-
-  defp filter_op_select(assigns) do
-    ~H"""
-    <select
-      name="filter_op"
-      class="pc-select pc-data-table__filter-op"
-      aria-label={"#{@label} operator"}
-    >
-      <option :for={op <- @ops} value={op} selected={op == @current_op}>
-        {op_label(@op_labels, op)}
-      </option>
-    </select>
-    """
-  end
-
   # event mode pushes the form; the hook closes the menu on submit
   defp filter_submit_js(nil, _target, _pop_id), do: nil
 
   defp filter_submit_js(event, target, _pop_id) do
     if target, do: JS.push(event, target: target), else: JS.push(event)
   end
-
-  # An op with no label is a custom one an adapter added - render the atom
-  # rather than raising mid-render, which is what Map.fetch!/2 did.
-  defp op_label(labels, op), do: Map.get(labels, op, humanize_op(op))
-
-  defp humanize_op(op), do: op |> to_string() |> String.replace("_", " ")
-
-  defp normalize_options(options) do
-    Enum.map(options, fn
-      {label, value} -> {label, value}
-      value -> {humanize(value), value}
-    end)
-  end
-
-  defp current_values(nil), do: []
-  defp current_values(%{value: value}), do: List.wrap(value)
-
-  # the engine accepts both range shapes, so both must render
-  defp current_pair(%{op: :between, value: [min, max]}), do: {min, max}
-  defp current_pair(%{op: :between, value: %{"min" => min, "max" => max}}), do: {min, max}
-  defp current_pair(%{op: :between}), do: {nil, nil}
-  defp current_pair(%{value: value}) when not is_list(value), do: {value, nil}
-  defp current_pair(_other), do: {nil, nil}
-
-  defp predicate_text(label, filter, op_labels, options) do
-    case State.valueless_op?(filter.op) do
-      true -> "#{label} #{op_label(op_labels, filter.op)}"
-      false -> "#{label} #{op_label(op_labels, filter.op)} #{display_value(filter, options)}"
-    end
-  end
-
-  defp display_value(%{op: :in, value: values}, options) do
-    labels = Map.new(options, fn {label, value} -> {to_string(value), label} end)
-    shown = values |> List.wrap() |> Enum.map(&Map.get(labels, to_string(&1), to_string(&1)))
-
-    case Enum.split(shown, 2) do
-      {first_two, []} -> Enum.join(first_two, ", ")
-      {first_two, rest} -> Enum.join(first_two, ", ") <> " +#{length(rest)}"
-    end
-  end
-
-  defp display_value(%{op: :between, value: [min, max]}, _options), do: "#{min}\u2013#{max}"
-
-  defp display_value(%{op: :between, value: %{"min" => min, "max" => max}}, _options),
-    do: "#{min}\u2013#{max}"
-
-  # hand-built states can carry shapes no editor produces - never crash
-  # the toolbar over one
-  defp display_value(%{value: value}, _options) when is_list(value),
-    do: Enum.map_join(value, ", ", &to_string/1)
-
-  defp display_value(%{value: %{} = value}, _options), do: inspect(value)
-  defp display_value(%{value: value}, _options), do: to_string(value)
 
   # Announced separately from the visible range: the visible string uses
   # an en dash, which screen readers frequently read as nothing at all

--- a/lib/petal_components/data_table/filter_editor.ex
+++ b/lib/petal_components/data_table/filter_editor.ex
@@ -1,0 +1,360 @@
+defmodule PetalComponents.DataTable.FilterEditor do
+  @moduledoc false
+  # The typed value editors shared by `PetalComponents.DataTable` (per-column
+  # filter popovers) and `PetalComponents.Filters` (the standalone filter bar),
+  # plus the State -> URL encoding both use to build link-mode patch URLs.
+  #
+  # One home for three things that must never diverge between the two
+  # components: the operator display names, the value formatting shown on a
+  # trigger or a chip, and the exact form markup the `PetalDataTable` hook
+  # reads back in link mode (`values[]`, `filter_op`, `value`, `value2`). The
+  # `pc-data-table__filter-*` class names are deliberately kept - the hook
+  # queries them and `assets/default.css` already carries the JS-free `:has`
+  # rules that hide the value input for valueless ops and reveal the second
+  # bound for `:between`.
+  #
+  # Editors are named by SHAPE, not by a caller's type vocabulary, because the
+  # two components spell their types differently (the data table's "select" is
+  # a checkbox list, the filter bar's "select" is a single choice):
+  #
+  #   * "text"    - operator select + text input
+  #   * "number"  - operator select + number input (+ a second bound for :between)
+  #   * "date"    - operator select + date input (+ a second bound for :between)
+  #   * "options" - checkbox list posting `values[]`, always the :in operator
+  #   * "choice"  - operator select + single <select name="value"> from options
+  #   * "boolean" - a yes/no select, operator pinned to :eq (no picker)
+
+  use Phoenix.Component
+
+  alias PetalComponents.DataTable.State
+
+  # eight or more options get a client-side filter box - a checkbox wall
+  # with no way to narrow it is where long lists go to die
+  @option_filter_threshold 8
+
+  @doc false
+  def default_op_labels do
+    %{
+      contains: "contains",
+      eq: "is",
+      starts_with: "starts with",
+      not_contains: "does not contain",
+      neq: "is not",
+      gt: ">",
+      gte: "≥",
+      lt: "<",
+      lte: "≤",
+      not_in: "is none of",
+      is_empty: "is empty",
+      is_not_empty: "is not empty",
+      between: "between",
+      in: "is any of",
+      before: "before",
+      on: "on",
+      after: "after"
+    }
+  end
+
+  attr :type, :string,
+    required: true,
+    values: ["text", "number", "date", "options", "choice", "boolean"],
+    doc: "the editor shape to render"
+
+  attr :ops, :list,
+    default: [],
+    doc: "the operator subset offered, all members of `State.ops/0`"
+
+  attr :default_op, :atom, default: :eq, doc: "the operator preselected when no filter is active"
+  attr :filter, :any, default: nil, doc: "the active filter map for this field, or nil"
+  attr :options, :list, default: [], doc: "normalized `{label, value}` pairs"
+  attr :op_labels, :map, required: true, doc: "operator atom -> display name"
+  attr :label, :string, required: true, doc: "the field's human label, used for aria names"
+
+  attr :filter_options_placeholder, :string,
+    default: "Filter options…",
+    doc: "the option-filter box's placeholder"
+
+  @doc false
+  def filter_editor(%{type: "options"} = assigns) do
+    current = assigns.filter |> current_values() |> Enum.map(&to_string/1)
+
+    assigns =
+      assigns
+      |> assign(:current, current)
+      |> assign(:show_option_filter, length(assigns.options) >= @option_filter_threshold)
+
+    ~H"""
+    <input
+      :if={@show_option_filter}
+      type="text"
+      data-pc-dt-option-filter
+      autocomplete="off"
+      placeholder={@filter_options_placeholder}
+      aria-label={"#{@label} option filter"}
+      class="pc-text-input pc-data-table__filter-value pc-data-table__option-filter"
+    />
+    <div class="pc-data-table__filter-options" role="group" aria-label={"#{@label} options"}>
+      <label :for={{label, value} <- @options} class="pc-data-table__filter-option">
+        <input
+          type="checkbox"
+          name="values[]"
+          value={value}
+          checked={to_string(value) in @current}
+          class="pc-checkbox"
+        />
+        <span>{label}</span>
+      </label>
+    </div>
+    """
+  end
+
+  def filter_editor(%{type: "number"} = assigns) do
+    {value, value2} = current_pair(assigns.filter)
+
+    assigns =
+      assigns
+      |> assign(:current_op, (assigns.filter && assigns.filter.op) || assigns.default_op)
+      |> assign(:value, value)
+      |> assign(:value2, value2)
+
+    ~H"""
+    <.filter_op_select ops={@ops} current_op={@current_op} op_labels={@op_labels} label={@label} />
+    <input
+      type="number"
+      step="any"
+      name="value"
+      value={@value}
+      aria-label={"#{@label} lower bound"}
+      class="pc-text-input pc-data-table__filter-value"
+    />
+    <input
+      :if={:between in @ops}
+      type="number"
+      step="any"
+      name="value2"
+      value={@value2}
+      class="pc-text-input pc-data-table__filter-value pc-data-table__filter-value2"
+      aria-label={"#{@label} upper bound"}
+    />
+    """
+  end
+
+  def filter_editor(%{type: "date"} = assigns) do
+    {value, value2} = current_pair(assigns.filter)
+
+    assigns =
+      assigns
+      |> assign(:current_op, (assigns.filter && assigns.filter.op) || assigns.default_op)
+      |> assign(:value, value && to_string(value))
+      |> assign(:value2, value2 && to_string(value2))
+
+    ~H"""
+    <.filter_op_select ops={@ops} current_op={@current_op} op_labels={@op_labels} label={@label} />
+    <input
+      type="date"
+      name="value"
+      value={@value}
+      aria-label={"#{@label} value"}
+      class="pc-text-input pc-data-table__filter-value"
+    />
+    <input
+      :if={:between in @ops}
+      type="date"
+      name="value2"
+      value={@value2}
+      class="pc-text-input pc-data-table__filter-value pc-data-table__filter-value2"
+      aria-label={"#{@label} upper bound"}
+    />
+    """
+  end
+
+  # A single choice from the registered options. Unlike "options" this posts
+  # one `value`, so `:eq` / `:neq` mean what the operator select says.
+  def filter_editor(%{type: "choice"} = assigns) do
+    assigns =
+      assigns
+      |> assign(:current_op, (assigns.filter && assigns.filter.op) || assigns.default_op)
+      |> assign(:value, (assigns.filter && to_string(assigns.filter.value)) || "")
+
+    ~H"""
+    <.filter_op_select ops={@ops} current_op={@current_op} op_labels={@op_labels} label={@label} />
+    <select
+      name="value"
+      class="pc-select pc-data-table__filter-value"
+      aria-label={"#{@label} value"}
+    >
+      <option value=""></option>
+      <option :for={{label, value} <- @options} value={value} selected={to_string(value) == @value}>
+        {label}
+      </option>
+    </select>
+    """
+  end
+
+  # There is exactly one operator worth offering for a boolean, so the picker
+  # is a hidden input rather than a one-item select nobody can act on.
+  def filter_editor(%{type: "boolean"} = assigns) do
+    assigns =
+      assign(assigns, :value, (assigns.filter && to_string(assigns.filter.value)) || "true")
+
+    ~H"""
+    <input type="hidden" name="filter_op" value="eq" />
+    <select
+      name="value"
+      class="pc-select pc-data-table__filter-value"
+      aria-label={"#{@label} value"}
+    >
+      <option value="true" selected={@value == "true"}>Yes</option>
+      <option value="false" selected={@value == "false"}>No</option>
+    </select>
+    """
+  end
+
+  def filter_editor(assigns) do
+    assigns =
+      assigns
+      |> assign(:current_op, (assigns.filter && assigns.filter.op) || assigns.default_op)
+      |> assign(:value, (assigns.filter && to_string(assigns.filter.value)) || nil)
+
+    ~H"""
+    <.filter_op_select ops={@ops} current_op={@current_op} op_labels={@op_labels} label={@label} />
+    <input
+      type="text"
+      name="value"
+      value={@value}
+      aria-label={"#{@label} value"}
+      class="pc-text-input pc-data-table__filter-value"
+    />
+    """
+  end
+
+  attr :ops, :list, required: true
+  attr :current_op, :atom, required: true
+  attr :op_labels, :map, required: true
+  attr :label, :string, required: true
+
+  defp filter_op_select(assigns) do
+    ~H"""
+    <select
+      name="filter_op"
+      class="pc-select pc-data-table__filter-op"
+      aria-label={"#{@label} operator"}
+    >
+      <option :for={op <- @ops} value={op} selected={op == @current_op}>
+        {op_label(@op_labels, op)}
+      </option>
+    </select>
+    """
+  end
+
+  # An op with no label is a custom one an adapter added - render the atom
+  # rather than raising mid-render, which is what Map.fetch!/2 did.
+  @doc false
+  def op_label(labels, op), do: Map.get(labels, op, humanize_op(op))
+
+  defp humanize_op(op), do: op |> to_string() |> String.replace("_", " ")
+
+  @doc false
+  def normalize_options(options) do
+    Enum.map(options, fn
+      {label, value} -> {label, value}
+      value -> {humanize(value), value}
+    end)
+  end
+
+  @doc false
+  def current_values(nil), do: []
+  def current_values(%{value: value}), do: List.wrap(value)
+
+  # the engine accepts both range shapes, so both must render
+  @doc false
+  def current_pair(%{op: :between, value: [min, max]}), do: {min, max}
+  def current_pair(%{op: :between, value: %{"min" => min, "max" => max}}), do: {min, max}
+  def current_pair(%{op: :between}), do: {nil, nil}
+  def current_pair(%{value: value}) when not is_list(value), do: {value, nil}
+  def current_pair(_other), do: {nil, nil}
+
+  @doc false
+  def predicate_text(label, filter, op_labels, options) do
+    case State.valueless_op?(filter.op) do
+      true -> "#{label} #{op_label(op_labels, filter.op)}"
+      false -> "#{label} #{op_label(op_labels, filter.op)} #{display_value(filter, options)}"
+    end
+  end
+
+  @doc false
+  def display_value(%{op: :in, value: values}, options) do
+    labels = Map.new(options, fn {label, value} -> {to_string(value), label} end)
+    shown = values |> List.wrap() |> Enum.map(&Map.get(labels, to_string(&1), to_string(&1)))
+
+    case Enum.split(shown, 2) do
+      {first_two, []} -> Enum.join(first_two, ", ")
+      {first_two, rest} -> Enum.join(first_two, ", ") <> " +#{length(rest)}"
+    end
+  end
+
+  def display_value(%{op: :between, value: [min, max]}, _options), do: "#{min}–#{max}"
+
+  def display_value(%{op: :between, value: %{"min" => min, "max" => max}}, _options),
+    do: "#{min}–#{max}"
+
+  # hand-built states can carry shapes no editor produces - never crash
+  # the toolbar over one
+  def display_value(%{value: value}, _options) when is_list(value),
+    do: Enum.map_join(value, ", ", &to_string/1)
+
+  def display_value(%{value: %{} = value}, _options), do: inspect(value)
+
+  def display_value(%{value: value}, options) do
+    labels = Map.new(options, fn {label, v} -> {to_string(v), label} end)
+    Map.get(labels, to_string(value), to_string(value))
+  end
+
+  @doc false
+  def humanize(field) do
+    field |> to_string() |> String.replace("_", " ") |> String.capitalize()
+  end
+
+  # -- link-mode URL encoding -------------------------------------------------
+  # Both components patch the SAME query shape, so the encoding lives once.
+
+  @doc false
+  def url_for(path, %State{} = state) do
+    query = state |> State.to_params() |> flatten_params() |> URI.encode_query()
+    join_query(path, query)
+  end
+
+  # a base path may already carry a query string - join accordingly
+  @doc false
+  def join_query(path, ""), do: path
+
+  def join_query(path, query) do
+    joiner = if String.contains?(path, "?"), do: "&", else: "?"
+    path <> joiner <> query
+  end
+
+  # filters encode as a list of maps - flatten to Phoenix-style indexed
+  # params so encode_query can carry them and from_params reads them
+  # back. Returns pairs, not a map: a list value (the :in op) needs the
+  # same key repeated ("...[value][]"), which a map cannot hold.
+  @doc false
+  def flatten_params(params) do
+    {filters, rest} = Map.pop(params, "filters")
+
+    Enum.sort(rest) ++
+      (filters
+       |> List.wrap()
+       |> Enum.with_index()
+       |> Enum.flat_map(fn {filter, i} ->
+         Enum.flat_map(filter, fn {k, v} -> filter_pairs("filters[#{i}][#{k}]", v) end)
+       end))
+  end
+
+  defp filter_pairs(key, values) when is_list(values),
+    do: Enum.map(values, &{"#{key}[]", &1})
+
+  defp filter_pairs(key, %{} = map),
+    do: Enum.map(map, fn {k, v} -> {"#{key}[#{k}]", v} end)
+
+  defp filter_pairs(key, value), do: [{key, value}]
+end

--- a/lib/petal_components/filters.ex
+++ b/lib/petal_components/filters.ex
@@ -1,0 +1,534 @@
+defmodule PetalComponents.Filters do
+  @moduledoc """
+  A schema-driven filter bar: the active filters as removable chips, plus an
+  "Add filter" popover that walks field -> operator -> value.
+
+  It speaks `PetalComponents.DataTable.State`, the same struct `<.data_table>`
+  is driven by, so it drops in next to a table sharing one state - or stands
+  alone above any list, card grid or custom query UI. The operator vocabulary
+  is `State.ops/0`; this component only ever selects subsets of it, and every
+  mutation goes through `State.put_filter/4` or `State.handle_op/3`.
+
+  Two wiring modes, inferred from which attr you pass (passing neither raises,
+  exactly like `data_table/1`):
+
+    * **link mode** (`path`) - every change is a `patch` URL built from
+      `State.to_params/1`. `handle_params` plus `State.from_params/2` is the
+      whole backend, and the URL is the state store:
+
+          def handle_params(params, _uri, socket) do
+            state = State.from_params(params, fields: [:name, :category, :price])
+            {rows, state} = Engine.List.run(all_products(), state)
+            {:noreply, assign(socket, rows: rows, table: state)}
+          end
+
+          <.filters id="f" state={@table} path={~p"/products"}>
+            <:field field={:name} label="Name" type="text" />
+            <:field field={:category} type="select" options={["tools", "toys"]} />
+            <:field field={:price} label="Price" type="number_range" />
+          </.filters>
+
+    * **event mode** (`on_change`) - chip removal, apply and clear-all push the
+      op-shaped payloads `State.handle_op/3` already parses, so a LiveView
+      already wired for an event-mode `data_table` gains a filter bar without a
+      single new handler clause:
+
+          def handle_event("table", params, socket) do
+            state = State.handle_op(socket.assigns.table, params, fields: [:name, :category])
+            {rows, state} = Engine.List.run(all_products(), state)
+            {:noreply, assign(socket, rows: rows, table: state)}
+          end
+
+          <.filters id="f" state={@table} on_change="table">
+            <:field field={:name} label="Name" type="text" />
+            <:field field={:category} type="select" options={["tools", "toys"]} />
+          </.filters>
+
+  ## Sharing one State with a data table
+
+  Point both at the same struct and the same event (or the same path) and they
+  compose with no glue: filter from the bar and the table updates, filter from
+  a column header and a chip appears.
+
+      <.filters id="products-filters" state={@table} on_change="table">
+        <:field field={:category} type="select" options={["tools", "toys"]} />
+        <:field field={:in_stock} label="In stock" type="boolean" />
+      </.filters>
+
+      <.data_table id="products" rows={@rows} state={@table} on_change="table">
+        <:col :let={p} field={:name} sortable>{p.name}</:col>
+        <:col :let={p} field={:category} filterable="select" options={["tools", "toys"]}>
+          {p.category}
+        </:col>
+      </.data_table>
+
+  ## Field types
+
+  The `:field` slot is the registry. `type` picks the operator subset (always a
+  subset of `State.ops/0`) and the value editor:
+
+  | type | operators | editor |
+  |---|---|---|
+  | `text` | `contains`, `not_contains`, `eq`, `neq`, `starts_with`, `is_empty`, `is_not_empty` | text input |
+  | `select` | `eq`, `neq`, `is_empty`, `is_not_empty` | single select from `options` |
+  | `multi` | `in` | checkbox list from `options` |
+  | `number_range` | `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `between`, `is_empty`, `is_not_empty` | number input, two for `between` |
+  | `date_range` | `before`, `on`, `after`, `between`, `is_empty`, `is_not_empty` | date input, two for `between` |
+  | `boolean` | `eq` | yes/no select, no operator picker |
+
+  Valueless operators (`is_empty`, `is_not_empty`) render no value input, per
+  `State.valueless_op?/1`.
+  """
+  use Phoenix.Component
+
+  import PetalComponents.Button
+  import PetalComponents.Icon
+
+  alias PetalComponents.DataTable.FilterEditor
+  alias PetalComponents.DataTable.State
+  alias Phoenix.LiveView.JS
+
+  # {editor shape, operator subset, preselected operator}. Every atom here is
+  # a member of State.ops/0 - a test asserts it, so a vocabulary change fails
+  # loudly rather than rendering an operator no engine can execute.
+  @types %{
+    "text" =>
+      {"text", ~w(contains not_contains eq neq starts_with is_empty is_not_empty)a, :contains},
+    "select" => {"choice", ~w(eq neq is_empty is_not_empty)a, :eq},
+    "multi" => {"options", ~w(in)a, :in},
+    "number_range" => {"number", ~w(eq neq gt gte lt lte between is_empty is_not_empty)a, :eq},
+    "date_range" => {"date", ~w(before on after between is_empty is_not_empty)a, :on},
+    "boolean" => {"boolean", ~w(eq)a, :eq}
+  }
+
+  @doc """
+  The operator subset offered per registry type, as `%{type => [op]}`.
+
+  Exposed so an app (and this library's own test suite) can assert the
+  vocabulary against `State.ops/0` rather than trusting a hand-copied list.
+  """
+  @spec type_operators() :: %{String.t() => [atom()]}
+  def type_operators, do: Map.new(@types, fn {type, {_shape, ops, _default}} -> {type, ops} end)
+
+  attr :id, :string, required: true, doc: "DOM id; every panel and chip id is derived from it"
+
+  attr :state, State,
+    required: true,
+    doc: "the state whose `filters` this bar renders and edits"
+
+  attr :path, :string,
+    default: nil,
+    doc: """
+    link mode: the base path filter changes patch to, with the state encoded
+    via `State.to_params/1`. Required unless `on_change` is set.
+    """
+
+  attr :on_change, :string,
+    default: nil,
+    doc: """
+    event mode: the event filter edits push, with the same op-shaped payloads
+    `State.handle_op/3` already accepts (`filter` / `clear_filters`).
+    """
+
+  attr :target, :any, default: nil, doc: "event mode: the phx-target (e.g. @myself)"
+
+  attr :add_filter_label, :string,
+    default: "Add filter",
+    doc: "the add trigger's label and its panel's accessible name, localizable"
+
+  attr :clear_filters_label, :string,
+    default: "Clear filters",
+    doc: "the clear-all affordance's label, localizable"
+
+  attr :apply_label, :string,
+    default: "Apply",
+    doc: "the value editor's submit label, localizable"
+
+  attr :remove_filter_label, :string,
+    default: "Remove filter",
+    doc: "prefix for a chip's remove button accessible name, localizable"
+
+  attr :active_filters_label, :string,
+    default: "Active filters",
+    doc: "the chip group's accessible name, localizable"
+
+  attr :no_filters_label, :string,
+    default: "No filters applied",
+    doc: "announced by the status region when nothing is filtered, localizable"
+
+  attr :all_fields_used_label, :string,
+    default: "Every field is already filtered",
+    doc: "shown in the add panel when no field is left to add, localizable"
+
+  attr :filter_op_labels, :map,
+    default: %{},
+    doc:
+      ~S|overrides for operator display names, e.g. %{contains: "enthält"} - same attr name and shape as data_table|
+
+  attr :filter_options_placeholder, :string,
+    default: "Filter options…",
+    doc: "the multi editor's option-filter placeholder (shown from 8 options up), localizable"
+
+  attr :class, :any, default: nil, doc: "extra classes on the bar's root element"
+
+  slot :field, required: true, doc: "the filterable field registry, one entry per field" do
+    attr :field, :atom, required: true, doc: "the state field this entry filters"
+    attr :label, :string, doc: "human name; defaults to the humanized field"
+
+    attr :type, :string,
+      values: ["text", "select", "multi", "date_range", "boolean", "number_range"],
+      doc: "picks the operator subset and the value editor; defaults to \"text\""
+
+    attr :options, :list,
+      doc:
+        ~S|select/multi: the pickable values, as strings or {label, value} tuples - same shape as data_table's :col options|
+  end
+
+  @doc """
+  Renders the filter bar for `state`, with one `:field` entry per filterable
+  field. Pass `path` for link mode or `on_change` for event mode.
+  """
+  def filters(assigns) do
+    if is_nil(assigns.path) and is_nil(assigns.on_change) do
+      raise ArgumentError, "filters needs either path (link mode) or on_change (event mode)"
+    end
+
+    link_mode? = is_nil(assigns.on_change)
+    op_labels = Map.merge(FilterEditor.default_op_labels(), assigns.filter_op_labels)
+    registry = Enum.map(assigns.field, &entry(&1, assigns.id))
+
+    active =
+      Enum.flat_map(assigns.state.filters, fn filter ->
+        case Enum.find(registry, &(&1.field == filter.field)) do
+          nil -> []
+          entry -> [Map.put(entry, :filter, filter)]
+        end
+      end)
+
+    available =
+      Enum.reject(registry, fn entry -> Enum.any?(active, &(&1.field == entry.field)) end)
+
+    assigns =
+      assigns
+      |> assign(:link_mode?, link_mode?)
+      |> assign(:op_labels, op_labels)
+      |> assign(:chips, chips(active, assigns.id))
+      |> assign(:available, Enum.map(available, &Map.put(&1, :filter, nil)))
+      |> assign(:status_text, status_text(active, op_labels, assigns))
+      |> assign(:add_trigger_id, "#{assigns.id}-add-trigger")
+      |> assign(:nav_template, link_mode? && nav_template(assigns.path, assigns.state))
+      |> assign(:filters_json, link_mode? && Jason.encode!(assigns.state.filters))
+      |> assign(
+        :clear_url,
+        assigns.path && FilterEditor.url_for(assigns.path, State.clear_filters(assigns.state))
+      )
+
+    ~H"""
+    <div
+      id={@id}
+      class={["pc-filters", @class]}
+      phx-hook="PetalDataTable"
+      data-nav-template={@nav_template || nil}
+      data-filters={@filters_json || nil}
+    >
+      <a :if={@link_mode?} data-pc-dt-nav data-phx-link="patch" data-phx-link-state="push" hidden></a>
+      <p class="sr-only" role="status" aria-atomic="true">{@status_text}</p>
+
+      <div
+        :if={@chips != []}
+        class="pc-filters__chips"
+        role="group"
+        aria-label={@active_filters_label}
+      >
+        <div :for={chip <- @chips} class="pc-filters__chip pc-popover">
+          <button
+            type="button"
+            id={chip.trigger_id}
+            data-pc-menu-trigger={chip.editor_id}
+            aria-haspopup="dialog"
+            aria-expanded="false"
+            aria-controls={chip.editor_id}
+            class="pc-popover__trigger pc-filters__chip-body"
+          >
+            <span class="pc-filters__chip-field">{chip.label}</span>
+            <span class="pc-filters__chip-op">{FilterEditor.op_label(@op_labels, chip.filter.op)}</span>
+            <span :if={not State.valueless_op?(chip.filter.op)} class="pc-filters__chip-value">
+              {FilterEditor.display_value(chip.filter, chip.options)}
+            </span>
+          </button>
+          <.link
+            :if={@link_mode?}
+            patch={FilterEditor.url_for(@path, State.put_filter(@state, chip.field, :eq, ""))}
+            phx-click={JS.focus(to: "##{chip.next_focus_id}")}
+            class="pc-filters__chip-remove"
+            aria-label={remove_label(assigns, chip)}
+          >
+            <.icon name="hero-x-mark" class="pc-filters__chip-remove-icon" aria-hidden="true" />
+          </.link>
+          <button
+            :if={!@link_mode?}
+            type="button"
+            class="pc-filters__chip-remove"
+            phx-click={remove_js(assigns, chip)}
+            aria-label={remove_label(assigns, chip)}
+          >
+            <.icon name="hero-x-mark" class="pc-filters__chip-remove-icon" aria-hidden="true" />
+          </button>
+          <div
+            id={chip.editor_id}
+            hidden
+            data-pc-menu
+            class="pc-popover__panel pc-popover__panel--bottom-start pc-filters__editor"
+          >
+            <.editor_form
+              entry={chip}
+              link_mode?={@link_mode?}
+              on_change={@on_change}
+              target={@target}
+              op_labels={@op_labels}
+              apply_label={@apply_label}
+              filter_options_placeholder={@filter_options_placeholder}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div class="pc-popover pc-filters__add">
+        <button
+          type="button"
+          id={@add_trigger_id}
+          data-pc-menu-trigger={"#{@id}-add"}
+          phx-click={reset_steps(@id)}
+          aria-haspopup="dialog"
+          aria-expanded="false"
+          aria-controls={"#{@id}-add"}
+          class="pc-popover__trigger pc-button pc-button--sm pc-button--gray-outline"
+        >
+          <.icon name="hero-plus-small" class="pc-filters__add-icon" aria-hidden="true" />
+          <span>{@add_filter_label}</span>
+        </button>
+        <div
+          id={"#{@id}-add"}
+          hidden
+          data-pc-menu
+          class="pc-popover__panel pc-popover__panel--bottom-start pc-filters__panel"
+        >
+          <div
+            id={"#{@id}-add-list"}
+            class="pc-filters__fields"
+            role="group"
+            aria-label={@add_filter_label}
+          >
+            <button
+              :for={entry <- @available}
+              type="button"
+              id={entry.field_button_id}
+              phx-click={show_step(@id, entry)}
+              class="pc-filters__field"
+            >
+              {entry.label}
+            </button>
+            <p :if={@available == []} class="pc-filters__none">{@all_fields_used_label}</p>
+          </div>
+          <div
+            :for={entry <- @available}
+            id={entry.step_id}
+            data-pc-step
+            class="pc-filters__step"
+          >
+            <button type="button" phx-click={reset_steps(@id, entry)} class="pc-filters__back">
+              <.icon name="hero-chevron-left" class="pc-filters__back-icon" aria-hidden="true" />
+              <span>{@add_filter_label}</span>
+            </button>
+            <p class="pc-filters__step-title">{entry.label}</p>
+            <.editor_form
+              entry={entry}
+              link_mode?={@link_mode?}
+              on_change={@on_change}
+              target={@target}
+              op_labels={@op_labels}
+              apply_label={@apply_label}
+              filter_options_placeholder={@filter_options_placeholder}
+            />
+          </div>
+        </div>
+      </div>
+
+      <%= if @chips != [] do %>
+        <.link
+          :if={@link_mode?}
+          patch={@clear_url}
+          phx-click={JS.focus(to: "##{@add_trigger_id}")}
+          class="pc-filters__clear"
+        >
+          {@clear_filters_label}
+        </.link>
+        <button
+          :if={!@link_mode?}
+          type="button"
+          class="pc-filters__clear"
+          phx-click={clear_js(assigns)}
+        >
+          {@clear_filters_label}
+        </button>
+      <% end %>
+    </div>
+    """
+  end
+
+  # -- the value editor form -------------------------------------------------
+
+  attr :entry, :map, required: true
+  attr :link_mode?, :boolean, required: true
+  attr :on_change, :string, default: nil
+  attr :target, :any, default: nil
+  attr :op_labels, :map, required: true
+  attr :apply_label, :string, required: true
+  attr :filter_options_placeholder, :string, required: true
+
+  # The same markup the data table's column editors post, so the PetalDataTable
+  # hook reads it back in link mode and State.handle_op/3 parses it in event
+  # mode. No new grammar on either side.
+  defp editor_form(assigns) do
+    ~H"""
+    <form
+      id={@entry.form_id}
+      class="pc-data-table__filter-form pc-filters__form"
+      phx-submit={@on_change && submit_js(@on_change, @target)}
+      data-pc-dt-filter={@link_mode? || nil}
+      data-field={@entry.field_str}
+    >
+      <input :if={!@link_mode?} type="hidden" name="op" value="filter" />
+      <input :if={!@link_mode?} type="hidden" name="field" value={@entry.field_str} />
+      <FilterEditor.filter_editor
+        type={@entry.shape}
+        ops={@entry.ops}
+        default_op={@entry.default_op}
+        filter={@entry.filter}
+        options={@entry.options}
+        op_labels={@op_labels}
+        label={@entry.label}
+        filter_options_placeholder={@filter_options_placeholder}
+      />
+      <.button size="sm" type="submit" class="pc-data-table__filter-apply">{@apply_label}</.button>
+    </form>
+    """
+  end
+
+  defp submit_js(event, nil), do: JS.push(event)
+  defp submit_js(event, target), do: JS.push(event, target: target)
+
+  # -- registry --------------------------------------------------------------
+
+  defp entry(slot, id) do
+    field = slot.field
+    field_str = to_string(field)
+    type = slot[:type] || "text"
+    {shape, ops, default_op} = Map.fetch!(@types, type)
+
+    %{
+      field: field,
+      field_str: field_str,
+      label: slot[:label] || FilterEditor.humanize(field),
+      type: type,
+      shape: shape,
+      ops: ops,
+      default_op: default_op,
+      options: FilterEditor.normalize_options(slot[:options] || []),
+      filter: nil,
+      editor_id: "#{id}-editor-#{field_str}",
+      trigger_id: "#{id}-chip-#{field_str}",
+      form_id: "#{id}-form-#{field_str}",
+      step_id: "#{id}-add-step-#{field_str}",
+      field_button_id: "#{id}-add-field-#{field_str}"
+    }
+  end
+
+  # Removing a chip removes the element focus is sitting on, and LiveView's
+  # patch would leave it on <body>. Each chip therefore knows where focus
+  # should land: the next chip, else the add trigger - which is always
+  # rendered, so this target can never be missing.
+  defp chips(active, id) do
+    trailing = active |> Enum.drop(1) |> Enum.map(& &1.trigger_id)
+    next_ids = trailing ++ ["#{id}-add-trigger"]
+
+    active
+    |> Enum.zip(next_ids)
+    |> Enum.map(fn {entry, next} -> Map.put(entry, :next_focus_id, next) end)
+  end
+
+  # -- wiring ----------------------------------------------------------------
+
+  # `filter` with no filter_op is exactly how the data table's inline clear
+  # removes a filter, so this needs no new server grammar.
+  defp remove_js(assigns, chip) do
+    assigns.on_change
+    |> push(assigns.target, %{"op" => "filter", "field" => chip.field_str})
+    |> JS.focus(to: "##{chip.next_focus_id}")
+  end
+
+  defp clear_js(assigns) do
+    assigns.on_change
+    |> push(assigns.target, %{"op" => "clear_filters"})
+    |> JS.focus(to: "##{assigns.add_trigger_id}")
+  end
+
+  defp push(event, nil, value), do: JS.push(event, value: value)
+  defp push(event, target, value), do: JS.push(event, value: value, target: target)
+
+  defp remove_label(assigns, chip) do
+    predicate =
+      FilterEditor.predicate_text(chip.label, chip.filter, assigns.op_labels, chip.options)
+
+    "#{assigns.remove_filter_label}: #{predicate}"
+  end
+
+  # Progressive disclosure with no hook and no server round trip: the panel
+  # holds the field list and every field's editor, and these commands swap
+  # which one is visible. CSS owns the display, so there is a complete rest
+  # state and nothing to animate.
+  defp show_step(id, entry) do
+    %JS{}
+    |> JS.add_class("pc-filters__fields--closed", to: "##{id}-add-list")
+    |> JS.remove_class("pc-filters__step--open", to: "##{id}-add [data-pc-step]")
+    |> JS.add_class("pc-filters__step--open", to: "##{entry.step_id}")
+    |> JS.focus_first(to: "##{entry.form_id}")
+  end
+
+  defp reset_steps(id, entry \\ nil) do
+    js =
+      %JS{}
+      |> JS.remove_class("pc-filters__fields--closed", to: "##{id}-add-list")
+      |> JS.remove_class("pc-filters__step--open", to: "##{id}-add [data-pc-step]")
+
+    if entry, do: JS.focus(js, to: "##{entry.field_button_id}"), else: js
+  end
+
+  # Link mode's Apply is the one interaction with no server-rendered href: the
+  # values only exist in the DOM. The PetalDataTable hook fills :filters in
+  # from the form and patches - the same template mechanism the data table's
+  # own column editors use.
+  defp nav_template(path, %State{} = state) do
+    rest =
+      %{state | filters: [], page: 1}
+      |> State.to_params()
+      |> FilterEditor.flatten_params()
+      |> URI.encode_query()
+
+    query = Enum.join([":filters"] ++ if(rest == "", do: [], else: [rest]), "&")
+    FilterEditor.join_query(path, query)
+  end
+
+  # Read by a live region, so removing a chip announces what is left rather
+  # than leaving the change silent.
+  defp status_text([], _op_labels, assigns), do: assigns.no_filters_label
+
+  defp status_text(active, op_labels, assigns) do
+    predicates =
+      Enum.map_join(active, ", ", fn entry ->
+        FilterEditor.predicate_text(entry.label, entry.filter, op_labels, entry.options)
+      end)
+
+    "#{assigns.active_filters_label}: #{predicates}"
+  end
+end

--- a/lib/petal_components/showcase/filters.ex
+++ b/lib/petal_components/showcase/filters.ex
@@ -1,0 +1,104 @@
+defmodule PetalComponents.Showcase.Filters do
+  @moduledoc false
+  use PetalComponents.Showcase,
+    component: PetalComponents.Filters,
+    title: "Filters"
+
+  alias PetalComponents.DataTable.Engine
+  alias PetalComponents.DataTable.State
+
+  def products do
+    names = ~w(Anvil Bellows Chisel Drawknife Eyelet Forge Gouge Hammer Ingot Jointer Kiln Lathe)
+    categories = ~w(hand power finishing)
+
+    for {name, i} <- Enum.with_index(names, 1) do
+      %{
+        id: i,
+        name: name,
+        category: Enum.at(categories, rem(i, 3)),
+        price: rem(i * 47, 300) + 15,
+        in_stock: rem(i, 4) != 0,
+        added_on: Date.add(~D[2026-01-01], i * 9)
+      }
+    end
+  end
+
+  example :empty, "Nothing filtered yet",
+    inert: true,
+    description:
+      "With no active filters the bar is one trigger. Open it and you get the field list, pick a field and the same panel swaps to that field's operator and value editor - no round trip, no hook, and Escape backs out with focus returned to the trigger." do
+    ~H"""
+    <.filters id="sx-filters-empty" state={%State{}} on_change="table">
+      <:field field={:name} label="Name" type="text" />
+      <:field
+        field={:category}
+        type="select"
+        options={[{"Hand tools", "hand"}, {"Power tools", "power"}, {"Finishing", "finishing"}]}
+      />
+      <:field field={:price} label="Price" type="number_range" />
+      <:field field={:in_stock} label="In stock" type="boolean" />
+      <:field field={:added_on} label="Added" type="date_range" />
+    </.filters>
+    """
+  end
+
+  example :chips, "Active filters as chips",
+    inert: true,
+    description:
+      "Every filter in the state renders as a chip: field, humanised operator, formatted value. between shows both bounds, in shows a truncated list, and a valueless op like is_empty shows no value at all. Click the chip body to reopen its editor pre-filled; the x removes it and moves focus to the next chip." do
+    ~H"""
+    <.filters
+      id="sx-filters-chips"
+      state={
+        %State{
+          filters: [
+            %{field: :category, op: :eq, value: "power"},
+            %{field: :price, op: :between, value: ["50", "150"]},
+            %{field: :name, op: :is_not_empty, value: true}
+          ]
+        }
+      }
+      on_change="table"
+    >
+      <:field field={:name} label="Name" type="text" />
+      <:field
+        field={:category}
+        type="select"
+        options={[{"Hand tools", "hand"}, {"Power tools", "power"}, {"Finishing", "finishing"}]}
+      />
+      <:field field={:price} label="Price" type="number_range" />
+      <:field field={:in_stock} label="In stock" type="boolean" />
+    </.filters>
+    """
+  end
+
+  example :shared_state, "One State, bar and table",
+    description:
+      "The composition proof. Both components read and write the same State struct, so filtering from the bar updates the table and filtering from a column header adds a chip. This example runs the free in-memory engine at render time in link mode - the whole backend is handle_params plus State.from_params/2." do
+    ~H"""
+    <% state = %State{
+      filters: [%{field: :category, op: :eq, value: "hand"}],
+      page_size: 5
+    } %>
+    <% {rows, state} =
+      Engine.List.run(PetalComponents.Showcase.Filters.products(), state) %>
+    <div class="flex flex-col gap-4">
+      <.filters id="sx-filters-shared" state={state} path="#">
+        <:field field={:name} label="Name" type="text" />
+        <:field
+          field={:category}
+          type="select"
+          options={[{"Hand tools", "hand"}, {"Power tools", "power"}, {"Finishing", "finishing"}]}
+        />
+        <:field field={:price} label="Price" type="number_range" />
+        <:field field={:in_stock} label="In stock" type="boolean" />
+      </.filters>
+      <.data_table id="sx-filters-table" rows={rows} state={state} path="#">
+        <:col :let={p} field={:name} sortable>{p.name}</:col>
+        <:col :let={p} field={:category} filterable="text">{p.category}</:col>
+        <:col :let={p} field={:price} sortable align="right">${p.price}</:col>
+      </.data_table>
+    </div>
+    """
+  end
+end

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -32,6 +32,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.LanguageSelect,
     PetalComponents.Showcase.SocialButton,
     PetalComponents.Showcase.Field,
+    PetalComponents.Showcase.Filters,
     PetalComponents.Showcase.InputGroup,
     PetalComponents.Showcase.InputOtp,
     PetalComponents.Showcase.Loading,

--- a/test/petal/filters_test.exs
+++ b/test/petal/filters_test.exs
@@ -1,0 +1,561 @@
+defmodule PetalComponents.FiltersTest do
+  use ComponentCase
+
+  import PetalComponents.Filters
+
+  alias PetalComponents.DataTable.State
+
+  @fields [:name, :category, :price, :in_stock, :added_on]
+
+  defp options, do: [{"Hand tools", "hand"}, {"Power tools", "power"}, {"Finishing", "finishing"}]
+
+  defp bar(assigns) do
+    assigns = Map.merge(%{state: %State{}, path: nil, on_change: nil, extra: %{}}, assigns)
+
+    rendered_to_string(~H"""
+    <.filters
+      id="f"
+      state={@state}
+      path={@path}
+      on_change={@on_change}
+      filter_op_labels={Map.get(@extra, :filter_op_labels, %{})}
+      target={Map.get(@extra, :target)}
+    >
+      <:field field={:name} label="Name" type="text" />
+      <:field field={:category} type="select" options={options()} />
+      <:field field={:price} label="Price" type="number_range" />
+      <:field field={:in_stock} label="In stock" type="boolean" />
+      <:field field={:added_on} label="Added" type="date_range" />
+    </.filters>
+    """)
+  end
+
+  # Rebuilds an event-mode payload from the DOM the way a browser would, so
+  # the round-trip below proves the rendered names, not names we hoped for.
+  defp form_payload(html, form_id, overrides) do
+    form = html |> parse_html() |> LazyHTML.query("##{form_id}")
+
+    named =
+      for el <- LazyHTML.query(form, "input[name], select[name]"),
+          [name] <- [LazyHTML.attribute(el, "name")],
+          name != "",
+          into: %{} do
+        value = el |> LazyHTML.attribute("value") |> List.first()
+        {name, value || ""}
+      end
+
+    Map.merge(named, overrides)
+  end
+
+  defp query(url),
+    do: url |> URI.parse() |> Map.get(:query) |> Kernel.||("") |> Plug.Conn.Query.decode()
+
+  defp text(doc, selector),
+    do: doc |> LazyHTML.query(selector) |> LazyHTML.text() |> String.trim()
+
+  defp href(html, selector) do
+    html |> parse_html() |> LazyHTML.query(selector) |> LazyHTML.attribute("href") |> List.first()
+  end
+
+  describe "wiring modes" do
+    test "raises when neither path nor on_change is given" do
+      assigns = %{}
+
+      assert_raise ArgumentError, ~r/either path \(link mode\) or on_change \(event mode\)/, fn ->
+        rendered_to_string(~H"""
+        <.filters id="f" state={%State{}}>
+          <:field field={:name} type="text" />
+        </.filters>
+        """)
+      end
+    end
+
+    test "link mode mounts the hook with a :filters nav template and a patch anchor" do
+      html = bar(%{path: "/products", state: %State{order_by: [name: :desc]}})
+
+      assert html =~ ~s(phx-hook="PetalDataTable")
+      assert html =~ ~s(data-nav-template="/products?:filters&amp;order_by=name%3Adesc")
+      assert html =~ "data-pc-dt-nav"
+      # the editors post to the hook, not to the server
+      assert html =~ "data-pc-dt-filter"
+      refute html =~ "phx-submit"
+    end
+
+    test "link mode publishes the committed filters as JSON for the hook" do
+      state = %State{filters: [%{field: :category, op: :eq, value: "hand"}]}
+      html = bar(%{path: "/products", state: state})
+
+      assert html =~ "data-filters="
+      assert html =~ "&quot;field&quot;:&quot;category&quot;"
+      assert html =~ "&quot;op&quot;:&quot;eq&quot;"
+    end
+
+    test "event mode needs no nav template, and every editor posts phx-submit" do
+      html = bar(%{on_change: "table"})
+
+      assert html =~ ~s(phx-hook="PetalDataTable")
+      refute html =~ "data-nav-template"
+      refute html =~ "data-pc-dt-filter"
+      assert html =~ ~s(name="op" value="filter")
+    end
+  end
+
+  describe "chips" do
+    test "render field label, operator label and formatted value" do
+      state = %State{filters: [%{field: :category, op: :eq, value: "power"}]}
+      html = bar(%{on_change: "table", state: state})
+      doc = parse_html(html)
+
+      assert text(doc, ".pc-filters__chip-field") == "Category"
+      assert text(doc, ".pc-filters__chip-op") == "is"
+      # the option LABEL, not the posted value
+      assert text(doc, ".pc-filters__chip-value") == "Power tools"
+    end
+
+    test "a valueless operator renders label and operator only" do
+      state = %State{filters: [%{field: :name, op: :is_empty, value: true}]}
+      html = bar(%{on_change: "table", state: state})
+      doc = parse_html(html)
+
+      assert text(doc, ".pc-filters__chip-op") == "is empty"
+      assert doc |> LazyHTML.query(".pc-filters__chip-value") |> Enum.count() == 0
+    end
+
+    test "between renders both bounds and in renders a truncated list" do
+      state = %State{
+        filters: [
+          %{field: :price, op: :between, value: ["50", "150"]},
+          %{field: :category, op: :in, value: ["hand", "power", "finishing"]}
+        ]
+      }
+
+      html = bar(%{on_change: "table", state: state})
+      values = html |> parse_html() |> LazyHTML.query(".pc-filters__chip-value") |> Enum.to_list()
+
+      assert values |> Enum.at(0) |> LazyHTML.text() |> String.trim() == "50–150"
+
+      assert values |> Enum.at(1) |> LazyHTML.text() |> String.trim() ==
+               "Hand tools, Power tools +1"
+    end
+
+    test "a filter on an unregistered field renders no chip" do
+      state = %State{filters: [%{field: :secret, op: :eq, value: "x"}]}
+      html = bar(%{on_change: "table", state: state})
+
+      refute html =~ "pc-filters__chip-field"
+    end
+
+    test "the chip body reopens that field's editor, pre-filled" do
+      state = %State{filters: [%{field: :name, op: :starts_with, value: "Ham"}]}
+      html = bar(%{on_change: "table", state: state})
+
+      assert html =~ ~s(data-pc-menu-trigger="f-editor-name")
+      assert html =~ ~s(id="f-editor-name")
+      assert html =~ ~s(value="Ham")
+      assert html =~ ~s(<option value="starts_with" selected>)
+    end
+  end
+
+  describe "operator vocabulary" do
+    test "every offered operator is a member of State.ops/0" do
+      offered = type_operators() |> Map.values() |> List.flatten() |> Enum.uniq()
+
+      assert offered != []
+
+      assert Enum.all?(offered, &(&1 in State.ops())),
+             "offered: #{inspect(offered -- State.ops())}"
+    end
+
+    test "each type offers exactly its documented subset" do
+      assert type_operators() == %{
+               "text" => [
+                 :contains,
+                 :not_contains,
+                 :eq,
+                 :neq,
+                 :starts_with,
+                 :is_empty,
+                 :is_not_empty
+               ],
+               "select" => [:eq, :neq, :is_empty, :is_not_empty],
+               "multi" => [:in],
+               "number_range" => [
+                 :eq,
+                 :neq,
+                 :gt,
+                 :gte,
+                 :lt,
+                 :lte,
+                 :between,
+                 :is_empty,
+                 :is_not_empty
+               ],
+               "date_range" => [:before, :on, :after, :between, :is_empty, :is_not_empty],
+               "boolean" => [:eq]
+             }
+    end
+
+    test "the rendered operator picker offers exactly the type's subset" do
+      html = bar(%{on_change: "table"})
+      doc = parse_html(html)
+
+      rendered =
+        doc
+        |> LazyHTML.query(~s(#f-form-added_on select[name="filter_op"] option))
+        |> Enum.map(fn opt -> opt |> LazyHTML.attribute("value") |> List.first() end)
+
+      assert rendered == ~w(before on after between is_empty is_not_empty)
+    end
+
+    test "boolean pins the operator to eq and renders no picker" do
+      html = bar(%{on_change: "table"})
+      doc = parse_html(html)
+
+      assert doc |> LazyHTML.query(~s(#f-form-in_stock select[name="filter_op"])) |> Enum.count() ==
+               0
+
+      assert html =~ ~s(<input type="hidden" name="filter_op" value="eq")
+    end
+
+    test "multi posts values[] and text/number/date post value" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.filters id="f" state={%State{}} on_change="table">
+          <:field field={:category} type="multi" options={["hand", "power"]} />
+        </.filters>
+        """)
+
+      assert html =~ ~s(name="values[]")
+      refute html =~ ~s(select[name="filter_op"])
+    end
+
+    test "between-capable types render a second bound, date_range included" do
+      html = bar(%{on_change: "table"})
+      doc = parse_html(html)
+
+      assert doc |> LazyHTML.query(~s(#f-form-price input[name="value2"])) |> Enum.count() == 1
+      assert doc |> LazyHTML.query(~s(#f-form-added_on input[name="value2"])) |> Enum.count() == 1
+    end
+  end
+
+  describe "event mode payloads" do
+    test "the apply form round-trips through State.handle_op/3" do
+      html = bar(%{on_change: "table"})
+
+      params = form_payload(html, "f-form-name", %{"filter_op" => "contains", "value" => "anvil"})
+
+      assert %State{filters: [%{field: :name, op: :contains, value: "anvil"}]} =
+               State.handle_op(%State{}, params, fields: @fields)
+    end
+
+    test "a between apply round-trips into a two-bound filter" do
+      html = bar(%{on_change: "table"})
+
+      params =
+        form_payload(html, "f-form-price", %{
+          "filter_op" => "between",
+          "value" => "50",
+          "value2" => "150"
+        })
+
+      assert %State{filters: [%{field: :price, op: :between, value: ["50", "150"]}]} =
+               State.handle_op(%State{}, params, fields: @fields)
+    end
+
+    test "a valueless apply round-trips without reading as a removal" do
+      html = bar(%{on_change: "table"})
+      params = form_payload(html, "f-form-name", %{"filter_op" => "is_empty", "value" => ""})
+
+      assert %State{filters: [%{field: :name, op: :is_empty}]} =
+               State.handle_op(%State{}, params, fields: @fields)
+    end
+
+    test "a multi apply round-trips into an :in filter" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.filters id="f" state={%State{}} on_change="table">
+          <:field field={:category} type="multi" options={["hand", "power"]} />
+        </.filters>
+        """)
+
+      params = form_payload(html, "f-form-category", %{"values" => ["hand", "power"]})
+
+      assert %State{filters: [%{field: :category, op: :in, value: ["hand", "power"]}]} =
+               State.handle_op(%State{}, params, fields: @fields)
+    end
+
+    test "chip removal pushes a filter op with no operator, which handle_op reads as removal" do
+      state = %State{filters: [%{field: :category, op: :eq, value: "hand"}], page: 4}
+      html = bar(%{on_change: "table", state: state})
+
+      assert html =~ ~s(&quot;op&quot;:&quot;filter&quot;)
+      assert html =~ ~s(&quot;field&quot;:&quot;category&quot;)
+
+      assert %State{filters: [], page: 1} =
+               State.handle_op(state, %{"op" => "filter", "field" => "category"}, fields: @fields)
+    end
+
+    test "clear all pushes clear_filters and is hidden while nothing is filtered" do
+      state = %State{filters: [%{field: :category, op: :eq, value: "hand"}]}
+      html = bar(%{on_change: "table", state: state})
+
+      assert html =~ ~s(&quot;op&quot;:&quot;clear_filters&quot;)
+      assert html =~ "pc-filters__clear"
+
+      refute bar(%{on_change: "table"}) =~ "pc-filters__clear"
+    end
+
+    test "target rides every pushed payload" do
+      state = %State{filters: [%{field: :category, op: :eq, value: "hand"}]}
+      html = bar(%{on_change: "table", state: state, extra: %{target: "#me"}})
+
+      assert html =~ ~s(&quot;target&quot;:&quot;#me&quot;)
+    end
+  end
+
+  describe "link mode URLs" do
+    test "a chip's remove href decodes back to the state without that filter" do
+      state = %State{
+        filters: [
+          %{field: :category, op: :eq, value: "hand"},
+          %{field: :price, op: :gt, value: "100"}
+        ]
+      }
+
+      html = bar(%{path: "/products", state: state})
+      url = href(html, ~s(.pc-filters__chip-remove[aria-label^="Remove filter: Category"]))
+
+      assert %State{filters: [%{field: :price, op: :gt, value: "100"}]} =
+               State.from_params(query(url), fields: @fields)
+    end
+
+    test "the clear-all href decodes back to an unfiltered state" do
+      state = %State{filters: [%{field: :category, op: :eq, value: "hand"}], page: 3}
+      html = bar(%{path: "/products", state: state})
+
+      assert %State{filters: [], page: 1} =
+               html |> href(".pc-filters__clear") |> query() |> State.from_params(fields: @fields)
+    end
+
+    test "defaults stay out of the URL" do
+      state = %State{filters: [%{field: :category, op: :eq, value: "hand"}]}
+      url = %{path: "/products", state: state} |> bar() |> href(".pc-filters__clear")
+
+      assert url == "/products"
+    end
+
+    test "removal and clear-all move focus off the element they delete" do
+      state = %State{
+        filters: [
+          %{field: :category, op: :eq, value: "hand"},
+          %{field: :price, op: :gt, value: "100"}
+        ]
+      }
+
+      html = bar(%{path: "/products", state: state})
+
+      # first chip hands focus to the second, the last to the add trigger
+      assert html =~ ~s(&quot;to&quot;:&quot;#f-chip-price&quot;)
+      assert html =~ ~s(&quot;to&quot;:&quot;#f-add-trigger&quot;)
+    end
+  end
+
+  describe "the add-filter panel" do
+    test "lists only fields that are not already filtered" do
+      state = %State{filters: [%{field: :category, op: :eq, value: "hand"}]}
+      html = bar(%{on_change: "table", state: state})
+      doc = parse_html(html)
+
+      labels =
+        doc |> LazyHTML.query(".pc-filters__field") |> Enum.map(&String.trim(LazyHTML.text(&1)))
+
+      assert labels == ["Name", "Price", "In stock", "Added"]
+    end
+
+    test "says so when every field is already filtered" do
+      state = %State{
+        filters: [
+          %{field: :name, op: :is_empty, value: true},
+          %{field: :category, op: :eq, value: "hand"},
+          %{field: :price, op: :gt, value: "1"},
+          %{field: :in_stock, op: :eq, value: "true"},
+          %{field: :added_on, op: :on, value: "2026-01-01"}
+        ]
+      }
+
+      html = bar(%{on_change: "table", state: state})
+
+      assert html =~ "Every field is already filtered"
+      refute html =~ "pc-filters__field&quot;"
+    end
+
+    test "picking a field swaps the panel to that field's editor and focuses it" do
+      html = bar(%{on_change: "table"})
+
+      assert html =~ ~s(&quot;pc-filters__fields--closed&quot;)
+      assert html =~ ~s(&quot;#f-add-step-name&quot;)
+      assert html =~ ~s(focus_first)
+      assert html =~ ~s(id="f-add-step-name")
+    end
+
+    test "the trigger is always rendered, so focus always has somewhere to land" do
+      assert bar(%{on_change: "table"}) =~ ~s(id="f-add-trigger")
+    end
+  end
+
+  describe "accessibility" do
+    test "the add trigger declares its popup and collapsed state" do
+      html = bar(%{on_change: "table"})
+
+      assert html =~ ~s(aria-haspopup="dialog")
+      assert html =~ ~s(aria-expanded="false")
+      assert html =~ ~s(aria-controls="f-add")
+    end
+
+    test "the chip list is announced as a labelled group" do
+      state = %State{filters: [%{field: :category, op: :eq, value: "hand"}]}
+      html = bar(%{on_change: "table", state: state})
+
+      assert html =~ ~s(role="group")
+      assert html =~ ~s(aria-label="Active filters")
+    end
+
+    test "a remove button names the filter it removes" do
+      state = %State{
+        filters: [
+          %{field: :category, op: :eq, value: "hand"},
+          %{field: :name, op: :is_empty, value: true}
+        ]
+      }
+
+      html = bar(%{on_change: "table", state: state})
+
+      assert html =~ ~s(aria-label="Remove filter: Category is Hand tools")
+      assert html =~ ~s(aria-label="Remove filter: Name is empty")
+    end
+
+    test "a live region reports the active filters, and says so when there are none" do
+      assert bar(%{on_change: "table"}) =~ ~s(role="status")
+      assert bar(%{on_change: "table"}) =~ "No filters applied"
+
+      state = %State{filters: [%{field: :category, op: :eq, value: "hand"}]}
+
+      assert bar(%{on_change: "table", state: state}) =~
+               "Active filters: Category is Hand tools"
+    end
+
+    test "the chip trigger controls its own editor panel" do
+      state = %State{filters: [%{field: :price, op: :gt, value: "10"}]}
+      html = bar(%{on_change: "table", state: state})
+
+      assert html =~ ~s(id="f-chip-price")
+      assert html =~ ~s(aria-controls="f-editor-price")
+    end
+
+    test "decorative icons are hidden from assistive tech" do
+      state = %State{filters: [%{field: :category, op: :eq, value: "hand"}]}
+      html = bar(%{on_change: "table", state: state})
+
+      assert has_icon?(html, "pc-filters__chip-remove-icon")
+      assert html =~ ~s(class="hero-x-mark pc-filters__chip-remove-icon" aria-hidden="true")
+    end
+
+    test "editor controls carry accessible names" do
+      html = bar(%{on_change: "table"})
+
+      assert html =~ ~s(aria-label="Price operator")
+      assert html =~ ~s(aria-label="Price lower bound")
+      assert html =~ ~s(aria-label="Price upper bound")
+      assert html =~ ~s(aria-label="In stock value")
+    end
+  end
+
+  describe "labels" do
+    test "filter_op_labels overrides reach both the chips and the operator picker" do
+      state = %State{filters: [%{field: :name, op: :contains, value: "an"}]}
+
+      html =
+        bar(%{
+          on_change: "table",
+          state: state,
+          extra: %{filter_op_labels: %{contains: "enthält"}}
+        })
+
+      doc = parse_html(html)
+
+      assert text(doc, ".pc-filters__chip-op") == "enthält"
+
+      options =
+        doc
+        |> LazyHTML.query(~s(#f-form-name select[name="filter_op"] option))
+        |> LazyHTML.text()
+
+      assert options =~ "enthält"
+    end
+
+    test "every user-facing string is overridable" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.filters
+          id="f"
+          state={%State{filters: [%{field: :name, op: :eq, value: "x"}]}}
+          on_change="table"
+          add_filter_label="Filtre"
+          clear_filters_label="Effacer"
+          apply_label="Appliquer"
+          remove_filter_label="Retirer"
+          active_filters_label="Filtres actifs"
+        >
+          <:field field={:name} label="Nom" type="text" />
+          <:field field={:price} label="Prix" type="number_range" />
+        </.filters>
+        """)
+
+      assert html =~ "Filtre"
+      assert html =~ "Effacer"
+      assert html =~ "Appliquer"
+      assert html =~ ~s(aria-label="Retirer: Nom is x")
+      assert html =~ ~s(aria-label="Filtres actifs")
+    end
+
+    test "a field with no label humanizes its atom" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.filters
+          id="f"
+          state={%State{filters: [%{field: :added_on, op: :on, value: "2026-01-01"}]}}
+          on_change="table"
+        >
+          <:field field={:added_on} type="date_range" />
+        </.filters>
+        """)
+
+      assert html =~ "Added on"
+    end
+  end
+
+  describe "styling hooks" do
+    test "class rides the root and the pc-filters section owns the chrome" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.filters id="f" state={%State{}} on_change="table" class="mb-6">
+          <:field field={:name} type="text" />
+        </.filters>
+        """)
+
+      assert html =~ ~s(class="pc-filters mb-6")
+      assert html =~ "pc-popover__panel--bottom-start"
+      assert html =~ "pc-filters__panel"
+    end
+  end
+end


### PR DESCRIPTION
Closes #619

## Summary

`<.filters>` renders the active filters as removable chips (field, humanised operator, formatted value) next to an "Add filter" popover that walks field -> operator -> value inside one panel, no server round trip. Both wiring modes ship, inferred the same way `data_table/1` infers them (passing neither raises).

Five parts per CONTRIBUTING.md:

1. `lib/petal_components/filters.ex` - the component, exported via `use PetalComponents`. Every attr and slot attr carries a `doc:`; the moduledoc carries usage examples for both modes and for the shared-State composition.
2. `assets/default.css` - a `pc-filters` section appended inside `@layer components`, nothing above it reflowed. Consumes `--pc-radius`, rides the gray ramp, dark via `dark:`, `focus-visible` only (no persistent `:focus` fills), `prefers-reduced-motion` respected.
3. `test/petal/filters_test.exs` - 41 tests.
4. `lib/petal_components/showcase/filters.ex` + its `registry.ex` entry.
5. A playground page: nav entry `filters` (one slug, 1:1), a field-types dial, and three scenarios - the standalone bar over a product list, the shared-State composition against a live `<.data_table>`, and a link-mode demo printing the query string it decoded.

Plus `### Unreleased` / `#### Added` in `CHANGELOG.md`.

## Relationship to `DataTable.State` - it drives it directly

Not independent. The component takes a `%State{}` and mutates it only through `State.put_filter/4` (link mode, server-rendered hrefs) and `State.handle_op/3` (event mode). It never defines an operator atom, never re-pins semantics, and never invents a payload shape. The per-type operator lists are subsets of `State.ops/0`, asserted programmatically in the suite so a vocabulary change fails loudly here.

Concretely: chip removal posts `%{"op" => "filter", "field" => f}` with no `filter_op`, which is exactly how the data table's inline clear already reads as a removal; clear-all posts `%{"op" => "clear_filters"}`; the editor form posts `filter_op` / `value` / `value2` / `values[]`, byte-for-byte the shapes `handle_op/3` parses. A LiveView already wired for an event-mode `data_table` gains a filter bar with **zero** new handler clauses. Link mode patches URLs built from `State.to_params/1`, so `handle_params` + `from_params/2` is the whole backend and the state is curl-able.

Because both components read one struct, pointing them at the same assign composes with no glue - visible in the playground's second example and in `active-light.png`, where the bar's chips and the table's column-filter triggers show the same predicates and the table has narrowed to the matching rows.

### The shared extraction

The issue suggested extracting the overlapping editors rather than copy-pasting, so `lib/petal_components/data_table/filter_editor.ex` (`@moduledoc false`) now owns the typed value editors, the operator display names, the value formatting, and the `State` -> URL encoding. `data_table.ex` consumes it.

Two deliberate choices there:

- Editors are named by **shape** (`text`, `number`, `date`, `options`, `choice`, `boolean`), not by either caller's type vocabulary - the data table's `select` is a checkbox list while the filter bar's `select` is a single choice, so a shared name keyed on "select" would have been a trap.
- The `pc-data-table__filter-*` class names are kept on the shared form. The `PetalDataTable` hook queries them and `default.css` already carries the JS-free `:has` rules that hide the value input for a valueless op and reveal the second bound for `:between`. Renaming would have meant touching the hook and its specs for no behavioural gain.

**The data table's rendered markup and event grammar are unchanged, and its full suite passes unmodified** - that is the backward-compatibility proof. `data_table.ex` net-shrinks by ~180 lines.

## Did I ship a hook? No

No new hook and **no JS changes at all** (`npm test` is untouched at 157). The existing `PetalDataTable` hook already does everything this needs: it drives in-page `[data-pc-menu]` panels (open/close, outside-tap dismiss, Escape with focus restore, flip and clamp on resize) and, in link mode, reads a `.pc-data-table__filter-form` back into a patch URL from a `:filters` nav template. The filter bar mounts the same hook and speaks the same data attributes. The issue's own guidance was to prefer reusing an existing hook, and this reuse cost zero new lines of JS.

Everything else is CSS-first: the add panel's step swap is `Phoenix.LiveView.JS` class toggling over CSS-owned `display`, so there is a complete rest state at both ends and nothing for reduced motion to sit through; the `between` second bound is still the existing `:has` rule.

## Deviations from the issue's API sketch

1. **`multi` supports `:in` only, not `:not_in`.** Both paths that turn an editor into a filter hardcode `:in` when a `values[]` list is present - `State.handle_op/3` (`is_list(params["values"])` wins before `filter_op` is read) and the hook's `readFilter`. Offering `:not_in` in the picker would have rendered an operator that silently became `:in`. Getting it working would need either a `State` grammar change or a hook change, both of which the issue rules out ("no changes to operator semantics", "never bypasses `handle_op/3`"). I chose the honest subset. **Flagging this as the one place the sketch and the shipped API differ on vocabulary** - happy to follow up with an `:not_in` path in `State` if you want it.

2. **The field list is a `role="group"` of buttons navigated by Tab, not a `role="menu"` navigated by arrow keys.** Arrow-key roving needs JS to move focus, and the only way to get it was new hook code. By not claiming menu semantics the pattern stays WAI-ARIA conformant as-is (a labelled group of buttons; Tab is the correct navigation for that role) and the whole flow is keyboard-operable: Tab to the trigger, Enter/Space opens, Tab through the field list, Enter picks, Tab reaches the inputs, Enter applies, Escape closes and returns focus to the trigger. The operator list is a native `<select>`, so arrow keys work there natively as the issue asks. Say the word and I'll add the roving handler.

3. **The "Add filter" trigger always renders**, even when every field is filtered (the panel then says so). It doubles as the guaranteed focus target after the last chip is removed - a trigger that appears only *after* the removal would be missing at the moment `JS.focus` runs.

4. **The add list offers only unfiltered fields.** The state model is one filter per field, and an already-filtered field is edited from its chip, so listing it twice would have meant two forms for one field.

5. **Extra localizable attrs** beyond the sketch: `remove_filter_label`, `active_filters_label`, `no_filters_label`, `all_fields_used_label`, `filter_options_placeholder`. Every user-facing string is overridable, asserted in the suite.

6. **`date_range` gains `:between`** (the data table's date editor has none), so the shared date editor renders a second bound only when `:between` is in the offered ops - which keeps the data table's markup identical.

## Accessibility

- Add trigger and chip bodies: `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls`.
- Chip list: `role="group"` + `aria-label="Active filters"`.
- Remove buttons name the filter, never a bare x: `aria-label="Remove filter: Category is Power tools"` (option **labels**, not posted values).
- Focus after removal goes to the next chip, else the add trigger - never `body`. Each chip's remove chains `JS.focus` onto the push (event mode) or the patch link (link mode).
- An `sr-only` `role="status"` region reports the resulting filter set, so a removal is announced rather than silent.
- Every editor control has an accessible name; decorative icons carry `aria-hidden="true"`.
- `focus-visible` rings only.

## Verification

| check | result |
|---|---|
| `mix format --check-formatted` | clean |
| `mix compile --force --warnings-as-errors` | clean |
| `mix credo` | **zero new entries** vs `origin/main` (diffed `--all --format=oneline`; the only delta is a line-number shift on a pre-existing `data_table.ex` complexity entry) |
| `mix test` | **913 -> 954**, 0 failures, 1 skipped (+41 new; every pre-existing data-table test passes unmodified) |
| `npm test` | **157 -> 157**, 0 failures (no JS touched) |

No test was weakened or deleted.

Verified in the playground on light and dark, and driven end to end in a real browser: opened the add panel, picked a field, watched the panel swap to the editor, selected `between` and watched the second bound appear from the `:has` rule alone, applied, and saw the chip, the narrowed list, the narrowed shared table and the URL round-trip in link mode.

## Screenshots

Captured from the playground page at 1280x2200, both schemes, empty and with filters applied. Not committed to the repo - I'll drop them into this thread rather than into `pr-assets`.
