### PR TITLE
feat(chat): chat_sources + inline citations (RAG answer grounding)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
 # Changelog
+
+### Unreleased
+
+#### Added
+
+- **Answer grounding for the chat family: inline citation chips and a
+  `chat_sources` row.** RAG answers are only trustworthy if you can see
+  where they came from, and until now the chat kit rendered the prose but
+  not the receipts. Prompt the model to cite as `[^N]` and hand the same
+  source maps to `markdown/1`: every complete marker turns into a numbered
+  chip that opens the source in a new tab, with a preview card (title,
+  domain, snippet) on hover or focus. `chat_sources/1` renders the deduped
+  list underneath - a native `<details>`, no JS, with `expanded` to open it
+  on render and `max_visible` to cap the list behind a "Show all" reveal.
+  `citation/1` is the chip on its own for prose you assemble yourself.
+  The streaming path takes the same option: `to_html/2` accepts
+  `sources:`, so chips light up as their markers complete and a
+  half-arrived `[^` never flashes broken output. Sources are plain maps
+  (`%{id, url, title, snippet, favicon_url}`) with string or atom keys;
+  everything but `url` is optional and degrades - no favicon means a letter
+  avatar, no snippet means a shorter row. Chip markup is minted server-side
+  from the numeric index plus escaped source fields and spliced into the
+  already-sanitized HTML outside code blocks, so model text can never reach
+  the page as live markup.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,165 @@
       transition-duration: 1ms;
     }
   }
+
+/* Chat — answer grounding: inline citation chips + the RAG sources row. */
+@layer components {
+  /* Inline citation chip -------------------------------------------------- */
+
+  /* Positioning context for the hover/focus preview card. */
+  .pc-chat__citation-wrap {
+    @apply relative inline-block align-baseline;
+  }
+
+  .pc-chat__citation {
+    @apply inline-flex min-w-4 items-center justify-center px-1 align-super text-[0.65em] font-semibold leading-none text-gray-600 no-underline transition-colors dark:text-gray-300;
+    @apply bg-gray-100 dark:bg-gray-400/17;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.125rem);
+    padding-block: 0.15em;
+  }
+
+  .pc-chat__citation:hover {
+    @apply bg-gray-200 text-gray-900 dark:bg-gray-400/25 dark:text-gray-100;
+  }
+
+  .pc-chat__citation:focus-visible {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  /* The chip's own <sup> would double-raise it — the chip is already
+     align-super, so keep the number on the chip's baseline. */
+  .pc-chat__citation-num {
+    @apply align-baseline;
+    top: 0;
+  }
+
+  .pc-chat__citation-card {
+    @apply pointer-events-none invisible absolute bottom-full left-0 z-20 mb-1 flex w-56 flex-col gap-1 border border-gray-200 bg-white p-2 text-xs leading-snug text-gray-600 opacity-0 shadow-lg transition-opacity duration-100 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300;
+    border-radius: var(--pc-radius, 0.625rem);
+  }
+
+  .pc-chat__citation-wrap:hover .pc-chat__citation-card,
+  .pc-chat__citation-wrap:focus-within .pc-chat__citation-card {
+    @apply visible opacity-100;
+  }
+
+  .pc-chat__citation-card-title {
+    @apply font-semibold text-gray-900 dark:text-gray-100;
+  }
+
+  .pc-chat__citation-card-domain {
+    @apply text-[0.9em] text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-chat__citation-card-snippet {
+    @apply line-clamp-3 text-gray-500 dark:text-gray-400;
+  }
+
+  /* Sources row ----------------------------------------------------------- */
+
+  .pc-chat__sources {
+    @apply mt-2 text-xs;
+  }
+
+  .pc-chat__sources-row {
+    @apply inline-flex cursor-pointer list-none items-center gap-1.5 border border-gray-200 px-2 py-1 font-medium text-gray-500 select-none dark:border-gray-700 dark:text-gray-400;
+    border-radius: var(--pc-radius, 0.625rem);
+  }
+
+  .pc-chat__sources-row::-webkit-details-marker {
+    display: none;
+  }
+
+  .pc-chat__sources-row:hover {
+    @apply bg-gray-50 text-gray-700 dark:bg-gray-400/10 dark:text-gray-200;
+  }
+
+  .pc-chat__sources-row:focus-visible {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  .pc-chat__sources-favicons {
+    @apply flex items-center;
+  }
+
+  /* Stacked favicon cluster — each one overlaps the last. */
+  .pc-chat__sources-favicons > * + * {
+    @apply -ml-1.5;
+  }
+
+  .pc-chat__sources-chevron {
+    @apply shrink-0 transition-transform duration-150;
+  }
+
+  /* Doubled selector + !important: icon sizing contract (see reasoning). */
+  .pc-chat__sources-chevron.pc-chat__sources-chevron {
+    width: 0.875rem !important;
+    height: 0.875rem !important;
+  }
+
+  .pc-chat__sources[open] > .pc-chat__sources-row .pc-chat__sources-chevron {
+    @apply rotate-90;
+  }
+
+  .pc-chat__sources-list {
+    @apply mt-2 flex list-none flex-col gap-1 p-0;
+  }
+
+  .pc-chat__source-link {
+    @apply flex items-start gap-2 border border-transparent p-2 no-underline transition-colors;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-chat__source-link:hover {
+    @apply border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-400/10;
+  }
+
+  .pc-chat__source-link:focus-visible {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  .pc-chat__source-favicon {
+    @apply mt-0.5 h-4 w-4 shrink-0 rounded-sm bg-gray-100 object-cover dark:bg-gray-400/17;
+  }
+
+  .pc-chat__source-favicon--letter {
+    @apply flex items-center justify-center text-[0.6rem] font-semibold text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-chat__source-text {
+    @apply flex min-w-0 flex-col gap-0.5;
+  }
+
+  .pc-chat__source-title {
+    @apply truncate font-medium text-gray-900 dark:text-gray-100;
+  }
+
+  .pc-chat__source-domain {
+    @apply truncate text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-chat__source-snippet {
+    @apply line-clamp-2 text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-chat__sources-more-summary {
+    @apply mt-1 inline-flex cursor-pointer list-none items-center px-2 py-1 font-medium text-gray-500 select-none hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200;
+  }
+
+  .pc-chat__sources-more-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .pc-chat__sources-more-summary:focus-visible {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pc-chat__citation,
+    .pc-chat__citation-card,
+    .pc-chat__sources-chevron,
+    .pc-chat__source-link {
+      transition-duration: 1ms;
+    }
+  }
+}

--- a/dev.exs
+++ b/dev.exs
@@ -212,6 +212,46 @@ defmodule Dev.PlaygroundLive do
     """
   ]
 
+  # A mocked RAG answer: the model cites its context with [^N] footnote markers
+  # and the app hands the same source maps to markdown/1 + chat_sources/1.
+  @chat_rag_sources [
+    %{
+      id: "1",
+      url: "https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html",
+      title: "Phoenix.LiveView — behaviour and lifecycle",
+      snippet:
+        "LiveView provides rich, real-time user experiences with server-rendered HTML over a persistent connection."
+    },
+    %{
+      id: "2",
+      url: "https://hexdocs.pm/phoenix_live_view/js-interop.html",
+      title: "JavaScript interoperability",
+      snippet:
+        "Client hooks let you run JavaScript when an element is added, updated or removed from the page."
+    },
+    %{
+      id: "3",
+      url: "https://hexdocs.pm/phoenix/Phoenix.Endpoint.html",
+      title: "Phoenix.Endpoint",
+      snippet: "The endpoint is the boundary where all requests to your application start."
+    },
+    %{
+      id: "4",
+      url: "https://elixir-lang.org/getting-started/processes.html",
+      title: "Processes"
+    }
+  ]
+
+  @chat_rag_answer """
+  LiveView holds a **persistent connection** and diffs the rendered tree on the
+  server, pushing only the parts that changed [^1]. Anything the server can't
+  own - focus, clipboard, a third-party widget - drops down to a client
+  hook [^2].
+
+  Requests still enter through the endpoint like any other Phoenix request [^3],
+  and each connected tab is just another cheap process [^4].
+  """
+
   @chat_history [
     %{id: "m-yesterday", role: :marker, text: "Yesterday"},
     %{id: "hist-q", role: :user, text: "Does it support dark mode?", stream_id: nil},
@@ -733,6 +773,7 @@ defmodule Dev.PlaygroundLive do
        tg_device: "desktop",
        tg_variant: "solid",
        tg_size: "md",
+       chat_rag_sources: @chat_rag_sources,
        chat: %{
          turns: [
            %{id: "m-today", role: :marker, text: "Today"},
@@ -742,7 +783,20 @@ defmodule Dev.PlaygroundLive do
              text: "How do I install petal_components?",
              stream_id: nil
            },
-           %{id: "seed-a", role: :assistant, text: @chat_seed_answer, stream_id: nil}
+           %{id: "seed-a", role: :assistant, text: @chat_seed_answer, stream_id: nil},
+           %{
+             id: "seed-rag-q",
+             role: :user,
+             text: "How does LiveView keep the page in sync?",
+             stream_id: nil
+           },
+           %{
+             id: "seed-rag-a",
+             role: :assistant,
+             text: @chat_rag_answer,
+             stream_id: nil,
+             sources: @chat_rag_sources
+           }
          ],
          streaming: false,
          seq: 1,
@@ -750,7 +804,10 @@ defmodule Dev.PlaygroundLive do
          variant: "plain",
          actions: "always",
          editing: nil,
-         sent: false
+         sent: false,
+         sources_expanded: false,
+         sources_max: 5,
+         rag_streaming: false
        },
        alert: %{
          color: "gray",
@@ -1202,6 +1259,27 @@ defmodule Dev.PlaygroundLive do
 
   def handle_info(:pg_skeleton_loaded, socket),
     do: {:noreply, update(socket, :skeleton, &%{&1 | loading: false})}
+
+  def handle_info({:chat_rag_tick, buffer, []}, socket) do
+    {:noreply,
+     socket
+     |> assign(:chat, %{socket.assigns.chat | rag_streaming: false})
+     |> push_event("pc-chat-rag-token", %{
+       id: "pg-chat-rag-stream",
+       html: Chat.to_html(buffer, sources: @chat_rag_sources)
+     })}
+  end
+
+  def handle_info({:chat_rag_tick, buffer, [word | rest]}, socket) do
+    buffer = if buffer == "", do: word, else: buffer <> " " <> word
+    Process.send_after(self(), {:chat_rag_tick, buffer, rest}, 60)
+
+    {:noreply,
+     push_event(socket, "pc-chat-rag-token", %{
+       id: "pg-chat-rag-stream",
+       html: Chat.to_html(buffer, sources: @chat_rag_sources)
+     })}
+  end
 
   def handle_info({:chat_tick, id, chunks}, socket) do
     chat = socket.assigns.chat
@@ -1707,6 +1785,32 @@ defmodule Dev.PlaygroundLive do
   def handle_event("ctl_chat", %{"k" => "variant", "v" => v}, socket)
       when v in ~w(plain bubbles) do
     {:noreply, assign(socket, :chat, %{socket.assigns.chat | variant: v})}
+  end
+
+  def handle_event("ctl_chat", %{"k" => "sources_expanded", "v" => v}, socket) do
+    {:noreply, assign(socket, :chat, %{socket.assigns.chat | sources_expanded: v == "open"})}
+  end
+
+  def handle_event("ctl_chat", %{"k" => "sources_max", "v" => v}, socket) do
+    max = if v == "all", do: length(@chat_rag_sources), else: String.to_integer(v)
+    {:noreply, assign(socket, :chat, %{socket.assigns.chat | sources_max: max})}
+  end
+
+  # Streams the same grounded answer word by word. Each tick re-renders the
+  # buffer through to_html/2, so the [^N] chips appear as the markers complete
+  # and a half-arrived "[^" never flashes broken.
+  def handle_event("chat_rag_stream", _params, socket) do
+    if socket.assigns.chat.rag_streaming do
+      {:noreply, socket}
+    else
+      words = String.split(@chat_rag_answer, " ")
+      Process.send_after(self(), {:chat_rag_tick, "", words}, 150)
+
+      {:noreply,
+       socket
+       |> assign(:chat, %{socket.assigns.chat | rag_streaming: true})
+       |> push_event("pc-chat-rag-token", %{id: "pg-chat-rag-stream", html: ""})}
+    end
   end
 
   def handle_event("ctl_chat", %{"k" => "actions", "v" => v}, socket)
@@ -8731,7 +8835,17 @@ defmodule Dev.PlaygroundLive do
               <%= if turn.stream_id do %>
                 <Chat.streaming_text id={turn.stream_id} />
               <% else %>
-                <Chat.markdown content={turn.text} id={"pg-chat-md-#{turn.id}"} />
+                <Chat.markdown
+                  content={turn.text}
+                  id={"pg-chat-md-#{turn.id}"}
+                  sources={Map.get(turn, :sources)}
+                />
+                <Chat.chat_sources
+                  :if={Map.get(turn, :sources)}
+                  sources={Map.get(turn, :sources)}
+                  expanded={@chat.sources_expanded}
+                  max_visible={@chat.sources_max}
+                />
               <% end %>
               <:actions :if={turn.stream_id == nil}>
                 <Chat.message_actions visible={@chat.actions}>
@@ -8806,7 +8920,88 @@ defmodule Dev.PlaygroundLive do
               </:item>
             </.toggle_group>
           </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">
+              sources expanded
+            </div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Sources expanded"
+              value={if @chat.sources_expanded, do: "open", else: "closed"}
+              on_change="ctl_chat"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={v <- ~w(closed open)}
+                value={v}
+                phx-value-k="sources_expanded"
+                phx-value-v={v}
+              >
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">max_visible</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Max visible sources"
+              value={
+                if @chat.sources_max >= length(@chat_rag_sources),
+                  do: "all",
+                  else: to_string(@chat.sources_max)
+              }
+              on_change="ctl_chat"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item :for={v <- ~w(2 5 all)} value={v} phx-value-k="sources_max" phx-value-v={v}>
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
         </div>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Citations while streaming</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        The same grounded answer, streamed. Each tick re-renders the growing buffer
+        through <code>to_html(buffer, sources: sources)</code>
+        and pushes the HTML at a format="markdown" streaming_text, so chips light up
+        as their markers complete. A half-arrived "[^" is left alone until the closing
+        bracket lands, so nothing flashes broken.
+      </p>
+      <div class="p-4 border border-gray-200 rounded-xl dark:border-gray-800">
+        <Chat.streaming_text id="pg-chat-rag-stream" event="pc-chat-rag-token" format="markdown" />
+        <div class="mt-3">
+          <Chat.chat_sources
+            sources={@chat_rag_sources}
+            expanded={@chat.sources_expanded}
+            max_visible={@chat.sources_max}
+          />
+        </div>
+        <.button
+          size="sm"
+          variant="outline"
+          class="mt-3"
+          phx-click="chat_rag_stream"
+          disabled={@chat.rag_streaming}
+        >
+          {if @chat.rag_streaming, do: "Streaming...", else: "Stream the grounded answer"}
+        </.button>
+      </div>
+
+      <div class="p-4 mt-3 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        Answer grounding is two pieces. Prompt the model to cite as <code>[^N]</code>
+        and pass the same source maps to <code>markdown/1</code>: complete markers
+        become chips, unmatched ones stay as plain text. Chips are real links - Tab
+        reaches one, the preview card opens on focus, Enter opens the source in a new
+        tab. <code>chat_sources</code>
+        is the deduped list underneath, a native
+        &lt;details&gt; with no JS: the dials above flip <code>expanded</code>
+        and cap the list with <code>max_visible</code>, which tucks the rest behind a
+        "Show all" reveal.
       </div>
       <div class="p-4 mt-3 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
         Streaming is real here: the LiveView pushes word-sized tokens with
@@ -8854,7 +9049,9 @@ defmodule Dev.PlaygroundLive do
           :message_actions,
           :copy_button,
           :suggestions,
-          :chat_error
+          :chat_error,
+          :chat_sources,
+          :citation
         ]}
       />
 

--- a/lib/petal_components/chat.ex
+++ b/lib/petal_components/chat.ex
@@ -10,6 +10,8 @@ defmodule PetalComponents.Chat do
     * `chat_message/1`  — a single message bubble (user or assistant)
     * `streaming_text/1` — token-by-token output via the `PetalChatStream` JS hook
     * `prompt_input/1`   — the composer (textarea + send)
+    * `chat_sources/1`   — the RAG sources row under an answer
+    * `citation/1`       — an inline numbered citation chip
 
   ## Importing
 
@@ -39,6 +41,42 @@ defmodule PetalComponents.Chat do
 
       import PetalComponents from "../../deps/petal_components/assets/js/petal_components"
       new LiveSocket("/live", Socket, { hooks: { ...PetalComponents }, ... })
+
+  ## Answer grounding (RAG citations)
+
+  Sources are plain maps — the host app supplies them, this library only renders
+  them. `url` is the only key that really matters; `title`, `snippet`,
+  `favicon_url` and `id` are optional and degrade gracefully:
+
+      sources = [
+        %{id: "1", url: "https://hexdocs.pm/phoenix_live_view", title: "Phoenix.LiveView",
+          snippet: "LiveView provides rich, real-time user experiences...",
+          favicon_url: "https://hexdocs.pm/favicon.ico"},
+        %{id: "2", url: "https://hexdocs.pm/phoenix", title: "Phoenix"}
+      ]
+
+  Prompt the model to cite with **`[^N]` footnote markers** ("cite your sources
+  inline as [^1], [^2] matching the numbered context"). Pass `sources` to
+  `markdown/1` and every complete marker becomes a chip; markers with no matching
+  source stay as plain text:
+
+      <Chat.chat_message role="assistant">
+        <Chat.markdown content={msg.text} sources={msg.sources} />
+        <Chat.chat_sources sources={msg.sources} />
+      </Chat.chat_message>
+
+  A marker resolves to the source whose `id` matches `N` and falls back to the
+  Nth source in the list, so an id-less list still works positionally.
+
+  The streaming path takes the same option — `to_html/2` renders the chips into
+  the HTML you push at a `format="markdown"` `streaming_text/1`. Half-arrived
+  markers (`[^` with no closing bracket yet) are left alone, so nothing flashes
+  broken mid-stream:
+
+      socket = push_event(socket, "pc-chat-token", %{
+        id: "answer",
+        html: PetalComponents.Chat.to_html(buffer, sources: sources)
+      })
 
   ## Styling
 
@@ -194,8 +232,22 @@ defmodule PetalComponents.Chat do
   `streaming_text/1`:
 
       socket = push_event(socket, "pc-chat-token", %{id: "answer", html: PetalComponents.Chat.to_html(buffer)})
+
+  Pass `:sources` to turn `[^N]` footnote markers into inline citation chips as
+  the answer streams (see the "Answer grounding" section in the moduledoc):
+
+      PetalComponents.Chat.to_html(buffer, sources: msg.sources)
+
+  ## Options
+
+    * `:sources` — list of source maps. `[^N]` markers matching a source render
+      as chips; unmatched and half-streamed markers are left untouched.
   """
-  def to_html(content), do: render_markdown(content)
+  def to_html(content, opts \\ []) do
+    content
+    |> render_markdown()
+    |> apply_citations(Keyword.get(opts, :sources))
+  end
 
   defp ensure_mdex! do
     if Code.ensure_loaded?(MDEx) do
@@ -275,10 +327,17 @@ defmodule PetalComponents.Chat do
   """
   attr :content, :string, required: true
   attr :id, :string, default: nil, doc: "pass a unique id to enable per-code-block copy buttons"
+
+  attr :sources, :list,
+    default: nil,
+    doc:
+      "when set, complete `[^N]` markers in the content render as inline citation chips for the matching source (by `id`, falling back to the Nth source). Unmatched markers stay as plain text"
+
   attr :class, :any, default: nil
 
   def markdown(assigns) do
-    assigns = assign(assigns, :html, render_markdown(assigns.content))
+    assigns =
+      assign(assigns, :html, apply_citations(render_markdown(assigns.content), assigns.sources))
 
     ~H"""
     <div id={@id} phx-hook={@id && "PetalCodeCopy"} class={["pc-chat__markdown", @class]}>
@@ -701,6 +760,288 @@ defmodule PetalComponents.Chat do
       </button>
     </div>
     """
+  end
+
+  @doc """
+  An inline numbered citation chip — the superscript marker that grounds a
+  sentence in a source. Hovering or focusing it reveals a small preview card
+  (title, domain, snippet); activating it opens the source in a new tab.
+
+  `markdown/1` and `to_html/2` mint these for you from `[^N]` markers, so you
+  rarely call it directly. Reach for it when you are assembling prose yourself:
+
+      Phoenix ships with LiveView <Chat.citation index={1} source={@source} />
+  """
+  attr :index, :integer, required: true, doc: "1-based citation number shown in the chip"
+
+  attr :source, :map,
+    required: true,
+    doc:
+      "the source map this chip points at: %{url, title, snippet, favicon_url}; every key but `url` is optional"
+
+  attr :class, :any, default: nil
+
+  def citation(assigns) do
+    assigns =
+      assign(assigns, :html, citation_html(assigns.index, normalize_source(assigns.source)))
+
+    ~H"""
+    <span class={@class && ["pc-chat__citation-outer", @class]}>{Phoenix.HTML.raw(@html)}</span>
+    """
+  end
+
+  @doc """
+  The sources row under a grounded answer. Collapsed it reads "4 sources" with a
+  stacked-favicon cluster; open it lists each source with its favicon, title,
+  domain and snippet. Native `<details>`, so no JS.
+
+      <Chat.chat_sources sources={@sources} />
+      <Chat.chat_sources sources={@sources} expanded max_visible={3} />
+
+  Sources are deduped by URL before render (the same page cited twice is one
+  row), and a nil or empty list renders nothing at all — no empty shell.
+  """
+  attr :sources, :list,
+    required: true,
+    doc:
+      "list of source maps: %{id, url, title, snippet, favicon_url}; snippet and favicon_url optional. Deduped by URL before render"
+
+  attr :expanded, :boolean,
+    default: false,
+    doc: "render the list open instead of the collapsed 'N sources' row"
+
+  attr :max_visible, :integer,
+    default: 5,
+    doc: "sources shown when expanded before a 'Show all (N)' control reveals the rest"
+
+  attr :label, :string,
+    default: nil,
+    doc: "override the collapsed row label; defaults to '{count} sources' / '1 source'"
+
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  def chat_sources(assigns) do
+    items = assigns.sources |> normalize_sources() |> dedupe_sources()
+
+    assigns =
+      assigns
+      |> assign(:items, items)
+      |> assign(:visible, Enum.take(items, max(assigns.max_visible, 0)))
+      |> assign(:overflow, Enum.drop(items, max(assigns.max_visible, 0)))
+      |> assign(:count, length(items))
+
+    ~H"""
+    <details :if={@items != []} class={["pc-chat__sources", @class]} open={@expanded} {@rest}>
+      <summary class="pc-chat__sources-row">
+        <span class="pc-chat__sources-favicons" aria-hidden="true">
+          <.source_favicon :for={source <- Enum.take(@items, 3)} source={source} />
+        </span>
+        <span class="pc-chat__sources-label">
+          {@label || if(@count == 1, do: "1 source", else: "#{@count} sources")}
+        </span>
+        <PetalComponents.Icon.icon name="hero-chevron-right" class="pc-chat__sources-chevron" />
+      </summary>
+      <ul class="pc-chat__sources-list" role="list">
+        <.source_row :for={source <- @visible} source={source} />
+      </ul>
+      <details :if={@overflow != []} class="pc-chat__sources-more">
+        <summary class="pc-chat__sources-more-summary">Show all ({@count})</summary>
+        <ul class="pc-chat__sources-list" role="list">
+          <.source_row :for={source <- @overflow} source={source} />
+        </ul>
+      </details>
+    </details>
+    """
+  end
+
+  attr :source, :map, required: true
+
+  defp source_row(assigns) do
+    ~H"""
+    <li class="pc-chat__source">
+      <a
+        href={@source.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="pc-chat__source-link"
+      >
+        <.source_favicon source={@source} />
+        <span class="pc-chat__source-text">
+          <span class="pc-chat__source-title">{@source.title || @source.url}</span>
+          <span :if={source_domain(@source)} class="pc-chat__source-domain">
+            {source_domain(@source)}
+          </span>
+          <span :if={@source.snippet} class="pc-chat__source-snippet">{@source.snippet}</span>
+        </span>
+      </a>
+    </li>
+    """
+  end
+
+  attr :source, :map, required: true
+
+  defp source_favicon(assigns) do
+    ~H"""
+    <img
+      :if={@source.favicon_url}
+      src={@source.favicon_url}
+      alt=""
+      aria-hidden="true"
+      loading="lazy"
+      class="pc-chat__source-favicon"
+    />
+    <span
+      :if={!@source.favicon_url}
+      aria-hidden="true"
+      class="pc-chat__source-favicon pc-chat__source-favicon--letter"
+    >
+      {source_initial(@source)}
+    </span>
+    """
+  end
+
+  # -- citation plumbing -----------------------------------------------------
+
+  # Only complete markers match, so a half-streamed "[^" never flashes a broken
+  # chip; it simply stays as text until the closing bracket arrives.
+  @citation_marker ~r/\[\^(\d+)\]/
+  @html_tag ~r/<[^>]*>/
+
+  defp apply_citations(html, sources) when is_binary(html) do
+    case citation_lookup(sources) do
+      lookup when map_size(lookup) == 0 -> html
+      lookup -> splice_citations(html, lookup)
+    end
+  end
+
+  # Walk the sanitized HTML as a tag/text token stream and rewrite markers in
+  # text nodes only: never inside an attribute, never inside <pre>/<code>. The
+  # chip markup is minted here from the numeric index plus escaped source
+  # fields, so model-controlled text can never reach the page as live markup.
+  defp splice_citations(html, lookup) do
+    @html_tag
+    |> Regex.split(html, include_captures: true)
+    |> Enum.reduce({[], 0}, fn part, {acc, depth} ->
+      cond do
+        String.starts_with?(part, "<") -> {[part | acc], code_depth(part, depth)}
+        depth > 0 -> {[part | acc], depth}
+        true -> {[replace_markers(part, lookup) | acc], depth}
+      end
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+    |> IO.iodata_to_binary()
+  end
+
+  defp code_depth(tag, depth) do
+    cond do
+      Regex.match?(~r{^</(?:pre|code)\s*>$}i, tag) -> max(depth - 1, 0)
+      Regex.match?(~r{^<(?:pre|code)(?:\s[^>]*)?>$}i, tag) -> depth + 1
+      true -> depth
+    end
+  end
+
+  defp replace_markers(text, lookup) do
+    Regex.replace(@citation_marker, text, fn marker, number ->
+      case Map.fetch(lookup, number) do
+        {:ok, source} -> citation_html(String.to_integer(number), source)
+        :error -> marker
+      end
+    end)
+  end
+
+  defp citation_lookup(sources) do
+    normalized = normalize_sources(sources)
+
+    by_position =
+      normalized
+      |> Enum.with_index(1)
+      |> Map.new(fn {source, index} -> {Integer.to_string(index), source} end)
+
+    by_id =
+      Enum.reduce(normalized, %{}, fn
+        %{id: nil}, acc -> acc
+        %{id: id} = source, acc -> Map.put_new(acc, to_string(id), source)
+      end)
+
+    Map.merge(by_position, by_id)
+  end
+
+  defp citation_html(index, source) do
+    title = source.title || source_domain(source) || "Source #{index}"
+    domain = source_domain(source)
+
+    ~s(<span class="pc-chat__citation-wrap"><a class="pc-chat__citation" href="#{esc(source.url)}") <>
+      ~s( target="_blank" rel="noopener noreferrer" aria-label="#{esc("Source #{index}: #{title}")}">) <>
+      ~s(<sup class="pc-chat__citation-num">#{index}</sup></a>) <>
+      ~s(<span class="pc-chat__citation-card" aria-hidden="true">) <>
+      citation_card_favicon(source) <>
+      ~s(<span class="pc-chat__citation-card-title">#{esc(title)}</span>) <>
+      if(domain,
+        do: ~s(<span class="pc-chat__citation-card-domain">#{esc(domain)}</span>),
+        else: ""
+      ) <>
+      if(source.snippet,
+        do: ~s(<span class="pc-chat__citation-card-snippet">#{esc(source.snippet)}</span>),
+        else: ""
+      ) <> ~s(</span></span>)
+  end
+
+  defp citation_card_favicon(%{favicon_url: nil} = source) do
+    ~s(<span class="pc-chat__source-favicon pc-chat__source-favicon--letter" aria-hidden="true">) <>
+      esc(source_initial(source)) <> ~s(</span>)
+  end
+
+  defp citation_card_favicon(source) do
+    ~s(<img class="pc-chat__source-favicon" src="#{esc(source.favicon_url)}" alt="") <>
+      ~s( aria-hidden="true" loading="lazy" />)
+  end
+
+  defp esc(nil), do: ""
+
+  defp esc(value),
+    do: value |> to_string() |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
+
+  defp normalize_sources(sources) when is_list(sources),
+    do: Enum.map(sources, &normalize_source/1)
+
+  defp normalize_sources(_), do: []
+
+  defp normalize_source(source) when is_map(source) do
+    %{
+      id: source_key(source, :id),
+      url: source_key(source, :url),
+      title: source_key(source, :title),
+      snippet: source_key(source, :snippet),
+      favicon_url: source_key(source, :favicon_url)
+    }
+  end
+
+  defp source_key(source, key) do
+    case Map.fetch(source, key) do
+      {:ok, value} -> value
+      :error -> Map.get(source, Atom.to_string(key))
+    end
+  end
+
+  defp dedupe_sources(sources), do: Enum.uniq_by(sources, & &1.url)
+
+  defp source_domain(%{url: url}) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{host: host} when is_binary(host) -> String.replace_prefix(host, "www.", "")
+      _ -> nil
+    end
+  end
+
+  defp source_domain(_), do: nil
+
+  defp source_initial(source) do
+    (source.title || source_domain(source) || "?")
+    |> String.trim()
+    |> String.first()
+    |> Kernel.||("?")
+    |> String.upcase()
   end
 
   defp render_markdown(nil), do: ""

--- a/lib/petal_components/showcase/chat.ex
+++ b/lib/petal_components/showcase/chat.ex
@@ -16,11 +16,44 @@ defmodule PetalComponents.Showcase.Chat do
       :message_actions,
       :copy_button,
       :suggestions,
-      :chat_error
+      :chat_error,
+      :chat_sources,
+      :citation
     ]
+
+  @rag_sources [
+    %{
+      id: "1",
+      url: "https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html",
+      title: "Phoenix.LiveView — behaviour and lifecycle",
+      snippet:
+        "LiveView provides rich, real-time user experiences with server-rendered HTML over a persistent connection."
+    },
+    %{
+      id: "2",
+      url: "https://hexdocs.pm/phoenix_live_view/js-interop.html",
+      title: "JavaScript interoperability",
+      snippet: "Client hooks let you run JavaScript when an element is added, updated or removed."
+    },
+    %{
+      id: "3",
+      url: "https://hexdocs.pm/phoenix/Phoenix.Endpoint.html",
+      title: "Phoenix.Endpoint",
+      snippet: "The endpoint is the boundary where all requests to your application start."
+    },
+    %{
+      id: "4",
+      url: "https://elixir-lang.org/getting-started/processes.html",
+      title: "Processes"
+    }
+  ]
 
   # Chat is not pulled in by `use PetalComponents`, so import it here.
   import PetalComponents.Chat
+
+  # Examples render with `assigns = %{}`, so the seed data comes from here
+  # rather than an assign.
+  defp rag_sources, do: @rag_sources
 
   example :flagship, "A complete chat",
     description:
@@ -180,6 +213,46 @@ defmodule PetalComponents.Showcase.Chat do
       <.marker variant="border" icon="hero-wrench-screwdriver">Running search_docs</.marker>
       <.chat_message role="assistant">Found 3 matches. Here's the most relevant one.</.chat_message>
     </.conversation>
+    """
+  end
+
+  example :chat_sources, "Sources and citations",
+    description:
+      "Answer grounding for RAG. Prompt the model to cite as [^N]; pass the same source maps to markdown/1 and the markers become chips (hover or tab to one for the preview card). chat_sources renders the deduped list below - native <details>, no JS." do
+    ~H"""
+    <.conversation id="showcase-chat-sources" class="w-full max-w-xl mx-auto">
+      <.chat_message role="user">How does LiveView keep the page in sync?</.chat_message>
+      <.chat_message role="assistant">
+        <.markdown
+          content="LiveView holds a **persistent connection** and diffs the rendered tree server-side, pushing only what changed [^1]. Anything the server can't own - focus, clipboard, third-party widgets - drops down to a client hook [^2].\n\nEvery request still enters through the endpoint [^3]."
+          sources={rag_sources()}
+        />
+        <.chat_sources sources={rag_sources()} />
+      </.chat_message>
+    </.conversation>
+    """
+  end
+
+  example :chat_sources_expanded, "Sources expanded",
+    description:
+      "expanded opens the row on render; max_visible caps the list and tucks the rest behind a \"Show all\" reveal. A source with no favicon_url falls back to a letter avatar, and no snippet just means a shorter row." do
+    ~H"""
+    <div class="w-full max-w-xl mx-auto">
+      <.chat_sources sources={rag_sources()} expanded max_visible={2} />
+    </div>
+    """
+  end
+
+  example :citation, "Citation chip",
+    description:
+      "The chip on its own, for prose you assemble yourself. It's a real link - Tab reaches it, the preview card opens on hover or focus, and activating it opens the source in a new tab." do
+    ~H"""
+    <p class="w-full max-w-xl mx-auto text-sm text-gray-700 dark:text-gray-300">
+      Processes in Elixir are cheap and isolated
+      <.citation index={4} source={Enum.at(rag_sources(), 3)} />
+      which is why a LiveView per tab is unremarkable
+      <.citation index={1} source={Enum.at(rag_sources(), 0)} />.
+    </p>
     """
   end
 

--- a/test/petal/chat_test.exs
+++ b/test/petal/chat_test.exs
@@ -141,6 +141,325 @@ defmodule PetalComponents.ChatTest do
     end
   end
 
+  describe "citations in markdown/1" do
+    setup do
+      %{
+        sources: [
+          %{
+            id: "1",
+            url: "https://hexdocs.pm/phoenix_live_view",
+            title: "Phoenix.LiveView",
+            snippet: "Rich, real-time user experiences.",
+            favicon_url: "https://hexdocs.pm/favicon.ico"
+          },
+          %{id: "2", url: "https://hexdocs.pm/phoenix", title: "Phoenix"}
+        ]
+      }
+    end
+
+    test "turns a [^N] marker into a citation chip wired to the matching source", %{
+      sources: sources
+    } do
+      assigns = %{md: "LiveView is great [^1] and so is Phoenix [^2].", sources: sources}
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      assert_has_class(html, "pc-chat__citation")
+      assert html =~ ~s{href="https://hexdocs.pm/phoenix_live_view"}
+      assert html =~ ~s{href="https://hexdocs.pm/phoenix"}
+      assert html =~ ~s{<sup class="pc-chat__citation-num">1</sup>}
+      assert html =~ ~s{<sup class="pc-chat__citation-num">2</sup>}
+      # the raw marker is gone
+      refute html =~ "[^1]"
+    end
+
+    test "without sources the marker passes through as plain text (today's behaviour)" do
+      assigns = %{md: "LiveView is great [^1]."}
+
+      html = rendered_to_string(~H|<.markdown content={@md} />|)
+
+      refute html =~ "pc-chat__citation"
+      assert html =~ "[^1]"
+    end
+
+    test "an unmatched marker renders as plain text, not a broken chip", %{sources: sources} do
+      assigns = %{md: "Something unsourced [^9].", sources: sources}
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      assert html =~ "[^9]"
+      refute html =~ "pc-chat__citation-num\">9<"
+    end
+
+    test "chips carry an accessible name naming the source", %{sources: sources} do
+      assigns = %{md: "Grounded [^1].", sources: sources}
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      assert html =~ ~s{aria-label="Source 1: Phoenix.LiveView"}
+    end
+
+    test "chip links open in a new tab safely", %{sources: sources} do
+      assigns = %{md: "Grounded [^1].", sources: sources}
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      assert html =~ ~s{target="_blank"}
+      assert html =~ ~s{rel="noopener noreferrer"}
+    end
+
+    test "model-controlled source fields are escaped in the chip and its card" do
+      assigns = %{
+        md: "Careful [^1].",
+        sources: [
+          %{
+            id: "1",
+            url: "https://example.com",
+            title: "<script>alert('x')</script>",
+            snippet: "<img src=x onerror=alert(1)>"
+          }
+        ]
+      }
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      refute html =~ "<script>alert"
+      refute html =~ "<img src=x"
+      assert html =~ "&lt;script&gt;"
+      assert html =~ "&lt;img src=x"
+    end
+
+    test "markers inside code blocks are left alone", %{sources: sources} do
+      assigns = %{md: "```elixir\nfoo = \"[^1]\"\n```", sources: sources}
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      refute html =~ "pc-chat__citation"
+      assert html =~ "[^1]"
+    end
+
+    test "a marker resolves positionally when sources have no ids" do
+      assigns = %{
+        md: "Positional [^2].",
+        sources: [%{url: "https://a.example"}, %{url: "https://b.example", title: "B"}]
+      }
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      assert html =~ ~s{href="https://b.example"}
+      assert html =~ ~s{aria-label="Source 2: B"}
+    end
+  end
+
+  describe "to_html/2 with sources (the streaming path)" do
+    setup do
+      %{sources: [%{id: "1", url: "https://example.com/doc", title: "The Doc"}]}
+    end
+
+    test "renders chip markup for complete markers", %{sources: sources} do
+      html = PetalComponents.Chat.to_html("Grounded [^1].", sources: sources)
+
+      assert html =~ "pc-chat__citation"
+      assert html =~ ~s{href="https://example.com/doc"}
+    end
+
+    test "leaves a half-streamed marker untouched so nothing flashes broken", %{sources: sources} do
+      html = PetalComponents.Chat.to_html("Grounded [^", sources: sources)
+
+      refute html =~ "pc-chat__citation"
+      assert html =~ "[^"
+    end
+
+    test "to_html/1 is unchanged" do
+      assert PetalComponents.Chat.to_html("Grounded [^1].") =~ "[^1]"
+    end
+  end
+
+  describe "citation/1" do
+    test "renders a standalone chip for a source map" do
+      assigns = %{source: %{url: "https://example.com", title: "Example"}}
+
+      html = rendered_to_string(~H|<.citation index={3} source={@source} />|)
+
+      assert_has_class(html, "pc-chat__citation")
+      assert html =~ ~s{aria-label="Source 3: Example"}
+      assert html =~ ~s{<sup class="pc-chat__citation-num">3</sup>}
+    end
+
+    test "the preview card is decorative — the title lives in the accessible name" do
+      assigns = %{source: %{url: "https://example.com", title: "Example", snippet: "Snip"}}
+
+      html = rendered_to_string(~H|<.citation index={1} source={@source} />|)
+
+      assert_has_class(html, "pc-chat__citation-card")
+      assert html =~ ~s{class="pc-chat__citation-card" aria-hidden="true"}
+      assert html =~ "Snip"
+    end
+
+    test "class is appended last" do
+      assigns = %{source: %{url: "https://example.com"}}
+
+      html = rendered_to_string(~H|<.citation index={1} source={@source} class="custom-chip" />|)
+
+      assert html =~ "custom-chip"
+    end
+  end
+
+  describe "chat_sources/1" do
+    setup do
+      %{
+        sources: [
+          %{
+            id: "1",
+            url: "https://hexdocs.pm/phoenix_live_view",
+            title: "Phoenix.LiveView",
+            snippet: "Rich, real-time user experiences.",
+            favicon_url: "https://hexdocs.pm/favicon.ico"
+          },
+          %{id: "2", url: "https://hexdocs.pm/phoenix", title: "Phoenix"},
+          %{id: "3", url: "https://elixir-lang.org", title: "Elixir"}
+        ]
+      }
+    end
+
+    test "renders a collapsed details row labelled with the count", %{sources: sources} do
+      assigns = %{sources: sources}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} />|)
+
+      assert_has_class(html, "pc-chat__sources")
+      assert_has_class(html, "pc-chat__sources-row")
+      assert html =~ "<details"
+      assert html =~ "<summary"
+      assert html =~ "3 sources"
+      refute Regex.match?(~r/<details[^>]*\sopen[\s>]/, html)
+    end
+
+    test "one source reads in the singular" do
+      assigns = %{sources: [%{url: "https://example.com", title: "Only"}]}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} />|)
+
+      assert html =~ "1 source"
+      refute html =~ "1 sources"
+    end
+
+    test "a custom label overrides the count", %{sources: sources} do
+      assigns = %{sources: sources}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} label="Used 3 pages" />|)
+
+      assert html =~ "Used 3 pages"
+      refute html =~ "3 sources"
+    end
+
+    test "expanded opens the list by default", %{sources: sources} do
+      assigns = %{sources: sources}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      assert Regex.match?(~r/<details[^>]*\sopen[\s>]/, html)
+    end
+
+    test "each source is a safe external link with title, domain and snippet", %{
+      sources: sources
+    } do
+      assigns = %{sources: sources}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      assert html =~ ~s{href="https://hexdocs.pm/phoenix_live_view"}
+      assert html =~ ~s{target="_blank"}
+      assert html =~ ~s{rel="noopener noreferrer"}
+      assert html =~ "Phoenix.LiveView"
+      assert html =~ "hexdocs.pm"
+      assert html =~ "Rich, real-time user experiences."
+      assert html =~ ~s{role="list"}
+    end
+
+    test "dedupes by url — the same page cited twice is one row" do
+      assigns = %{
+        sources: [
+          %{id: "1", url: "https://example.com/a", title: "A"},
+          %{id: "2", url: "https://example.com/a", title: "A again"}
+        ]
+      }
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      assert html =~ "1 source"
+      refute html =~ "A again"
+    end
+
+    test "nil and empty sources render nothing at all" do
+      assigns = %{}
+
+      refute rendered_to_string(~H|<.chat_sources sources={[]} />|) =~ "pc-chat__sources"
+      refute rendered_to_string(~H|<.chat_sources sources={nil} />|) =~ "pc-chat__sources"
+    end
+
+    test "max_visible overflows into a 'Show all' reveal", %{sources: sources} do
+      assigns = %{sources: sources}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded max_visible={2} />|)
+
+      assert_has_class(html, "pc-chat__sources-more")
+      assert html =~ "Show all (3)"
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded max_visible={5} />|)
+
+      refute html =~ "pc-chat__sources-more"
+    end
+
+    test "a source without favicon_url degrades to a letter avatar" do
+      assigns = %{sources: [%{url: "https://example.com", title: "Example"}]}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      assert_has_class(html, "pc-chat__source-favicon--letter")
+      assert html =~ ">E<" or html =~ "E\n"
+    end
+
+    test "favicons are decorative", %{sources: sources} do
+      assigns = %{sources: sources}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      assert html =~ ~s{alt=""}
+      assert html =~ ~s{loading="lazy"}
+    end
+
+    test "a source without a snippet renders a clean row" do
+      assigns = %{sources: [%{url: "https://example.com", title: "Example"}]}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      refute html =~ "pc-chat__source-snippet"
+      assert html =~ "Example"
+    end
+
+    test "string-keyed source maps render identically to atom-keyed ones" do
+      assigns = %{
+        sources: [%{"id" => "1", "url" => "https://example.com", "title" => "Stringy"}]
+      }
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      assert html =~ "Stringy"
+      assert html =~ ~s{href="https://example.com"}
+    end
+
+    test "class is appended last and rest passes through", %{sources: sources} do
+      assigns = %{sources: sources}
+
+      html =
+        rendered_to_string(~H|<.chat_sources sources={@sources} class="mine" id="src-block" />|)
+
+      assert html =~ "mine"
+      assert html =~ ~s{id="src-block"}
+    end
+  end
+
   describe "tool_call/1" do
     test "renders the tool name and a completed check" do
       assigns = %{}


### PR DESCRIPTION
Closes #615

## Stack position

**1 of 4** in the 4.18.0 chat stack. This branch (`feat/chat-sources`) is cut from `origin/main` and is the base of the other three:

| # | Issue | Branch | Builds on |
|---|---|---|---|
| **1** | **#615 chat_sources + citations** | **`feat/chat-sources`** | **`main`** |
| 2 | #616 composer attachments | `feat/chat-attachments` | `feat/chat-sources` |
| 3 | #617 chat questionnaire | `feat/chat-questionnaire` | `feat/chat-attachments` |
| 4 | #618 tool_call states | `feat/chat-tool-call` | `feat/chat-questionnaire` |

The PR is opened against `main` because this one genuinely sits on `main`, so the diff here is exactly this issue's work. **Please merge in order 615 → 616 → 617 → 618** — the later PRs in the stack will show a cumulative diff until the ones below them land.

## Summary

Answer grounding for the chat family. Prompt the model to cite with `[^N]` footnote markers, hand the same source maps to `markdown/1`, and the markers become numbered chips; `chat_sources/1` renders the deduped source list underneath.

- **`citation/1`** — the inline chip. Superscript number, preview card (favicon, title, domain, snippet) on hover or focus, activating it opens the source in a new tab.
- **`chat_sources/1`** — native `<details>`/`<summary>`, matching `reasoning/1`'s no-JS approach. Collapsed it reads "4 sources" with a stacked-favicon cluster. Deduped by URL, `expanded` opens it on render, `max_visible` tucks the overflow behind a nested "Show all (N)" reveal, and a nil/empty list renders nothing at all (no empty shell).
- **`markdown/1`** gains a `sources` attr; **`to_html/2`** gains a `:sources` option for the streaming path.

Sources are plain maps — `%{id, url, title, snippet, favicon_url}`, string or atom keys both accepted. Everything but `url` is optional: no `favicon_url` falls back to a letter avatar, no `snippet` is just a shorter row.

### How the marker → chip transform works

Option (b) from the issue: **post-process the sanitized HTML.** MDEx's footnote extension is not enabled here, so `[^N]` survives as literal text in the output, and splicing after sanitization means the chip markup can't be eaten by the sanitizer.

The output is walked as a tag/text token stream, so markers are only ever rewritten inside text nodes — never inside an attribute value, and never inside `<pre>`/`<code>` (a `[^1]` in a code sample stays a code sample). The chip markup is minted from the numeric index plus `Phoenix.HTML.html_escape`d source fields, so nothing model-controlled reaches the page as live markup. Only complete markers match, so a half-streamed `[^` is left untouched until its closing bracket arrives.

A marker resolves to the source whose `id` matches `N`, falling back to the Nth source, so an id-less list still works positionally.

## Deviations from the issue's sketch

1. **The chip is an `<a>`, not a `<button>`.** The issue's a11y section says "real `<button>`s ... never bare `<sup>` text". The intent — a real interactive element carrying an accessible name — is met, but the action is "open this URL in a new tab", which is an anchor's job. As a `<button>` it would need JS to navigate; as an `<a href target="_blank" rel="noopener noreferrer">` it works with zero JS, gets middle-click/copy-link for free, and matches `external_links/1` in the same file. Happy to flip it if you'd rather hold the line on `<button>`.

2. **No popover / hover_card machinery — the preview card is pure CSS.** `hover_card/1` hasn't landed, and composing `PetalPopover` would have meant a hook and an id-per-chip for `aria-controls`, on markup that is spliced into a raw HTML string with no assigns to generate ids from. The card is a sibling `<span>` shown on `:hover` / `:focus-within` of the wrapper. This is the CSS-first house rule, and it keeps the "no new positioning system" non-goal honest. Trade-off: no flip/collision handling — the card is fixed above-left of the chip.

3. **The preview card is `aria-hidden="true"`.** It is a visual affordance whose title and domain are already in the chip's accessible name, and whose snippet is reachable in the `chat_sources` list below. This avoids inventing ids for `aria-describedby` inside spliced HTML and avoids a screen reader reading the same title twice per chip.

4. **`to_html/2` rather than a separate function** — `def to_html(content, opts \\ [])`, so existing `to_html/1` call sites are untouched.

## Backward compatibility

**No existing test was modified or deleted, and no existing attr default changed.** Every pre-existing chat test passes unmodified.

- `markdown/1` without `sources` (the default, `nil`) is byte-identical to before — there's an explicit test for it (`"without sources the marker passes through as plain text (today's behaviour)"`).
- `to_html/1` still exists and behaves exactly as it did (tested).
- `citation/1` and `chat_sources/1` are net-new function names. `Chat` is not pulled in by `use PetalComponents`, so neither can collide with a consumer's helpers.
- CSS is appended in a **new `@layer components { }` block** at the tail of `assets/default.css` — nothing above it reflowed, and being inside a layer means consumer utilities passed via `class` still win.

## Verification

| Check | Result |
|---|---|
| `mix format --check-formatted` | clean |
| `mix compile --force --warnings-as-errors` | clean |
| `mix credo` | 14 refactoring / 31 readability — **identical to `origin/main`, zero new entries** |
| `mix test` | **940 tests, 0 failures, 1 skipped** (baseline 913 / 0 / 1 — **+27 new**) |
| `npm test` | **157 passed** (baseline 157 — no JS touched) |

## Playground

Extended the existing AI Chat page (slug `chat`) — no new nav slug.

- The seeded thread now carries a mocked RAG answer citing **4 sources** with `[^N]` markers, with the `chat_sources` row underneath.
- A **"Citations while streaming"** section: each tick re-renders the growing buffer through `to_html(buffer, sources: sources)` and pushes it at a `format="markdown"` `streaming_text`, so chips light up as their markers complete.
- Dials: `sources expanded` (closed / open) and `max_visible` (2 / 5 / all).

Verified light + dark, keyboard-only (Tab reaches a chip, the preview card opens on focus, Enter opens the source), and the streaming demo end to end.

## Accessibility

- Chips are real links with `aria-label="Source N: {title}"` — the number alone is never the accessible name.
- Source links: `target="_blank"` + `rel="noopener noreferrer"`.
- Favicons are decorative (`alt=""`, `aria-hidden="true"`, `loading="lazy"`).
- The sources row uses native `<summary>` semantics — no ARIA needed.
- `focus-visible` rings in primary on the chip, the summary and each source link. No persistent `:focus` fills.
- `prefers-reduced-motion` collapses the card reveal and chevron rotation transitions.
