### PR TITLE
feat(sortable): drag-to-reorder lists and grids, keyboard-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,38 @@
 # Changelog
+
+### Unreleased
+
+#### Added
+
+- **New `sortable` component: drag-to-reorder lists and grids, with a
+  keyboard path that is not an afterthought.** Drag a row (or only its
+  grip, with `handle`) and the list reorders under your finger with the
+  gaps animating into place; on drop it pushes ONE `on_reorder` event
+  carrying `%{"id", "from", "to"}` so your `handle_event` can persist the
+  order. LiveView stays the source of truth: the DOM has already moved,
+  so the patch is a visual no-op, and a server that says no snaps the
+  items back. `orientation="grid"` wraps items into a grid and teaches
+  the arrow keys to move in two dimensions, reading the column count off
+  the live layout so a responsive grid steps correctly at every
+  breakpoint. Works with LiveView streams - pass `phx-update="stream"`
+  through and give items a `dom_id`; reconciliation is by
+  `data-sortable-id`, never by index.
+
+  Keyboard reorder is a first-class path, not a fallback: Space lifts,
+  the arrows move, Space drops, Escape cancels, and every transition is
+  announced through a visually hidden `aria-live` region ("Picked up
+  Discovery call, position 1 of 5"). Focus follows the item it moved.
+  On touch a long press lifts, so a tap or a scroll still does what it
+  always did.
+
+  One `PetalSortable` hook, zero npm dependencies - pointer events,
+  `setPointerCapture` and hand-rolled FLIP transforms. All the order
+  maths and the whole lift state machine are pure functions, so they are
+  unit-tested without a DOM. There is no cloned drag overlay: the real
+  element moves through the list, which keeps the accessible order equal
+  to the DOM order at every instant and keeps form state and media
+  inside a row intact.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,109 @@
       transition-duration: 1ms;
     }
   }
+
+/* Sortable - drag-to-reorder lists and grids.
+ * The dragged element IS the overlay: it is really moved through the list as
+ * you drag, so there is no clone and the accessible order is always the DOM
+ * order. Siblings FLIP into the gap; the transform transition below is the
+ * whole animation, which is why reduced motion is one media query at the
+ * bottom rather than a branch in the hook. */
+@layer components {
+  .pc-sortable {
+    @apply flex flex-col gap-2;
+  }
+
+  .pc-sortable--grid {
+    @apply grid grid-cols-2 gap-3 sm:grid-cols-3;
+  }
+
+  .pc-sortable__item {
+    @apply relative flex items-center gap-3 px-3 py-2.5 bg-white border border-gray-200 text-gray-900 shadow-xs;
+    @apply dark:bg-gray-400/8 dark:border-gray-400/20 dark:text-gray-100;
+    @apply focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500/50 focus-visible:border-primary-500;
+    /* manipulation, not none: the page must still scroll under a list that
+       happens to be sortable. A lift vetoes the scroll itself, from the
+       hook's non-passive touchmove, once a long press has earned it. */
+    touch-action: manipulation;
+    transition:
+      transform 200ms cubic-bezier(0.2, 0, 0, 1),
+      box-shadow 150ms ease-out;
+    border-radius: var(--pc-radius, 0.625rem);
+  }
+
+  /* Whole-item drag: the row itself is the grab target. In handle mode the
+     grip owns the cursor instead, so the row stays an ordinary row. */
+  .pc-sortable:not([data-handle="true"]):not([data-disabled="true"])
+    .pc-sortable__item:not([data-disabled="true"]) {
+    @apply cursor-grab;
+  }
+
+  /* The lifted item, pointer or keyboard: the floating-panel treatment used
+     by popover and modal, so it reads as being above the list. */
+  .pc-sortable__item--dragging,
+  .pc-sortable__item--lifted {
+    @apply z-30 bg-white shadow-lg border-primary-500 dark:bg-gray-900 dark:border-primary-500/70;
+  }
+
+  .pc-sortable__item--dragging {
+    /* pointer-driven, so a transition here would lag the finger */
+    @apply cursor-grabbing select-none;
+    transition: none;
+    scale: 1.02;
+  }
+
+  .pc-sortable__item--lifted {
+    @apply ring-2 ring-primary-500/50;
+  }
+
+  /* Nothing under the pointer should paint a hover or select text mid-drag. */
+  .pc-sortable--dragging {
+    @apply select-none;
+  }
+
+  .pc-sortable--dragging .pc-sortable__item:not(.pc-sortable__item--dragging) {
+    @apply pointer-events-none;
+  }
+
+  .pc-sortable__item--disabled {
+    @apply opacity-60 cursor-not-allowed bg-gray-50 dark:bg-gray-400/4;
+  }
+
+  .pc-sortable__handle {
+    @apply flex shrink-0 items-center justify-center -ml-1 p-1 cursor-grab text-gray-400 transition-colors;
+    @apply hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300;
+    @apply focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500/50;
+    /* the grip is the one surface that trades page scroll for dragging */
+    touch-action: none;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-sortable__handle[aria-disabled="true"] {
+    @apply cursor-not-allowed opacity-50 hover:text-gray-400 dark:hover:text-gray-500;
+  }
+
+  .pc-sortable--dragging .pc-sortable__handle {
+    @apply cursor-grabbing;
+  }
+
+  .pc-sortable__grip {
+    @apply w-4 h-4;
+  }
+
+  /* The keyboard instructions and the announcement region: present for
+     assistive tech, absent from layout (sr-only is absolutely positioned, so
+     a flex or grid parent never sees them as children). */
+  .pc-sortable__sr {
+    @apply sr-only;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pc-sortable__item {
+      transition: none;
+    }
+
+    .pc-sortable__item--dragging {
+      scale: 1;
+    }
+  }
+}

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -4925,6 +4925,691 @@ export const PetalComboBox = {
   },
 };
 
+// Sortable: every order decision as a pure function.
+//
+// Drag-to-reorder is one of the few things CSS and Phoenix.LiveView.JS
+// genuinely cannot do - pointer tracking, FLIP gap animation and a keyboard
+// lift state machine all need imperative code. So the hook exists, but the
+// thinking does not live in it: the reorder maths, the arrow-key stepping,
+// the announcement strings and the whole lift state machine are pure
+// functions here, unit-tested in test/js/sortable.test.js without a DOM. The
+// hook below is only the layer that reads rects, moves nodes and talks to
+// LiveView.
+export const SortableCore = {
+  // A tap is not a drag and a scroll is not a lift. Touch waits for a long
+  // press; mouse and pen wait for real movement so a plain click still is one.
+  LONG_PRESS_MS: 250,
+  TOUCH_SLOP_PX: 8,
+  POINTER_SLOP_PX: 4,
+
+  arrayMove(list, from, to) {
+    const next = list.slice();
+    if (from < 0 || from >= next.length) return next;
+    const clamped = Math.max(0, Math.min(to, next.length - 1));
+    const [moved] = next.splice(from, 1);
+    next.splice(clamped, 0, moved);
+    return next;
+  },
+
+  // Where a pointer at (x, y) wants the dragged item, given every item's rect
+  // in current DOM order.
+  //
+  // The two orientations genuinely want different rules. A list has rows of
+  // varying height, so it uses midpoints: an item is displaced only once the
+  // pointer crosses its centre line, which is the hysteresis that stops two
+  // unequal rows flickering back and forth across one boundary. A grid has
+  // uniform cells and reflows in two dimensions, where the same rule sends an
+  // item somewhere it was never dragged (hover the bottom-left cell from the
+  // left and reading-order counting lands you top-right). So a grid uses the
+  // cell under the pointer directly. That works because the list is reordered
+  // live as you drag: the rects ARE the current arrangement, so the cell you
+  // are over is exactly the slot you are asking for, and once the item lands
+  // there the pointer is still inside it - stable, not oscillating.
+  indexFromPoint({ rects, x, y, orientation = "vertical", activeIndex = -1 }) {
+    if (orientation === "grid") {
+      const over = rects.findIndex(
+        (r) =>
+          x >= r.left && x <= r.left + r.width && y >= r.top && y <= r.top + r.height,
+      );
+
+      // Only fall through to counting when the pointer is in a gutter or off
+      // the end of the grid, where no cell can answer.
+      if (over !== -1) return over;
+    }
+
+    let passed = 0;
+
+    rects.forEach((rect, i) => {
+      if (i === activeIndex) return;
+      if (SortableCore.pointerPassed(rect, x, y, orientation)) passed += 1;
+    });
+
+    return Math.max(0, Math.min(passed, rects.length - 1));
+  },
+
+  pointerPassed(rect, x, y, orientation) {
+    if (orientation === "grid") {
+      // Reading order: a whole row above the pointer is behind it, a whole
+      // row below is ahead, and within its own row it is a left/right call.
+      if (y > rect.top + rect.height) return true;
+      if (y < rect.top) return false;
+      return x > rect.left + rect.width / 2;
+    }
+
+    return y > rect.top + rect.height / 2;
+  },
+
+  // One arrow-key step, clamped to the list. Returns null for a key this
+  // component does not own, so the hook leaves that event alone.
+  nextKeyboardIndex({
+    index,
+    key,
+    orientation = "vertical",
+    columns = 1,
+    count,
+  }) {
+    const span = Math.max(1, columns);
+
+    const step =
+      orientation === "grid"
+        ? { ArrowLeft: -1, ArrowRight: 1, ArrowUp: -span, ArrowDown: span }[key]
+        : { ArrowUp: -1, ArrowDown: 1 }[key];
+
+    if (step === undefined) return null;
+
+    return Math.max(0, Math.min(index + step, count - 1));
+  },
+
+  // Screen readers get no feedback from a moving box, so every transition
+  // says where the item now is. Positions are 1-based for humans.
+  announce(phase, label, index, total) {
+    const at = `position ${index + 1} of ${total}`;
+
+    switch (phase) {
+      case "lift":
+        return `Picked up ${label}, ${at}`;
+      case "move":
+        return `Moved ${label} to ${at}`;
+      case "drop":
+        return `Dropped ${label} at ${at}`;
+      case "cancel":
+        return `Reorder cancelled. ${label} returned to ${at}`;
+      default:
+        return "";
+    }
+  },
+
+  // The keyboard lift state machine, pure. `state` is null when idle.
+  // Returns the next state, what to announce, the id order the DOM should
+  // now be in (null = unchanged), the reorder event to push (null = none),
+  // and whether the key was ours to swallow.
+  keyboardReduce(state, action) {
+    const unchanged = {
+      state,
+      announcement: null,
+      order: null,
+      event: null,
+      handled: false,
+    };
+
+    switch (action.type) {
+      case "lift": {
+        // A disabled item is not liftable, and a second lift is the drop.
+        if (state || action.disabled) return unchanged;
+
+        const order = action.order.slice();
+        const from = order.indexOf(action.id);
+        if (from === -1) return unchanged;
+
+        const label = action.label || action.id;
+
+        return {
+          state: { id: action.id, label, from, index: from, order, origin: order },
+          announcement: SortableCore.announce("lift", label, from, order.length),
+          order: null,
+          event: null,
+          handled: true,
+        };
+      }
+
+      case "move": {
+        if (!state) return unchanged;
+
+        const to = SortableCore.nextKeyboardIndex({
+          index: state.index,
+          key: action.key,
+          orientation: action.orientation,
+          columns: action.columns,
+          count: state.order.length,
+        });
+
+        if (to === null) return unchanged;
+
+        // Clamped against an end of the list: ours to swallow (the page must
+        // not scroll under a lifted item) but nothing moved, so stay quiet.
+        if (to === state.index) return { ...unchanged, handled: true };
+
+        const order = SortableCore.arrayMove(state.order, state.index, to);
+
+        return {
+          state: { ...state, index: to, order },
+          announcement: SortableCore.announce(
+            "move",
+            state.label,
+            to,
+            order.length,
+          ),
+          order,
+          event: null,
+          handled: true,
+        };
+      }
+
+      case "drop": {
+        if (!state) return unchanged;
+
+        // Landing where it started is not a reorder. Announce it, but do not
+        // make the server persist a no-op.
+        const moved = state.index !== state.from;
+
+        return {
+          state: null,
+          announcement: SortableCore.announce(
+            "drop",
+            state.label,
+            state.index,
+            state.order.length,
+          ),
+          order: null,
+          event: moved
+            ? { id: state.id, from: state.from, to: state.index }
+            : null,
+          handled: true,
+        };
+      }
+
+      case "cancel": {
+        if (!state) return unchanged;
+
+        return {
+          state: null,
+          announcement: SortableCore.announce(
+            "cancel",
+            state.label,
+            state.from,
+            state.origin.length,
+          ),
+          order: state.origin,
+          event: null,
+          handled: true,
+        };
+      }
+
+      default:
+        return unchanged;
+    }
+  },
+};
+
+const SORTABLE_ITEM = ".pc-sortable__item";
+
+export const PetalSortable = {
+  mounted() {
+    this.kb = null; // keyboard lift state, owned by SortableCore.keyboardReduce
+    this.drag = null; // an in-flight pointer drag
+    this.press = null; // a press that has not earned a lift yet
+
+    this.onPointerDown = (e) => this.pointerDown(e);
+    this.onPointerMove = (e) => this.pointerMove(e);
+    this.onPointerUp = (e) => this.pointerUp(e);
+    this.onKeyDown = (e) => this.keyDown(e);
+    // iOS turns a long press into a selection callout and a context menu,
+    // which is exactly the gesture that lifts an item here.
+    this.onContextMenu = (e) => {
+      if (this.drag) e.preventDefault();
+    };
+    // Pointer events alone cannot cancel a scroll the browser has already
+    // claimed. A non-passive touchmove is the only reliable veto.
+    this.onTouchMove = (e) => {
+      if (this.drag) e.preventDefault();
+    };
+
+    this.el.addEventListener("pointerdown", this.onPointerDown);
+    this.el.addEventListener("keydown", this.onKeyDown);
+    this.el.addEventListener("contextmenu", this.onContextMenu);
+    this.el.addEventListener("touchmove", this.onTouchMove, { passive: false });
+    window.addEventListener("pointermove", this.onPointerMove, {
+      passive: false,
+    });
+    window.addEventListener("pointerup", this.onPointerUp);
+    window.addEventListener("pointercancel", this.onPointerUp);
+  },
+
+  // A patch can replace or reorder the very children this hook is holding
+  // rects for, so an in-flight pointer drag is abandoned rather than left
+  // animating a detached tree. A keyboard lift is cheaper to keep: re-resolve
+  // it by data-sortable-id, never by the index we remembered.
+  updated() {
+    if (this.press || this.drag) this.abortPointer();
+    if (!this.kb) return;
+
+    const order = this.ids();
+    const index = order.indexOf(this.kb.id);
+
+    if (index === -1) {
+      this.kb = null;
+      return;
+    }
+
+    this.kb = { ...this.kb, order, index };
+    const el = this.itemById(this.kb.id);
+    if (el) el.classList.add("pc-sortable__item--lifted");
+  },
+
+  destroyed() {
+    this.abortPointer();
+    this.el.removeEventListener("pointerdown", this.onPointerDown);
+    this.el.removeEventListener("keydown", this.onKeyDown);
+    this.el.removeEventListener("contextmenu", this.onContextMenu);
+    this.el.removeEventListener("touchmove", this.onTouchMove);
+    window.removeEventListener("pointermove", this.onPointerMove);
+    window.removeEventListener("pointerup", this.onPointerUp);
+    window.removeEventListener("pointercancel", this.onPointerUp);
+  },
+
+  // --- reading the DOM -----------------------------------------------------
+
+  items() {
+    return Array.from(this.el.querySelectorAll(`:scope > ${SORTABLE_ITEM}`));
+  },
+
+  ids() {
+    return this.items().map((el) => el.dataset.sortableId);
+  },
+
+  itemById(id) {
+    return this.items().find((el) => el.dataset.sortableId === id) || null;
+  },
+
+  labelFor(el) {
+    return (
+      el.dataset.sortableLabel ||
+      el.textContent.trim().slice(0, 80) ||
+      el.dataset.sortableId
+    );
+  },
+
+  disabled() {
+    return this.el.dataset.disabled === "true";
+  },
+
+  orientation() {
+    return this.el.dataset.orientation === "grid" ? "grid" : "vertical";
+  },
+
+  // How many items share the first row. Read from live rects rather than a
+  // configured column count, so a responsive grid steps correctly at every
+  // breakpoint without being told what it is.
+  columns() {
+    const items = this.items();
+    if (items.length === 0) return 1;
+
+    const top = items[0].getBoundingClientRect().top;
+    let n = 0;
+
+    for (const el of items) {
+      if (Math.abs(el.getBoundingClientRect().top - top) > 1) break;
+      n += 1;
+    }
+
+    return Math.max(1, n);
+  },
+
+  // --- moving the DOM ------------------------------------------------------
+
+  measure() {
+    const map = new Map();
+    this.items().forEach((el) => map.set(el, el.getBoundingClientRect()));
+    return map;
+  },
+
+  // FLIP: every sibling is snapped back to where it was, then released to
+  // transition home. The transition itself lives in CSS, which is what makes
+  // prefers-reduced-motion a one-line media query rather than a JS branch.
+  flip(before) {
+    const items = this.items();
+    const active = this.drag && this.drag.el;
+
+    items.forEach((el) => {
+      const first = before.get(el);
+      if (!first || el === active) return;
+
+      const last = el.getBoundingClientRect();
+      const dx = first.left - last.left;
+      const dy = first.top - last.top;
+      if (dx === 0 && dy === 0) return;
+
+      el.style.transition = "none";
+      el.style.transform = `translate3d(${dx}px, ${dy}px, 0)`;
+    });
+
+    // One forced reflow so the inverted positions are the browser's current
+    // truth; without it the clear below is coalesced and nothing animates.
+    void this.el.offsetHeight;
+
+    items.forEach((el) => {
+      if (el === active) return;
+      el.style.transition = "";
+      el.style.transform = "";
+    });
+  },
+
+  moveTo(el, index) {
+    const others = this.items().filter((item) => item !== el);
+    const before = others[index];
+
+    if (before) this.el.insertBefore(el, before);
+    else this.el.appendChild(el);
+  },
+
+  // Re-sorting by appending in order: each append moves an existing node, so
+  // the list ends up in exactly `order` with no nodes created or destroyed.
+  // Focus is restored because moving a focused node drops focus in Safari.
+  applyOrder(order) {
+    const before = this.measure();
+    const focused = document.activeElement;
+
+    order.forEach((id) => {
+      const el = this.itemById(id);
+      if (el) this.el.appendChild(el);
+    });
+
+    this.flip(before);
+    if (focused && this.el.contains(focused)) focused.focus();
+  },
+
+  // --- talking to the server ----------------------------------------------
+
+  say(text) {
+    if (!text) return;
+
+    const region = document.getElementById(`${this.el.id}-live`);
+    if (!region) return;
+
+    // Re-announcing an identical string (two moves into the same slot) needs
+    // the region to actually change, so clear it first.
+    region.textContent = "";
+    region.textContent = text;
+  },
+
+  emit(id, from, to) {
+    const detail = { id, from, to };
+    const name = this.el.dataset.onReorder;
+
+    if (name) {
+      if (this.el.getAttribute("phx-target")) {
+        this.pushEventTo(this.el, name, detail);
+      } else {
+        this.pushEvent(name, detail);
+      }
+    }
+
+    // Dead views and plain-JS consumers get the same payload, mirroring
+    // petal:otp-complete on input_otp.
+    this.el.dispatchEvent(
+      new CustomEvent("petal:sortable", { bubbles: true, detail }),
+    );
+  },
+
+  // --- pointer -------------------------------------------------------------
+
+  pointerDown(e) {
+    if (this.disabled() || this.kb || this.press || this.drag) return;
+    if (e.pointerType === "mouse" && e.button !== 0) return;
+
+    const el = e.target.closest(SORTABLE_ITEM);
+    if (!el || el.parentElement !== this.el) return;
+    if (el.dataset.disabled === "true") return;
+
+    // Handle mode: everything outside the grip stays interactive, so links
+    // and checkboxes inside a row keep working.
+    if (
+      this.el.dataset.handle === "true" &&
+      !e.target.closest("[data-sortable-handle]")
+    ) {
+      return;
+    }
+
+    const touch = e.pointerType === "touch";
+
+    this.press = {
+      el,
+      x: e.clientX,
+      y: e.clientY,
+      pointerId: e.pointerId,
+      touch,
+      timer: touch ? setTimeout(() => this.lift(), SortableCore.LONG_PRESS_MS) : null,
+    };
+  },
+
+  pointerMove(e) {
+    if (this.press && !this.drag) {
+      const dist = Math.hypot(e.clientX - this.press.x, e.clientY - this.press.y);
+
+      // A finger that moves before the long press expires is scrolling the
+      // page, not lifting. A mouse that moves at all is dragging.
+      if (this.press.touch) {
+        if (dist > SortableCore.TOUCH_SLOP_PX) this.abortPointer();
+      } else if (dist > SortableCore.POINTER_SLOP_PX) {
+        this.lift();
+      }
+    }
+
+    if (!this.drag) return;
+
+    e.preventDefault();
+    this.track(e.clientX, e.clientY);
+
+    const items = this.items();
+    const activeIndex = items.indexOf(this.drag.el);
+    if (activeIndex === -1) return this.abortPointer();
+
+    const to = SortableCore.indexFromPoint({
+      rects: items.map((el) => el.getBoundingClientRect()),
+      x: e.clientX,
+      y: e.clientY,
+      orientation: this.orientation(),
+      activeIndex,
+    });
+
+    if (to === activeIndex) return;
+
+    const before = this.measure();
+    this.moveTo(this.drag.el, to);
+    this.syncHome();
+    this.track(e.clientX, e.clientY);
+    this.flip(before);
+  },
+
+  pointerUp() {
+    if (this.drag) return this.finishDrag();
+    if (this.press) this.abortPointer();
+  },
+
+  lift() {
+    const press = this.press;
+    if (!press) return;
+
+    clearTimeout(press.timer);
+    this.press = null;
+
+    const rect = press.el.getBoundingClientRect();
+
+    this.drag = {
+      el: press.el,
+      id: press.el.dataset.sortableId,
+      label: this.labelFor(press.el),
+      from: this.ids().indexOf(press.el.dataset.sortableId),
+      pointerId: press.pointerId,
+      // Where inside the item the pointer grabbed it, so it does not jump.
+      offsetX: rect.left - press.x,
+      offsetY: rect.top - press.y,
+      home: { left: rect.left, top: rect.top },
+    };
+
+    press.el.classList.add("pc-sortable__item--dragging");
+    this.el.classList.add("pc-sortable--dragging");
+
+    // Capture keeps the stream of pointer events coming to this node even
+    // when the pointer outruns it, and lets preventDefault veto the scroll.
+    try {
+      press.el.setPointerCapture(press.pointerId);
+    } catch {
+      /* capture is best-effort; the window listeners still fire */
+    }
+
+    this.say(
+      SortableCore.announce(
+        "lift",
+        this.drag.label,
+        this.drag.from,
+        this.items().length,
+      ),
+    );
+  },
+
+  // The dragged node is really moved through the list as you drag, so its
+  // layout position changes underneath it. Re-read that home position and
+  // the transform stays a pure pointer offset instead of accumulating drift.
+  syncHome() {
+    const el = this.drag.el;
+    const prev = el.style.transform;
+
+    el.style.transform = "none";
+    const rect = el.getBoundingClientRect();
+    el.style.transform = prev;
+
+    this.drag.home = { left: rect.left, top: rect.top };
+  },
+
+  track(x, y) {
+    const { home, offsetX, offsetY, el } = this.drag;
+    const dx = x + offsetX - home.left;
+    const dy = y + offsetY - home.top;
+
+    el.style.transform = `translate3d(${dx}px, ${dy}px, 0)`;
+  },
+
+  finishDrag() {
+    const drag = this.drag;
+    this.drag = null;
+    this.clearDragStyles(drag);
+
+    const to = this.ids().indexOf(drag.id);
+    if (to === -1) return;
+
+    this.say(
+      SortableCore.announce("drop", drag.label, to, this.items().length),
+    );
+
+    if (to !== drag.from) this.emit(drag.id, drag.from, to);
+  },
+
+  // Drop everything without emitting: a press that turned out to be a click,
+  // or a drag whose DOM was pulled out from under it by a patch.
+  abortPointer() {
+    if (this.press) {
+      clearTimeout(this.press.timer);
+      this.press = null;
+    }
+
+    if (this.drag) {
+      const drag = this.drag;
+      this.drag = null;
+      this.clearDragStyles(drag);
+    }
+  },
+
+  clearDragStyles(drag) {
+    drag.el.style.transform = "";
+    drag.el.style.transition = "";
+    drag.el.classList.remove("pc-sortable__item--dragging");
+    this.el.classList.remove("pc-sortable--dragging");
+
+    try {
+      drag.el.releasePointerCapture(drag.pointerId);
+    } catch {
+      /* already released, or never captured */
+    }
+  },
+
+  // --- keyboard ------------------------------------------------------------
+
+  keyDown(e) {
+    if (this.disabled()) return;
+
+    const el = e.target.closest(SORTABLE_ITEM);
+    if (!el || el.parentElement !== this.el) return;
+
+    const action = this.actionFor(e, el);
+    if (!action) return;
+
+    const result = SortableCore.keyboardReduce(this.kb, action);
+    if (!result.handled) return;
+
+    e.preventDefault();
+
+    const lifted = this.kb;
+    this.kb = result.state;
+
+    if (result.order) this.applyOrder(result.order);
+    if (result.state) el.classList.add("pc-sortable__item--lifted");
+    if (!result.state && lifted) this.unlift(lifted.id);
+    if (result.announcement) this.say(result.announcement);
+    if (result.event) {
+      this.emit(result.event.id, result.event.from, result.event.to);
+    }
+  },
+
+  actionFor(e, el) {
+    if (e.key === " " || e.key === "Spacebar" || e.key === "Space") {
+      return this.kb
+        ? { type: "drop" }
+        : {
+            type: "lift",
+            id: el.dataset.sortableId,
+            label: this.labelFor(el),
+            order: this.ids(),
+            disabled: el.dataset.disabled === "true",
+          };
+    }
+
+    if (e.key === "Escape") return { type: "cancel" };
+
+    if (e.key.startsWith("Arrow")) {
+      return {
+        type: "move",
+        key: e.key,
+        orientation: this.orientation(),
+        columns: this.orientation() === "grid" ? this.columns() : 1,
+      };
+    }
+
+    return null;
+  },
+
+  // Focus follows the item, not the slot it used to sit in - a drop that
+  // left focus behind would strand a keyboard user two rows from their work.
+  unlift(id) {
+    const el = this.itemById(id);
+    if (!el) return;
+
+    el.classList.remove("pc-sortable__item--lifted");
+    const target = el.querySelector("[data-sortable-handle]") || el;
+    target.focus();
+  },
+};
+
 // Link-mode wiring for the data table's quick search and rows-per-page
 // select. Event mode posts through plain phx-change forms and never
 // mounts this hook; link mode has no events by design (handle_params is
@@ -5454,4 +6139,5 @@ export default {
   PetalCommandDialog,
   PetalComboBox,
   PetalDataTable,
+  PetalSortable,
 };

--- a/dev.exs
+++ b/dev.exs
@@ -295,6 +295,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "card", name: "Card", ready: true},
         %{slug: "carousel", name: "Carousel", ready: true},
         %{slug: "accordion", name: "Accordion", ready: true},
+        %{slug: "sortable", name: "Sortable", ready: true},
         %{slug: "container", name: "Container", ready: true}
       ]
     },
@@ -785,6 +786,29 @@ defmodule Dev.PlaygroundLive do
        slider: %{thumbs: "dual", format: "money", disabled: false, fill: true},
        slider_form: slider_form("money"),
        otp: %{length: 6, grouped: false, pattern: "numeric", disabled: false},
+       sortable: %{
+         handle: true,
+         orientation: "vertical",
+         disabled: false,
+         # the server IS the order: the hook reorders optimistically, this
+         # list is what the next render paints from
+         todos: [
+           %{id: "release", title: "Cut the 4.1 release build", locked: false},
+           %{id: "changelog", title: "Write the changelog", locked: false},
+           %{id: "docs", title: "Update the docs site", locked: false},
+           %{id: "invoices", title: "Send the March invoices", locked: true},
+           %{id: "standup", title: "Prep Monday standup", locked: false}
+         ],
+         photos: [
+           %{id: "harbour", title: "Harbour at dawn", tone: "from-sky-400 to-indigo-500"},
+           %{id: "ridge", title: "Ridge line", tone: "from-emerald-400 to-teal-600"},
+           %{id: "salt", title: "Salt flats", tone: "from-amber-300 to-orange-500"},
+           %{id: "pines", title: "Pines in fog", tone: "from-slate-400 to-slate-700"},
+           %{id: "dunes", title: "Dunes", tone: "from-rose-400 to-pink-600"},
+           %{id: "estuary", title: "Estuary", tone: "from-violet-400 to-purple-600"}
+         ],
+         log: []
+       },
        progress: %{
          value: 0,
          color: "primary",
@@ -1448,6 +1472,41 @@ defmodule Dev.PlaygroundLive do
     do:
       {:noreply,
        update(socket, :otp, &Map.update!(&1, String.to_existing_atom(k), fn v -> !v end))}
+
+  def handle_event("ctl_sortable", %{"k" => "orientation", "v" => v}, socket)
+      when v in ~w(vertical grid),
+      do: {:noreply, update(socket, :sortable, &%{&1 | orientation: v})}
+
+  def handle_event("ctl_sortable", %{"k" => k}, socket) when k in ~w(handle disabled),
+    do:
+      {:noreply,
+       update(socket, :sortable, &Map.update!(&1, String.to_existing_atom(k), fn v -> !v end))}
+
+  # The whole server-truth story in one handler. The hook already moved the
+  # DOM optimistically and pushed this; we move the list the same way, so the
+  # next render agrees with what is on screen and the patch is a visual no-op.
+  # Place by id, not by index - `from` is only a sanity check, because under
+  # concurrency it can be stale while the id never is.
+  def handle_event("pg_sortable", %{"id" => id, "from" => from, "to" => to}, socket)
+      when is_integer(from) and is_integer(to) do
+    {:noreply,
+     update(socket, :sortable, fn s ->
+       key = if s.orientation == "grid", do: :photos, else: :todos
+       items = Map.fetch!(s, key)
+
+       case Enum.find_index(items, &(&1.id == id)) do
+         nil ->
+           s
+
+         index ->
+           item = Enum.at(items, index)
+           moved = items |> List.delete_at(index) |> List.insert_at(to, item)
+           entry = "#{item.title}: #{index + 1} -> #{to + 1}"
+
+           s |> Map.put(key, moved) |> Map.put(:log, Enum.take([entry | s.log], 5))
+       end
+     end)}
+  end
 
   def handle_event("ctl_switch", %{"k" => "size", "v" => v}, socket) when v in ~w(xs sm md lg xl),
     do: {:noreply, update(socket, :switch, &%{&1 | size: v})}
@@ -7028,6 +7087,133 @@ defmodule Dev.PlaygroundLive do
         registry - the same source petal.build renders, so the playground and the marketing
         docs can't drift.
       </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "sortable"} = assigns) do
+    ~H"""
+    <div class="max-w-3xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">Sortable</h1>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        Drag a row to reorder it. Or don't touch the mouse at all: Tab to a row (or its grip),
+        press Space to lift it, arrow keys to move it, Space to drop, Escape to change your
+        mind. Every step is announced to a screen reader.
+      </p>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        This demo is live. The drop pushes one event, this LiveView reorders its own list, and
+        the running log underneath is the SERVER's order, not the browser's. Reload the page
+        and the order you left it in is still there.
+      </p>
+
+      <div class="mt-8 overflow-hidden border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="px-4 py-8 sm:px-6">
+          <.sortable
+            :if={@sortable.orientation == "vertical"}
+            id="pg-sortable-todos"
+            on_reorder="pg_sortable"
+            handle={@sortable.handle}
+            disabled={@sortable.disabled}
+          >
+            <:item
+              :for={todo <- @sortable.todos}
+              id={todo.id}
+              label={todo.title}
+              disabled={todo.locked}
+            >
+              <span class="grow">{todo.title}</span>
+              <.badge :if={todo.locked} size="sm" color="gray" label="locked" />
+            </:item>
+          </.sortable>
+
+          <.sortable
+            :if={@sortable.orientation == "grid"}
+            id="pg-sortable-photos"
+            on_reorder="pg_sortable"
+            orientation="grid"
+            handle={@sortable.handle}
+            disabled={@sortable.disabled}
+          >
+            <:item
+              :for={photo <- @sortable.photos}
+              id={photo.id}
+              label={photo.title}
+              class="flex-col !items-stretch !gap-2 !p-2"
+            >
+              <div class={["h-20 rounded-md bg-gradient-to-br", photo.tone]}></div>
+              <span class="text-xs text-gray-600 dark:text-gray-300">{photo.title}</span>
+            </:item>
+          </.sortable>
+        </div>
+
+        <div class="flex flex-wrap items-end gap-x-8 gap-y-4 px-4 py-4 border-t border-gray-200 sm:px-6 dark:border-gray-800">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">orientation</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Orientation"
+              value={@sortable.orientation}
+              on_change="ctl_sortable"
+            >
+              <:item :for={o <- ~w(vertical grid)} value={o} phx-value-k="orientation" phx-value-v={o}>
+                {o}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">extras</div>
+            <.toggle_group
+              multiple
+              variant="outline"
+              size="sm"
+              aria_label="Extras"
+              value={
+                for {k, on} <- [{"handle", @sortable.handle}, {"disabled", @sortable.disabled}],
+                    on,
+                    do: k
+              }
+              on_change="ctl_sortable"
+            >
+              <:item value="handle" phx-value-k="handle">grip handle</:item>
+              <:item value="disabled" phx-value-k="disabled">disabled</:item>
+            </.toggle_group>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-4 mt-4 border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="text-[11px] font-medium tracking-wide text-gray-400">
+          server order (persisted in the LiveView, newest move first)
+        </div>
+        <ol class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+          <li :for={entry <- @sortable.log} class="font-mono text-xs">{entry}</li>
+          <li :if={@sortable.log == []} class="text-gray-400 dark:text-gray-500">
+            nothing moved yet
+          </li>
+        </ol>
+        <div class="mt-3 font-mono text-xs text-gray-500 break-all dark:text-gray-400">
+          {Enum.map_join(
+            if(@sortable.orientation == "grid", do: @sortable.photos, else: @sortable.todos),
+            ", ",
+            & &1.id
+          )}
+        </div>
+      </div>
+
+      <div
+        :for={ex <- examples_for(PetalComponents.Showcase.Sortable, ~w(handle grid disabled)a)}
+        class="mt-10"
+      >
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
+      <.showcase_props component={PetalComponents.Sortable} function={:sortable} />
     </div>
     """
   end

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -62,6 +62,7 @@ defmodule PetalComponents do
         Skeleton,
         SlideOver,
         SocialButton,
+        Sortable,
         Sparkline,
         ShineBorder,
         SpotlightCard,

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -47,6 +47,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.ShineBorder,
     PetalComponents.Showcase.Skeleton,
     PetalComponents.Showcase.SlideOver,
+    PetalComponents.Showcase.Sortable,
     PetalComponents.Showcase.Sparkline,
     PetalComponents.Showcase.SpotlightCard,
     PetalComponents.Showcase.Stepper,

--- a/lib/petal_components/showcase/sortable.ex
+++ b/lib/petal_components/showcase/sortable.ex
@@ -1,0 +1,69 @@
+defmodule PetalComponents.Showcase.Sortable do
+  @moduledoc false
+  use PetalComponents.Showcase, component: PetalComponents.Sortable, title: "Sortable"
+
+  example :basic, "Drag to reorder",
+    description:
+      "Grab any row and drag it. On drop the component pushes one on_reorder event with the item id and its old and new index, and your handler persists the order. Tab to a row and press Space to do the same thing without a mouse. Needs the PetalSortable hook from the bundle." do
+    ~H"""
+    <.sortable id="showcase-stages" on_reorder="reorder_stages">
+      <:item id="discovery" label="Discovery call">Discovery call</:item>
+      <:item id="demo" label="Product demo">Product demo</:item>
+      <:item id="proposal" label="Proposal sent">Proposal sent</:item>
+      <:item id="closed" label="Closed won">Closed won</:item>
+    </.sortable>
+    """
+  end
+
+  example :handle, "Handle only",
+    description:
+      "handle puts a grip on each row and only the grip starts a drag, so everything else in the row stays clickable. The grip is also the tab stop, with its own accessible name." do
+    ~H"""
+    <.sortable id="showcase-todos" on_reorder="reorder_todos" handle>
+      <:item id="deploy" label="Ship the release build">
+        <span>Ship the release build</span>
+      </:item>
+      <:item id="changelog" label="Write the changelog">
+        <span>Write the changelog</span>
+      </:item>
+      <:item id="invoices" label="Send the invoices" disabled>
+        <span>Send the invoices</span>
+        <span class="ml-auto text-xs text-gray-500 dark:text-gray-400">locked</span>
+      </:item>
+    </.sortable>
+    """
+  end
+
+  example :grid, "Grid",
+    description:
+      "orientation=\"grid\" wraps items into a grid and teaches the arrow keys to move in two dimensions. The column count is read from the live layout, so a responsive grid steps correctly at every breakpoint." do
+    ~H"""
+    <.sortable id="showcase-gallery" on_reorder="reorder_photos" orientation="grid">
+      <:item id="harbour" label="Harbour at dawn">
+        <span class="text-sm">Harbour at dawn</span>
+      </:item>
+      <:item id="ridge" label="Ridge line">
+        <span class="text-sm">Ridge line</span>
+      </:item>
+      <:item id="salt" label="Salt flats">
+        <span class="text-sm">Salt flats</span>
+      </:item>
+      <:item id="pines" label="Pines in fog">
+        <span class="text-sm">Pines in fog</span>
+      </:item>
+    </.sortable>
+    """
+  end
+
+  example :disabled, "Disabled",
+    description:
+      "disabled on the container turns the whole list inert: no drag, no keyboard lift, and the items leave the tab order. Use it while an order is saving, or when the viewer has read-only access." do
+    ~H"""
+    <.sortable id="showcase-locked" on_reorder="reorder_locked" handle disabled>
+      <:item id="one" label="First">First</:item>
+      <:item id="two" label="Second">Second</:item>
+      <:item id="three" label="Third">Third</:item>
+    </.sortable>
+    """
+  end
+end

--- a/lib/petal_components/sortable.ex
+++ b/lib/petal_components/sortable.ex
@@ -1,0 +1,290 @@
+defmodule PetalComponents.Sortable do
+  @moduledoc """
+  A drag-to-reorder list or grid.
+
+  The user drags an item (or lifts it with the keyboard), the DOM reorders
+  optimistically with animated gaps, and on drop the component pushes ONE
+  event carrying `%{"id" => ..., "from" => ..., "to" => ...}`. Your
+  `handle_event/3` persists the new order and re-renders. LiveView stays the
+  source of truth: the optimistic DOM already matches, so the patch is a
+  visual no-op. Rejecting a move snaps the items back, which is the correct
+  failure behaviour rather than a bug - but a stream has to be told to do it,
+  see "Rejecting a move" below.
+
+  Needs the `PetalSortable` hook from the petal_components JS bundle.
+
+  ## Examples
+
+  A plain list. `on_reorder` is an event name, not a `JS` struct, because the
+  move has to reach the server to be persisted:
+
+      <.sortable id="stages" on_reorder="reorder_stages">
+        <:item :for={stage <- @stages} id={stage.id}>
+          {stage.name}
+        </:item>
+      </.sortable>
+
+  Handle mode, where only the grip starts a drag so the rest of the row stays
+  clickable (links, checkboxes, inline edit):
+
+      <.sortable id="todos" on_reorder="reorder_todos" handle>
+        <:item :for={todo <- @todos} id={todo.id} label={todo.title} disabled={todo.locked}>
+          <input type="checkbox" checked={todo.done} phx-click="toggle" phx-value-id={todo.id} />
+          <span>{todo.title}</span>
+        </:item>
+      </.sortable>
+
+  A grid, where the arrow keys move in two dimensions:
+
+      <.sortable id="gallery" on_reorder="reorder_photos" orientation="grid">
+        <:item :for={photo <- @photos} id={photo.id} label={photo.alt}>
+          <img src={photo.url} alt={photo.alt} />
+        </:item>
+      </.sortable>
+
+  ## Stream-backed lists
+
+  Streams are the usual way to render a reorderable list. Pass
+  `phx-update="stream"` through to the root (it lands on the element that
+  directly contains the items) and give each item BOTH ids: `dom_id` is the
+  stream's DOM id, `id` is your record's real id, which is what arrives in the
+  event. Reconciliation is by `data-sortable-id`, never by index.
+
+      <.sortable id="todos" on_reorder="reorder" phx-update="stream">
+        <:item :for={{dom_id, todo} <- @streams.todos} id={todo.id} dom_id={dom_id}>
+          {todo.title}
+        </:item>
+      </.sortable>
+
+  And the handler that makes the server the source of truth. Reinserting every
+  item at its new position is what keeps a later full re-render in agreement
+  with the DOM the hook already produced:
+
+      def handle_event("reorder", %{"id" => id, "from" => from, "to" => to}, socket) do
+        todos =
+          socket.assigns.todos
+          |> List.delete_at(from)
+          |> List.insert_at(to, Enum.at(socket.assigns.todos, from))
+
+        {:ok, _} = Todos.persist_order(todos)
+
+        socket =
+          Enum.reduce(Enum.with_index(todos), socket, fn {todo, index}, acc ->
+            stream_insert(acc, :todos, todo, at: index)
+          end)
+
+        {:noreply, assign(socket, :todos, todos)}
+      end
+
+  The `id` in the payload is the item's `data-sortable-id`, so a handler that
+  prefers identity over index can ignore `from` entirely and place by id.
+  Prefer that: treat the payload as "move `id` to index `to`" and use `from`
+  only as a sanity check. Under concurrency (someone else reordered between
+  the render and the drop) `from` can be stale, but the id never is.
+
+  ## Rejecting a move
+
+  Read this before shipping a sortable that can say no.
+
+  For a list rendered from assigns, rejection needs no work: the next render
+  is the server's order, so the items snap back on their own.
+
+  Streams do not behave that way. Stream updates are ops, not a diff, so a
+  handler that rejects a move and sends no stream ops leaves the DOM in the
+  client's order forever, silently disagreeing with the server. Rejection has
+  to be explicit:
+
+      def handle_event("reorder", %{"id" => id, "to" => to}, socket) do
+        case Todos.move(id, to) do
+          {:ok, todos} ->
+            {:noreply, restream(socket, todos)}
+
+          {:error, :locked} ->
+            # say no out loud: without this the client keeps its own order
+            {:noreply,
+             socket
+             |> stream(:todos, Todos.list(), reset: true)
+             |> put_flash(:error, "That list is locked.")}
+        end
+      end
+
+  ## Dead views and JS interop
+
+  Alongside the pushed event, a drop dispatches a bubbling `petal:sortable`
+  `CustomEvent` with the same `detail` (`{id, from, to}`), mirroring
+  `petal:otp-complete` on `input_otp`. Outside LiveView, listen for that.
+
+  ## Keyboard
+
+  Tab reaches each item (or its handle in handle mode), then:
+
+    * `Space` lifts the focused item
+    * arrow keys move it one position (up/down in a list; all four in a grid)
+    * `Space` drops it, and only then does `on_reorder` fire
+    * `Escape` cancels and restores the original position
+
+  Every transition is announced through a visually hidden `aria-live="polite"`
+  region, and focus stays on the moved item after a drop.
+
+  ## Touch
+
+  A long press of roughly 250ms lifts an item. A tap or a scroll gesture does
+  not, so the page still scrolls normally with a sortable on screen.
+
+  ## One caveat worth knowing
+
+  There is no cloned drag overlay: the real element is moved through the list
+  as you drag it, which keeps the accessible order equal to the DOM order at
+  every instant and keeps form state, media and measured widths intact. The
+  cost is that a server patch arriving mid-drag replaces the nodes being
+  animated, so the hook abandons that drag rather than animating a detached
+  tree. In an app pushing frequent unrelated updates into the same container
+  (presence, live counters) a drag can be cut short. A keyboard lift survives
+  a patch: it re-resolves itself by `data-sortable-id`.
+
+  ## Planned follow-ups
+
+  v1 is deliberately one container. These are the known gaps, each additive
+  rather than breaking, and the event shape is designed so a kanban board can
+  be composed on top:
+
+    * cross-container drag (kanban) via a `group` attr and a container id in
+      the payload
+    * multi-select drag
+    * auto-scrolling a scroll container while dragging near its edge
+    * nested sortables
+  """
+  use Phoenix.Component
+
+  attr :id, :string, required: true, doc: "DOM id; the hook mounts here"
+
+  attr :on_reorder, :string,
+    required: true,
+    doc: "event name pushed on drop with %{id, from, to} (string-key params)"
+
+  attr :handle, :boolean,
+    default: false,
+    doc: "when true only the grip handle initiates drag; when false the whole item does"
+
+  attr :disabled, :boolean, default: false, doc: "disables all drag and keyboard reorder"
+
+  attr :orientation, :string,
+    default: "vertical",
+    values: ["vertical", "grid"],
+    doc: "vertical = single-column list; grid = wrapping grid, arrow keys move in 2D"
+
+  attr :target, :any,
+    default: nil,
+    doc: "optional phx-target for the reorder event (a live component's @myself)"
+
+  attr :class, :any, default: nil, doc: "extra classes for the list container"
+  attr :rest, :global, doc: ~s|passed to the list container, e.g. phx-update="stream"|
+
+  slot :item, required: true, doc: "one per sortable entry" do
+    attr :id, :string, doc: "stable item identity, rendered as data-sortable-id (required)"
+
+    attr :dom_id, :string,
+      doc: "the element's id; defaults to :id. Pass the stream dom_id for stream-backed lists"
+
+    attr :disabled, :boolean,
+      doc:
+        "this item cannot be grabbed or lifted. It can still be displaced when its neighbours move"
+
+    attr :label, :string, doc: "accessible name used in announcements and the handle label"
+    attr :class, :any, doc: "extra classes for this item"
+  end
+
+  def sortable(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      class={[
+        "pc-sortable",
+        @orientation == "grid" && "pc-sortable--grid",
+        @disabled && "pc-sortable--disabled",
+        @class
+      ]}
+      role="list"
+      phx-hook="PetalSortable"
+      phx-target={@target}
+      data-on-reorder={@on_reorder}
+      data-orientation={@orientation}
+      data-handle={@handle && "true"}
+      data-disabled={@disabled && "true"}
+      {@rest}
+    >
+      <div
+        :for={item <- @item}
+        id={item[:dom_id] || item.id}
+        class={[
+          "pc-sortable__item",
+          item_disabled?(@disabled, item) && "pc-sortable__item--disabled",
+          item[:class]
+        ]}
+        role="listitem"
+        data-sortable-id={item.id}
+        data-sortable-label={item[:label]}
+        data-disabled={item_disabled?(@disabled, item) && "true"}
+        aria-roledescription="sortable"
+        aria-describedby={"#{@id}-instructions"}
+        tabindex={item_tabindex(@disabled, @handle, item)}
+      >
+        <button
+          :if={@handle}
+          type="button"
+          class="pc-sortable__handle"
+          tabindex={item_disabled?(@disabled, item) && "-1"}
+          aria-label={"Reorder #{item[:label] || item.id}"}
+          aria-describedby={"#{@id}-instructions"}
+          aria-disabled={item_disabled?(@disabled, item) && "true"}
+          data-sortable-handle
+        >
+          <svg
+            class="pc-sortable__grip"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <circle cx="7" cy="4" r="1.5" />
+            <circle cx="13" cy="4" r="1.5" />
+            <circle cx="7" cy="10" r="1.5" />
+            <circle cx="13" cy="10" r="1.5" />
+            <circle cx="7" cy="16" r="1.5" />
+            <circle cx="13" cy="16" r="1.5" />
+          </svg>
+        </button>
+        {render_slot(item)}
+      </div>
+    </div>
+    <p id={"#{@id}-instructions"} class="pc-sortable__sr">
+      Press Space to lift this item, the arrow keys to move it, Space again to drop it, or Escape to cancel.
+    </p>
+    <%!-- phx-update="ignore" is load-bearing: the hook writes the announcement
+    here, and the server renders this element empty. Without it the very patch
+    the drop caused would wipe the announcement back out. --%>
+    <div
+      id={"#{@id}-live"}
+      class="pc-sortable__sr"
+      phx-update="ignore"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+    </div>
+    """
+  end
+
+  defp item_disabled?(true, _item), do: true
+  defp item_disabled?(_disabled, item), do: item[:disabled] == true
+
+  # In handle mode the grip is the tab stop, not the row, so the row itself
+  # never takes focus. Disabled either way means out of the tab order.
+  defp item_tabindex(container_disabled, handle, item) do
+    cond do
+      item_disabled?(container_disabled, item) -> nil
+      handle -> nil
+      true -> "0"
+    end
+  end
+end

--- a/test/js/sortable.test.js
+++ b/test/js/sortable.test.js
@@ -1,0 +1,686 @@
+// PetalSortable: the reorder maths and the keyboard lift state machine.
+//
+// Everything that decides an ORDER lives in SortableCore as a pure function,
+// so most of this file needs no DOM at all. The hook specs at the bottom
+// cover only the wiring - which key does what, what reaches the server, and
+// what a long press has to earn before it counts as a lift.
+//
+// The markup mirrors what PetalComponents.Sortable renders;
+// test/petal/sortable_test.exs pins that structure on the Elixir side, so
+// update both together if the anatomy changes.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import hooks, { SortableCore } from "../../assets/js/petal_components.js";
+
+// ---------------------------------------------------------------------------
+// Pure: the reorder maths
+// ---------------------------------------------------------------------------
+
+describe("SortableCore.arrayMove", () => {
+  const list = ["a", "b", "c", "d"];
+
+  it("moves an item down", () => {
+    expect(SortableCore.arrayMove(list, 0, 2)).toEqual(["b", "c", "a", "d"]);
+  });
+
+  it("moves an item up", () => {
+    expect(SortableCore.arrayMove(list, 3, 1)).toEqual(["a", "d", "b", "c"]);
+  });
+
+  it("moving to the same index is a no-op", () => {
+    expect(SortableCore.arrayMove(list, 2, 2)).toEqual(list);
+  });
+
+  it("clamps a destination past either end", () => {
+    expect(SortableCore.arrayMove(list, 0, 99)).toEqual(["b", "c", "d", "a"]);
+    expect(SortableCore.arrayMove(list, 3, -5)).toEqual(["d", "a", "b", "c"]);
+  });
+
+  it("never mutates the input", () => {
+    const original = list.slice();
+    SortableCore.arrayMove(list, 0, 3);
+    expect(list).toEqual(original);
+  });
+
+  it("ignores an out-of-range source", () => {
+    expect(SortableCore.arrayMove(list, 9, 0)).toEqual(list);
+  });
+});
+
+describe("SortableCore.indexFromPoint - vertical", () => {
+  // four 40px rows stacked from y=0, so midpoints are 20, 60, 100, 140
+  const rects = [0, 1, 2, 3].map((i) => ({
+    top: i * 40,
+    left: 0,
+    width: 200,
+    height: 40,
+  }));
+
+  const at = (y, activeIndex = 0) =>
+    SortableCore.indexFromPoint({ rects, x: 100, y, activeIndex });
+
+  it("stays put above the first midpoint it has not crossed", () => {
+    expect(at(5)).toBe(0);
+  });
+
+  it("counts each midpoint the pointer has passed", () => {
+    // dragging row 0 downward: row 1's midpoint is 60, row 2's is 100
+    expect(at(70)).toBe(1);
+    expect(at(110)).toBe(2);
+    expect(at(150)).toBe(3);
+  });
+
+  it("clamps past the end of the list", () => {
+    expect(at(10_000)).toBe(3);
+  });
+
+  it("skips the dragged item's own rect", () => {
+    // dragging the LAST row up to y=70: it has passed rows 0 and 1, so it
+    // lands at index 2. Row 3's own rect must not count towards that.
+    expect(SortableCore.indexFromPoint({ rects, x: 100, y: 70, activeIndex: 3 })).toBe(2);
+  });
+
+  it("a pointer above everything lands at index 0", () => {
+    expect(SortableCore.indexFromPoint({ rects, x: 100, y: -50, activeIndex: 3 })).toBe(0);
+  });
+});
+
+describe("SortableCore.indexFromPoint - grid", () => {
+  // 2 columns x 2 rows of 100x100 cells at (0,0), (100,0), (0,100), (100,100)
+  const rects = [
+    { top: 0, left: 0, width: 100, height: 100 },
+    { top: 0, left: 100, width: 100, height: 100 },
+    { top: 100, left: 0, width: 100, height: 100 },
+    { top: 100, left: 100, width: 100, height: 100 },
+  ];
+
+  const at = (x, y, activeIndex = 0) =>
+    SortableCore.indexFromPoint({ rects, x, y, orientation: "grid", activeIndex });
+
+  it("the cell under the pointer is the slot being asked for", () => {
+    // this is the case reading-order counting gets wrong: dragged from the
+    // top-left, the pointer is over the bottom-left cell, so index 2 - not
+    // the top-right cell that counting midpoints in reading order produces
+    expect(at(20, 150)).toBe(2);
+    expect(at(180, 150)).toBe(3);
+    expect(at(180, 50)).toBe(1);
+  });
+
+  it("anywhere inside a cell counts, not just past its midpoint", () => {
+    // uniform cells reflow into each other, so the dragged item lands where
+    // the pointer already is and stays put - no midpoint hysteresis needed
+    expect(at(120, 50)).toBe(1);
+    expect(at(190, 50)).toBe(1);
+  });
+
+  it("hovering its own cell asks for no move", () => {
+    expect(at(50, 50)).toBe(0);
+    expect(SortableCore.indexFromPoint({
+      rects,
+      x: 150,
+      y: 150,
+      orientation: "grid",
+      activeIndex: 3,
+    })).toBe(3);
+  });
+
+  it("falls back to reading order in the gutters and past the end", () => {
+    // below every cell: the whole grid is behind the pointer
+    expect(at(50, 500)).toBe(3);
+    // above every cell
+    expect(SortableCore.indexFromPoint({
+      rects,
+      x: 50,
+      y: -100,
+      orientation: "grid",
+      activeIndex: 3,
+    })).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure: arrow-key stepping
+// ---------------------------------------------------------------------------
+
+describe("SortableCore.nextKeyboardIndex", () => {
+  it("vertical lists move one row per press", () => {
+    expect(SortableCore.nextKeyboardIndex({ index: 2, key: "ArrowUp", count: 5 })).toBe(1);
+    expect(SortableCore.nextKeyboardIndex({ index: 2, key: "ArrowDown", count: 5 })).toBe(3);
+  });
+
+  it("vertical lists ignore the horizontal arrows", () => {
+    expect(SortableCore.nextKeyboardIndex({ index: 2, key: "ArrowLeft", count: 5 })).toBe(null);
+    expect(SortableCore.nextKeyboardIndex({ index: 2, key: "ArrowRight", count: 5 })).toBe(null);
+  });
+
+  it("grids step by one horizontally and by a full row vertically", () => {
+    const grid = { orientation: "grid", columns: 3, count: 9 };
+
+    expect(SortableCore.nextKeyboardIndex({ ...grid, index: 4, key: "ArrowLeft" })).toBe(3);
+    expect(SortableCore.nextKeyboardIndex({ ...grid, index: 4, key: "ArrowRight" })).toBe(5);
+    expect(SortableCore.nextKeyboardIndex({ ...grid, index: 4, key: "ArrowUp" })).toBe(1);
+    expect(SortableCore.nextKeyboardIndex({ ...grid, index: 4, key: "ArrowDown" })).toBe(7);
+  });
+
+  it("clamps at both ends rather than wrapping", () => {
+    expect(SortableCore.nextKeyboardIndex({ index: 0, key: "ArrowUp", count: 5 })).toBe(0);
+    expect(SortableCore.nextKeyboardIndex({ index: 4, key: "ArrowDown", count: 5 })).toBe(4);
+
+    const grid = { orientation: "grid", columns: 3, count: 9 };
+    expect(SortableCore.nextKeyboardIndex({ ...grid, index: 1, key: "ArrowUp" })).toBe(0);
+    expect(SortableCore.nextKeyboardIndex({ ...grid, index: 7, key: "ArrowDown" })).toBe(8);
+  });
+
+  it("returns null for keys the component does not own", () => {
+    expect(SortableCore.nextKeyboardIndex({ index: 0, key: "Tab", count: 5 })).toBe(null);
+    expect(SortableCore.nextKeyboardIndex({ index: 0, key: "a", count: 5 })).toBe(null);
+  });
+
+  it("treats a zero column count as a single column", () => {
+    expect(
+      SortableCore.nextKeyboardIndex({
+        index: 0,
+        key: "ArrowDown",
+        orientation: "grid",
+        columns: 0,
+        count: 4,
+      }),
+    ).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure: announcements
+// ---------------------------------------------------------------------------
+
+describe("SortableCore.announce", () => {
+  it("reports 1-based positions to humans", () => {
+    expect(SortableCore.announce("lift", "Demo", 1, 7)).toBe(
+      "Picked up Demo, position 2 of 7",
+    );
+    expect(SortableCore.announce("move", "Demo", 2, 7)).toBe(
+      "Moved Demo to position 3 of 7",
+    );
+    expect(SortableCore.announce("drop", "Demo", 2, 7)).toBe(
+      "Dropped Demo at position 3 of 7",
+    );
+    expect(SortableCore.announce("cancel", "Demo", 1, 7)).toBe(
+      "Reorder cancelled. Demo returned to position 2 of 7",
+    );
+  });
+
+  it("is empty for an unknown phase", () => {
+    expect(SortableCore.announce("wat", "Demo", 0, 1)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure: the keyboard lift state machine
+// ---------------------------------------------------------------------------
+
+describe("SortableCore.keyboardReduce", () => {
+  const order = ["a", "b", "c", "d"];
+  const lift = (overrides = {}) =>
+    SortableCore.keyboardReduce(null, {
+      type: "lift",
+      id: "a",
+      label: "Alpha",
+      order,
+      ...overrides,
+    });
+
+  it("lift captures the order and announces the position", () => {
+    const r = lift();
+
+    expect(r.handled).toBe(true);
+    expect(r.state).toMatchObject({ id: "a", label: "Alpha", from: 0, index: 0 });
+    expect(r.state.order).toEqual(order);
+    expect(r.announcement).toBe("Picked up Alpha, position 1 of 4");
+    expect(r.event).toBe(null);
+    expect(r.order).toBe(null);
+  });
+
+  it("lift falls back to the id when there is no label", () => {
+    expect(lift({ label: null }).announcement).toBe("Picked up a, position 1 of 4");
+  });
+
+  it("a disabled item cannot be lifted, and the key is not swallowed", () => {
+    const r = lift({ disabled: true });
+
+    expect(r.state).toBe(null);
+    expect(r.handled).toBe(false);
+    expect(r.announcement).toBe(null);
+  });
+
+  it("an unknown id cannot be lifted", () => {
+    expect(lift({ id: "zzz" }).state).toBe(null);
+  });
+
+  it("moving reorders the captured order and announces the new position", () => {
+    const lifted = lift().state;
+    const r = SortableCore.keyboardReduce(lifted, { type: "move", key: "ArrowDown" });
+
+    expect(r.order).toEqual(["b", "a", "c", "d"]);
+    expect(r.state.index).toBe(1);
+    expect(r.state.from).toBe(0);
+    expect(r.announcement).toBe("Moved Alpha to position 2 of 4");
+    expect(r.handled).toBe(true);
+  });
+
+  it("moves compose across presses", () => {
+    let state = lift().state;
+
+    for (const key of ["ArrowDown", "ArrowDown"]) {
+      const r = SortableCore.keyboardReduce(state, { type: "move", key });
+      state = r.state;
+    }
+
+    expect(state.order).toEqual(["b", "c", "a", "d"]);
+    expect(state.index).toBe(2);
+  });
+
+  it("a move clamped at the end is swallowed but announces nothing", () => {
+    const lifted = lift().state;
+    const r = SortableCore.keyboardReduce(lifted, { type: "move", key: "ArrowUp" });
+
+    expect(r.handled).toBe(true);
+    expect(r.order).toBe(null);
+    expect(r.announcement).toBe(null);
+    expect(r.state).toBe(lifted);
+  });
+
+  it("arrows do nothing at all when nothing is lifted", () => {
+    const r = SortableCore.keyboardReduce(null, { type: "move", key: "ArrowDown" });
+
+    expect(r.handled).toBe(false);
+    expect(r.state).toBe(null);
+    expect(r.order).toBe(null);
+  });
+
+  it("dropping is the only thing that produces an event", () => {
+    const moved = SortableCore.keyboardReduce(lift().state, {
+      type: "move",
+      key: "ArrowDown",
+    }).state;
+
+    const r = SortableCore.keyboardReduce(moved, { type: "drop" });
+
+    expect(r.event).toEqual({ id: "a", from: 0, to: 1 });
+    expect(r.announcement).toBe("Dropped Alpha at position 2 of 4");
+    expect(r.state).toBe(null);
+  });
+
+  it("dropping where it started announces but pushes nothing", () => {
+    const r = SortableCore.keyboardReduce(lift().state, { type: "drop" });
+
+    expect(r.event).toBe(null);
+    expect(r.announcement).toBe("Dropped Alpha at position 1 of 4");
+    expect(r.state).toBe(null);
+  });
+
+  it("escape restores the original order and fires nothing", () => {
+    const moved = SortableCore.keyboardReduce(lift().state, {
+      type: "move",
+      key: "ArrowDown",
+    }).state;
+
+    const r = SortableCore.keyboardReduce(moved, { type: "cancel" });
+
+    expect(r.order).toEqual(order);
+    expect(r.event).toBe(null);
+    expect(r.state).toBe(null);
+    expect(r.announcement).toBe("Reorder cancelled. Alpha returned to position 1 of 4");
+  });
+
+  it("escape with nothing lifted is not swallowed", () => {
+    expect(SortableCore.keyboardReduce(null, { type: "cancel" }).handled).toBe(false);
+  });
+
+  it("an unknown action changes nothing", () => {
+    const lifted = lift().state;
+    const r = SortableCore.keyboardReduce(lifted, { type: "nope" });
+
+    expect(r.state).toBe(lifted);
+    expect(r.handled).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The hook: wiring only
+// ---------------------------------------------------------------------------
+
+const mounted = [];
+
+function mount({ handle = false, disabled = false, orientation = "vertical" } = {}) {
+  const el = document.createElement("div");
+  el.id = "sortable";
+  el.className = "pc-sortable";
+  el.dataset.onReorder = "reorder";
+  el.dataset.orientation = orientation;
+  if (handle) el.dataset.handle = "true";
+  if (disabled) el.dataset.disabled = "true";
+
+  el.innerHTML = ["a", "b", "c"]
+    .map(
+      (id) => `
+      <div class="pc-sortable__item" id="${id}" data-sortable-id="${id}"
+           data-sortable-label="Item ${id}" role="listitem" tabindex="0"
+           ${id === "c" ? 'data-disabled="true"' : ""}>
+        ${handle ? '<button type="button" data-sortable-handle>grip</button>' : ""}
+        <span>Item ${id}</span>
+      </div>`,
+    )
+    .join("");
+
+  // the live region is a sibling of the container, exactly as the component
+  // renders it (a child would break phx-update="stream")
+  const live = document.createElement("div");
+  live.id = "sortable-live";
+  live.setAttribute("aria-live", "polite");
+
+  document.body.appendChild(el);
+  document.body.appendChild(live);
+
+  const hook = Object.create(hooks.PetalSortable);
+  hook.el = el;
+  hook.pushed = [];
+  hook.pushEvent = (name, payload) => hook.pushed.push([name, payload]);
+  hook.pushEventTo = (target, name, payload) =>
+    hook.pushed.push(["to", name, payload]);
+  hook.mounted();
+  mounted.push(hook);
+
+  const custom = [];
+  el.addEventListener("petal:sortable", (e) => custom.push(e.detail));
+
+  return {
+    hook,
+    el,
+    live,
+    custom,
+    ids: () => Array.from(el.children).map((c) => c.dataset.sortableId),
+    item: (id) => el.querySelector(`[data-sortable-id="${id}"]`),
+  };
+}
+
+function key(target, k) {
+  const ev = new KeyboardEvent("keydown", { key: k, bubbles: true, cancelable: true });
+  target.dispatchEvent(ev);
+  return ev;
+}
+
+// jsdom has no PointerEvent; a MouseEvent with the pointer fields defined on
+// it is indistinguishable to addEventListener.
+function pointer(type, props = {}) {
+  const { pointerType = "mouse", pointerId = 1, ...rest } = props;
+  const ev = new MouseEvent(type, { bubbles: true, cancelable: true, ...rest });
+  Object.defineProperty(ev, "pointerType", { value: pointerType });
+  Object.defineProperty(ev, "pointerId", { value: pointerId });
+  return ev;
+}
+
+afterEach(() => {
+  mounted.splice(0).forEach((hook) => hook.destroyed());
+  document.body.innerHTML = "";
+  vi.useRealTimers();
+});
+
+describe("PetalSortable - keyboard", () => {
+  it("space lifts, arrows move the DOM, space drops and pushes once", () => {
+    const s = mount();
+    const a = s.item("a");
+
+    key(a, " ");
+    expect(a.classList.contains("pc-sortable__item--lifted")).toBe(true);
+    expect(s.live.textContent).toBe("Picked up Item a, position 1 of 3");
+
+    key(a, "ArrowDown");
+    expect(s.ids()).toEqual(["b", "a", "c"]);
+    expect(s.live.textContent).toBe("Moved Item a to position 2 of 3");
+    expect(s.hook.pushed).toEqual([]);
+
+    key(a, " ");
+    expect(s.live.textContent).toBe("Dropped Item a at position 2 of 3");
+    expect(s.hook.pushed).toEqual([["reorder", { id: "a", from: 0, to: 1 }]]);
+    expect(a.classList.contains("pc-sortable__item--lifted")).toBe(false);
+  });
+
+  it("the drop also dispatches petal:sortable for dead views", () => {
+    const s = mount();
+
+    key(s.item("a"), " ");
+    key(s.item("a"), "ArrowDown");
+    key(s.item("a"), " ");
+
+    expect(s.custom).toEqual([{ id: "a", from: 0, to: 1 }]);
+  });
+
+  it("escape restores the order and pushes nothing", () => {
+    const s = mount();
+    const a = s.item("a");
+
+    key(a, " ");
+    key(a, "ArrowDown");
+    key(a, "ArrowDown");
+    expect(s.ids()).toEqual(["b", "c", "a"]);
+
+    key(a, "Escape");
+    expect(s.ids()).toEqual(["a", "b", "c"]);
+    expect(s.hook.pushed).toEqual([]);
+    expect(s.custom).toEqual([]);
+    expect(s.live.textContent).toBe("Reorder cancelled. Item a returned to position 1 of 3");
+  });
+
+  it("dropping back where it started pushes nothing", () => {
+    const s = mount();
+    const a = s.item("a");
+
+    key(a, " ");
+    key(a, "ArrowDown");
+    key(a, "ArrowUp");
+    key(a, " ");
+
+    expect(s.ids()).toEqual(["a", "b", "c"]);
+    expect(s.hook.pushed).toEqual([]);
+  });
+
+  it("swallows the keys it owns so the page does not scroll under a lift", () => {
+    const s = mount();
+    const a = s.item("a");
+
+    expect(key(a, " ").defaultPrevented).toBe(true);
+    expect(key(a, "ArrowDown").defaultPrevented).toBe(true);
+    // clamped at the top: still ours, still swallowed
+    key(a, "ArrowUp");
+    expect(key(a, "ArrowUp").defaultPrevented).toBe(true);
+  });
+
+  it("leaves keys it does not own alone", () => {
+    const s = mount();
+    const a = s.item("a");
+
+    expect(key(a, "Tab").defaultPrevented).toBe(false);
+    expect(key(a, "ArrowDown").defaultPrevented).toBe(false);
+    expect(key(a, "Escape").defaultPrevented).toBe(false);
+  });
+
+  it("a disabled item cannot be lifted", () => {
+    const s = mount();
+
+    key(s.item("c"), " ");
+
+    expect(s.live.textContent).toBe("");
+    expect(s.item("c").classList.contains("pc-sortable__item--lifted")).toBe(false);
+  });
+
+  it("a disabled container short-circuits everything", () => {
+    const s = mount({ disabled: true });
+
+    key(s.item("a"), " ");
+    key(s.item("a"), "ArrowDown");
+
+    expect(s.ids()).toEqual(["a", "b", "c"]);
+    expect(s.live.textContent).toBe("");
+    expect(s.hook.pushed).toEqual([]);
+  });
+
+  it("in handle mode the drop returns focus to the grip", () => {
+    const s = mount({ handle: true });
+    const grip = s.item("a").querySelector("[data-sortable-handle]");
+
+    grip.focus();
+    key(grip, " ");
+    key(grip, "ArrowDown");
+    key(grip, " ");
+
+    expect(s.ids()).toEqual(["b", "a", "c"]);
+    expect(document.activeElement).toBe(grip);
+  });
+
+  it("keeps announcing when the same string comes round twice", () => {
+    const s = mount();
+    const a = s.item("a");
+
+    key(a, " ");
+    key(a, "ArrowDown");
+    key(a, "ArrowUp");
+    key(a, "ArrowDown");
+
+    expect(s.live.textContent).toBe("Moved Item a to position 2 of 3");
+  });
+
+  it("pushes to a live component when phx-target is set", () => {
+    const s = mount();
+    s.el.setAttribute("phx-target", "3");
+
+    key(s.item("a"), " ");
+    key(s.item("a"), "ArrowDown");
+    key(s.item("a"), " ");
+
+    expect(s.hook.pushed).toEqual([["to", "reorder", { id: "a", from: 0, to: 1 }]]);
+  });
+});
+
+describe("PetalSortable - a patch mid-lift", () => {
+  it("re-resolves a keyboard lift by data-sortable-id, not by index", () => {
+    const s = mount();
+    const a = s.item("a");
+
+    key(a, " ");
+
+    // the server pushed an unrelated update that put another row first
+    s.el.insertBefore(s.item("c"), a);
+    s.hook.updated();
+
+    expect(s.hook.kb.index).toBe(1);
+    expect(s.hook.kb.order).toEqual(["c", "a", "b"]);
+  });
+
+  it("drops the lift entirely when the item is gone", () => {
+    const s = mount();
+
+    key(s.item("a"), " ");
+    s.item("a").remove();
+    s.hook.updated();
+
+    expect(s.hook.kb).toBe(null);
+  });
+});
+
+describe("PetalSortable - the long-press threshold", () => {
+  beforeEach(() => vi.useFakeTimers());
+
+  it("a short touch does not lift", () => {
+    const s = mount();
+    const a = s.item("a");
+
+    a.dispatchEvent(pointer("pointerdown", { pointerType: "touch", clientX: 0, clientY: 0 }));
+    vi.advanceTimersByTime(100);
+    window.dispatchEvent(pointer("pointerup", { pointerType: "touch" }));
+
+    expect(s.hook.drag).toBe(null);
+    expect(s.live.textContent).toBe("");
+  });
+
+  it("a long press lifts", () => {
+    const s = mount();
+    const a = s.item("a");
+
+    a.dispatchEvent(pointer("pointerdown", { pointerType: "touch", clientX: 0, clientY: 0 }));
+    vi.advanceTimersByTime(SortableCore.LONG_PRESS_MS);
+
+    expect(s.hook.drag).not.toBe(null);
+    expect(a.classList.contains("pc-sortable__item--dragging")).toBe(true);
+    expect(s.live.textContent).toBe("Picked up Item a, position 1 of 3");
+  });
+
+  it("a finger that moves before the timer is scrolling, not lifting", () => {
+    const s = mount();
+    const a = s.item("a");
+
+    a.dispatchEvent(pointer("pointerdown", { pointerType: "touch", clientX: 0, clientY: 0 }));
+    window.dispatchEvent(
+      pointer("pointermove", { pointerType: "touch", clientX: 0, clientY: 40 }),
+    );
+    vi.advanceTimersByTime(SortableCore.LONG_PRESS_MS * 2);
+
+    expect(s.hook.drag).toBe(null);
+    expect(s.live.textContent).toBe("");
+  });
+
+  it("a mouse lifts on movement, not on the press itself", () => {
+    const s = mount();
+    const a = s.item("a");
+
+    a.dispatchEvent(pointer("pointerdown", { clientX: 0, clientY: 0 }));
+    expect(s.hook.drag).toBe(null);
+
+    // under the slop: still just a click
+    window.dispatchEvent(pointer("pointermove", { clientX: 2, clientY: 0 }));
+    expect(s.hook.drag).toBe(null);
+
+    window.dispatchEvent(pointer("pointermove", { clientX: 30, clientY: 0 }));
+    expect(s.hook.drag).not.toBe(null);
+  });
+
+  it("a disabled item and a disabled container never start a press", () => {
+    const s = mount();
+    s.item("c").dispatchEvent(pointer("pointerdown", { clientX: 0, clientY: 0 }));
+    expect(s.hook.press).toBe(null);
+
+    const off = mount({ disabled: true });
+    off.item("a").dispatchEvent(pointer("pointerdown", { clientX: 0, clientY: 0 }));
+    expect(off.hook.press).toBe(null);
+  });
+
+  it("in handle mode only the grip starts a press", () => {
+    const s = mount({ handle: true });
+    const a = s.item("a");
+
+    a.querySelector("span").dispatchEvent(pointer("pointerdown", { clientX: 0, clientY: 0 }));
+    expect(s.hook.press).toBe(null);
+
+    a.querySelector("[data-sortable-handle]")
+      .dispatchEvent(pointer("pointerdown", { clientX: 0, clientY: 0 }));
+    expect(s.hook.press).not.toBe(null);
+  });
+
+  it("a right-click is not a drag", () => {
+    const s = mount();
+    s.item("a").dispatchEvent(pointer("pointerdown", { button: 2, clientX: 0, clientY: 0 }));
+    expect(s.hook.press).toBe(null);
+  });
+});
+
+describe("PetalSortable - teardown", () => {
+  it("destroyed stops listening on the window", () => {
+    const s = mount();
+    mounted.splice(mounted.indexOf(s.hook), 1);
+    s.hook.destroyed();
+
+    s.item("a").dispatchEvent(pointer("pointerdown", { clientX: 0, clientY: 0 }));
+    window.dispatchEvent(pointer("pointermove", { clientX: 99, clientY: 0 }));
+
+    expect(s.hook.drag).toBe(null);
+  });
+});

--- a/test/petal/sortable_test.exs
+++ b/test/petal/sortable_test.exs
@@ -1,0 +1,278 @@
+defmodule PetalComponents.SortableTest do
+  @moduledoc """
+  Tests for PetalComponents.Sortable - the drag-to-reorder list and grid.
+
+  The rendered contract here is what the PetalSortable hook reads at runtime
+  (test/js/sortable.test.js pins the other half), so a change to a data
+  attribute or a class name has to be made in both places on purpose.
+  """
+
+  use ComponentCase
+  import PetalComponents.Sortable
+
+  defp list(assigns \\ %{}) do
+    assigns = Map.merge(%{disabled: false, handle: false, orientation: "vertical"}, assigns)
+
+    rendered_to_string(~H"""
+    <.sortable
+      id="stages"
+      on_reorder="reorder"
+      handle={@handle}
+      disabled={@disabled}
+      orientation={@orientation}
+    >
+      <:item id="a" label="Discovery">Discovery</:item>
+      <:item id="b" label="Demo">Demo</:item>
+      <:item id="c" label="Proposal" disabled>Proposal</:item>
+    </.sortable>
+    """)
+  end
+
+  defp items(html), do: html |> parse_html() |> LazyHTML.query(".pc-sortable__item")
+
+  defp attrs(nodes, name), do: LazyHTML.attribute(nodes, name)
+
+  describe "container" do
+    test "renders the hook and the attributes it reads" do
+      html = list()
+      root = html |> parse_html() |> LazyHTML.query("#stages")
+
+      assert_has_class(html, "pc-sortable")
+      assert attrs(root, "phx-hook") == ["PetalSortable"]
+      assert attrs(root, "data-on-reorder") == ["reorder"]
+      assert attrs(root, "data-orientation") == ["vertical"]
+      assert attrs(root, "role") == ["list"]
+      # not in handle or disabled mode, so neither flag is stamped
+      assert attrs(root, "data-handle") == []
+      assert attrs(root, "data-disabled") == []
+    end
+
+    test "grid orientation adds the modifier and the data attr" do
+      html = list(%{orientation: "grid"})
+      root = html |> parse_html() |> LazyHTML.query("#stages")
+
+      assert_has_class(html, "pc-sortable--grid")
+      assert attrs(root, "data-orientation") == ["grid"]
+    end
+
+    test "class merges onto the container rather than replacing it" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sortable id="s" on_reorder="reorder" class="mt-6 max-w-md">
+          <:item id="a">A</:item>
+        </.sortable>
+        """)
+
+      root = html |> parse_html() |> LazyHTML.query("#s")
+      [classes] = attrs(root, "class")
+
+      assert classes =~ "pc-sortable"
+      assert classes =~ "mt-6"
+      assert classes =~ "max-w-md"
+    end
+
+    test "rest passes through to the container, including phx-update" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sortable id="s" on_reorder="reorder" phx-update="stream" data-testid="board">
+          <:item id="a">A</:item>
+        </.sortable>
+        """)
+
+      root = html |> parse_html() |> LazyHTML.query("#s")
+
+      assert attrs(root, "phx-update") == ["stream"]
+      assert attrs(root, "data-testid") == ["board"]
+    end
+
+    test "target renders as phx-target so a live component can own the event" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sortable id="s" on_reorder="reorder" target="#board">
+          <:item id="a">A</:item>
+        </.sortable>
+        """)
+
+      assert html |> parse_html() |> LazyHTML.query("#s") |> attrs("phx-target") == ["#board"]
+    end
+  end
+
+  describe "items" do
+    test "each item carries its sortable id and the a11y attributes" do
+      html = list()
+      nodes = items(html)
+
+      assert Enum.count(nodes) == 3
+      assert attrs(nodes, "data-sortable-id") == ["a", "b", "c"]
+      assert attrs(nodes, "role") == ["listitem", "listitem", "listitem"]
+
+      assert attrs(nodes, "aria-roledescription") == [
+               "sortable",
+               "sortable",
+               "sortable"
+             ]
+
+      assert attrs(nodes, "aria-describedby") == [
+               "stages-instructions",
+               "stages-instructions",
+               "stages-instructions"
+             ]
+    end
+
+    test "the element id defaults to the sortable id and dom_id overrides it" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sortable id="s" on_reorder="reorder">
+          <:item id="42" dom_id="todos-42">Buy milk</:item>
+          <:item id="43">Walk dog</:item>
+        </.sortable>
+        """)
+
+      nodes = items(html)
+
+      # streams need the stream dom id on the element, while the server still
+      # wants the record id in the event payload - hence two ids, not one
+      assert attrs(nodes, "id") == ["todos-42", "43"]
+      assert attrs(nodes, "data-sortable-id") == ["42", "43"]
+    end
+
+    test "the label rides along for announcements" do
+      assert attrs(items(list()), "data-sortable-label") == ["Discovery", "Demo", "Proposal"]
+    end
+
+    test "items are in the tab order, and disabled ones are not" do
+      nodes = items(list())
+
+      # a and b are focusable; c is disabled so it has no tabindex at all
+      assert attrs(nodes, "tabindex") == ["0", "0"]
+      assert attrs(nodes, "data-disabled") == ["true"]
+      assert Enum.count(LazyHTML.query(nodes, ".pc-sortable__item--disabled")) == 1
+    end
+  end
+
+  describe "handle mode" do
+    test "renders a grip button with an accessible name, and moves the tab stop to it" do
+      html = list(%{handle: true})
+      handles = html |> parse_html() |> LazyHTML.query(".pc-sortable__handle")
+
+      assert Enum.count(handles) == 3
+
+      assert attrs(handles, "aria-label") == [
+               "Reorder Discovery",
+               "Reorder Demo",
+               "Reorder Proposal"
+             ]
+
+      assert attrs(handles, "data-sortable-handle") == ["", "", ""]
+      assert attrs(handles, "type") == ["button", "button", "button"]
+
+      # the grip is the tab stop now, so no row carries a tabindex
+      assert attrs(items(html), "tabindex") == []
+
+      # and the disabled row's grip leaves the tab order
+      assert attrs(handles, "aria-disabled") == ["true"]
+      assert attrs(handles, "tabindex") == ["-1"]
+    end
+
+    test "no handle without the attr" do
+      refute_has_class(list(), "pc-sortable__handle")
+      assert list() |> parse_html() |> LazyHTML.query(".pc-sortable__handle") |> Enum.empty?()
+    end
+  end
+
+  describe "disabled container" do
+    test "stamps the flag, the modifier, and empties the tab order" do
+      html = list(%{disabled: true})
+      root = html |> parse_html() |> LazyHTML.query("#stages")
+      nodes = items(html)
+
+      assert attrs(root, "data-disabled") == ["true"]
+      assert_has_class(html, "pc-sortable--disabled")
+      assert attrs(nodes, "tabindex") == []
+      assert attrs(nodes, "data-disabled") == ["true", "true", "true"]
+    end
+  end
+
+  describe "announcements" do
+    test "renders one polite live region and the keyboard instructions" do
+      html = list()
+      doc = parse_html(html)
+
+      live = LazyHTML.query(doc, "#stages-live")
+      assert attrs(live, "aria-live") == ["polite"]
+      assert attrs(live, "role") == ["status"]
+      assert attrs(live, "aria-atomic") == ["true"]
+
+      # the hook writes the announcement into an element the server renders
+      # empty, so the patch caused by the drop would otherwise wipe it
+      assert attrs(live, "phx-update") == ["ignore"]
+
+      instructions = LazyHTML.query(doc, "#stages-instructions")
+      assert Enum.count(instructions) == 1
+      assert LazyHTML.text(instructions) =~ "Press Space to lift"
+      assert LazyHTML.text(instructions) =~ "Escape to cancel"
+    end
+
+    test "the live region and instructions sit outside the list container" do
+      # phx-update="stream" requires the container's children to be exactly
+      # the stream items, so neither may be nested inside it
+      html = list()
+      inside = html |> parse_html() |> LazyHTML.query("#stages .pc-sortable__sr")
+
+      assert Enum.empty?(inside)
+      assert html |> parse_html() |> LazyHTML.query(".pc-sortable__sr") |> Enum.count() == 2
+    end
+  end
+
+  describe "stream-backed rendering" do
+    # Reconciliation is by data-sortable-id, never by index: a stream that
+    # re-renders in a new order must keep every id, with no duplication and
+    # no dependence on the position an item happened to hold before.
+    defp stream_html(entries) do
+      assigns = %{entries: entries}
+
+      rendered_to_string(~H"""
+      <.sortable id="todos" on_reorder="reorder" phx-update="stream">
+        <:item :for={{dom_id, todo} <- @entries} id={todo.id} dom_id={dom_id} label={todo.title}>
+          {todo.title}
+        </:item>
+      </.sortable>
+      """)
+    end
+
+    test "a reordered stream renders the same ids in the new order, once each" do
+      todos = [
+        %{id: "1", title: "Ship it"},
+        %{id: "2", title: "Write it up"},
+        %{id: "3", title: "Sleep"}
+      ]
+
+      entries = Enum.map(todos, &{"todos-#{&1.id}", &1})
+      first = stream_html(entries)
+
+      assert attrs(items(first), "data-sortable-id") == ["1", "2", "3"]
+      assert attrs(items(first), "id") == ["todos-1", "todos-2", "todos-3"]
+
+      # the server applies the {"id" => "3", "from" => 2, "to" => 0} it was
+      # sent and re-renders; the dom ids travel with their records
+      reordered = [Enum.at(entries, 2) | Enum.take(entries, 2)]
+      second = stream_html(reordered)
+
+      ids = attrs(items(second), "data-sortable-id")
+      assert ids == ["3", "1", "2"]
+      assert ids == Enum.uniq(ids)
+      assert attrs(items(second), "id") == ["todos-3", "todos-1", "todos-2"]
+
+      # identity, not position: every dom id survives the move intact
+      assert Enum.sort(attrs(items(first), "id")) == Enum.sort(attrs(items(second), "id"))
+    end
+  end
+end


### PR DESCRIPTION
Closes #620

## Summary

`<.sortable>` plus one `PetalSortable` hook: drag-to-reorder lists and grids for LiveView. Drag a row (or only its grip with `handle`) and the list reorders under the pointer with the gaps animating into place; on drop it pushes ONE `on_reorder` event carrying `%{"id", "from", "to"}` so the app persists the order. Zero npm dependencies - pointer events, `setPointerCapture` and hand-rolled FLIP transforms.

Five parts per CONTRIBUTING: module, `pc-sortable` CSS section, both test suites, showcase module + registry entry, playground page. Plus `### Unreleased` in the changelog.

All the order maths and the whole keyboard lift state machine live in an exported `SortableCore` as pure functions, so they unit-test without a DOM. The hook is only the layer that reads rects, moves nodes and talks to LiveView.

## Hook justification

CSS and `Phoenix.LiveView.JS` cannot do pointer-tracked drag, FLIP gap animation, or a keyboard lift state machine. Maintainer signed this off on the issue. The hook is kept as thin as I could make it: every decision that produces an *order* is a pure function outside it.

## How LiveView reconciliation was resolved - who owns order after a drop

**The server owns order. The client owns it only for the instant between the drop and the patch.**

The DOM reorders optimistically as you drag, so on drop it already shows the intended order. Then the event goes up, the app persists, and the patch re-renders in that same order - a visual no-op. If the server disagrees, the patch is what corrects the DOM, which is the right failure behaviour rather than a bug.

Two things fell out of building it that are documented loudly in the moduledoc:

1. **Streams do not snap back on their own.** Stream updates are ops, not a diff. A handler that rejects a move and sends no stream ops leaves the DOM in the client's order forever, silently disagreeing with the server. The "Rejecting a move" section spells this out with a `stream(..., reset: true)` example. This is the one thing that would bite a real app and that no unit test would catch.
2. **`from` can be stale, the id never is.** Under concurrency someone else may have reordered between the render and the drop. The docs tell you to treat the payload as "move `id` to index `to`" and use `from` as a sanity check only.

Mid-drag patches: because there is no cloned overlay (see deviations), a patch can replace the nodes being animated. The hook abandons that drag rather than animating a detached tree. A keyboard lift is cheaper and survives - `updated()` re-resolves it by `data-sortable-id`, never by the remembered index. Both documented.

One bug this actually surfaced in the browser: the live region is written by the hook and rendered empty by the server, so the drop's own patch wiped the announcement back out. It now carries `phx-update="ignore"`, with a test pinning that.

## Keyboard map

Tab reaches each item, or its grip in handle mode.

| Key | Does |
|---|---|
| `Space` | lift the focused item - "Picked up X, position 2 of 7" |
| `Arrow` keys | move it one position; up/down in a list, all four in a grid - "Moved X to position 3 of 7" |
| `Space` | drop - "Dropped X at position 3 of 7". Only now does `on_reorder` fire, and not at all if it landed where it started |
| `Escape` | cancel, restore the original order, announce it, push nothing |

Focus follows the item after a drop (the grip in handle mode). Announcements go to a visually hidden `aria-live="polite"` region, pointer drops included, not just keyboard ones. Items carry `aria-roledescription="sortable"` and `aria-describedby` pointing at hidden instructions. Disabled items and disabled containers leave the tab order.

## Deviations from the issue's API sketch

1. **Added `dom_id` to the `:item` slot.** Streams need the stream dom id on the element while the server wants the record id in the payload. Two ids, two attrs; `dom_id` defaults to `id`. The sketch omitted it and stream usage does not work without it.
2. **No `pc-sortable__overlay` / `pc-sortable__item--placeholder`.** The issue's class list implies dnd-kit's model - original stays as a faded placeholder, a clone follows the pointer. I used SortableJS's instead: the real element is moved through the list and gets a transform plus scale and shadow. The issue also says "the accessible list order is always the real DOM order", which the clone model fights; a clone additionally breaks form state, media and measured widths inside a row, and doubles the a11y surface for no gain. The classes shipped are `pc-sortable`, `--grid`, `--disabled`, `--dragging`, `__item`, `__item--dragging`, `__item--lifted`, `__item--disabled`, `__handle`, `__grip`, `__sr`.
3. **The live region and the instructions are siblings of the list, not children.** `phx-update="stream"` requires the container's children to be exactly the stream items, so a nested live region would break every stream user. `aria-describedby` works across the document. Both are `sr-only`, so absolutely positioned and invisible to a flex or grid parent.
4. **Grid hit-testing does not use reading-order midpoints.** A list uses midpoints (hysteresis matters when rows have different heights). A grid uses the cell under the pointer, because the same midpoint rule sends an item somewhere it was never dragged - hover the bottom-left cell from its left half and reading-order counting lands the item top-right. This is safe because the list is reordered live, so the rects are the current arrangement and the item lands where the pointer already is. Falls back to counting in the gutters and past the end. My own test expectations caught this; both models are covered by specs.
5. **Added a `target` attr** rendering `phx-target`, so a sortable inside a LiveComponent can own its own event.
6. **Added `label` and `class` to the `:item` slot.** `label` is the accessible name used in the handle's `aria-label` and in every announcement, rendered as `data-sortable-label` for the hook; it falls back to the item's text.
7. **Per-item `disabled` means "cannot be grabbed", not "cannot move".** A disabled row is still displaced when its neighbours move around it. Fixed-anchor semantics is a different feature (pinned rows). Called out in the attr doc since "locked row" invites the other reading.
8. **Auto-scroll is not implemented** - the issue lists it under non-goals. It is in the moduledoc's planned follow-ups alongside cross-container drag, multi-select and nested sortables.

## What I verified interactively vs by unit test

Driven in a real browser on the playground page (`/c/sortable`), light and dark:

- **Keyboard reorder end to end.** Focused a grip, Space, two ArrowDowns, Space. The list moved, the live region read "Dropped Cut the 4.1 release build at position 2 of 5", and the server log showed `Cut the 4.1 release build: 1 -> 2`. Nothing was pushed until the drop - the log still read "nothing moved yet" mid-lift, which is the `lifted.png` screenshot.
- **Escape.** Lifted, moved twice, Escape: order restored, "Reorder cancelled. Prep Monday standup returned to position 5 of 5", server log unchanged.
- **Grid 2D arrows.** In a 3-column grid, ArrowDown moved position 1 to position 4 (a full row), ArrowRight to 5, drop persisted as `Harbour at dawn: 1 -> 5`.
- **A real pointer drag.** Dragged a grip down the list; the row moved and the server logged `Cut the 4.1 release build: 1 -> 4`. That event can only have come from the hook, so the pointer path is genuinely exercised, not just asserted.
- **The `phx-update="ignore"` bug**, found by reading the live region after a drop and seeing it empty.

Unit-tested rather than driven: touch long-press thresholds (fake timers), pointer slop, `petal:sortable` dispatch, `pushEventTo` when `phx-target` is set, the patch-mid-lift re-resolution, and all the pure maths. **Not tested on a real touch device** - the touch path is jsdom specs plus the standard `touch-action` / non-passive `touchmove` / `setPointerCapture` combination. That deserves a phone before release.

## Tests

| Suite | Before | After |
|---|---|---|
| `mix test` | 913, 1 skipped | **928**, 1 skipped, 0 failures |
| `npm test` | 157 | **214**, 0 failures |

`mix credo` vs `origin/main`: **zero new entries** (diffed the full sorted output both ways).
`mix format --check-formatted` and `mix compile --force --warnings-as-errors` both clean.

15 ComponentCase tests cover the container attrs, item a11y attrs, `dom_id`, tab order, handle mode, both disabled levels, the grid modifier, `class` merging, `rest` passthrough, the live region (including `phx-update="ignore"`), and a stream-backed render asserting a reordered stream keeps every id exactly once and reconciles by `data-sortable-id` rather than position.

57 JS tests cover `arrayMove`, vertical and grid hit-testing, arrow stepping and clamping, the announcement strings, the full lift/move/drop/cancel state machine including both disabled short-circuits and the no-op drop, plus hook wiring: which keys are swallowed, what reaches the server, focus after a drop, the long-press threshold, and teardown.

## Not done

- A LiveView `live_isolated` stream test. `test/petal/a11y_live_test.exs` is a skipped stub, not a harness, and there is no endpoint wired for live tests in this repo. Stream reconciliation is covered at the render level (ids survive a reorder, once each, keyed by `data-sortable-id`) and the playground proves the round trip against a real LiveView. Happy to wire a live test if you want one, but it needs test infrastructure this repo does not have yet.
- Real-device touch, as above.

## Screenshots

Light, dark and a keyboard lift mid-move (item at position 3, server log still "nothing moved yet") are attached below.
