### PR TITLE
feat(resizable): split panes with draggable, keyboard-operable dividers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,34 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **New `resizable` component family: split panes with dividers you can drag
+  and key.** `<.resizable_group>` wraps `<.resizable_panel>` and
+  `<.resizable_handle>` children into the layout primitive behind docs sites
+  with an adjustable sidebar, IDE workspaces and editor/preview splits. Panels
+  are sized as percentages of the group and rendered as `flex: <pct> 1 0px`, so
+  a window resize keeps the split proportional instead of stranding a pane at a
+  pixel width. `default_size`, `min_size`, `max_size`, `collapsible` and
+  `collapsed_size` per panel; both orientations; two-panel and n-panel groups.
+  Nested groups are first class: the `PetalResizable` hook only ever looks at
+  its own direct children, so a horizontal split inside a vertical one gets two
+  independent hooks that never fight over a panel.
+
+  Keyboard resizing is not an afterthought. Every handle is a WAI-ARIA
+  `separator` in the tab order with live `aria-valuenow`/`valuemin`/`valuemax`
+  and `aria-controls` on the panel before it. Arrows move it by 2 points (10
+  with shift), `Home` shrinks or collapses, `End` grows to max, `Enter` toggles
+  a collapsible pane, and arrows perpendicular to the separator do nothing, per
+  the pattern. Drag uses pointer capture so a fast drag cannot lose the
+  divider, and double-click resets a divider's two panes to their defaults.
+
+  Nothing is persisted for you. On release and on keyboard commit the group
+  fires a bubbling `petal:resizable-resize` DOM event with the percentages and,
+  when `on_resize` is set, pushes the same payload to your LiveView. Collapse
+  and expand fire `petal:resizable-collapse`. Store it in the session, the URL
+  or localStorage, whichever suits.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,116 @@
       transition-duration: 1ms;
     }
   }
+
+/* Resizable - split panes with draggable, keyboard-operable separators.
+ * The painted divider is a hairline; the hit area around it is much larger,
+ * which is the difference between a splitter you can grab and one you hunt. */
+@layer components {
+  .pc-resizable {
+    @apply flex flex-row w-full h-full overflow-hidden;
+  }
+
+  .pc-resizable--vertical {
+    @apply flex-col;
+  }
+
+  /* min-w-0/min-h-0 matter: a flex item defaults to min-size auto, which would
+   * refuse to shrink past its content and quietly break every clamp. */
+  .pc-resizable__panel {
+    @apply relative min-w-0 min-h-0 overflow-hidden;
+  }
+
+  /* The element IS the hit area (1px painted line, 11px grabbable). Negative
+   * margins pull the neighbouring panels back so the extra width costs no
+   * layout - the panels still meet on the hairline. */
+  .pc-resizable__handle {
+    @apply relative z-10 flex items-center justify-center shrink-0 self-stretch;
+    @apply w-[11px] -mx-[5px] cursor-col-resize touch-none select-none outline-none;
+  }
+
+  .pc-resizable--vertical > .pc-resizable__handle {
+    @apply w-auto mx-0 h-[11px] -my-[5px] cursor-row-resize;
+  }
+
+  /* The hairline itself. A pseudo-element so hover, drag and focus can tint it
+   * without touching the hit area's geometry. */
+  .pc-resizable__handle::before {
+    content: "";
+    @apply absolute w-px h-full bg-gray-200 transition-colors duration-150 ease-out;
+    @apply dark:bg-gray-400/20;
+  }
+
+  .pc-resizable--vertical > .pc-resizable__handle::before {
+    @apply w-full h-px;
+  }
+
+  .pc-resizable__handle:hover::before,
+  .pc-resizable__handle:focus-visible::before,
+  .pc-resizable__handle--dragging::before {
+    @apply bg-primary-500;
+  }
+
+  /* Never a persistent :focus fill. The ring is for keyboard users only, and
+   * on a splitter it has to be unmissable - arrows do nothing until you can
+   * see which separator has focus. */
+  .pc-resizable__handle:focus-visible {
+    @apply ring-2 ring-primary-500/50;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.375rem), 0.125rem);
+  }
+
+  /* The grip pill: the visible "you can drag this" affordance. */
+  .pc-resizable__grip {
+    @apply relative z-10 flex items-center justify-center;
+    @apply w-[11px] h-6 border border-gray-200 bg-gray-50 text-gray-400;
+    @apply transition-colors duration-150 ease-out;
+    @apply dark:border-gray-400/20 dark:bg-gray-800 dark:text-gray-500;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.375rem), 0.125rem);
+  }
+
+  .pc-resizable--vertical > .pc-resizable__handle .pc-resizable__grip {
+    @apply w-6 h-[11px];
+  }
+
+  /* Three dots, drawn with a repeating gradient so the grip needs no markup. */
+  .pc-resizable__grip::after {
+    content: "";
+    @apply block w-[2px] h-[10px];
+    background-image: repeating-linear-gradient(
+      to bottom,
+      currentColor 0 2px,
+      transparent 2px 4px
+    );
+  }
+
+  .pc-resizable--vertical > .pc-resizable__handle .pc-resizable__grip::after {
+    @apply w-[10px] h-[2px];
+    background-image: repeating-linear-gradient(
+      to right,
+      currentColor 0 2px,
+      transparent 2px 4px
+    );
+  }
+
+  .pc-resizable__handle:hover .pc-resizable__grip,
+  .pc-resizable__handle:focus-visible .pc-resizable__grip,
+  .pc-resizable__handle--dragging .pc-resizable__grip {
+    @apply border-primary-500 text-primary-500;
+  }
+
+  /* Mid-drag the pointer belongs to the separator: no text selection, and no
+   * child element stealing the pointer stream from the captured handle. */
+  .pc-resizable--dragging {
+    @apply select-none;
+  }
+
+  .pc-resizable--dragging .pc-resizable__panel {
+    @apply pointer-events-none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pc-resizable__handle::before,
+    .pc-resizable__grip {
+      transition-duration: 1ms;
+    }
+  }
+}

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -5424,6 +5424,464 @@ export const PetalDataTable = {
   },
 };
 
+// ---------------------------------------------------------------------------
+// Resizable
+//
+// The maths lives in pure functions below the hook so it can be unit-tested
+// without a DOM (test/js/resizable.test.js). Everything is percentages of the
+// group: sizes always sum to 100, a resize only ever moves the two panels
+// either side of one handle, and their pair total is conserved - which is why
+// no operation can ever drift the whole layout.
+// ---------------------------------------------------------------------------
+
+export const RESIZABLE_STEP = 2;
+export const RESIZABLE_SHIFT_STEP = 10;
+
+const clampPct = (n, lo, hi) => Math.min(Math.max(n, lo), hi);
+
+// Floating point drift is real when you add and subtract percentages a few
+// hundred times over a drag. Six places is far below anything a layout can
+// show and keeps the "sums to 100" invariant exact enough to assert on.
+const roundPct = (n) => Math.round(n * 1e6) / 1e6;
+
+/**
+ * Read one panel's constraints off its data-* attributes.
+ * @param {HTMLElement} el
+ */
+export function resizableConstraint(el) {
+  const num = (v, fallback) => {
+    const n = parseFloat(v);
+    return Number.isFinite(n) ? n : fallback;
+  };
+
+  return {
+    min: num(el.dataset.min, 10),
+    max: num(el.dataset.max, 100),
+    default: el.dataset.default === undefined ? null : num(el.dataset.default, null),
+    collapsible: el.dataset.collapsible === "true",
+    collapsedSize: num(el.dataset.collapsedSize, 0),
+  };
+}
+
+/**
+ * Initial sizes: honour every default_size, split the remainder equally
+ * between the unsized panels, then normalise so the row sums to 100.
+ * @param {Array<object>} constraints
+ * @returns {number[]}
+ */
+export function distributeSizes(constraints) {
+  const n = constraints.length;
+  if (n === 0) return [];
+
+  const sizes = constraints.map((c) =>
+    typeof c.default === "number" && Number.isFinite(c.default) ? c.default : null,
+  );
+  const knownTotal = sizes.reduce((sum, s) => (s === null ? sum : sum + s), 0);
+  const unsized = sizes.filter((s) => s === null).length;
+
+  if (unsized > 0) {
+    const share = Math.max(0, 100 - knownTotal) / unsized;
+    for (let i = 0; i < n; i++) if (sizes[i] === null) sizes[i] = share;
+  }
+
+  const clamped = sizes.map((s, i) => clampPct(s, 0, constraints[i].max));
+  const total = clamped.reduce((a, b) => a + b, 0);
+  if (total <= 0) return clamped.map(() => roundPct(100 / n));
+
+  return clamped.map((s) => roundPct((s * 100) / total));
+}
+
+// Where a collapsible panel wants to land, or null to take the normal path.
+// The threshold sits halfway between collapsed and min, so the snap in and the
+// snap out happen at the same place - no hysteresis gap to get stuck in.
+function snapTarget(c, current, desired) {
+  if (!c.collapsible) return null;
+
+  const threshold = c.collapsedSize + (c.min - c.collapsedSize) / 2;
+  const wasCollapsed = current <= c.collapsedSize + 0.001;
+
+  if (desired < threshold) {
+    return { size: c.collapsedSize, collapsed: true, changed: !wasCollapsed };
+  }
+  if (wasCollapsed) {
+    return { size: Math.max(c.min, desired), collapsed: false, changed: true };
+  }
+  return null;
+}
+
+/**
+ * Move the separator at `index` by `deltaPct`, conserving the pair total and
+ * respecting BOTH adjacent panels' min/max (and collapse, when enabled).
+ *
+ * @returns {{sizes: number[], collapse: ?{index: number, collapsed: boolean}}}
+ */
+export function resolveDrag(sizes, index, deltaPct, constraints) {
+  const next = sizes.slice();
+  const a = index;
+  const b = index + 1;
+  if (a < 0 || b >= sizes.length) return { sizes: next, collapse: null };
+
+  const ca = constraints[a];
+  const cb = constraints[b];
+  const pairTotal = sizes[a] + sizes[b];
+  const desiredA = sizes[a] + deltaPct;
+
+  let targetA = desiredA;
+  let collapse = null;
+  let snapped = false;
+
+  const snapA = snapTarget(ca, sizes[a], desiredA);
+  if (snapA) {
+    targetA = snapA.size;
+    snapped = snapA.collapsed;
+    if (snapA.changed) collapse = { index: a, collapsed: snapA.collapsed };
+  } else {
+    const snapB = snapTarget(cb, sizes[b], pairTotal - desiredA);
+    if (snapB) {
+      targetA = pairTotal - snapB.size;
+      snapped = snapB.collapsed;
+      if (snapB.changed) collapse = { index: b, collapsed: snapB.collapsed };
+    }
+  }
+
+  // A collapsed panel is allowed to sit below its own min - that is the whole
+  // point of collapsing. Every other target gets clamped by both panels.
+  if (!snapped) {
+    const lo = Math.max(ca.min, pairTotal - cb.max);
+    const hi = Math.min(ca.max, pairTotal - cb.min);
+    targetA = clampPct(targetA, Math.min(lo, hi), hi);
+  }
+
+  next[a] = roundPct(targetA);
+  next[b] = roundPct(pairTotal - targetA);
+  return { sizes: next, collapse };
+}
+
+/**
+ * Home / End on a focused separator: drive the preceding panel to its floor
+ * ("min", collapsing it when it can collapse) or its ceiling ("max").
+ */
+export function resolveEdge(sizes, index, edge, constraints) {
+  const ca = constraints[index];
+  if (!ca) return { sizes: sizes.slice(), collapse: null };
+
+  const target =
+    edge === "min" ? (ca.collapsible ? ca.collapsedSize : ca.min) : ca.max;
+
+  return resolveDrag(sizes, index, target - sizes[index], constraints);
+}
+
+/** Enter on a focused separator: collapse or restore the preceding panel. */
+export function resolveToggle(sizes, index, constraints) {
+  const ca = constraints[index];
+  if (!ca || !ca.collapsible) return { sizes: sizes.slice(), collapse: null };
+
+  const isCollapsed = sizes[index] <= ca.collapsedSize + 0.001;
+  const restore = Math.max(ca.min, ca.default ?? ca.min);
+  const target = isCollapsed ? restore : ca.collapsedSize;
+
+  return resolveDrag(sizes, index, target - sizes[index], constraints);
+}
+
+/**
+ * Double-click a separator: put its two panels back on their default_size
+ * ratio, spending only the space those two already hold.
+ */
+export function resolveReset(sizes, index, constraints) {
+  const next = sizes.slice();
+  const a = index;
+  const b = index + 1;
+  if (a < 0 || b >= sizes.length) return { sizes: next, collapse: null };
+
+  const ca = constraints[a];
+  const cb = constraints[b];
+  const pairTotal = sizes[a] + sizes[b];
+  const da = ca.default;
+  const db = cb.default;
+
+  let targetA;
+  if (da != null && db != null && da + db > 0) targetA = (da / (da + db)) * pairTotal;
+  else if (da != null) targetA = da;
+  else if (db != null) targetA = pairTotal - db;
+  else targetA = pairTotal / 2;
+
+  const lo = Math.max(ca.min, pairTotal - cb.max);
+  const hi = Math.min(ca.max, pairTotal - cb.min);
+  targetA = clampPct(targetA, Math.min(lo, hi), hi);
+
+  next[a] = roundPct(targetA);
+  next[b] = roundPct(pairTotal - targetA);
+
+  // Resetting a collapsed panel back to its default expands it, and an expand
+  // is something listeners want to hear about.
+  const wasCollapsed = ca.collapsible && sizes[a] <= ca.collapsedSize + 0.001;
+  const stillCollapsed = ca.collapsible && next[a] <= ca.collapsedSize + 0.001;
+  const collapse =
+    wasCollapsed && !stillCollapsed ? { index: a, collapsed: false } : null;
+
+  return { sizes: next, collapse };
+}
+
+/**
+ * The arrow-key step for a separator, or null when the key is perpendicular to
+ * it (a no-op, per the WAI-ARIA window splitter pattern).
+ *
+ * @param {string} key KeyboardEvent.key
+ * @param {boolean} shiftKey
+ * @param {string} orientation the GROUP's orientation
+ */
+export function keyboardDelta(key, shiftKey, orientation) {
+  const step = shiftKey ? RESIZABLE_SHIFT_STEP : RESIZABLE_STEP;
+
+  if (orientation === "vertical") {
+    if (key === "ArrowUp") return -step;
+    if (key === "ArrowDown") return step;
+    return null;
+  }
+
+  if (key === "ArrowLeft") return -step;
+  if (key === "ArrowRight") return step;
+  return null;
+}
+
+export const PetalResizable = {
+  mounted() {
+    this.dragging = null;
+    this.collect();
+    this.sizes = distributeSizes(this.constraints);
+    this.apply();
+
+    this.onPointerDown = (e) => this.startDrag(e);
+    this.onPointerMove = (e) => this.moveDrag(e);
+    this.onPointerUp = (e) => this.endDrag(e);
+    this.onKeyDown = (e) => this.keydown(e);
+    this.onDblClick = (e) => this.dblclick(e);
+
+    // Delegated on the group. A nested group's handles bubble through here, so
+    // every handler resolves the handle back to THIS group's list and bails
+    // when it is not one of ours - that is what keeps nested hooks independent.
+    this.el.addEventListener("pointerdown", this.onPointerDown);
+    this.el.addEventListener("pointermove", this.onPointerMove);
+    this.el.addEventListener("pointerup", this.onPointerUp);
+    this.el.addEventListener("pointercancel", this.onPointerUp);
+    this.el.addEventListener("lostpointercapture", this.onPointerUp);
+    this.el.addEventListener("keydown", this.onKeyDown);
+    this.el.addEventListener("dblclick", this.onDblClick);
+  },
+
+  // A LiveView patch re-renders panels from the server, which restores the
+  // server's flex values and wipes the aria the hook stamped. Re-assert.
+  // Panel count can change too, so re-derive sizes when it does.
+  updated() {
+    const before = this.panels.length;
+    this.collect();
+    if (this.panels.length !== before) this.sizes = distributeSizes(this.constraints);
+    this.apply();
+  },
+
+  destroyed() {
+    this.releaseBody();
+    this.el.removeEventListener("pointerdown", this.onPointerDown);
+    this.el.removeEventListener("pointermove", this.onPointerMove);
+    this.el.removeEventListener("pointerup", this.onPointerUp);
+    this.el.removeEventListener("pointercancel", this.onPointerUp);
+    this.el.removeEventListener("lostpointercapture", this.onPointerUp);
+    this.el.removeEventListener("keydown", this.onKeyDown);
+    this.el.removeEventListener("dblclick", this.onDblClick);
+  },
+
+  // :scope > … is the whole nesting story: an inner group's panels are not
+  // direct children of the outer group, so they are invisible to it.
+  collect() {
+    this.orientation = this.el.dataset.orientation === "vertical" ? "vertical" : "horizontal";
+    this.panels = Array.from(this.el.querySelectorAll(":scope > [data-pc-resizable-panel]"));
+    this.handles = Array.from(this.el.querySelectorAll(":scope > [data-pc-resizable-handle]"));
+    this.constraints = this.panels.map(resizableConstraint);
+  },
+
+  handleIndex(target) {
+    if (!target || !target.closest) return -1;
+    const handle = target.closest("[data-pc-resizable-handle]");
+    return handle ? this.handles.indexOf(handle) : -1;
+  },
+
+  apply() {
+    this.panels.forEach((panel, i) => {
+      const size = this.sizes[i];
+      if (typeof size !== "number") return;
+      panel.style.flex = `${size} 1 0px`;
+    });
+
+    this.handles.forEach((handle, i) => {
+      const c = this.constraints[i];
+      if (!c) return;
+      const panel = this.panels[i];
+      handle.setAttribute("aria-valuenow", String(Math.round(this.sizes[i])));
+      handle.setAttribute("aria-valuemin", String(c.collapsible ? c.collapsedSize : c.min));
+      handle.setAttribute("aria-valuemax", String(c.max));
+      handle.setAttribute(
+        "aria-orientation",
+        this.orientation === "horizontal" ? "vertical" : "horizontal",
+      );
+      if (panel && panel.id) handle.setAttribute("aria-controls", panel.id);
+    });
+  },
+
+  groupExtent() {
+    const rect = this.el.getBoundingClientRect();
+    const extent = this.orientation === "vertical" ? rect.height : rect.width;
+    return extent > 0 ? extent : 0;
+  },
+
+  startDrag(e) {
+    const index = this.handleIndex(e.target);
+    if (index < 0 || index + 1 >= this.panels.length) return;
+    if (e.button !== undefined && e.button !== 0) return;
+
+    const handle = this.handles[index];
+    // Pointer capture is what stops a fast drag from losing the separator the
+    // moment the cursor outruns it.
+    if (handle.setPointerCapture && e.pointerId !== undefined) {
+      try {
+        handle.setPointerCapture(e.pointerId);
+      } catch {
+        /* capture is a nicety, not a requirement */
+      }
+    }
+
+    this.dragging = {
+      index,
+      start: this.orientation === "vertical" ? e.clientY : e.clientX,
+      startSizes: this.sizes.slice(),
+      extent: this.groupExtent(),
+      moved: false,
+    };
+
+    handle.classList.add("pc-resizable__handle--dragging");
+    this.el.classList.add("pc-resizable--dragging");
+    this.holdBody();
+    e.preventDefault();
+  },
+
+  moveDrag(e) {
+    if (!this.dragging) return;
+    const { index, start, startSizes, extent } = this.dragging;
+    if (extent <= 0) return;
+
+    const pos = this.orientation === "vertical" ? e.clientY : e.clientX;
+    const deltaPct = ((pos - start) / extent) * 100;
+    const target = startSizes[index] + deltaPct;
+
+    const { sizes, collapse } = resolveDrag(
+      this.sizes,
+      index,
+      target - this.sizes[index],
+      this.constraints,
+    );
+
+    this.dragging.moved = true;
+    this.sizes = sizes;
+    this.apply();
+    if (collapse) this.emitCollapse(collapse);
+  },
+
+  endDrag(e) {
+    if (!this.dragging) return;
+    const { index, moved } = this.dragging;
+    const handle = this.handles[index];
+
+    if (handle) {
+      handle.classList.remove("pc-resizable__handle--dragging");
+      if (handle.releasePointerCapture && e && e.pointerId !== undefined) {
+        try {
+          handle.releasePointerCapture(e.pointerId);
+        } catch {
+          /* already released */
+        }
+      }
+    }
+
+    this.el.classList.remove("pc-resizable--dragging");
+    this.releaseBody();
+    this.dragging = null;
+    if (moved) this.commit();
+  },
+
+  keydown(e) {
+    const index = this.handleIndex(e.target);
+    if (index < 0 || index + 1 >= this.panels.length) return;
+
+    let result = null;
+
+    if (e.key === "Home") result = resolveEdge(this.sizes, index, "min", this.constraints);
+    else if (e.key === "End") result = resolveEdge(this.sizes, index, "max", this.constraints);
+    else if (e.key === "Enter") result = resolveToggle(this.sizes, index, this.constraints);
+    else {
+      const delta = keyboardDelta(e.key, e.shiftKey, this.orientation);
+      if (delta === null) return;
+      result = resolveDrag(this.sizes, index, delta, this.constraints);
+    }
+
+    e.preventDefault();
+    this.sizes = result.sizes;
+    this.apply();
+    if (result.collapse) this.emitCollapse(result.collapse);
+    this.commit();
+  },
+
+  dblclick(e) {
+    const index = this.handleIndex(e.target);
+    if (index < 0 || index + 1 >= this.panels.length) return;
+
+    const { sizes, collapse } = resolveReset(this.sizes, index, this.constraints);
+    this.sizes = sizes;
+    this.apply();
+    if (collapse) this.emitCollapse(collapse);
+    this.commit();
+  },
+
+  holdBody() {
+    const body = document.body;
+    if (!body) return;
+    this.bodyCursor = body.style.cursor;
+    this.bodySelect = body.style.userSelect;
+    body.style.cursor = this.orientation === "vertical" ? "row-resize" : "col-resize";
+    body.style.userSelect = "none";
+  },
+
+  releaseBody() {
+    const body = document.body;
+    if (!body || this.bodyCursor === undefined) return;
+    body.style.cursor = this.bodyCursor;
+    body.style.userSelect = this.bodySelect;
+    this.bodyCursor = undefined;
+    this.bodySelect = undefined;
+  },
+
+  emitCollapse({ index, collapsed }) {
+    const panel = this.panels[index];
+    this.el.dispatchEvent(
+      new CustomEvent("petal:resizable-collapse", {
+        bubbles: true,
+        detail: { panel_id: panel ? panel.id || null : null, collapsed },
+      }),
+    );
+  },
+
+  // The whole persistence story: an event on release, and the same payload
+  // pushed to the LiveView when on_resize is set. The library stores nothing.
+  commit() {
+    const sizes = this.sizes.map((s) => Math.round(s * 100) / 100);
+
+    this.el.dispatchEvent(
+      new CustomEvent("petal:resizable-resize", { bubbles: true, detail: { sizes } }),
+    );
+
+    const event = this.el.dataset.onResize;
+    if (event && this.pushEvent) this.pushEvent(event, { sizes });
+  },
+};
+
 export default {
   PetalChart,
   PetalColorScheme,
@@ -5454,4 +5912,5 @@ export default {
   PetalCommandDialog,
   PetalComboBox,
   PetalDataTable,
+  PetalResizable,
 };

--- a/dev.exs
+++ b/dev.exs
@@ -295,7 +295,8 @@ defmodule Dev.PlaygroundLive do
         %{slug: "card", name: "Card", ready: true},
         %{slug: "carousel", name: "Carousel", ready: true},
         %{slug: "accordion", name: "Accordion", ready: true},
-        %{slug: "container", name: "Container", ready: true}
+        %{slug: "container", name: "Container", ready: true},
+        %{slug: "resizable", name: "Resizable", ready: true}
       ]
     },
     %{
@@ -766,6 +767,8 @@ defmodule Dev.PlaygroundLive do
        checkbox: %{layout: "row", disabled: false, error: false},
        select: %{disabled: false, error: false, help: false},
        combo: %{disabled: false, chosen: nil},
+       rsz: %{orientation: "horizontal", with_handle: true, collapsible: true},
+       rsz_sizes: [65, 35],
        rich: %{labels: ~w(feat bug imp des), team: ~w(amelia jonah)},
        dt: PetalComponents.DataTable.State |> struct(page_size: 5) |> run_dt(),
        dt_selected: [],
@@ -1448,6 +1451,21 @@ defmodule Dev.PlaygroundLive do
     do:
       {:noreply,
        update(socket, :otp, &Map.update!(&1, String.to_existing_atom(k), fn v -> !v end))}
+
+  def handle_event("ctl_rsz", %{"k" => "orientation", "v" => v}, socket)
+      when v in ~w(horizontal vertical),
+      do: {:noreply, update(socket, :rsz, &%{&1 | orientation: v})}
+
+  def handle_event("ctl_rsz", %{"k" => k}, socket) when k in ~w(with_handle collapsible),
+    do:
+      {:noreply,
+       update(socket, :rsz, &Map.update!(&1, String.to_existing_atom(k), fn v -> !v end))}
+
+  # The persistence hook point: on_resize pushes the released percentages here.
+  # A real app would stash these in the session, the URL or localStorage - the
+  # library itself stores nothing.
+  def handle_event("pg_resize", %{"sizes" => sizes}, socket),
+    do: {:noreply, assign(socket, :rsz_sizes, Enum.map(sizes, &round/1))}
 
   def handle_event("ctl_switch", %{"k" => "size", "v" => v}, socket) when v in ~w(xs sm md lg xl),
     do: {:noreply, update(socket, :switch, &%{&1 | size: v})}
@@ -7659,6 +7677,165 @@ defmodule Dev.PlaygroundLive do
         registry - the same source petal.build renders, so the playground and the marketing
         docs can't drift.
       </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "resizable"} = assigns) do
+    ~H"""
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">Resizable</h1>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        Split panes with dividers you can drag - and key. Sizes are percentages of the
+        group, so the split stays proportional when the window changes. Nested groups
+        each mount their own hook and only touch their own direct children.
+      </p>
+      <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+        <span class="font-medium text-gray-700 dark:text-gray-200">Try the keyboard:</span>
+        tab to a divider, then arrows to resize (hold shift for a bigger step),
+        <kbd class="px-1 font-mono text-xs">Home</kbd>
+        to shrink or collapse, <kbd class="px-1 font-mono text-xs">End</kbd>
+        to grow, <kbd class="px-1 font-mono text-xs">Enter</kbd>
+        to toggle a collapsible pane. Double-click a divider to reset it.
+      </p>
+
+      <div class="mt-8 overflow-hidden border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="p-6">
+          <.resizable_group
+            id={"pg-rsz-#{@rsz.orientation}-#{@rsz.with_handle}-#{@rsz.collapsible}"}
+            orientation={@rsz.orientation}
+            class="h-64 border border-gray-200 rounded-xl dark:border-gray-400/20"
+          >
+            <.resizable_panel
+              id="pg-rsz-nav"
+              default_size={28}
+              min_size={18}
+              collapsible={@rsz.collapsible}
+            >
+              <nav class="h-full p-4 text-sm bg-gray-50 dark:bg-gray-800/40">
+                <div class="mb-2 text-[11px] font-semibold tracking-wide text-gray-400 uppercase">
+                  Components
+                </div>
+                <ul class="space-y-1.5 text-gray-600 dark:text-gray-300">
+                  <li>Button</li>
+                  <li class="font-medium text-gray-900 dark:text-white">Resizable</li>
+                  <li>Table</li>
+                </ul>
+              </nav>
+            </.resizable_panel>
+            <.resizable_handle
+              orientation={@rsz.orientation}
+              with_handle={@rsz.with_handle}
+              controls="pg-rsz-nav"
+              label="Resize navigation"
+            />
+            <.resizable_panel default_size={72} min_size={30}>
+              <div class="h-full p-5 overflow-auto">
+                <h3 class="text-base font-semibold text-gray-900 dark:text-white">Resizable</h3>
+                <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                  Drag the divider. With collapsible on, pull the nav past half its
+                  min_size and it snaps shut - pull back out and it reopens.
+                </p>
+              </div>
+            </.resizable_panel>
+          </.resizable_group>
+        </div>
+
+        <div class="flex flex-wrap items-end gap-x-8 gap-y-4 px-4 sm:px-6 py-4 [&>div]:min-w-0 [&>div]:max-w-full border-t border-gray-200 dark:border-gray-800">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">orientation</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Orientation"
+              value={@rsz.orientation}
+              on_change="ctl_rsz"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={o <- ~w(horizontal vertical)}
+                value={o}
+                phx-value-k="orientation"
+                phx-value-v={o}
+              >
+                {o}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">extras</div>
+            <.toggle_group
+              multiple
+              variant="outline"
+              size="sm"
+              aria_label="Extras"
+              value={
+                for {k, on} <- [
+                      {"with_handle", @rsz.with_handle},
+                      {"collapsible", @rsz.collapsible}
+                    ],
+                    on,
+                    do: k
+              }
+              on_change="ctl_rsz"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item value="with_handle" phx-value-k="with_handle">with handle</:item>
+              <:item value="collapsible" phx-value-k="collapsible">collapsible sidebar</:item>
+            </.toggle_group>
+          </div>
+        </div>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">on_resize: the persistence hook point</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        Drag or key the divider below. On release the group pushes the released
+        percentages to this LiveView, which is where an app would persist them. The
+        library stores nothing itself - the same payload also rides a bubbling
+        <code class="text-xs">petal:resizable-resize</code>
+        DOM event for non-LiveView listeners.
+      </p>
+      <.resizable_group
+        id="pg-rsz-persist"
+        orientation="vertical"
+        on_resize="pg_resize"
+        class="h-64 border border-gray-200 rounded-xl dark:border-gray-400/20"
+      >
+        <.resizable_panel id="pg-rsz-editor" default_size={65} min_size={25}>
+          <div class="h-full p-4 font-mono text-xs leading-5 text-gray-700 whitespace-pre dark:text-gray-200">
+            <div>&lt;.resizable_group orientation="vertical" on_resize="pg_resize"&gt;</div>
+            <div></div>
+            <div>def handle_event("pg_resize", params, socket), do:</div>
+            <div>assign(socket, :rsz_sizes, params["sizes"])</div>
+          </div>
+        </.resizable_panel>
+        <.resizable_handle
+          orientation="vertical"
+          controls="pg-rsz-editor"
+          with_handle
+          label="Resize console"
+        />
+        <.resizable_panel default_size={35} min_size={15}>
+          <div class="h-full p-4 font-mono text-xs bg-gray-50 dark:bg-gray-800/40">
+            <div class="text-gray-400">last pushed sizes</div>
+            <div class="mt-1 text-gray-700 dark:text-gray-200">
+              {Enum.map_join(@rsz_sizes, " / ", &"#{&1}%")}
+            </div>
+          </div>
+        </.resizable_panel>
+      </.resizable_group>
+
+      <div :for={ex <- PetalComponents.Showcase.Resizable.examples()} class="mt-10">
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <.showcase_props component={PetalComponents.Resizable} function={:resizable_group} />
+      <.showcase_props component={PetalComponents.Resizable} function={:resizable_panel} />
+      <.showcase_props component={PetalComponents.Resizable} function={:resizable_handle} />
     </div>
     """
   end

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -59,6 +59,7 @@ defmodule PetalComponents do
         Popover,
         Progress,
         Rating,
+        Resizable,
         Skeleton,
         SlideOver,
         SocialButton,

--- a/lib/petal_components/resizable.ex
+++ b/lib/petal_components/resizable.ex
@@ -1,0 +1,252 @@
+defmodule PetalComponents.Resizable do
+  use Phoenix.Component
+
+  @moduledoc """
+  Split-pane layout groups with draggable, keyboard-operable dividers.
+
+  This is the layout primitive behind docs sites with an adjustable sidebar,
+  IDE-style workspaces and editor/preview splits. Three components compose it:
+
+    * `resizable_group/1` - the flex container that owns the `PetalResizable` hook
+    * `resizable_panel/1` - a sized pane
+    * `resizable_handle/1` - the separator between two panes
+
+  Panels are sized as **percentages of the group** and rendered as
+  `flex: <pct> 1 0px`, so a window resize keeps the split proportional. The
+  hook reads only its DIRECT children, which is what makes nested groups work:
+  each group owns its own hook instance and never touches an inner group's
+  panels.
+
+  The library stores nothing. On drag release and on keyboard commit the group
+  dispatches a bubbling `petal:resizable-resize` DOM event carrying
+  `detail.sizes` (percentages in panel order) and, when `on_resize` is set,
+  pushes the same payload to your LiveView. Persist it wherever you like -
+  session, URL params, localStorage.
+
+  ## Keyboard
+
+  With a handle focused (it is in the tab order):
+
+    * `ArrowLeft` / `ArrowRight` - resize a vertical separator by 2 points
+    * `ArrowUp` / `ArrowDown` - resize a horizontal separator by 2 points
+    * hold `Shift` for a 10-point step
+    * `Home` - shrink the preceding panel to its `min_size` (collapse it if collapsible)
+    * `End` - grow the preceding panel to its `max_size`
+    * `Enter` - toggle collapse on a collapsible preceding panel
+
+  Arrows perpendicular to the separator are a no-op, per the WAI-ARIA window
+  splitter pattern.
+
+  ## Examples
+
+  A docs layout: a collapsible sidebar and a content pane.
+
+      <.resizable_group id="docs" class="h-80">
+        <.resizable_panel id="docs-nav" default_size={25} min_size={15} collapsible>
+          Navigation
+        </.resizable_panel>
+        <.resizable_handle controls="docs-nav" with_handle />
+        <.resizable_panel default_size={75}>
+          Content
+        </.resizable_panel>
+      </.resizable_group>
+
+  A vertical split that reports its sizes back to the LiveView.
+
+      <.resizable_group id="editor" orientation="vertical" on_resize="split_changed" class="h-96">
+        <.resizable_panel id="editor-code" default_size={70} min_size={30}>Code</.resizable_panel>
+        <.resizable_handle orientation="vertical" controls="editor-code" />
+        <.resizable_panel default_size={30} min_size={10}>Output</.resizable_panel>
+      </.resizable_group>
+
+  Nested groups - a horizontal split inside a vertical one. Each group gets its
+  own id and its own hook.
+
+      <.resizable_group id="ide" orientation="vertical" class="h-96">
+        <.resizable_panel default_size={75}>
+          <.resizable_group id="ide-top" class="h-full">
+            <.resizable_panel id="ide-files" default_size={20} min_size={10}>Files</.resizable_panel>
+            <.resizable_handle controls="ide-files" />
+            <.resizable_panel default_size={50}>Editor</.resizable_panel>
+            <.resizable_handle />
+            <.resizable_panel default_size={30}>Preview</.resizable_panel>
+          </.resizable_group>
+        </.resizable_panel>
+        <.resizable_handle orientation="vertical" />
+        <.resizable_panel default_size={25} min_size={10}>Terminal</.resizable_panel>
+      </.resizable_group>
+  """
+
+  @doc """
+  The container. Renders a flex row (or column) and mounts the `PetalResizable`
+  hook, which owns dragging, keyboard resizing, clamping and the resize events.
+
+  Put `resizable_panel/1` and `resizable_handle/1` children in it, alternating,
+  with a handle between every adjacent pair of panels. Give the group a height
+  (`class="h-80"`, `class="h-full"`, ...) - a flex container has none of its own.
+  """
+  attr :id, :string,
+    default: nil,
+    doc: "auto-generated when omitted; set it so the resize events can be told apart"
+
+  attr :orientation, :string,
+    default: "horizontal",
+    values: ["horizontal", "vertical"],
+    doc: "horizontal = panels side by side (vertical dividers); vertical = panels stacked"
+
+  attr :on_resize, :string,
+    default: nil,
+    doc:
+      "optional LiveView event name pushed on drag release and keyboard commit with %{\"sizes\" => [..]} percentages"
+
+  attr :class, :any, default: nil, doc: "extra classes on the group; this is where height goes"
+  attr :rest, :global
+
+  slot :inner_block,
+    required: true,
+    doc: "resizable_panel and resizable_handle children, in order"
+
+  def resizable_group(assigns) do
+    assigns = assign(assigns, :id, assigns.id || "pc-resizable-#{Ecto.UUID.generate()}")
+
+    ~H"""
+    <div
+      id={@id}
+      class={[
+        "pc-resizable",
+        @orientation == "vertical" && "pc-resizable--vertical",
+        @class
+      ]}
+      phx-hook="PetalResizable"
+      data-orientation={@orientation}
+      data-on-resize={@on_resize}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+
+  @doc """
+  One pane of a group.
+
+  `default_size` is a percentage of the group. Panels without one grow to share
+  whatever is left (`flex: 1 1 0px`); when a group mixes sized and unsized
+  panels the hook normalises the shares on mount so the sized ones land on their
+  exact percentage.
+
+  Give the panel an `id` if a handle needs to point `aria-controls` at it, or if
+  you want to read the panel out of a `petal:resizable-collapse` event.
+  """
+  attr :id, :string, default: nil, doc: "needed for aria-controls and collapse events"
+
+  attr :default_size, :integer,
+    default: nil,
+    doc: "initial size as a percentage of the group; unsized panels share the remainder equally"
+
+  attr :min_size, :integer,
+    default: 10,
+    doc: "smallest percentage the panel can be dragged or keyed down to"
+
+  attr :max_size, :integer, default: 100, doc: "largest percentage the panel can grow to"
+
+  attr :collapsible, :boolean,
+    default: false,
+    doc:
+      "when true, dragging below roughly half the min_size snaps the panel to collapsed_size and fires petal:resizable-collapse"
+
+  attr :collapsed_size, :integer, default: 0, doc: "the size the panel snaps to when collapsed"
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  slot :inner_block, required: true
+
+  def resizable_panel(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      class={["pc-resizable__panel", @class]}
+      style={panel_style(@default_size)}
+      data-pc-resizable-panel
+      data-min={@min_size}
+      data-max={@max_size}
+      data-default={@default_size}
+      data-collapsible={@collapsible && "true"}
+      data-collapsed-size={@collapsed_size}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+
+  @doc """
+  The separator between two panels.
+
+  It is the accessible control: `role="separator"`, in the tab order, and
+  carrying the live `aria-valuenow` for the panel before it. Note the
+  inversion - a handle in a `horizontal` group (panels side by side) is a
+  VERTICAL separator, so pass the group's `orientation` and the component flips
+  it for you.
+
+  The painted line is a hairline; the hit area around it is deliberately much
+  larger. `with_handle` adds the visible grip.
+
+  Server-rendered `aria-valuenow`/`valuemin`/`valuemax` are a starting point -
+  the hook restamps all three (plus `aria-orientation` and, when the preceding
+  panel has an id, `aria-controls`) from the live layout on mount and on every
+  resize.
+  """
+  attr :orientation, :string,
+    default: "horizontal",
+    values: ["horizontal", "vertical"],
+    doc: "the ORIENTATION OF THE GROUP; the separator's own aria-orientation is the inverse"
+
+  attr :with_handle, :boolean, default: false, doc: "renders the visible grip-dot affordance"
+
+  attr :controls, :string,
+    default: nil,
+    doc:
+      "id of the preceding panel, for aria-controls; the hook fills it in when the panel has one"
+
+  attr :value_now, :integer,
+    default: 50,
+    doc: "initial aria-valuenow (the preceding panel's size); the hook keeps it current"
+
+  attr :value_min, :integer, default: 0, doc: "initial aria-valuemin for the preceding panel"
+  attr :value_max, :integer, default: 100, doc: "initial aria-valuemax for the preceding panel"
+
+  attr :label, :string,
+    default: "Resize panels",
+    doc: "accessible name for the separator; override per split when a page has several"
+
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  def resizable_handle(assigns) do
+    ~H"""
+    <div
+      class={[
+        "pc-resizable__handle",
+        @with_handle && "pc-resizable__handle--with-handle",
+        @class
+      ]}
+      data-pc-resizable-handle
+      role="separator"
+      tabindex="0"
+      aria-orientation={if @orientation == "horizontal", do: "vertical", else: "horizontal"}
+      aria-valuenow={@value_now}
+      aria-valuemin={@value_min}
+      aria-valuemax={@value_max}
+      aria-controls={@controls}
+      aria-label={@label}
+      {@rest}
+    >
+      <span :if={@with_handle} class="pc-resizable__grip" aria-hidden="true"></span>
+    </div>
+    """
+  end
+
+  defp panel_style(nil), do: "flex: 1 1 0px"
+  defp panel_style(size), do: "flex: #{size} 1 0px"
+end

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -44,6 +44,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.Popover,
     PetalComponents.Showcase.Progress,
     PetalComponents.Showcase.Rating,
+    PetalComponents.Showcase.Resizable,
     PetalComponents.Showcase.ShineBorder,
     PetalComponents.Showcase.Skeleton,
     PetalComponents.Showcase.SlideOver,

--- a/lib/petal_components/showcase/resizable.ex
+++ b/lib/petal_components/showcase/resizable.ex
@@ -1,0 +1,133 @@
+defmodule PetalComponents.Showcase.Resizable do
+  @moduledoc false
+  use PetalComponents.Showcase,
+    component: PetalComponents.Resizable,
+    title: "Resizable",
+    functions: [:resizable_group, :resizable_panel, :resizable_handle]
+
+  example :docs, "Docs layout with a collapsible sidebar",
+    description:
+      "The everyday split: a navigation rail you can drag narrower, and content that takes the rest. The sidebar is collapsible, so dragging it below half its min_size snaps it shut and fires petal:resizable-collapse; dragging back out reopens it at min_size. Double-click the separator to put both panes back on their default_size. Tab to the separator and the arrow keys do the same job - Home collapses, End grows it to max." do
+    ~H"""
+    <.resizable_group
+      id="sx-rsz-docs"
+      class="h-64 border border-gray-200 rounded-xl dark:border-gray-400/20"
+    >
+      <.resizable_panel id="sx-rsz-docs-nav" default_size={25} min_size={15} collapsible>
+        <nav class="h-full p-4 text-sm bg-gray-50 dark:bg-gray-800/40">
+          <div class="mb-2 text-[11px] font-semibold tracking-wide text-gray-400 uppercase">
+            Getting started
+          </div>
+          <ul class="space-y-1.5 text-gray-600 dark:text-gray-300">
+            <li>Installation</li>
+            <li class="font-medium text-gray-900 dark:text-white">Theming</li>
+            <li>Dark mode</li>
+            <li>Upgrading</li>
+          </ul>
+        </nav>
+      </.resizable_panel>
+      <.resizable_handle controls="sx-rsz-docs-nav" with_handle label="Resize navigation" />
+      <.resizable_panel default_size={75} min_size={30}>
+        <article class="h-full p-5 overflow-auto">
+          <h3 class="text-base font-semibold text-gray-900 dark:text-white">Theming</h3>
+          <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+            Every component reads its colours off the theme rail, so setting the
+            primary ramp once retints the whole library. Drag the divider to see
+            how the two panes trade space.
+          </p>
+        </article>
+      </.resizable_panel>
+    </.resizable_group>
+    """
+  end
+
+  example :ide, "Nested groups: an IDE workspace",
+    description:
+      "The nesting case. A vertical group holds a horizontal group on top (files, editor, preview) and a terminal below. Each group mounts its own hook and only ever touches its own direct children, so the inner separators and the outer one never fight over a panel." do
+    ~H"""
+    <.resizable_group
+      id="sx-rsz-ide"
+      orientation="vertical"
+      class="h-80 border border-gray-200 rounded-xl dark:border-gray-400/20"
+    >
+      <.resizable_panel default_size={70} min_size={30}>
+        <.resizable_group id="sx-rsz-ide-top" class="h-full">
+          <.resizable_panel id="sx-rsz-ide-files" default_size={22} min_size={12}>
+            <div class="h-full p-3 text-xs bg-gray-50 dark:bg-gray-800/40">
+              <div class="mb-2 font-semibold text-gray-400">EXPLORER</div>
+              <ul class="space-y-1 text-gray-600 dark:text-gray-300">
+                <li>lib/</li>
+                <li class="pl-3 font-medium text-gray-900 dark:text-white">resizable.ex</li>
+                <li>assets/</li>
+                <li>test/</li>
+              </ul>
+            </div>
+          </.resizable_panel>
+          <.resizable_handle controls="sx-rsz-ide-files" label="Resize file tree" />
+          <.resizable_panel id="sx-rsz-ide-editor" default_size={48} min_size={25}>
+            <div class="h-full p-3 overflow-auto font-mono text-xs leading-5 text-gray-700 whitespace-pre dark:text-gray-200">
+              <div>&lt;.resizable_group id="ide" orientation="vertical"&gt;</div>
+              <div>&lt;.resizable_panel default_size={70}&gt;</div>
+              <div>&lt;.editor /&gt;</div>
+              <div>&lt;/.resizable_panel&gt;</div>
+              <div>&lt;.resizable_handle orientation="vertical" with_handle /&gt;</div>
+              <div>&lt;.resizable_panel default_size={30} min_size={10}&gt;</div>
+              <div>&lt;.terminal /&gt;</div>
+              <div>&lt;/.resizable_panel&gt;</div>
+              <div>&lt;/.resizable_group&gt;</div>
+            </div>
+          </.resizable_panel>
+          <.resizable_handle controls="sx-rsz-ide-editor" with_handle label="Resize editor" />
+          <.resizable_panel default_size={30} min_size={15}>
+            <div class="h-full p-3 text-xs bg-gray-50 dark:bg-gray-800/40">
+              <div class="mb-2 font-semibold text-gray-400">PREVIEW</div>
+              <div class="border border-gray-200 rounded-lg h-16 dark:border-gray-400/20"></div>
+            </div>
+          </.resizable_panel>
+        </.resizable_group>
+      </.resizable_panel>
+      <.resizable_handle orientation="vertical" with_handle label="Resize terminal" />
+      <.resizable_panel id="sx-rsz-ide-term" default_size={30} min_size={10}>
+        <div class="h-full p-3 overflow-auto font-mono text-xs leading-5 text-gray-500 dark:text-gray-400">
+          <div>$ mix test</div>
+          <div>916 tests, 0 failures</div>
+        </div>
+      </.resizable_panel>
+    </.resizable_group>
+    """
+  end
+
+  example :vertical, "Vertical split",
+    description:
+      "Stacked panes with a horizontal separator. aria-orientation inverts: the group is vertical, so the separator is horizontal and Up/Down resize it while Left/Right are a no-op. Wire on_resize to a handle_event and the released percentages arrive on the server, ready to persist - the library itself stores nothing." do
+    ~H"""
+    <.resizable_group
+      id="sx-rsz-vertical"
+      orientation="vertical"
+      class="h-72 border border-gray-200 rounded-xl dark:border-gray-400/20"
+    >
+      <.resizable_panel id="sx-rsz-vertical-code" default_size={65} min_size={25}>
+        <div class="h-full p-4 overflow-auto font-mono text-xs leading-5 text-gray-700 whitespace-pre dark:text-gray-200">
+          <div>&lt;.resizable_group orientation="vertical" on_resize="split"&gt;</div>
+          <div>&lt;.resizable_panel id="code" default_size={65} min_size={25} /&gt;</div>
+          <div>&lt;.resizable_handle orientation="vertical" controls="code" /&gt;</div>
+          <div>&lt;.resizable_panel default_size={35} min_size={15} /&gt;</div>
+          <div>&lt;/.resizable_group&gt;</div>
+        </div>
+      </.resizable_panel>
+      <.resizable_handle
+        orientation="vertical"
+        controls="sx-rsz-vertical-code"
+        with_handle
+        label="Resize console"
+      />
+      <.resizable_panel default_size={35} min_size={15}>
+        <div class="h-full p-4 font-mono text-xs bg-gray-50 dark:bg-gray-800/40">
+          <div class="text-gray-400">console</div>
+          <div class="mt-1 text-gray-600 dark:text-gray-300">Compiling 1 file (.ex)</div>
+        </div>
+      </.resizable_panel>
+    </.resizable_group>
+    """
+  end
+end

--- a/test/js/resizable.test.js
+++ b/test/js/resizable.test.js
@@ -1,0 +1,537 @@
+// PetalResizable: the sizing maths, and the hook wiring on top of it.
+//
+// Everything is a percentage of the group. Two invariants carry the whole
+// component and every spec here is ultimately about one of them:
+//   1. the sizes array always sums to 100
+//   2. an operation on one separator only ever moves its two panels
+// The Elixir side pins the markup this reads (test/petal/resizable_test.exs);
+// update both together if the anatomy changes.
+import { afterEach, describe, expect, it } from "vitest";
+
+import hooks, {
+  distributeSizes,
+  keyboardDelta,
+  resizableConstraint,
+  resolveDrag,
+  resolveEdge,
+  resolveReset,
+  resolveToggle,
+} from "../../assets/js/petal_components.js";
+
+import { pointerEvent } from "./helpers.js";
+
+const c = (over = {}) => ({
+  min: 10,
+  max: 100,
+  default: null,
+  collapsible: false,
+  collapsedSize: 0,
+  ...over,
+});
+
+const sum = (sizes) => sizes.reduce((a, b) => a + b, 0);
+
+describe("distributeSizes", () => {
+  it("splits an all-unsized group equally", () => {
+    expect(distributeSizes([c(), c(), c()])).toEqual([
+      100 / 3,
+      100 / 3,
+      100 / 3,
+    ].map((n) => Math.round(n * 1e6) / 1e6));
+  });
+
+  it("honours every default_size when they already add up", () => {
+    expect(distributeSizes([c({ default: 25 }), c({ default: 75 })])).toEqual([
+      25, 75,
+    ]);
+  });
+
+  it("gives unsized panels the remainder, split between them", () => {
+    const sizes = distributeSizes([c({ default: 50 }), c(), c()]);
+    expect(sizes).toEqual([50, 25, 25]);
+  });
+
+  it("normalises defaults that do not add up to 100", () => {
+    const sizes = distributeSizes([c({ default: 30 }), c({ default: 30 })]);
+    expect(sizes).toEqual([50, 50]);
+    expect(sum(sizes)).toBeCloseTo(100, 6);
+  });
+
+  it("returns nothing for an empty group", () => {
+    expect(distributeSizes([])).toEqual([]);
+  });
+});
+
+describe("resizableConstraint", () => {
+  it("reads the data-* contract the Elixir panel renders", () => {
+    const el = document.createElement("div");
+    el.dataset.min = "15";
+    el.dataset.max = "60";
+    el.dataset.default = "25";
+    el.dataset.collapsible = "true";
+    el.dataset.collapsedSize = "4";
+
+    expect(resizableConstraint(el)).toEqual({
+      min: 15,
+      max: 60,
+      default: 25,
+      collapsible: true,
+      collapsedSize: 4,
+    });
+  });
+
+  it("falls back to the component defaults when attributes are absent", () => {
+    const el = document.createElement("div");
+    expect(resizableConstraint(el)).toEqual({
+      min: 10,
+      max: 100,
+      default: null,
+      collapsible: false,
+      collapsedSize: 0,
+    });
+  });
+});
+
+describe("resolveDrag", () => {
+  const pair = [c({ min: 20, max: 80 }), c({ min: 20, max: 80 })];
+
+  it("moves both adjacent panels and conserves the total", () => {
+    const { sizes } = resolveDrag([50, 50], 0, 10, pair);
+    expect(sizes).toEqual([60, 40]);
+    expect(sum(sizes)).toBeCloseTo(100, 6);
+  });
+
+  it("clamps at the primary panel's max", () => {
+    const { sizes } = resolveDrag([50, 50], 0, 40, pair);
+    expect(sizes).toEqual([80, 20]);
+  });
+
+  it("clamps at the primary panel's min", () => {
+    const { sizes } = resolveDrag([50, 50], 0, -40, pair);
+    expect(sizes).toEqual([20, 80]);
+  });
+
+  it("respects the FOLLOWING panel's min, not just the primary's", () => {
+    // panel a could legally reach 90, but b refuses to go under 35
+    const constraints = [c({ min: 10, max: 90 }), c({ min: 35, max: 90 })];
+    const { sizes } = resolveDrag([50, 50], 0, 100, constraints);
+    expect(sizes).toEqual([65, 35]);
+    expect(sum(sizes)).toBeCloseTo(100, 6);
+  });
+
+  it("respects the following panel's max", () => {
+    const constraints = [c({ min: 5, max: 90 }), c({ min: 5, max: 60 })];
+    const { sizes } = resolveDrag([50, 50], 0, -100, constraints);
+    expect(sizes).toEqual([40, 60]);
+  });
+
+  it("leaves panels either side of the pair untouched", () => {
+    const three = [c(), c(), c()];
+    const { sizes } = resolveDrag([30, 40, 30], 1, 10, three);
+    expect(sizes).toEqual([30, 50, 20]);
+    expect(sum(sizes)).toBeCloseTo(100, 6);
+  });
+
+  it("is a no-op on an out-of-range separator", () => {
+    const { sizes, collapse } = resolveDrag([50, 50], 1, 10, pair);
+    expect(sizes).toEqual([50, 50]);
+    expect(collapse).toBeNull();
+  });
+
+  describe("collapse", () => {
+    const collapsible = [
+      c({ min: 20, max: 80, collapsible: true, default: 25 }),
+      c({ min: 10, max: 100 }),
+    ];
+
+    it("snaps shut below half the min and reports the collapse", () => {
+      const { sizes, collapse } = resolveDrag([25, 75], 0, -20, collapsible);
+      expect(sizes).toEqual([0, 100]);
+      expect(collapse).toEqual({ index: 0, collapsed: true });
+    });
+
+    it("does not snap while still above the threshold, it just clamps", () => {
+      const { sizes, collapse } = resolveDrag([25, 75], 0, -3, collapsible);
+      expect(sizes).toEqual([22, 78]);
+      expect(collapse).toBeNull();
+    });
+
+    it("stays collapsed on a small nudge, without re-firing", () => {
+      const { sizes, collapse } = resolveDrag([0, 100], 0, 3, collapsible);
+      expect(sizes).toEqual([0, 100]);
+      expect(collapse).toBeNull();
+    });
+
+    it("expands back to min_size once dragged past the threshold", () => {
+      const { sizes, collapse } = resolveDrag([0, 100], 0, 15, collapsible);
+      expect(sizes).toEqual([20, 80]);
+      expect(collapse).toEqual({ index: 0, collapsed: false });
+    });
+
+    it("collapses the FOLLOWING panel when the drag pushes it shut", () => {
+      const constraints = [
+        c({ min: 10, max: 100 }),
+        c({ min: 20, max: 80, collapsible: true }),
+      ];
+      const { sizes, collapse } = resolveDrag([75, 25], 0, 20, constraints);
+      expect(sizes).toEqual([100, 0]);
+      expect(collapse).toEqual({ index: 1, collapsed: true });
+    });
+
+    it("honours a non-zero collapsed_size", () => {
+      const constraints = [
+        c({ min: 20, max: 80, collapsible: true, collapsedSize: 5 }),
+        c(),
+      ];
+      const { sizes, collapse } = resolveDrag([25, 75], 0, -25, constraints);
+      expect(sizes).toEqual([5, 95]);
+      expect(collapse).toEqual({ index: 0, collapsed: true });
+    });
+  });
+});
+
+describe("resolveEdge", () => {
+  it("Home shrinks a plain panel to its min", () => {
+    const { sizes } = resolveEdge([50, 50], 0, "min", [
+      c({ min: 20 }),
+      c({ min: 10 }),
+    ]);
+    expect(sizes).toEqual([20, 80]);
+  });
+
+  it("Home collapses a collapsible panel instead of stopping at min", () => {
+    const { sizes, collapse } = resolveEdge([50, 50], 0, "min", [
+      c({ min: 20, collapsible: true }),
+      c({ min: 0 }),
+    ]);
+    expect(sizes).toEqual([0, 100]);
+    expect(collapse).toEqual({ index: 0, collapsed: true });
+  });
+
+  it("End grows the panel to its max, bounded by its neighbour's min", () => {
+    const { sizes } = resolveEdge([50, 50], 0, "max", [
+      c({ max: 90 }),
+      c({ min: 25 }),
+    ]);
+    expect(sizes).toEqual([75, 25]);
+    expect(sum(sizes)).toBeCloseTo(100, 6);
+  });
+});
+
+describe("resolveToggle", () => {
+  const constraints = [
+    c({ min: 20, max: 80, default: 25, collapsible: true }),
+    c({ min: 10 }),
+  ];
+
+  it("collapses an open panel", () => {
+    const { sizes, collapse } = resolveToggle([25, 75], 0, constraints);
+    expect(sizes).toEqual([0, 100]);
+    expect(collapse).toEqual({ index: 0, collapsed: true });
+  });
+
+  it("restores a collapsed panel to its default", () => {
+    const { sizes, collapse } = resolveToggle([0, 100], 0, constraints);
+    expect(sizes).toEqual([25, 75]);
+    expect(collapse).toEqual({ index: 0, collapsed: false });
+  });
+
+  it("is a no-op on a panel that cannot collapse", () => {
+    const { sizes, collapse } = resolveToggle([50, 50], 0, [c(), c()]);
+    expect(sizes).toEqual([50, 50]);
+    expect(collapse).toBeNull();
+  });
+});
+
+describe("resolveReset", () => {
+  it("puts the two adjacent panels back on their default ratio", () => {
+    const constraints = [c({ default: 25 }), c({ default: 75 })];
+    const { sizes } = resolveReset([70, 30], 0, constraints);
+    expect(sizes).toEqual([25, 75]);
+  });
+
+  it("spends only the space the pair already holds", () => {
+    const constraints = [c({ default: 25 }), c({ default: 75 }), c()];
+    const { sizes } = resolveReset([50, 20, 30], 0, constraints);
+    expect(sizes).toEqual([17.5, 52.5, 30]);
+    expect(sum(sizes)).toBeCloseTo(100, 6);
+  });
+
+  it("splits the pair evenly when neither panel declared a default", () => {
+    const { sizes } = resolveReset([70, 30], 0, [c(), c()]);
+    expect(sizes).toEqual([50, 50]);
+  });
+
+  it("reports the expand when it reopens a collapsed panel", () => {
+    const constraints = [
+      c({ default: 25, min: 20, collapsible: true }),
+      c({ default: 75 }),
+    ];
+    const { sizes, collapse } = resolveReset([0, 100], 0, constraints);
+    expect(sizes).toEqual([25, 75]);
+    expect(collapse).toEqual({ index: 0, collapsed: false });
+  });
+});
+
+describe("keyboardDelta", () => {
+  it("steps a vertical separator with Left and Right", () => {
+    expect(keyboardDelta("ArrowLeft", false, "horizontal")).toBe(-2);
+    expect(keyboardDelta("ArrowRight", false, "horizontal")).toBe(2);
+  });
+
+  it("steps a horizontal separator with Up and Down", () => {
+    expect(keyboardDelta("ArrowUp", false, "vertical")).toBe(-2);
+    expect(keyboardDelta("ArrowDown", false, "vertical")).toBe(2);
+  });
+
+  it("takes a bigger bite with Shift", () => {
+    expect(keyboardDelta("ArrowRight", true, "horizontal")).toBe(10);
+    expect(keyboardDelta("ArrowUp", true, "vertical")).toBe(-10);
+  });
+
+  it("is a no-op for arrows perpendicular to the separator", () => {
+    expect(keyboardDelta("ArrowUp", false, "horizontal")).toBeNull();
+    expect(keyboardDelta("ArrowDown", false, "horizontal")).toBeNull();
+    expect(keyboardDelta("ArrowLeft", false, "vertical")).toBeNull();
+    expect(keyboardDelta("ArrowRight", false, "vertical")).toBeNull();
+  });
+
+  it("ignores keys that are not arrows", () => {
+    expect(keyboardDelta("a", false, "horizontal")).toBeNull();
+    expect(keyboardDelta("Tab", false, "vertical")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The hook on top of the maths: ARIA stamping, the events, and the guard that
+// keeps a nested group's separators away from the outer hook.
+// ---------------------------------------------------------------------------
+
+const mounted = [];
+
+function panelHtml(id, { size, min = 10, max = 100, collapsible, collapsedSize = 0 } = {}) {
+  return `<div id="${id}" class="pc-resizable__panel" data-pc-resizable-panel
+    data-min="${min}" data-max="${max}"
+    ${size === undefined ? "" : `data-default="${size}"`}
+    ${collapsible ? 'data-collapsible="true"' : ""}
+    data-collapsed-size="${collapsedSize}"></div>`;
+}
+
+const handleHtml = `<div class="pc-resizable__handle" data-pc-resizable-handle role="separator"
+  tabindex="0" aria-orientation="vertical" aria-valuenow="50" aria-valuemin="0"
+  aria-valuemax="100"></div>`;
+
+function mount({ orientation = "horizontal", onResize = null, panels } = {}) {
+  const el = document.createElement("div");
+  el.id = "grp";
+  el.className = "pc-resizable";
+  el.dataset.orientation = orientation;
+  if (onResize) el.dataset.onResize = onResize;
+
+  const cells =
+    panels ||
+    [panelHtml("p0", { size: 25, min: 20, collapsible: true }), panelHtml("p1", { size: 75 })];
+  el.innerHTML = cells.join(handleHtml);
+  document.body.appendChild(el);
+
+  // jsdom lays nothing out, so the group has no size of its own. Pointer maths
+  // divides by this, so give it the 1000px a real group would report.
+  el.getBoundingClientRect = () => ({ width: 1000, height: 1000, top: 0, left: 0 });
+
+  const hook = Object.create(hooks.PetalResizable);
+  hook.el = el;
+  hook.pushed = [];
+  hook.pushEvent = (name, payload) => hook.pushed.push([name, payload]);
+
+  const resizes = [];
+  const collapses = [];
+  el.addEventListener("petal:resizable-resize", (e) => resizes.push(e.detail));
+  el.addEventListener("petal:resizable-collapse", (e) => collapses.push(e.detail));
+
+  hook.mounted();
+  mounted.push({ hook, el });
+
+  return { hook, el, resizes, collapses };
+}
+
+const handles = (el) => Array.from(el.querySelectorAll("[data-pc-resizable-handle]"));
+const flexOf = (el, id) => el.querySelector(`#${id}`).style.flex;
+
+function key(target, k, props = {}) {
+  target.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: k, ...props }));
+}
+
+describe("PetalResizable hook", () => {
+  afterEach(() => {
+    mounted.splice(0).forEach(({ hook, el }) => {
+      hook.destroyed();
+      el.remove();
+    });
+  });
+
+  it("applies the distributed sizes as flex-grow on mount", () => {
+    const { el } = mount();
+    expect(flexOf(el, "p0")).toBe("25 1 0px");
+    expect(flexOf(el, "p1")).toBe("75 1 0px");
+  });
+
+  it("stamps the live ARIA contract onto every separator", () => {
+    const { el } = mount();
+    const [h] = handles(el);
+
+    expect(h.getAttribute("aria-valuenow")).toBe("25");
+    // the panel is collapsible, so its floor is the collapsed size
+    expect(h.getAttribute("aria-valuemin")).toBe("0");
+    expect(h.getAttribute("aria-valuemax")).toBe("100");
+    expect(h.getAttribute("aria-orientation")).toBe("vertical");
+    expect(h.getAttribute("aria-controls")).toBe("p0");
+  });
+
+  it("inverts aria-orientation for a vertical group", () => {
+    const { el } = mount({ orientation: "vertical" });
+    expect(handles(el)[0].getAttribute("aria-orientation")).toBe("horizontal");
+  });
+
+  it("resizes on an arrow key and keeps aria-valuenow current", () => {
+    const { el } = mount();
+    const [h] = handles(el);
+
+    key(h, "ArrowRight");
+
+    expect(flexOf(el, "p0")).toBe("27 1 0px");
+    expect(flexOf(el, "p1")).toBe("73 1 0px");
+    expect(h.getAttribute("aria-valuenow")).toBe("27");
+  });
+
+  it("takes a 10-point step with Shift", () => {
+    const { el } = mount();
+    key(handles(el)[0], "ArrowRight", { shiftKey: true });
+    expect(flexOf(el, "p0")).toBe("35 1 0px");
+  });
+
+  it("ignores arrows perpendicular to the separator", () => {
+    const { el } = mount();
+    key(handles(el)[0], "ArrowUp");
+    expect(flexOf(el, "p0")).toBe("25 1 0px");
+  });
+
+  it("Home collapses the collapsible primary panel, End grows it to max", () => {
+    const { el, collapses } = mount();
+    const [h] = handles(el);
+
+    key(h, "Home");
+    expect(flexOf(el, "p0")).toBe("0 1 0px");
+    expect(collapses).toEqual([{ panel_id: "p0", collapsed: true }]);
+
+    key(h, "End");
+    expect(flexOf(el, "p0")).toBe("90 1 0px");
+  });
+
+  it("Enter toggles collapse and restore", () => {
+    const { el, collapses } = mount();
+    const [h] = handles(el);
+
+    key(h, "Enter");
+    expect(flexOf(el, "p0")).toBe("0 1 0px");
+
+    key(h, "Enter");
+    expect(flexOf(el, "p0")).toBe("25 1 0px");
+    expect(collapses).toEqual([
+      { panel_id: "p0", collapsed: true },
+      { panel_id: "p0", collapsed: false },
+    ]);
+  });
+
+  it("commits the sizes on every keyboard resize", () => {
+    const { el, resizes } = mount({ onResize: "split" });
+    const hook = mounted[mounted.length - 1].hook;
+
+    key(handles(el)[0], "ArrowRight");
+
+    expect(resizes).toEqual([{ sizes: [27, 73] }]);
+    expect(hook.pushed).toEqual([["split", { sizes: [27, 73] }]]);
+  });
+
+  it("does not push when no on_resize event is configured", () => {
+    const { el, resizes } = mount();
+    const hook = mounted[mounted.length - 1].hook;
+
+    key(handles(el)[0], "ArrowRight");
+
+    expect(resizes).toHaveLength(1);
+    expect(hook.pushed).toEqual([]);
+  });
+
+  it("drags through pointer events and commits once on release", () => {
+    const { el, resizes } = mount();
+    const [h] = handles(el);
+    h.setPointerCapture = () => {};
+    h.releasePointerCapture = () => {};
+
+    h.dispatchEvent(pointerEvent("pointerdown", "mouse", { clientX: 250, button: 0 }));
+    el.dispatchEvent(pointerEvent("pointermove", "mouse", { clientX: 400 }));
+
+    // 150px of a 1000px group is 15 points
+    expect(flexOf(el, "p0")).toBe("40 1 0px");
+    expect(resizes).toHaveLength(0);
+    expect(document.body.style.userSelect).toBe("none");
+
+    h.dispatchEvent(pointerEvent("pointerup", "mouse", { clientX: 400 }));
+
+    expect(resizes).toEqual([{ sizes: [40, 60] }]);
+    expect(document.body.style.userSelect).toBe("");
+  });
+
+  it("double-click resets the pair to their defaults", () => {
+    const { el, resizes } = mount();
+    const [h] = handles(el);
+
+    key(h, "ArrowRight", { shiftKey: true });
+    expect(flexOf(el, "p0")).toBe("35 1 0px");
+
+    h.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+
+    expect(flexOf(el, "p0")).toBe("25 1 0px");
+    expect(resizes[resizes.length - 1]).toEqual({ sizes: [25, 75] });
+  });
+
+  it("ignores separators belonging to a nested group", () => {
+    const { el } = mount({
+      panels: [
+        `<div id="p0" class="pc-resizable__panel" data-pc-resizable-panel data-min="10" data-max="100" data-default="50" data-collapsed-size="0">
+           <div id="inner" class="pc-resizable" data-orientation="horizontal">
+             ${panelHtml("i0", { size: 40 })}
+             ${handleHtml.replace("data-pc-resizable-handle", 'data-pc-resizable-handle id="inner-h"')}
+             ${panelHtml("i1", { size: 60 })}
+           </div>
+         </div>`,
+        panelHtml("p1", { size: 50 }),
+      ],
+    });
+
+    const outer = mounted[mounted.length - 1].hook;
+    expect(outer.panels.map((p) => p.id)).toEqual(["p0", "p1"]);
+    expect(outer.handles).toHaveLength(1);
+
+    // an inner separator's keydown bubbles up to the outer group; it must not
+    // move the outer panels
+    key(el.querySelector("#inner-h"), "ArrowRight");
+    expect(flexOf(el, "p0")).toBe("50 1 0px");
+  });
+
+  it("restores the body cursor when torn down mid-drag", () => {
+    const { el } = mount();
+    const [h] = handles(el);
+    h.setPointerCapture = () => {};
+
+    h.dispatchEvent(pointerEvent("pointerdown", "mouse", { clientX: 250, button: 0 }));
+    expect(document.body.style.cursor).toBe("col-resize");
+
+    mounted.splice(0).forEach(({ hook, el: node }) => {
+      hook.destroyed();
+      node.remove();
+    });
+
+    expect(document.body.style.cursor).toBe("");
+  });
+});

--- a/test/petal/resizable_test.exs
+++ b/test/petal/resizable_test.exs
@@ -1,0 +1,261 @@
+defmodule PetalComponents.ResizableTest do
+  @moduledoc """
+  Tests for PetalComponents.Resizable - the split-pane layout group.
+
+  The live behaviour (drag, clamping, collapse, keyboard) belongs to the
+  PetalResizable hook and is covered in test/js/resizable.test.js. What matters
+  here is the contract the hook and assistive tech read off the markup: the
+  hook root, the panel data-* constraints, and the separator's ARIA.
+  """
+
+  use ComponentCase
+  import PetalComponents.Resizable
+
+  describe "resizable_group/1" do
+    test "renders the hook root, the orientation class and data-orientation" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.resizable_group id="g">
+          <.resizable_panel>a</.resizable_panel>
+          <.resizable_handle />
+          <.resizable_panel>b</.resizable_panel>
+        </.resizable_group>
+        """)
+
+      assert html =~ ~s(phx-hook="PetalResizable")
+      assert html =~ ~s(data-orientation="horizontal")
+      assert html =~ "pc-resizable"
+      refute html =~ "pc-resizable--vertical"
+    end
+
+    test "vertical orientation adds the modifier class and flips data-orientation" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.resizable_group id="g" orientation="vertical">
+          <.resizable_panel>a</.resizable_panel>
+        </.resizable_group>
+        """)
+
+      assert html =~ "pc-resizable--vertical"
+      assert html =~ ~s(data-orientation="vertical")
+    end
+
+    test "generates an id when none is given" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.resizable_group>
+          <.resizable_panel>a</.resizable_panel>
+        </.resizable_group>
+        """)
+
+      assert html =~ ~s(id="pc-resizable-)
+    end
+
+    test "on_resize rides along as data-on-resize for the hook to push" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.resizable_group id="g" on_resize="split_changed">
+          <.resizable_panel>a</.resizable_panel>
+        </.resizable_group>
+        """)
+
+      assert html =~ ~s(data-on-resize="split_changed")
+    end
+
+    test "class and rest pass through" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.resizable_group id="g" class="h-80" data-test="group">
+          <.resizable_panel>a</.resizable_panel>
+        </.resizable_group>
+        """)
+
+      assert html =~ "h-80"
+      assert html =~ ~s(data-test="group")
+    end
+  end
+
+  describe "resizable_panel/1" do
+    test "default_size becomes the flex-grow share plus the data-* constraints" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.resizable_panel id="p" default_size={25} min_size={15} max_size={60}>
+          Nav
+        </.resizable_panel>
+        """)
+
+      assert html =~ ~s(style="flex: 25 1 0px")
+      assert html =~ "data-pc-resizable-panel"
+      assert html =~ ~s(data-min="15")
+      assert html =~ ~s(data-max="60")
+      assert html =~ ~s(data-default="25")
+      assert html =~ ~s(data-collapsed-size="0")
+      refute html =~ "data-collapsible"
+    end
+
+    test "unsized panels get the equal-share default" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.resizable_group id="g">
+          <.resizable_panel>a</.resizable_panel>
+          <.resizable_handle />
+          <.resizable_panel>b</.resizable_panel>
+        </.resizable_group>
+        """)
+
+      assert count_substring(html, ~s(style="flex: 1 1 0px")) == 2
+      refute html =~ "data-default="
+    end
+
+    test "collapsible surfaces both collapse attributes" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.resizable_panel collapsible collapsed_size={4}>Nav</.resizable_panel>
+        """)
+
+      assert html =~ ~s(data-collapsible="true")
+      assert html =~ ~s(data-collapsed-size="4")
+    end
+
+    test "class and rest pass through" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.resizable_panel class="bg-white" data-test="panel">a</.resizable_panel>
+        """)
+
+      assert html =~ "pc-resizable__panel"
+      assert html =~ "bg-white"
+      assert html =~ ~s(data-test="panel")
+    end
+  end
+
+  describe "resizable_handle/1" do
+    test "the separator contract: role, tab stop, ARIA values and aria-controls" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.resizable_handle controls="nav" value_now={25} value_min={15} value_max={60} />
+        """)
+
+      assert html =~ ~s(role="separator")
+      assert html =~ ~s(tabindex="0")
+      assert html =~ ~s(aria-controls="nav")
+      assert html =~ ~s(aria-valuenow="25")
+      assert html =~ ~s(aria-valuemin="15")
+      assert html =~ ~s(aria-valuemax="60")
+      assert html =~ ~s(aria-label="Resize panels")
+      assert html =~ "data-pc-resizable-handle"
+    end
+
+    test "aria-orientation is the inverse of the group's orientation" do
+      assigns = %{}
+
+      horizontal =
+        rendered_to_string(~H"""
+        <.resizable_handle orientation="horizontal" />
+        """)
+
+      vertical =
+        rendered_to_string(~H"""
+        <.resizable_handle orientation="vertical" />
+        """)
+
+      # side-by-side panels are divided by a VERTICAL separator
+      assert horizontal =~ ~s(aria-orientation="vertical")
+      assert vertical =~ ~s(aria-orientation="horizontal")
+    end
+
+    test "with_handle adds the grip modifier and the grip element" do
+      assigns = %{}
+
+      bare =
+        rendered_to_string(~H"""
+        <.resizable_handle />
+        """)
+
+      gripped =
+        rendered_to_string(~H"""
+        <.resizable_handle with_handle />
+        """)
+
+      refute bare =~ "pc-resizable__handle--with-handle"
+      refute bare =~ "pc-resizable__grip"
+      assert gripped =~ "pc-resizable__handle--with-handle"
+      assert gripped =~ "pc-resizable__grip"
+      assert gripped =~ ~s(aria-hidden="true")
+    end
+
+    test "label overrides the accessible name; class and rest pass through" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.resizable_handle label="Resize navigation" class="opacity-50" data-test="handle" />
+        """)
+
+      assert html =~ ~s(aria-label="Resize navigation")
+      assert html =~ "opacity-50"
+      assert html =~ ~s(data-test="handle")
+    end
+  end
+
+  describe "nesting" do
+    test "a nested group renders two independent hook roots, each owning its own panels" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.resizable_group id="outer" orientation="vertical">
+          <.resizable_panel default_size={70}>
+            <.resizable_group id="inner">
+              <.resizable_panel id="inner-a" default_size={30}>files</.resizable_panel>
+              <.resizable_handle controls="inner-a" />
+              <.resizable_panel default_size={70}>editor</.resizable_panel>
+            </.resizable_group>
+          </.resizable_panel>
+          <.resizable_handle orientation="vertical" />
+          <.resizable_panel default_size={30}>terminal</.resizable_panel>
+        </.resizable_group>
+        """)
+
+      assert count_substring(html, ~s(phx-hook="PetalResizable")) == 2
+      assert html =~ ~s(id="outer")
+      assert html =~ ~s(id="inner")
+
+      doc = parse_html(html)
+
+      # :scope > … is what the hook uses; assert the DOM actually gives each
+      # group its own direct-child panels, three inside and two outside.
+      outer_panels =
+        doc |> LazyHTML.query("#outer > [data-pc-resizable-panel]") |> Enum.count()
+
+      inner_panels =
+        doc |> LazyHTML.query("#inner > [data-pc-resizable-panel]") |> Enum.count()
+
+      assert outer_panels == 2
+      assert inner_panels == 2
+
+      assert doc |> LazyHTML.query("#outer > [data-pc-resizable-handle]") |> Enum.count() == 1
+      assert doc |> LazyHTML.query("#inner > [data-pc-resizable-handle]") |> Enum.count() == 1
+    end
+  end
+end


### PR DESCRIPTION
Closes #621

## Summary

`<.resizable_group>` / `<.resizable_panel>` / `<.resizable_handle>` plus the `PetalResizable` hook, a `pc-resizable` CSS section, both test suites, a showcase module and a `/c/resizable` playground page.

Panels are percentages of the group, rendered as `flex: <pct> 1 0px`, so the split stays proportional through a window resize. Per-panel `default_size` / `min_size` / `max_size` / `collapsible` / `collapsed_size`, both orientations, n-panel groups. Nested groups are first class: the hook only ever resolves `:scope > [data-pc-resizable-panel]`, so a horizontal split inside a vertical one gets two independent hook instances that cannot see each other's panels.

The sizing maths is a set of pure exported functions (`distributeSizes`, `resolveDrag`, `resolveEdge`, `resolveToggle`, `resolveReset`, `keyboardDelta`), which is what makes the clamping testable without a DOM. Zero new dependencies, npm or hex.

## Deviations from the issue's API sketch

The sketch has the group taking a free-form `inner_block` of panels and handles, and the handle carrying live `aria-valuenow` / `aria-valuemin` / `aria-valuemax` / `aria-controls`. A function component cannot introspect its own `inner_block`, so at render time a handle has no way to know which panel precedes it, and a panel has no way to know how many siblings it shares the remainder with. Three consequences:

1. **`resizable_handle` gained `orientation`, `controls`, `value_now`, `value_min`, `value_max` and `label` attrs.** `orientation` is the GROUP's orientation and the component inverts it for `aria-orientation` (a handle in a horizontal group is a vertical separator). The other three server-render a starting point; the hook restamps all of them, plus `aria-orientation` and `aria-controls` (from the preceding panel's `id`), on mount and after every resize. So the markup contract is always present for SSR and assistive tech, and always correct once the hook is up. `label` defaults to "Resize panels" and is the accessible name.

2. **Unsized panels render `flex: 1 1 0px`.** An all-unsized group is therefore an exact equal share with no JS at all. When a group MIXES sized and unsized panels the server cannot compute the remainder, so the hook normalises the shares in `mounted()` before first paint. Documented on the component.

3. **`resizable_panel` gained an `id` attr** (needed for `aria-controls` and for reading the panel out of a collapse event).

Everything else follows the sketch: `data-pc-resizable-panel` / `-handle` markers, the `data-min` / `-max` / `-default` / `-collapsible` / `-collapsed-size` contract, `phx-hook="PetalResizable"` + `data-orientation` on the group, and the two `petal:*` DOM events.

One more small thing: `Enter` is listed in the issue's keyboard map but not in its "variants & states" checklist; it is implemented (toggle collapse) and tested.

## Keyboard map

Focus is on the handle (it is a `role="separator"` tab stop).

| Key | Effect |
|---|---|
| `ArrowLeft` / `ArrowRight` | resize a vertical separator by 2 points |
| `ArrowUp` / `ArrowDown` | resize a horizontal separator by 2 points |
| `Shift` + any of the above | 10-point step |
| `Home` | shrink the preceding panel to `min_size`, or collapse it when `collapsible` |
| `End` | grow the preceding panel to `max_size` |
| `Enter` | toggle collapse on a collapsible preceding panel |

Arrows perpendicular to the separator are a no-op, per the pattern. Keyboard resizes clamp identically to drag and fire the same resize / collapse events.

## How sizes persist

They don't, by design (the issue's non-goal). The library stores nothing. On pointer release and on every keyboard commit the group dispatches a bubbling `petal:resizable-resize` with `detail.sizes` (percentages in panel order) and, when `on_resize` is set, pushes `%{"sizes" => [..]}` to the LiveView. Collapse and expand dispatch `petal:resizable-collapse` with `detail: {panel_id, collapsed}`. Session, URL params or localStorage is the app's call. The playground page wires `on_resize` to a `handle_event` that renders the last pushed percentages, so the round trip is visible.

## What I verified interactively vs by unit test

Driven in a real Chrome against the playground on :4035, reading attributes back out of the live DOM:

- **Arrow resize**: sidebar 28% → 46% over 9 `ArrowRight` presses, `aria-valuenow` tracking it the whole way and the panel landing on `flex: 46 1 0px`
- **Pointer drag**: real `mouse down` / `move` × 3 / `up` on the separator moved the sidebar 28% → 50.94%, `aria-valuenow` 51. Pointer capture path exercised end to end
- **`Home` collapse**: `flex: 0 1 0px`, `aria-valuenow` 0, sidebar gone (see `collapsed` screenshot)
- **`Enter` restore**: back to `flex: 28 1 0px`
- **Perpendicular no-op**: `ArrowRight` on the vertical group's separator left `aria-valuenow` at 55
- **`on_resize` round trip**: 5 × `ArrowUp` on the vertical group put "55% / 45%" on the server-rendered panel next to it
- Light and dark, both by toggling the playground scheme switch

Unit tested rather than driven in the browser: the clamping edge cases (both panels' min and max bounding one drag), non-zero `collapsed_size`, collapse of the FOLLOWING panel, double-click reset ratios, `distributeSizes` normalisation, and the nested-group guard (an inner handle's `keydown` bubbling to the outer hook must not move the outer panels). The JS suite also drives the hook itself with synthetic pointer events for the drag / release / commit sequence.

## Test counts

| Suite | Before | After |
|---|---|---|
| `mix test` | 913 (0 failures, 1 skipped) | 927 (0 failures, 1 skipped) |
| `npm test` | 157 | 206 |

`mix credo`: 14 refactoring opportunities / 31 readability issues on `main`, unchanged on this branch. `mix format --check-formatted` and `mix compile --force --warnings-as-errors` both clean.

## Screenshots

Captured but not attached here (they are local PNGs, and I have not touched `pr-assets`): `light.png`, `dark.png`, `resized.png` (sidebar keyed out to 46% with the focus ring on the separator, and the vertical group showing "55% / 45%" pushed back from `on_resize`) and `collapsed.png` (sidebar collapsed to 0 via `Home`). Happy to attach them if you want them on the PR.
