### PR TITLE
feat(sidebar): the app-shell navigation family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,33 @@
 # Changelog
+### Unreleased
+
+#### Added
+
+- **New `sidebar` family: the app-shell navigation almost every LiveView
+  product ends up hand-rolling.** Five components compose the whole
+  anatomy - `sidebar_shell` (the flex wrapper), `sidebar` (the `<nav>`
+  landmark with header and footer slots), `sidebar_group` (a labelled,
+  optionally collapsible run of items), `sidebar_item` (icon, label,
+  badge, active state, and arbitrarily nested sub-items) and
+  `sidebar_trigger` (the rail toggle and the mobile burger). Three
+  collapse modes: `icon` for the rail, `offcanvas` to hide it, `none` to
+  pin it. `side="right"` gives you an inspector panel, and two sidebars
+  in one shell keep separate state.
+
+  Collapse is CSS-first: the trigger flips a `data-collapsed` attribute
+  with `Phoenix.LiveView.JS` and stylesheets do the rest, so there is no
+  hook and no round trip. The server still renders the initial value
+  through the `collapsed` attr, so a `live_redirect` can never flash the
+  wrong state. Below `md` the sidebar becomes an off-canvas sheet: the
+  shell's content region goes `inert`, Escape closes it, the scrim
+  closes it, and focus returns to the trigger.
+
+  Accessibility: a `<nav>` landmark with an accessible name,
+  `aria-current="page"` on the active item, the WAI-ARIA disclosure
+  pattern on collapsible groups and nested items, labels that stay in
+  the accessibility tree when the rail collapses, and transitions that
+  drop to instant under `prefers-reduced-motion`.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,281 @@
       transition-duration: 1ms;
     }
   }
+
+/* Sidebar - the app-shell navigation rail.
+ *
+ * Wrapped in its own @layer components block on purpose: everything after the
+ * showcase-props section above sits OUTSIDE any cascade layer, and unlayered
+ * rules outrank a consumer's utilities, which would quietly break
+ * <.sidebar class="..."> overrides.
+ *
+ * State lives in data attributes on .pc-sidebar (data-collapsed,
+ * data-mobile-open, data-collapsible, data-side) so LiveView.JS can flip them
+ * with no hook and no round trip. Collapse behaviour is scoped to md and up;
+ * below that the sidebar is a sheet, and none of the rail rules apply.
+ */
+@layer components {
+  .pc-sidebar-shell {
+    @apply flex w-full min-h-svh bg-white dark:bg-gray-950;
+  }
+
+  .pc-sidebar-shell__main {
+    @apply flex flex-col flex-1 min-w-0;
+  }
+
+  .pc-sidebar {
+    --pc-sidebar-width: 16rem;
+    /* Wide enough for a 2rem trigger plus a 1.25rem brand mark in the header
+       without clipping, which 3.5rem was not. */
+    --pc-sidebar-icon-width: 4rem;
+    @apply relative flex-none self-stretch;
+    width: var(--pc-sidebar-width);
+    transition: width 200ms ease;
+  }
+
+  .pc-sidebar[data-side="right"] {
+    @apply order-last;
+  }
+
+  .pc-sidebar__panel {
+    /* h-full tracks a bounded shell (a demo frame, a dashboard card); max-h-svh
+       caps it at the viewport so sticky still works under long page content. */
+    @apply sticky top-0 z-30 flex flex-col w-full h-full overflow-hidden bg-gray-50 border-gray-200 max-h-svh dark:bg-gray-900 dark:border-gray-800;
+  }
+
+  .pc-sidebar[data-side="left"] .pc-sidebar__panel {
+    @apply border-r;
+  }
+
+  .pc-sidebar[data-side="right"] .pc-sidebar__panel {
+    @apply border-l;
+  }
+
+  /* focus_wrap traps Tab between its two sentinel divs. On desktop that would
+     fence the whole page into the sidebar, so the sentinels only exist while
+     the mobile sheet is actually open. */
+  .pc-sidebar:not([data-mobile-open="true"]) .pc-sidebar__panel > [tabindex="0"][aria-hidden="true"] {
+    @apply hidden;
+  }
+
+  .pc-sidebar__scrim {
+    @apply hidden;
+  }
+
+  .pc-sidebar__nav {
+    @apply flex flex-col flex-1 min-h-0;
+  }
+
+  .pc-sidebar__header {
+    @apply flex items-center flex-none gap-2 px-3 border-b border-gray-200 h-14 dark:border-gray-800;
+  }
+
+  .pc-sidebar__brand {
+    @apply text-sm font-semibold truncate text-gray-900 dark:text-gray-50;
+  }
+
+  .pc-sidebar__content {
+    @apply flex flex-col flex-1 gap-4 px-2 py-4 overflow-x-hidden overflow-y-auto;
+  }
+
+  .pc-sidebar__footer {
+    @apply flex-none px-2 py-3 border-t border-gray-200 dark:border-gray-800;
+  }
+
+  /* Groups */
+
+  .pc-sidebar-group {
+    @apply flex flex-col gap-1;
+  }
+
+  .pc-sidebar-group__label {
+    @apply px-2 py-1 text-xs font-medium tracking-wide truncate text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-sidebar-group__toggle {
+    @apply flex items-center w-full gap-1 text-left cursor-pointer;
+    @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-sidebar-group__toggle .pc-sidebar-group__label {
+    @apply flex-1;
+  }
+
+  .pc-sidebar-group__chevron {
+    @apply flex-none w-3.5 h-3.5 mr-2 text-gray-400;
+    transition: rotate 150ms ease;
+  }
+
+  .pc-sidebar-group__toggle[aria-expanded="true"] .pc-sidebar-group__chevron {
+    rotate: 90deg;
+  }
+
+  .pc-sidebar-group__items {
+    @apply flex flex-col gap-0.5;
+  }
+
+  .pc-sidebar-group__items[data-open="false"] {
+    @apply hidden;
+  }
+
+  /* Items */
+
+  .pc-sidebar-item__parent {
+    @apply flex flex-col gap-0.5;
+  }
+
+  .pc-sidebar-item {
+    @apply flex items-center w-full gap-2.5 px-2 py-2 text-sm font-medium text-left cursor-pointer;
+    @apply text-gray-700 hover:bg-gray-200/70 hover:text-gray-900;
+    @apply dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-50;
+    @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+    transition: background-color 150ms ease, color 150ms ease;
+  }
+
+  .pc-sidebar-item--active {
+    @apply bg-gray-200 text-gray-900 dark:bg-gray-800 dark:text-gray-50;
+  }
+
+  .pc-sidebar-item__icon {
+    @apply flex-none w-5 h-5;
+  }
+
+  .pc-sidebar-item__label {
+    @apply flex-1 truncate;
+  }
+
+  .pc-sidebar-item__badge {
+    @apply flex-none px-1.5 py-0.5 text-xs font-semibold tabular-nums text-gray-600 bg-gray-200 dark:text-gray-300 dark:bg-gray-800;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.375rem), 0.125rem);
+  }
+
+  .pc-sidebar-item--active .pc-sidebar-item__badge {
+    @apply text-gray-900 bg-white dark:text-gray-50 dark:bg-gray-950;
+  }
+
+  .pc-sidebar-item__chevron {
+    @apply flex-none w-3.5 h-3.5 text-gray-400;
+    transition: rotate 150ms ease;
+  }
+
+  .pc-sidebar-item[aria-expanded="true"] .pc-sidebar-item__chevron {
+    rotate: 90deg;
+  }
+
+  .pc-sidebar-item__sub {
+    @apply flex flex-col gap-0.5 pl-4 ml-4 border-l border-gray-200 dark:border-gray-800;
+  }
+
+  .pc-sidebar-item__sub[data-open="false"] {
+    @apply hidden;
+  }
+
+  /* Trigger */
+
+  .pc-sidebar-trigger {
+    @apply inline-flex items-center justify-center flex-none w-8 h-8 cursor-pointer;
+    @apply text-gray-600 hover:bg-gray-200/70 hover:text-gray-900;
+    @apply dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-50;
+    @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+    transition: background-color 150ms ease, color 150ms ease;
+  }
+
+  .pc-sidebar-trigger__icon {
+    @apply w-5 h-5;
+  }
+
+  /* Desktop: the collapse rail. */
+  @media (width >= 48rem) {
+    .pc-sidebar-trigger--mobile {
+      @apply hidden;
+    }
+
+    .pc-sidebar[data-collapsible="icon"][data-collapsed="true"] {
+      width: var(--pc-sidebar-icon-width);
+    }
+
+    .pc-sidebar[data-collapsible="offcanvas"][data-collapsed="true"] {
+      @apply w-0;
+    }
+
+    .pc-sidebar[data-collapsible="offcanvas"][data-collapsed="true"] .pc-sidebar__panel {
+      @apply hidden;
+    }
+
+    /* Icon rail: labels stay in the accessibility tree, they just stop taking
+       space. The title attribute carries the same text on hover. */
+    .pc-sidebar[data-collapsible="icon"][data-collapsed="true"] .pc-sidebar-item__label,
+    .pc-sidebar[data-collapsible="icon"][data-collapsed="true"] .pc-sidebar-item__badge,
+    .pc-sidebar[data-collapsible="icon"][data-collapsed="true"] .pc-sidebar-group__label,
+    .pc-sidebar[data-collapsible="icon"][data-collapsed="true"] .pc-sidebar__brand {
+      @apply sr-only;
+    }
+
+    .pc-sidebar[data-collapsible="icon"][data-collapsed="true"] .pc-sidebar-item__chevron,
+    .pc-sidebar[data-collapsible="icon"][data-collapsed="true"] .pc-sidebar-group__chevron,
+    .pc-sidebar[data-collapsible="icon"][data-collapsed="true"] .pc-sidebar-item__sub {
+      @apply hidden;
+    }
+
+    .pc-sidebar[data-collapsible="icon"][data-collapsed="true"] .pc-sidebar-item {
+      @apply justify-center px-0;
+    }
+
+    .pc-sidebar[data-collapsible="icon"][data-collapsed="true"] .pc-sidebar__header {
+      @apply justify-center px-0;
+    }
+  }
+
+  /* Mobile: the sheet takeover. Anything collapsible leaves the flow and slides
+     in over the shell; collapsible="none" stays pinned. */
+  @media (width < 48rem) {
+    .pc-sidebar-trigger--collapse {
+      @apply hidden;
+    }
+
+    .pc-sidebar:not([data-collapsible="none"]) {
+      @apply w-0;
+    }
+
+    .pc-sidebar:not([data-collapsible="none"]) .pc-sidebar__panel {
+      @apply fixed inset-y-0 z-50 border-0;
+      width: var(--pc-sidebar-width);
+      max-width: 85vw;
+      transition: transform 200ms ease;
+    }
+
+    .pc-sidebar:not([data-collapsible="none"])[data-side="left"] .pc-sidebar__panel {
+      @apply left-0;
+      transform: translateX(-100%);
+    }
+
+    .pc-sidebar:not([data-collapsible="none"])[data-side="right"] .pc-sidebar__panel {
+      @apply right-0;
+      transform: translateX(100%);
+    }
+
+    /* Must carry the same :not() + attribute weight as the per-side rules above,
+       or those win the specificity tie and the panel stays translated off-screen. */
+    .pc-sidebar:not([data-collapsible="none"])[data-mobile-open="true"] .pc-sidebar__panel {
+      transform: translateX(0);
+    }
+
+    .pc-sidebar[data-mobile-open="true"] .pc-sidebar__scrim {
+      @apply fixed inset-0 z-40 block bg-gray-950/50;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pc-sidebar,
+    .pc-sidebar__panel,
+    .pc-sidebar-item,
+    .pc-sidebar-item__chevron,
+    .pc-sidebar-group__chevron,
+    .pc-sidebar-trigger {
+      transition: none;
+    }
+  }
+}

--- a/dev.exs
+++ b/dev.exs
@@ -272,6 +272,7 @@ defmodule Dev.PlaygroundLive do
         %{slug: "pagination", name: "Pagination", ready: true},
         %{slug: "breadcrumbs", name: "Breadcrumbs", ready: true},
         %{slug: "stepper", name: "Stepper", ready: true},
+        %{slug: "sidebar", name: "Sidebar", ready: true},
         %{slug: "menu", name: "Menu", ready: true},
         %{slug: "navigation-menu", name: "Navigation menu", ready: true},
         %{slug: "user-menu", name: "User menu", ready: true},
@@ -833,6 +834,12 @@ defmodule Dev.PlaygroundLive do
        page: %{current: 3, sibling: 1, boundary: 1},
        skeleton: %{animation: "pulse", loading: false},
        accordion: %{variant: "default", multiple: false, size: "md"},
+       sidebar: %{
+         collapsible: "icon",
+         side: "left",
+         collapsed: false,
+         badges: true
+       },
        stepper: %{orientation: "horizontal", size: "md", labels: "beside", at: 0, done: false},
        toast: %{pos: "bottom-right", undone: 0},
        car: %{
@@ -1237,6 +1244,19 @@ defmodule Dev.PlaygroundLive do
 
   def handle_event("ctl_accordion", %{"k" => "size", "v" => v}, socket) when v in ~w(sm md),
     do: {:noreply, update(socket, :accordion, &%{&1 | size: v})}
+
+  def handle_event("ctl_sidebar", %{"k" => "collapsible", "v" => v}, socket)
+      when v in ~w(icon offcanvas none),
+      do: {:noreply, update(socket, :sidebar, &%{&1 | collapsible: v})}
+
+  def handle_event("ctl_sidebar", %{"k" => "side", "v" => v}, socket) when v in ~w(left right),
+    do: {:noreply, update(socket, :sidebar, &%{&1 | side: v})}
+
+  def handle_event("ctl_sidebar", %{"k" => "collapsed"}, socket),
+    do: {:noreply, update(socket, :sidebar, &%{&1 | collapsed: !&1.collapsed})}
+
+  def handle_event("ctl_sidebar", %{"k" => "badges"}, socket),
+    do: {:noreply, update(socket, :sidebar, &%{&1 | badges: !&1.badges})}
 
   def handle_event("ctl_stepper", %{"k" => "orientation", "v" => v}, socket)
       when v in ~w(horizontal vertical),
@@ -6115,6 +6135,184 @@ defmodule Dev.PlaygroundLive do
 
       <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
         These examples render from the shared <code>PetalComponents.Showcase.Card</code>
+        registry - the same source petal.build renders, so the playground and the marketing
+        docs can't drift.
+      </div>
+    </div>
+    """
+  end
+
+  defp render_page(%{active: "sidebar"} = assigns) do
+    ~H"""
+    <div class="max-w-4xl px-4 py-8 mx-auto sm:px-8 sm:py-10">
+      <h1 class="text-3xl font-bold tracking-tight">Sidebar</h1>
+      <p class="mt-2 text-gray-500 dark:text-gray-400">
+        The app shell almost every LiveView product hand-rolls: grouped nav with icons and
+        badges, a collapse rail, and a sheet takeover on mobile. Collapse is a data attribute
+        flipped by LiveView.JS - no hook, no round trip.
+      </p>
+
+      <div class="mt-8 border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="p-6">
+          <.sidebar_shell
+            for="pg-sidebar"
+            class="h-[30rem] min-h-0 overflow-hidden border border-gray-200 rounded-lg dark:border-gray-800"
+          >
+            <:sidebar>
+              <.sidebar
+                id="pg-sidebar"
+                label="Product"
+                side={@sidebar.side}
+                collapsible={@sidebar.collapsible}
+                collapsed={@sidebar.collapsed}
+              >
+                <:header>
+                  <.icon name="hero-cube" class="w-5 h-5 shrink-0 text-primary-500" />
+                  <span class="pc-sidebar__brand">Acme Inc</span>
+                  <.sidebar_trigger for="pg-sidebar" class="ml-auto" />
+                </:header>
+
+                <.sidebar_group label="Workspace">
+                  <.sidebar_item
+                    label="Dashboard"
+                    path="#"
+                    link_type="a"
+                    icon="hero-home"
+                    active
+                  />
+                  <.sidebar_item
+                    label="Inbox"
+                    path="#"
+                    link_type="a"
+                    icon="hero-inbox"
+                    badge={if @sidebar.badges, do: "12"}
+                  />
+                  <.sidebar_item
+                    label="Invoices"
+                    path="#"
+                    link_type="a"
+                    icon="hero-document-text"
+                    badge={if @sidebar.badges, do: "3"}
+                  />
+                </.sidebar_group>
+
+                <.sidebar_group id="pg-sidebar-acct" label="Account" collapsible>
+                  <.sidebar_item
+                    id="pg-sidebar-settings"
+                    label="Settings"
+                    icon="hero-cog-6-tooth"
+                    open
+                  >
+                    <.sidebar_item label="Profile" path="#" link_type="a" />
+                    <.sidebar_item label="Billing" path="#" link_type="a" />
+                  </.sidebar_item>
+                  <.sidebar_item label="Team" path="#" link_type="a" icon="hero-user-group" />
+                </.sidebar_group>
+
+                <:footer>
+                  <.sidebar_item
+                    label="Ada Lovelace"
+                    path="#"
+                    link_type="a"
+                    icon="hero-user-circle"
+                  />
+                </:footer>
+              </.sidebar>
+            </:sidebar>
+
+            <header class="flex items-center flex-none gap-3 px-4 border-b border-gray-200 h-14 dark:border-gray-800">
+              <.sidebar_trigger for="pg-sidebar" target="mobile" />
+              <span class="text-sm font-semibold">Dashboard</span>
+            </header>
+            <div class="p-4 text-sm text-gray-500 dark:text-gray-400">
+              Page content. Narrow the window below 768px and the sidebar becomes a sheet -
+              this region goes inert, Escape closes it, and focus returns to the burger.
+            </div>
+          </.sidebar_shell>
+        </div>
+
+        <div class="grid gap-5 px-6 py-5 border-t border-gray-100 md:grid-cols-2 dark:border-gray-800/80">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">collapsible</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Collapse mode"
+              value={@sidebar.collapsible}
+              on_change="ctl_sidebar"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={v <- ~w(icon offcanvas none)}
+                value={v}
+                phx-value-k="collapsible"
+                phx-value-v={v}
+              >
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">side</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Side"
+              value={@sidebar.side}
+              on_change="ctl_sidebar"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item :for={v <- ~w(left right)} value={v} phx-value-k="side" phx-value-v={v}>
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div class="md:col-span-2">
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">state</div>
+            <.toggle_group
+              multiple
+              variant="outline"
+              size="sm"
+              aria_label="State"
+              value={
+                for {k, on} <- [{"collapsed", @sidebar.collapsed}, {"badges", @sidebar.badges}],
+                    on,
+                    do: k
+              }
+              on_change="ctl_sidebar"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item value="collapsed" phx-value-k="collapsed">collapsed on first paint</:item>
+              <:item value="badges" phx-value-k="badges">badges</:item>
+            </.toggle_group>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-4 mt-3 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        The "collapsed on first paint" dial is the <code>collapsed</code>
+        attr - it is what the server renders, so a live_redirect can never flash the wrong
+        state. The toggle in the sidebar header is the client-side flip: it changes the DOM
+        without telling the server, which is why re-running a dial resets it. Persist the
+        choice by keeping it in your own assign and passing it back in.
+      </div>
+
+      <div :for={ex <- PetalComponents.Showcase.Sidebar.examples()} class="mt-10">
+        <h2 class="mb-1 text-lg font-semibold">{ex.title}</h2>
+        <p :if={ex.description} class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          {ex.description}
+        </p>
+        <.showcase_example example={ex} />
+      </div>
+
+      <h2 class="mt-10 mb-2 text-lg font-semibold">Properties</h2>
+      <.showcase_props
+        component={PetalComponents.Sidebar}
+        functions={[:sidebar_shell, :sidebar, :sidebar_group, :sidebar_item, :sidebar_trigger]}
+      />
+
+      <div class="p-4 mt-6 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        These examples render from the shared <code>PetalComponents.Showcase.Sidebar</code>
         registry - the same source petal.build renders, so the playground and the marketing
         docs can't drift.
       </div>

--- a/lib/petal_components.ex
+++ b/lib/petal_components.ex
@@ -64,6 +64,7 @@ defmodule PetalComponents do
         SocialButton,
         Sparkline,
         ShineBorder,
+        Sidebar,
         SpotlightCard,
         Stepper,
         Table,

--- a/lib/petal_components/showcase/registry.ex
+++ b/lib/petal_components/showcase/registry.ex
@@ -45,6 +45,7 @@ defmodule PetalComponents.Showcase.Registry do
     PetalComponents.Showcase.Progress,
     PetalComponents.Showcase.Rating,
     PetalComponents.Showcase.ShineBorder,
+    PetalComponents.Showcase.Sidebar,
     PetalComponents.Showcase.Skeleton,
     PetalComponents.Showcase.SlideOver,
     PetalComponents.Showcase.Sparkline,

--- a/lib/petal_components/showcase/sidebar.ex
+++ b/lib/petal_components/showcase/sidebar.ex
@@ -1,0 +1,158 @@
+defmodule PetalComponents.Showcase.Sidebar do
+  @moduledoc false
+  use PetalComponents.Showcase,
+    component: PetalComponents.Sidebar,
+    title: "Sidebar",
+    functions: [:sidebar_shell, :sidebar, :sidebar_group, :sidebar_item, :sidebar_trigger]
+
+  example :app_shell, "App shell",
+    description:
+      "The whole anatomy: a shell, a branded header, two labelled groups, icons and a badge, and a footer. The rail toggle in the header collapses it to icons - no server round trip." do
+    ~H"""
+    <.sidebar_shell
+      for="sb-shell"
+      class="h-[30rem] min-h-0 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
+    >
+      <:sidebar>
+        <.sidebar id="sb-shell" label="Main">
+          <:header>
+            <.icon name="hero-cube" class="w-5 h-5 shrink-0 text-primary-500" />
+            <span class="pc-sidebar__brand">Acme Inc</span>
+            <.sidebar_trigger for="sb-shell" class="ml-auto" />
+          </:header>
+
+          <.sidebar_group label="Workspace">
+            <.sidebar_item label="Dashboard" path="#" link_type="a" icon="hero-home" active />
+            <.sidebar_item label="Inbox" path="#" link_type="a" icon="hero-inbox" badge="12" />
+            <.sidebar_item label="Customers" path="#" link_type="a" icon="hero-users" />
+          </.sidebar_group>
+
+          <.sidebar_group label="Account">
+            <.sidebar_item label="Settings" icon="hero-cog-6-tooth" open>
+              <.sidebar_item label="Profile" path="#" link_type="a" />
+              <.sidebar_item label="Billing" path="#" link_type="a" />
+            </.sidebar_item>
+            <.sidebar_item label="Team" path="#" link_type="a" icon="hero-user-group" />
+          </.sidebar_group>
+
+          <:footer>
+            <.sidebar_item
+              label="Sign out"
+              path="#"
+              link_type="a"
+              icon="hero-arrow-left-start-on-rectangle"
+            />
+          </:footer>
+        </.sidebar>
+      </:sidebar>
+
+      <header class="flex items-center flex-none gap-3 px-4 border-b border-gray-200 h-14 dark:border-gray-800">
+        <.sidebar_trigger for="sb-shell" target="mobile" />
+        <span class="text-sm font-semibold">Dashboard</span>
+      </header>
+      <div class="p-4 text-sm text-gray-500 dark:text-gray-400">
+        Your page content lives here. It is marked inert while the mobile sheet is open.
+      </div>
+    </.sidebar_shell>
+    """
+  end
+
+  example :collapsed_rail, "Collapsed rail",
+    description:
+      "collapsible=\"icon\" with collapsed set - the rail the app renders on first paint. Labels drop to screen-reader-only text and the title attribute carries them on hover, so nothing is lost." do
+    ~H"""
+    <.sidebar_shell
+      for="sb-rail"
+      class="h-[22rem] min-h-0 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
+    >
+      <:sidebar>
+        <.sidebar id="sb-rail" label="Compact" collapsible="icon" collapsed>
+          <:header>
+            <.icon name="hero-cube" class="w-5 h-5 shrink-0 text-primary-500" />
+            <span class="pc-sidebar__brand">Acme</span>
+          </:header>
+
+          <.sidebar_group label="Workspace">
+            <.sidebar_item label="Dashboard" path="#" link_type="a" icon="hero-home" active />
+            <.sidebar_item label="Inbox" path="#" link_type="a" icon="hero-inbox" badge="12" />
+            <.sidebar_item label="Customers" path="#" link_type="a" icon="hero-users" />
+          </.sidebar_group>
+
+          <:footer>
+            <.sidebar_trigger for="sb-rail" class="mx-auto" />
+          </:footer>
+        </.sidebar>
+      </:sidebar>
+
+      <div class="p-4 text-sm text-gray-500 dark:text-gray-400">
+        Hit the toggle at the bottom of the rail to expand it back out.
+      </div>
+    </.sidebar_shell>
+    """
+  end
+
+  example :collapsible_groups, "Collapsible groups",
+    description:
+      "Groups follow the WAI-ARIA disclosure pattern: the label becomes a button carrying aria-expanded, and the run of items it controls is hidden or shown by CSS." do
+    ~H"""
+    <.sidebar_shell
+      for="sb-groups"
+      class="h-[22rem] min-h-0 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
+    >
+      <:sidebar>
+        <.sidebar id="sb-groups" label="Docs" collapsible="none">
+          <.sidebar_group label="Getting started" collapsible open>
+            <.sidebar_item label="Installation" path="#" link_type="a" active />
+            <.sidebar_item label="Theming" path="#" link_type="a" />
+          </.sidebar_group>
+
+          <.sidebar_group label="Components" collapsible open={false}>
+            <.sidebar_item label="Button" path="#" link_type="a" />
+            <.sidebar_item label="Modal" path="#" link_type="a" />
+            <.sidebar_item label="Table" path="#" link_type="a" />
+          </.sidebar_group>
+
+          <.sidebar_group>
+            <.sidebar_item label="Changelog" path="#" link_type="a" icon="hero-sparkles" />
+          </.sidebar_group>
+        </.sidebar>
+      </:sidebar>
+
+      <div class="p-4 text-sm text-gray-500 dark:text-gray-400">
+        Click a group label to collapse it. collapsible="none" pins this sidebar open at every width.
+      </div>
+    </.sidebar_shell>
+    """
+  end
+
+  example :inspector, "Right-hand inspector",
+    description:
+      "side=\"right\" plus an offcanvas mode gives you an inspector panel. Two sidebars in one shell just need different ids - their state never crosses." do
+    ~H"""
+    <.sidebar_shell
+      for="sb-inspector"
+      class="h-[20rem] min-h-0 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
+    >
+      <:sidebar>
+        <.sidebar id="sb-inspector" label="Inspector" side="right" collapsible="offcanvas">
+          <:header>
+            <span class="pc-sidebar__brand">Properties</span>
+            <.sidebar_trigger for="sb-inspector" class="ml-auto" label="Hide inspector" />
+          </:header>
+
+          <.sidebar_group label="Layer">
+            <.sidebar_item label="Fill" path="#" link_type="a" icon="hero-swatch" active />
+            <.sidebar_item label="Stroke" path="#" link_type="a" icon="hero-pencil" />
+            <.sidebar_item label="Effects" path="#" link_type="a" icon="hero-sparkles" />
+          </.sidebar_group>
+        </.sidebar>
+      </:sidebar>
+
+      <div class="flex items-center gap-3 p-4">
+        <.sidebar_trigger for="sb-inspector" label="Show inspector" />
+        <span class="text-sm text-gray-500 dark:text-gray-400">Canvas</span>
+      </div>
+    </.sidebar_shell>
+    """
+  end
+end

--- a/lib/petal_components/sidebar.ex
+++ b/lib/petal_components/sidebar.ex
@@ -1,0 +1,478 @@
+defmodule PetalComponents.Sidebar do
+  @moduledoc """
+  The app-shell navigation sidebar: a fixed rail of grouped links that collapses
+  to icons on desktop and takes over as a sheet on mobile.
+
+  Five function components compose the shell:
+
+    * `sidebar_shell/1` - the flex wrapper holding the sidebar and your page content
+    * `sidebar/1` - the `<nav>` landmark itself, with header/footer slots
+    * `sidebar_group/1` - a labelled (optionally collapsible) run of items
+    * `sidebar_item/1` - one link, or a parent with nested sub-items
+    * `sidebar_trigger/1` - the button that collapses the rail or opens the sheet
+
+  ## Usage
+
+      <.sidebar_shell for="app-sidebar">
+        <:sidebar>
+          <.sidebar id="app-sidebar" label="Main" collapsible="icon">
+            <:header>
+              <.icon name="hero-cube" class="w-6 h-6 shrink-0" />
+              <span class="pc-sidebar__brand">Acme</span>
+            </:header>
+
+            <.sidebar_group label="Workspace">
+              <.sidebar_item label="Dashboard" path="/" icon="hero-home" active />
+              <.sidebar_item label="Inbox" path="/inbox" icon="hero-inbox" badge="12" />
+            </.sidebar_group>
+
+            <.sidebar_group label="Account" collapsible open>
+              <.sidebar_item label="Settings" icon="hero-cog-6-tooth">
+                <.sidebar_item label="Profile" path="/settings/profile" />
+                <.sidebar_item label="Billing" path="/settings/billing" />
+              </.sidebar_item>
+            </.sidebar_group>
+
+            <:footer>
+              <.sidebar_item label="Sign out" path="/sign-out" icon="hero-arrow-left-start-on-rectangle" />
+            </:footer>
+          </.sidebar>
+        </:sidebar>
+
+        <header class="flex items-center gap-3 p-4">
+          <.sidebar_trigger for="app-sidebar" target="mobile" />
+          <h1>Dashboard</h1>
+        </header>
+        <main class="p-4">Your page</main>
+      </.sidebar_shell>
+
+  ## Collapse and state
+
+  Collapse is client-side by design: `sidebar_trigger/1` flips a `data-collapsed`
+  attribute on the sidebar with `Phoenix.LiveView.JS`, and CSS does the rest. No
+  round trip, no hook.
+
+  The server still owns the *initial* value through the `collapsed` attr, so the
+  first paint is already correct and a `live_redirect` cannot flash the wrong
+  state - the attribute is rendered, not read back from the client. To persist
+  the choice across navigation, keep it in your own assign (or a session cookie
+  you read in the plug pipeline) and pass it back in:
+
+      <.sidebar id="app-sidebar" collapsed={@sidebar_collapsed}>
+
+  ...then have the trigger tell the server as well as the DOM:
+
+      <.sidebar_trigger for="app-sidebar" on_click={JS.push("toggle_sidebar")} />
+
+  ## Responsive behaviour
+
+  Below the `md` breakpoint (768px) a `collapsible="icon"` or `"offcanvas"`
+  sidebar leaves the flow entirely and becomes an off-canvas sheet, opened by a
+  `target="mobile"` trigger. While the sheet is open the shell's content region
+  is marked `inert`, Escape closes it, clicking the scrim closes it, and focus
+  returns to the trigger. `collapsible="none"` stays put at every width.
+
+  ## Theming
+
+  The sidebar reads two custom properties, so apps can retune widths without
+  touching `pc-*` internals:
+
+      .pc-sidebar { --pc-sidebar-width: 18rem; --pc-sidebar-icon-width: 4.5rem; }
+
+  The breakpoint is fixed at `md` in this version; CSS media queries cannot read
+  custom properties.
+  """
+  use Phoenix.Component
+
+  import PetalComponents.Helpers, only: [compose_js: 2, uniq_id: 2]
+  import PetalComponents.Icon
+  import PetalComponents.Link
+
+  alias Phoenix.LiveView.JS
+
+  attr :for, :string,
+    required: true,
+    doc:
+      "id of the `sidebar/1` this shell wraps. The content region is rendered as `<for>-main` so the trigger can mark it inert while the mobile sheet is open"
+
+  attr :class, :any, default: nil, doc: "CSS class for the shell wrapper"
+  attr :rest, :global
+
+  slot :sidebar, required: true, doc: "the `sidebar/1` itself"
+
+  slot :inner_block,
+    required: true,
+    doc:
+      "everything else in the shell - topbar, page content. Marked inert while the sheet is open"
+
+  @doc """
+  The app shell: a flex row holding the sidebar beside your page content.
+
+  Optional - a `sidebar/1` works inside your own layout too - but the shell is
+  what gives the mobile sheet something to mark `inert`, so use it if you want
+  the accessible sheet behaviour for free.
+  """
+  def sidebar_shell(assigns) do
+    assigns = assign(assigns, :main_id, "#{Map.fetch!(assigns, :for)}-main")
+
+    ~H"""
+    <div class={["pc-sidebar-shell", @class]} {@rest}>
+      {render_slot(@sidebar)}
+      <div id={@main_id} class="pc-sidebar-shell__main">
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
+  end
+
+  attr :id, :string, required: true, doc: "unique id - `sidebar_trigger/1` targets this"
+
+  attr :label, :string,
+    default: "Sidebar",
+    doc: "accessible name for the nav landmark (`aria-label`)"
+
+  attr :side, :string,
+    default: "left",
+    values: ["left", "right"],
+    doc: "which edge the sidebar sits on. Two sidebars in one shell just need different ids"
+
+  attr :collapsible, :string,
+    default: "icon",
+    values: ["icon", "offcanvas", "none"],
+    doc:
+      "icon collapses to a rail of icons, offcanvas hides it completely, none pins it open at every width"
+
+  attr :collapsed, :boolean,
+    default: false,
+    doc: "initial collapsed state, rendered server-side so the first paint is never wrong"
+
+  attr :on_close, JS,
+    default: %JS{},
+    doc: "additional JS commands to run when the mobile sheet closes (LiveView.JS only)"
+
+  attr :class, :any, default: nil, doc: "CSS class for the sidebar"
+  attr :rest, :global
+
+  slot :header, doc: "pinned top area - logo, workspace switcher"
+  slot :footer, doc: "pinned bottom area, typically a user menu"
+  slot :inner_block, required: true, doc: "`sidebar_group/1` and `sidebar_item/1` content"
+
+  @doc """
+  The sidebar itself: a `<nav>` landmark wrapped in the collapse/sheet machinery.
+  """
+  def sidebar(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      class={["pc-sidebar", @class]}
+      data-side={@side}
+      data-collapsible={@collapsible}
+      data-collapsed={to_string(@collapsed)}
+      data-mobile-open="false"
+      data-close={hide_sidebar(@on_close, @id)}
+      phx-window-keydown={JS.exec("data-close", to: "##{@id}[data-mobile-open='true']")}
+      phx-key="escape"
+      {@rest}
+    >
+      <div
+        class="pc-sidebar__scrim"
+        aria-hidden="true"
+        phx-click={JS.exec("data-close", to: "##{@id}")}
+      >
+      </div>
+
+      <.focus_wrap id={"#{@id}-panel"} class="pc-sidebar__panel">
+        <nav class="pc-sidebar__nav" aria-label={@label}>
+          <div :if={@header != []} class="pc-sidebar__header">
+            {render_slot(@header)}
+          </div>
+
+          <div class="pc-sidebar__content">
+            {render_slot(@inner_block)}
+          </div>
+
+          <div :if={@footer != []} class="pc-sidebar__footer">
+            {render_slot(@footer)}
+          </div>
+        </nav>
+      </.focus_wrap>
+    </div>
+    """
+  end
+
+  attr :id, :string, default: nil, doc: "defaults to a slug of the label"
+  attr :label, :string, default: nil, doc: "group heading. Omit for an unlabelled run of items"
+
+  attr :collapsible, :boolean,
+    default: false,
+    doc: "turns the label into a disclosure button (WAI-ARIA disclosure pattern)"
+
+  attr :open, :boolean, default: true, doc: "initial state when collapsible"
+
+  attr :on_toggle, JS,
+    default: %JS{},
+    doc: "additional JS commands to run when the group is toggled (LiveView.JS only)"
+
+  attr :class, :any, default: nil, doc: "CSS class for the group"
+  attr :rest, :global
+
+  slot :inner_block, required: true, doc: "`sidebar_item/1` children"
+
+  @doc """
+  A labelled run of items. Pass `collapsible` to make the label a disclosure toggle.
+  """
+  def sidebar_group(assigns) do
+    # `attr default: nil` already puts :id in assigns, so assign_new would no-op.
+    assigns =
+      assign(assigns, :id, assigns.id || uniq_id(assigns.label || "group", "pc-sidebar-group"))
+
+    ~H"""
+    <div class={["pc-sidebar-group", @class]} {@rest}>
+      <button
+        :if={@label && @collapsible}
+        type="button"
+        class="pc-sidebar-group__toggle"
+        aria-expanded={to_string(@open)}
+        aria-controls={"#{@id}-items"}
+        phx-click={toggle_group(@on_toggle, @id)}
+      >
+        <span class="pc-sidebar-group__label">{@label}</span>
+        <.icon name="hero-chevron-right" class="pc-sidebar-group__chevron" />
+      </button>
+
+      <div :if={@label && !@collapsible} class="pc-sidebar-group__label">{@label}</div>
+
+      <div id={"#{@id}-items"} class="pc-sidebar-group__items" data-open={to_string(@open)}>
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
+  end
+
+  attr :id, :string, default: nil, doc: "defaults to a slug of the label"
+
+  attr :label, :string,
+    required: true,
+    doc: "the item text. Kept for screen readers when collapsed"
+
+  attr :path, :string, default: nil, doc: "where the item links to. Omit when it has sub-items"
+
+  attr :icon, :any,
+    default: nil,
+    doc:
+      ~s|a heroicon name ("hero-home"), a function component, or a raw SVG string - the house icon convention|
+
+  attr :active, :boolean,
+    default: false,
+    doc:
+      "marks the current page. Emits `aria-current=\"page\"`. Your app decides, never the component"
+
+  attr :badge, :string, default: nil, doc: "trailing badge text, e.g. an unread count"
+
+  attr :link_type, :string,
+    default: "live_redirect",
+    values: ["live_redirect", "live_patch", "a", "button"],
+    doc: "how the item navigates, matching `PetalComponents.Link.a/1`"
+
+  attr :open, :boolean, default: false, doc: "initial state of the sub-menu, when it has one"
+
+  attr :on_toggle, JS,
+    default: %JS{},
+    doc: "additional JS commands to run when the sub-menu is toggled (LiveView.JS only)"
+
+  attr :class, :any, default: nil, doc: "CSS class for the item"
+  attr :rest, :global
+
+  slot :inner_block, doc: "nested `sidebar_item/1` children. Turns the item into a disclosure"
+
+  @doc """
+  One navigation item: icon, label, optional badge, optional nested sub-items.
+  """
+  def sidebar_item(%{inner_block: []} = assigns) do
+    ~H"""
+    <.a
+      to={@path}
+      link_type={@link_type}
+      class={["pc-sidebar-item", @active && "pc-sidebar-item--active", @class]}
+      title={@label}
+      aria-current={@active && "page"}
+      {@rest}
+    >
+      <.sidebar_icon :if={@icon} icon={@icon} />
+      <span class="pc-sidebar-item__label">{@label}</span>
+      <span :if={@badge} class="pc-sidebar-item__badge">{@badge}</span>
+    </.a>
+    """
+  end
+
+  def sidebar_item(assigns) do
+    assigns = assign(assigns, :id, assigns.id || uniq_id(assigns.label, "pc-sidebar-item"))
+
+    ~H"""
+    <div class="pc-sidebar-item__parent">
+      <button
+        type="button"
+        class={["pc-sidebar-item", @active && "pc-sidebar-item--active", @class]}
+        title={@label}
+        aria-expanded={to_string(@open)}
+        aria-controls={"#{@id}-sub"}
+        phx-click={toggle_group(@on_toggle, @id)}
+        {@rest}
+      >
+        <.sidebar_icon :if={@icon} icon={@icon} />
+        <span class="pc-sidebar-item__label">{@label}</span>
+        <span :if={@badge} class="pc-sidebar-item__badge">{@badge}</span>
+        <.icon name="hero-chevron-right" class="pc-sidebar-item__chevron" />
+      </button>
+
+      <div id={"#{@id}-sub"} class="pc-sidebar-item__sub" data-open={to_string(@open)}>
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
+  end
+
+  attr :for, :string, required: true, doc: "id of the `sidebar/1` this button controls"
+
+  attr :id, :string,
+    default: nil,
+    doc:
+      ~s|a `target="mobile"` trigger defaults to `"<for>-trigger"`, which is where focus returns when the sheet closes. Collapse triggers get no id by default, so a shell can carry both without colliding|
+
+  attr :target, :string,
+    default: "collapse",
+    values: ["collapse", "mobile"],
+    doc:
+      "collapse toggles the desktop rail (hidden below md); mobile opens the off-canvas sheet (hidden from md up)"
+
+  attr :label, :string, default: "Toggle sidebar", doc: "accessible name for the button"
+
+  attr :on_click, JS,
+    default: %JS{},
+    doc:
+      "additional JS commands to run on click - e.g. `JS.push(\"toggle_sidebar\")` to mirror the state server-side"
+
+  attr :class, :any, default: nil, doc: "CSS class for the trigger"
+  attr :rest, :global
+
+  slot :inner_block, doc: "custom button content. Defaults to a hamburger/panel icon"
+
+  @doc """
+  The button that collapses the rail (`target="collapse"`) or opens the mobile
+  sheet (`target="mobile"`).
+  """
+  def sidebar_trigger(assigns) do
+    # Only the mobile trigger claims the derived id: it is where hide_sidebar/2
+    # restores focus to, so exactly one element may hold it. A shell commonly has
+    # both a burger and a rail toggle pointing at the same sidebar, and giving
+    # them the same default id would duplicate it.
+    assigns =
+      assign(
+        assigns,
+        :id,
+        assigns.id || if(assigns.target == "mobile", do: "#{Map.fetch!(assigns, :for)}-trigger")
+      )
+
+    ~H"""
+    <button
+      id={@id}
+      type="button"
+      class={["pc-sidebar-trigger", "pc-sidebar-trigger--#{@target}", @class]}
+      aria-label={@label}
+      aria-controls={@for}
+      aria-expanded={@target == "mobile" && "false"}
+      phx-click={
+        if @target == "mobile",
+          do: show_sidebar(@on_click, @for),
+          else: toggle_sidebar(@on_click, @for)
+      }
+      {@rest}
+    >
+      <%= if @inner_block != [] do %>
+        {render_slot(@inner_block)}
+      <% else %>
+        <.icon
+          name={if @target == "mobile", do: "hero-bars-3", else: "hero-view-columns"}
+          class="pc-sidebar-trigger__icon"
+        />
+      <% end %>
+    </button>
+    """
+  end
+
+  @doc """
+  Toggles the desktop collapsed state of the sidebar with the given id.
+
+  Pure client-side: flips `data-collapsed` and lets CSS do the work.
+  """
+  def toggle_sidebar(js \\ %JS{}, id) do
+    compose_js(
+      js,
+      JS.toggle_attribute({"data-collapsed", "true", "false"}, to: "##{id}")
+    )
+  end
+
+  @doc """
+  Opens the mobile sheet for the sidebar with the given id.
+
+  Marks the shell's content region inert, locks body scroll and moves focus into
+  the nav.
+  """
+  def show_sidebar(js \\ %JS{}, id) do
+    compose_js(
+      js,
+      %JS{}
+      |> JS.set_attribute({"data-mobile-open", "true"}, to: "##{id}")
+      |> JS.set_attribute({"aria-expanded", "true"}, to: "##{id}-trigger")
+      |> JS.set_attribute({"inert", ""}, to: "##{id}-main")
+      |> JS.add_class("overflow-hidden", to: "body")
+      |> JS.focus_first(to: "##{id} .pc-sidebar__nav")
+    )
+  end
+
+  @doc """
+  Closes the mobile sheet for the sidebar with the given id and restores focus to
+  its trigger.
+  """
+  def hide_sidebar(js \\ %JS{}, id) do
+    compose_js(
+      js,
+      %JS{}
+      |> JS.set_attribute({"data-mobile-open", "false"}, to: "##{id}")
+      |> JS.set_attribute({"aria-expanded", "false"}, to: "##{id}-trigger")
+      |> JS.remove_attribute("inert", to: "##{id}-main")
+      |> JS.remove_class("overflow-hidden", to: "body")
+      |> JS.focus(to: "##{id}-trigger")
+    )
+  end
+
+  # Disclosure toggle shared by groups and parent items: flip aria-expanded on
+  # the button that was clicked, and data-open on the panel it controls.
+  defp toggle_group(js, id) do
+    compose_js(
+      js,
+      %JS{}
+      |> JS.toggle_attribute({"aria-expanded", "true", "false"})
+      |> JS.toggle_attribute({"data-open", "true", "false"}, to: "##{id}-sub, ##{id}-items")
+    )
+  end
+
+  attr :icon, :any, required: true
+
+  defp sidebar_icon(assigns) do
+    ~H"""
+    <%= cond do %>
+      <% is_function(@icon) -> %>
+        {Phoenix.LiveView.TagEngine.component(
+          @icon,
+          [class: "pc-sidebar-item__icon"],
+          {__ENV__.module, __ENV__.function, __ENV__.file, __ENV__.line}
+        )}
+      <% is_binary(@icon) and String.match?(@icon, ~r/svg|img/) -> %>
+        <span class="pc-sidebar-item__icon">{Phoenix.HTML.raw(@icon)}</span>
+      <% true -> %>
+        <.icon name={@icon} class="pc-sidebar-item__icon" />
+    <% end %>
+    """
+  end
+end

--- a/test/petal/sidebar_test.exs
+++ b/test/petal/sidebar_test.exs
@@ -1,0 +1,826 @@
+defmodule PetalComponents.SidebarTest do
+  use ComponentCase
+
+  import PetalComponents.Sidebar
+
+  defp query(html, selector) do
+    html |> LazyHTML.from_fragment() |> LazyHTML.query(selector)
+  end
+
+  defp attr_of(html, selector, attribute) do
+    html |> query(selector) |> LazyHTML.attribute(attribute) |> List.first()
+  end
+
+  describe "sidebar_shell/1" do
+    test "wraps the sidebar slot beside an inert-able main region" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_shell for="sb">
+          <:sidebar><span>the rail</span></:sidebar>
+          <p>page content</p>
+        </.sidebar_shell>
+        """)
+
+      assert html =~ "pc-sidebar-shell"
+      assert html =~ "the rail"
+      assert html =~ "page content"
+      # The trigger targets this id to toggle inert while the sheet is open.
+      assert attr_of(html, ".pc-sidebar-shell__main", "id") == "sb-main"
+    end
+
+    test "class is appended, not replaced, so consumer utilities win" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_shell for="sb" class="h-96" data-testid="shell">
+          <:sidebar>rail</:sidebar>
+          main
+        </.sidebar_shell>
+        """)
+
+      classes = attr_of(html, "div.pc-sidebar-shell", "class")
+      assert classes =~ "pc-sidebar-shell"
+      assert classes =~ "h-96"
+      assert html =~ ~s(data-testid="shell")
+    end
+  end
+
+  describe "sidebar/1" do
+    test "renders a nav landmark with an accessible name" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar id="sb" label="Primary">
+          <span>items</span>
+        </.sidebar>
+        """)
+
+      assert attr_of(html, "nav.pc-sidebar__nav", "aria-label") == "Primary"
+    end
+
+    test "label defaults to Sidebar" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar id="sb">items</.sidebar>
+        """)
+
+      assert attr_of(html, "nav.pc-sidebar__nav", "aria-label") == "Sidebar"
+    end
+
+    test "state rides on data attributes with sane defaults" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar id="sb">items</.sidebar>
+        """)
+
+      assert attr_of(html, "#sb", "data-side") == "left"
+      assert attr_of(html, "#sb", "data-collapsible") == "icon"
+      assert attr_of(html, "#sb", "data-collapsed") == "false"
+      assert attr_of(html, "#sb", "data-mobile-open") == "false"
+    end
+
+    test "collapsed is rendered server-side, so the first paint is already the rail" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar id="sb" collapsed>items</.sidebar>
+        """)
+
+      assert attr_of(html, "#sb", "data-collapsed") == "true"
+    end
+
+    for mode <- ~w(icon offcanvas none) do
+      test "collapsible=#{mode} is emitted as a data attribute" do
+        assigns = %{mode: unquote(mode)}
+
+        html =
+          rendered_to_string(~H"""
+          <.sidebar id="sb" collapsible={@mode}>items</.sidebar>
+          """)
+
+        assert attr_of(html, "#sb", "data-collapsible") == unquote(mode)
+      end
+    end
+
+    for side <- ~w(left right) do
+      test "side=#{side} is emitted as a data attribute" do
+        assigns = %{side: unquote(side)}
+
+        html =
+          rendered_to_string(~H"""
+          <.sidebar id="sb" side={@side}>items</.sidebar>
+          """)
+
+        assert attr_of(html, "#sb", "data-side") == unquote(side)
+      end
+    end
+
+    test "header and footer slots render only when given" do
+      assigns = %{}
+
+      bare =
+        rendered_to_string(~H"""
+        <.sidebar id="sb">body</.sidebar>
+        """)
+
+      refute bare =~ "pc-sidebar__header"
+      refute bare =~ "pc-sidebar__footer"
+      assert bare =~ "body"
+
+      full =
+        rendered_to_string(~H"""
+        <.sidebar id="sb">
+          <:header>brand</:header>
+          body
+          <:footer>user menu</:footer>
+        </.sidebar>
+        """)
+
+      assert full =~ "pc-sidebar__header"
+      assert full =~ "brand"
+      assert full =~ "pc-sidebar__footer"
+      assert full =~ "user menu"
+    end
+
+    test "the mobile sheet is fenced, escapable and dismissable by scrim" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar id="sb">items</.sidebar>
+        """)
+
+      # focus containment: LiveView's focus_wrap around the panel
+      assert attr_of(html, ".pc-sidebar__panel", "phx-hook") == "Phoenix.FocusWrap"
+      assert attr_of(html, ".pc-sidebar__panel", "id") == "sb-panel"
+
+      # Escape closes, but only while the sheet is actually open - the exec
+      # selector is gated on data-mobile-open so Escape on desktop is a no-op.
+      assert attr_of(html, "#sb", "phx-key") == "escape"
+      keydown = attr_of(html, "#sb", "phx-window-keydown")
+      assert keydown =~ "exec"
+      assert keydown =~ "data-close"
+      assert keydown =~ ~s(sb[data-mobile-open=)
+
+      # scrim click closes
+      assert query(html, ".pc-sidebar__scrim") |> Enum.count() == 1
+      assert attr_of(html, ".pc-sidebar__scrim", "aria-hidden") == "true"
+      assert attr_of(html, ".pc-sidebar__scrim", "phx-click") =~ "data-close"
+    end
+
+    test "the close command clears inert, unlocks scroll and restores focus to the trigger" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar id="sb">items</.sidebar>
+        """)
+
+      close = attr_of(html, "#sb", "data-close")
+
+      assert close =~ ~s(data-mobile-open)
+      assert close =~ "remove_attr"
+      assert close =~ "inert"
+      assert close =~ "sb-main"
+      assert close =~ "overflow-hidden"
+      assert close =~ "focus"
+      assert close =~ "sb-trigger"
+    end
+
+    test "on_close JS is composed ahead of the component's own commands" do
+      assigns = %{js: Phoenix.LiveView.JS.push("sidebar_closed")}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar id="sb" on_close={@js}>items</.sidebar>
+        """)
+
+      assert attr_of(html, "#sb", "data-close") =~ "sidebar_closed"
+    end
+
+    test "two sidebars in one page do not cross-wire" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <div>
+          <.sidebar id="left-sb">a</.sidebar>
+          <.sidebar id="right-sb" side="right">b</.sidebar>
+        </div>
+        """)
+
+      assert attr_of(html, "#left-sb", "data-close") =~ "left-sb-main"
+      refute attr_of(html, "#left-sb", "data-close") =~ "right-sb"
+      assert attr_of(html, "#right-sb", "data-close") =~ "right-sb-main"
+      refute attr_of(html, "#right-sb", "data-close") =~ "left-sb-main"
+    end
+
+    test "class and global attrs pass through" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar id="sb" class="w-72" data-testid="sb">items</.sidebar>
+        """)
+
+      assert attr_of(html, "#sb", "class") =~ "pc-sidebar"
+      assert attr_of(html, "#sb", "class") =~ "w-72"
+      assert attr_of(html, "#sb", "data-testid") == "sb"
+    end
+  end
+
+  describe "sidebar_group/1" do
+    test "renders a plain label when not collapsible" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_group label="Workspace">items</.sidebar_group>
+        """)
+
+      assert html =~ "Workspace"
+      assert query(html, "button.pc-sidebar-group__toggle") |> Enum.empty?()
+      assert query(html, "div.pc-sidebar-group__label") |> Enum.count() == 1
+    end
+
+    test "an unlabelled group renders no heading at all" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_group>items</.sidebar_group>
+        """)
+
+      refute html =~ "pc-sidebar-group__label"
+      assert html =~ "items"
+    end
+
+    test "collapsible groups follow the disclosure pattern" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_group id="grp" label="Account" collapsible>items</.sidebar_group>
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-group__toggle", "aria-expanded") == "true"
+      assert attr_of(html, "button.pc-sidebar-group__toggle", "aria-controls") == "grp-items"
+      assert attr_of(html, "#grp-items", "data-open") == "true"
+    end
+
+    test "open={false} renders a closed disclosure" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_group id="grp" label="Account" collapsible open={false}>items</.sidebar_group>
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-group__toggle", "aria-expanded") == "false"
+      assert attr_of(html, "#grp-items", "data-open") == "false"
+    end
+
+    test "the toggle flips aria-expanded and the panel together" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_group id="grp" label="Account" collapsible>items</.sidebar_group>
+        """)
+
+      click = attr_of(html, "button.pc-sidebar-group__toggle", "phx-click")
+      assert click =~ "aria-expanded"
+      assert click =~ "grp-items"
+      # CSS-first: a JS attribute flip, no hook.
+      refute click =~ "phx-hook"
+    end
+
+    test "on_toggle JS is composed in" do
+      assigns = %{js: Phoenix.LiveView.JS.push("group_toggled")}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_group id="grp" label="Account" collapsible on_toggle={@js}>items</.sidebar_group>
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-group__toggle", "phx-click") =~ "group_toggled"
+    end
+
+    test "id falls back to a slug of the label" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_group label="Account" collapsible>items</.sidebar_group>
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-group__toggle", "aria-controls") =~
+               "pc-sidebar-group-account"
+    end
+
+    test "class and global attrs pass through" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_group label="A" class="mt-6" data-testid="grp">items</.sidebar_group>
+        """)
+
+      assert attr_of(html, ".pc-sidebar-group", "class") =~ "mt-6"
+      assert attr_of(html, ".pc-sidebar-group", "data-testid") == "grp"
+    end
+  end
+
+  describe "sidebar_item/1" do
+    test "renders a link with its label kept for screen readers" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Dashboard" path="/dash" />
+        """)
+
+      assert attr_of(html, "a.pc-sidebar-item", "href") == "/dash"
+      assert html =~ "Dashboard"
+      # the collapsed rail hides the label visually, so title carries it on hover
+      assert attr_of(html, "a.pc-sidebar-item", "title") == "Dashboard"
+    end
+
+    test "the active item is marked with aria-current=page" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Dashboard" path="/dash" active />
+        """)
+
+      assert attr_of(html, "a.pc-sidebar-item", "aria-current") == "page"
+      assert attr_of(html, "a.pc-sidebar-item", "class") =~ "pc-sidebar-item--active"
+    end
+
+    test "an inactive item emits no aria-current" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Dashboard" path="/dash" />
+        """)
+
+      assert attr_of(html, "a.pc-sidebar-item", "aria-current") == nil
+      refute html =~ "pc-sidebar-item--active"
+    end
+
+    test "renders a heroicon by name" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Home" path="/" icon="hero-home" />
+        """)
+
+      assert has_icon?(html)
+      assert html =~ "pc-sidebar-item__icon"
+    end
+
+    test "renders a function component icon" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Home" path="/" icon={&custom_icon/1} />
+        """)
+
+      assert html =~ "custom-icon-svg"
+      assert html =~ "pc-sidebar-item__icon"
+    end
+
+    test "renders a raw svg string icon" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Home" path="/" icon="<svg id='raw-icon'></svg>" />
+        """)
+
+      assert html =~ "raw-icon"
+    end
+
+    test "no icon renders no icon element" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Home" path="/" />
+        """)
+
+      refute html =~ "pc-sidebar-item__icon"
+    end
+
+    test "a badge renders trailing text" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Inbox" path="/inbox" badge="12" />
+        """)
+
+      assert query(html, ".pc-sidebar-item__badge") |> LazyHTML.text() == "12"
+    end
+
+    test "no badge renders no badge element" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Inbox" path="/inbox" />
+        """)
+
+      refute html =~ "pc-sidebar-item__badge"
+    end
+
+    test "link_type=live_redirect (the default) navigates" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Home" path="/" />
+        """)
+
+      assert attr_of(html, "a.pc-sidebar-item", "data-phx-link") == "redirect"
+    end
+
+    test "link_type=live_patch patches" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Home" path="/" link_type="live_patch" />
+        """)
+
+      assert attr_of(html, "a.pc-sidebar-item", "data-phx-link") == "patch"
+    end
+
+    test "link_type=a renders a plain anchor" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Home" path="/" link_type="a" />
+        """)
+
+      assert attr_of(html, "a.pc-sidebar-item", "href") == "/"
+      assert attr_of(html, "a.pc-sidebar-item", "data-phx-link") == nil
+    end
+
+    test "link_type=button renders a button" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Sign out" link_type="button" phx-click="sign_out" />
+        """)
+
+      assert query(html, "button.pc-sidebar-item") |> Enum.count() == 1
+      assert html =~ ~s(phx-click="sign_out")
+    end
+
+    test "nested sub-items turn the item into a disclosure" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item id="settings" label="Settings" icon="hero-cog-6-tooth">
+          <.sidebar_item label="Profile" path="/profile" />
+          <.sidebar_item label="Billing" path="/billing" />
+        </.sidebar_item>
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-item", "aria-expanded") == "false"
+      assert attr_of(html, "button.pc-sidebar-item", "aria-controls") == "settings-sub"
+      assert attr_of(html, "#settings-sub", "data-open") == "false"
+      assert attr_of(html, "#settings-sub", "class") =~ "pc-sidebar-item__sub"
+
+      # the children are ordinary items
+      assert query(html, "#settings-sub a.pc-sidebar-item") |> Enum.count() == 2
+      assert html =~ "Profile"
+      assert html =~ "Billing"
+    end
+
+    test "an open sub-menu renders expanded" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item id="settings" label="Settings" open>
+          <.sidebar_item label="Profile" path="/profile" active />
+        </.sidebar_item>
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-item", "aria-expanded") == "true"
+      assert attr_of(html, "#settings-sub", "data-open") == "true"
+      # a nested item still carries aria-current
+      assert attr_of(html, "#settings-sub a.pc-sidebar-item", "aria-current") == "page"
+    end
+
+    test "a parent item can be active and badged too" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item id="settings" label="Settings" active badge="3">
+          <.sidebar_item label="Profile" path="/profile" />
+        </.sidebar_item>
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-item", "class") =~ "pc-sidebar-item--active"
+      assert query(html, ".pc-sidebar-item__badge") |> LazyHTML.text() == "3"
+    end
+
+    test "the sub-menu toggle is a JS attribute flip, not a hook" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item id="settings" label="Settings">
+          <.sidebar_item label="Profile" path="/profile" />
+        </.sidebar_item>
+        """)
+
+      click = attr_of(html, "button.pc-sidebar-item", "phx-click")
+      assert click =~ "aria-expanded"
+      assert click =~ "settings-sub"
+      refute html =~ "phx-hook"
+    end
+
+    test "on_toggle JS is composed into the sub-menu toggle" do
+      assigns = %{js: Phoenix.LiveView.JS.push("submenu_toggled")}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item id="settings" label="Settings" on_toggle={@js}>
+          <.sidebar_item label="Profile" path="/profile" />
+        </.sidebar_item>
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-item", "phx-click") =~ "submenu_toggled"
+    end
+
+    test "class and global attrs pass through" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_item label="Home" path="/" class="font-bold" data-testid="item" />
+        """)
+
+      assert attr_of(html, "a.pc-sidebar-item", "class") =~ "font-bold"
+      assert attr_of(html, "a.pc-sidebar-item", "data-testid") == "item"
+    end
+  end
+
+  describe "sidebar_trigger/1" do
+    test "targets the sidebar it names" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_trigger for="sb" />
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-trigger", "aria-controls") == "sb"
+      assert attr_of(html, "button.pc-sidebar-trigger", "aria-label") == "Toggle sidebar"
+    end
+
+    test "only the mobile trigger claims the derived focus-restore id" do
+      assigns = %{}
+
+      # A shell commonly carries both a burger and a rail toggle for the same
+      # sidebar. Only one element may hold the id focus returns to.
+      html =
+        rendered_to_string(~H"""
+        <div>
+          <.sidebar_trigger for="sb" target="mobile" />
+          <.sidebar_trigger for="sb" />
+        </div>
+        """)
+
+      assert query(html, "#sb-trigger") |> Enum.count() == 1
+
+      assert attr_of(html, ".pc-sidebar-trigger--mobile", "id") == "sb-trigger"
+      assert attr_of(html, ".pc-sidebar-trigger--collapse", "id") == nil
+    end
+
+    test "the collapse target flips data-collapsed on its sidebar only" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_trigger for="sb" />
+        """)
+
+      click = attr_of(html, "button.pc-sidebar-trigger", "phx-click")
+      assert click =~ "data-collapsed"
+      assert click =~ "#sb"
+      assert attr_of(html, "button.pc-sidebar-trigger", "class") =~ "pc-sidebar-trigger--collapse"
+    end
+
+    test "the mobile target opens the sheet, marks the shell inert and moves focus in" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_trigger for="sb" target="mobile" />
+        """)
+
+      click = attr_of(html, "button.pc-sidebar-trigger", "phx-click")
+      assert click =~ "data-mobile-open"
+      assert click =~ "inert"
+      assert click =~ "sb-main"
+      assert click =~ "overflow-hidden"
+      assert click =~ "focus"
+      assert attr_of(html, "button.pc-sidebar-trigger", "class") =~ "pc-sidebar-trigger--mobile"
+      # it is a disclosure for the sheet, so it reports state
+      assert attr_of(html, "button.pc-sidebar-trigger", "aria-expanded") == "false"
+    end
+
+    test "the collapse trigger is not a sheet disclosure" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_trigger for="sb" />
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-trigger", "aria-expanded") == nil
+    end
+
+    test "triggers for different sidebars do not cross-wire" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <div>
+          <.sidebar_trigger for="left-sb" target="mobile" />
+          <.sidebar_trigger for="right-sb" target="mobile" />
+        </div>
+        """)
+
+      left = attr_of(html, "#left-sb-trigger", "phx-click")
+      right = attr_of(html, "#right-sb-trigger", "phx-click")
+
+      assert left =~ "left-sb"
+      refute left =~ "right-sb"
+      assert right =~ "right-sb"
+      refute right =~ "left-sb"
+    end
+
+    test "an explicit id wins over the derived one" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_trigger for="sb" id="my-trigger" />
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-trigger", "id") == "my-trigger"
+    end
+
+    test "a custom label names the button" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_trigger for="sb" label="Hide navigation" />
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-trigger", "aria-label") == "Hide navigation"
+    end
+
+    test "renders a default icon, or the inner block when given" do
+      assigns = %{}
+
+      default =
+        rendered_to_string(~H"""
+        <.sidebar_trigger for="sb" />
+        """)
+
+      assert has_icon?(default)
+
+      custom =
+        rendered_to_string(~H"""
+        <.sidebar_trigger for="sb">Menu</.sidebar_trigger>
+        """)
+
+      assert custom =~ "Menu"
+      refute has_icon?(custom)
+    end
+
+    test "on_click JS is composed ahead of the component's own commands" do
+      assigns = %{js: Phoenix.LiveView.JS.push("toggle_sidebar")}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_trigger for="sb" on_click={@js} />
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-trigger", "phx-click") =~ "toggle_sidebar"
+    end
+
+    test "class and global attrs pass through" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_trigger for="sb" class="ml-auto" data-testid="trig" />
+        """)
+
+      assert attr_of(html, "button.pc-sidebar-trigger", "class") =~ "ml-auto"
+      assert attr_of(html, "button.pc-sidebar-trigger", "data-testid") == "trig"
+    end
+  end
+
+  describe "JS command helpers" do
+    test "toggle_sidebar/1 flips only the collapsed attribute" do
+      js = toggle_sidebar("sb") |> Jason.encode!()
+
+      assert js =~ "toggle_attr"
+      assert js =~ "data-collapsed"
+      assert js =~ "#sb"
+      refute js =~ "data-mobile-open"
+    end
+
+    test "show_sidebar/1 opens the sheet and fences the shell" do
+      js = show_sidebar("sb") |> Jason.encode!()
+
+      assert js =~ ~s(data-mobile-open)
+      assert js =~ "inert"
+      assert js =~ "#sb-main"
+      assert js =~ "overflow-hidden"
+      assert js =~ "focus_first"
+    end
+
+    test "hide_sidebar/1 unwinds all of it and restores focus" do
+      js = hide_sidebar("sb") |> Jason.encode!()
+
+      assert js =~ "remove_attr"
+      assert js =~ "inert"
+      assert js =~ "#sb-trigger"
+      assert js =~ "remove_class"
+    end
+  end
+
+  describe "composition" do
+    test "a full app shell renders one nav, one main and the whole item tree" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <.sidebar_shell for="app">
+          <:sidebar>
+            <.sidebar id="app" label="Main">
+              <:header>Acme</:header>
+              <.sidebar_group label="Workspace">
+                <.sidebar_item label="Dashboard" path="/" icon="hero-home" active />
+                <.sidebar_item label="Inbox" path="/inbox" icon="hero-inbox" badge="12" />
+              </.sidebar_group>
+              <.sidebar_group id="acct" label="Account" collapsible>
+                <.sidebar_item id="set" label="Settings" open>
+                  <.sidebar_item label="Profile" path="/profile" />
+                </.sidebar_item>
+              </.sidebar_group>
+              <:footer>
+                <.sidebar_item label="Sign out" path="/out" />
+              </:footer>
+            </.sidebar>
+          </:sidebar>
+          <.sidebar_trigger for="app" target="mobile" />
+          <main>page</main>
+        </.sidebar_shell>
+        """)
+
+      assert query(html, "nav[aria-label='Main']") |> Enum.count() == 1
+      assert query(html, "#app-main") |> Enum.count() == 1
+      assert query(html, "[aria-current='page']") |> Enum.count() == 1
+      assert query(html, "#acct-items") |> Enum.count() == 1
+      assert attr_of(html, "#set-sub", "data-open") == "true"
+      assert attr_of(html, "#app-trigger", "aria-controls") == "app"
+      assert html =~ "Acme"
+      assert html =~ "Sign out"
+    end
+  end
+
+  defp custom_icon(assigns) do
+    ~H"""
+    <svg id="custom-icon-svg" class={@class}></svg>
+    """
+  end
+end


### PR DESCRIPTION
Closes #622

Draft, and deliberately so. #622 is a two-phase brief: the spec gets signed off before the code lands. The spec is below, written as decisions with rationale. The code is pushed alongside it so the decisions are readable as working software rather than prose, but **the spec is the thing to review first** - if a decision goes the other way, the code follows it.

## Summary

Five function components, all CSS-first, no hook, no new dependencies:

| Component | What it is |
|---|---|
| `sidebar_shell/1` | flex wrapper holding the sidebar beside your page content |
| `sidebar/1` | the `<nav>` landmark, with `header` / `footer` slots and the collapse + sheet machinery |
| `sidebar_group/1` | a labelled, optionally collapsible run of items |
| `sidebar_item/1` | icon + label + badge + active state, or a parent with nested sub-items |
| `sidebar_trigger/1` | the rail toggle (`target="collapse"`) or the mobile burger (`target="mobile"`) |

Three collapse modes (`icon`, `offcanvas`, `none`), `side="left"|"right"`, multi-sidebar by construction.

---

# Phase 1: the spec

## 1. Composition anatomy

**Decision: five function components, with slots collapsing the rest.**

shadcn's ~25 sub-components exist because React has no slot primitive. Phoenix does, so:

- `SidebarHeader` / `SidebarFooter` → `<:header>` / `<:footer>` slots on `sidebar/1`
- `SidebarContent` → the default `inner_block`
- `SidebarMenu` + `SidebarMenuItem` + `SidebarMenuButton` → one `sidebar_item/1`
- `SidebarMenuSub` + `SidebarMenuSubItem` → `sidebar_item/1` nested inside `sidebar_item/1` (self-recursive, which a slot cannot be - this is why items are a function and not a slot)
- `SidebarMenuBadge` → the `badge` attr
- `SidebarGroupLabel` + `SidebarGroupContent` → attrs on `sidebar_group/1`
- `SidebarProvider` → `sidebar_shell/1`, which owns nothing but layout and the inert target
- `SidebarRail` → **dropped as a separate component**, see deviations

Groups and items are functions rather than slots specifically because sub-items need arbitrary depth. Everything that does *not* need recursion is a slot, per `accordion.ex` / `navigation_menu.ex` house style.

## 2. The namespace question

**Decision: `sidebar_*` prefix family, exported from `use PetalComponents`.**

Survey of what the names have to dodge:

- `lib/petal_components.ex` exports nothing starting with `sidebar`. `Menu` owns the adjacent `vertical_menu` / `menu_group` / `vertical_menu_item`; no collision.
- `Phoenix.Component` and `phx.new` core_components: no `sidebar*`.
- **Downstream is the real risk.** Petal Pro and Petal Boilerplate both ship their own `sidebar_layout/1` built on `vertical_menu`, and plenty of hand-rolled apps define one too. An import conflict is a hard compile error - you cannot shadow an import with a local of the same name/arity - so exporting `sidebar_layout` would break those installs on `mix deps.update`.

So: **the layout wrapper is named `sidebar_shell/1`, not `sidebar_layout/1`.** That is the single highest-collision name in the family and it is the one we do not take. The other five names are self-prefixed and collide with essentially nothing.

I considered the `PetalComponents.Chat` treatment (namespaced, opt-in, excluded from `use PetalComponents`) and rejected it. Chat is excluded because its members have *generic* names (`markdown/1`) that no amount of care fixes. The sidebar family is the opposite case: the names are already namespaced by their prefix. Chat is also a niche add-on, whereas the sidebar is the flagship block component - making it the one family that imports differently would be a permanent ergonomics tax to dodge a one-time, loud, one-line-fixable compile error.

**One thing I'd like your call on, and did NOT ship:** `lib/petal_components.ex` is `defmacro __using__(_)` - it ignores opts, so a consumer who *does* collide has no way to say `use PetalComponents, except: [sidebar: 1]`. Their only escape is dropping `use PetalComponents` in that one module and hand-importing. Adding `except:` / `only:` passthrough is a ~10 line non-breaking change that would defuse this and every future name collision. It felt like scope creep on a component PR and it touches the library's front door, so it's yours to decide. Happy to add it here or in a separate PR.

## 3. Collapse behaviour and where state lives

**Decision: the DOM owns the live state, the server owns the initial state. No cookie, no hook, no round trip.**

- The trigger flips `data-collapsed="true"|"false"` on the sidebar via `JS.toggle_attribute`. CSS does everything else. Toggling is instant and costs nothing.
- The **initial** value is the `collapsed` attr, rendered server-side into that same attribute.

That second point is the whole answer to "how does a `live_redirect` not flash the wrong state": there is no client-side read-then-apply step to flash. The attribute arrives correct in the first byte of HTML. shadcn needs the cookie read in middleware for exactly this reason; in LiveView the app already has somewhere to put it.

Escape hatches, in increasing order of durability:

1. Do nothing - state is per-page-load, which is right for a lot of apps.
2. Keep it in an assign and pass `collapsed={@sidebar_collapsed}`, plus `on_click={JS.push("toggle_sidebar")}` on the trigger so the server hears about it. Survives `live_patch` and `live_redirect` within the LiveView's lifetime.
3. Persist that assign to a session cookie in your own `handle_event` and read it in `mount` (or in the plug pipeline for dead renders). Survives everything.

The component ships **no persistence plumbing at all**, per the issue's non-goals. `on_click` and `on_close` are `JS` attrs composed ahead of the component's own commands (the `compose_js/2` house pattern), which is the whole seam.

**Non-goal I'm respecting loudly: Cmd+B is not shipped.** `phx-window-keydown` + `phx-key` matches on `key` only, with no modifier predicate, so a hook-free Cmd+B would fire on every bare `b` - including inside text inputs. The issue says to flag a hook for sign-off rather than sneak one in, so: **do you want a hook for this?** It'd be ~15 lines and the library's fourth. My lean is no for v1; apps that want it can bind it themselves and call `PetalComponents.Sidebar.toggle_sidebar/1`, which is public for exactly this.

## 4. Mobile behaviour

**Decision: shares `slide_over`'s interaction grammar, does not reuse the module.**

`slide_over/1` is a modal dialog with a title bar, a close button, `role="dialog"` and `aria-modal`. A nav sheet is a navigation landmark. Wrapping the nav in a dialog would either double the landmark or lose it, and `slide_over` push-pushes a `close_slide_over` event that the app must handle - which would drag server state into a component that otherwise needs none. So the sheet is built inline, matching the `dev.exs` mobile menu grammar point for point:

| `dev.exs` mobile menu | `<.sidebar>` |
|---|---|
| `focus_wrap` fence | `focus_wrap` around the panel |
| `inert` on background regions | `inert` set on `#<id>-main` by the trigger, removed on close |
| Escape closes | `phx-window-keydown` + `phx-key="escape"` |
| `phx-remove={JS.focus(to: burger)}` | `JS.focus(to: "#<id>-trigger")` in the close command |
| scrim / click-away | `phx-click` on `.pc-sidebar__scrim` |

Two mechanics worth flagging in review, because both are slightly clever:

**Escape is gated on a selector, not on server state.** `dev.exs` can `:if`-render the overlay because `@nav_open` is an assign; here the state is in the DOM. So the keydown runs `JS.exec("data-close", to: "#<id>[data-mobile-open='true']")` - if the sheet is shut the selector matches nothing and the whole command is a no-op. That's how Escape on desktop avoids yanking focus to the trigger.

**`focus_wrap`'s sentinels are CSS-disabled unless the sheet is open.** `focus_wrap` traps Tab whenever it's in the DOM, which on desktop would fence the entire page inside the sidebar. Since it can't be conditionally rendered, this rule turns it off instead:

```css
.pc-sidebar:not([data-mobile-open="true"]) .pc-sidebar__panel > [tabindex="0"][aria-hidden="true"] { display: none; }
```

`display: none` removes the sentinels from the tab order, so the trap only exists while the sheet is open. It leans on `focus_wrap`'s rendered shape rather than its ids, but it *is* leaning on an implementation detail - if you'd rather not, the alternative is making the sheet's open state server-owned like `dev.exs`, at the cost of every consumer needing a `handle_event`. Happy to switch.

## 5. Multi-sidebar support

**Decision: supported structurally in v1, documented via the inspector example.**

There is no shared/global state to collide over - every id, data attribute and JS target is derived from the sidebar's own `id`. Two sidebars in one shell with different ids simply cannot cross-wire, and there are tests asserting that for both the sidebars and their triggers. `side="right"` + `collapsible="offcanvas"` is the inspector-panel shape, shipped as a showcase example.

The one shared thing is the shell's `-main` region, which both would mark inert - correct behaviour, since either open sheet should fence the page.

## 6. Theming surface

**Decision: two custom properties on `.pc-sidebar`.**

```css
.pc-sidebar { --pc-sidebar-width: 16rem; --pc-sidebar-icon-width: 3.5rem; }
```

Both are read by the width rules, so an app retunes by setting them on `.pc-sidebar` (or per-instance via `style`), never by overriding `pc-*` internals.

**The breakpoint is not a variable and cannot be.** CSS media queries can't read custom properties. It's fixed at `md` (48rem) to match the rest of the library. Container queries would make it configurable-ish and are a fair follow-up, but they'd change the layout contract, so not in v1.

---

# Relationship to `menu` / `navigation_menu` / `user_dropdown_menu`

This is the question I most want checked, since the brief explicitly warns against forking a fourth navigation implementation.

**What it does NOT duplicate.** `navigation_menu` is a horizontal top-nav with hover-opened mega-menu panels - different axis, different interaction, no overlap. `user_dropdown_menu` is a popover of account links; the sidebar `<:footer>` slot is designed to *hold* one, and the issue's own playground spec asks for exactly that composition.

**Where it genuinely overlaps: `vertical_menu`.** Both render a vertical run of nav links with icons, active state and nested disclosures. The honest position:

- **This is not a layout shell around `vertical_menu`.** They have incompatible API shapes. `vertical_menu` is **data-driven** (`menu_items={[%{name:, label:, path:, icon:, menu_items: [...]}]}` + `current_page={:atom}`, with active state inferred by matching `name` against `current_page`). `sidebar_item` is **slot-composed**, with `active` passed explicitly and never inferred. The issue's non-goals rule out a data-driven list API here, and it rules out inferring active state - so `sidebar_item` could not have been `vertical_menu` underneath without violating both.
- **`vertical_menu` also can't collapse.** Its markup has no seam for an icon rail: the label is a plain `<div>` with no hook for the collapsed treatment, submenus are toggled by inline `style="display:..."` set server-side (which fights any CSS-driven collapse), and there's no `title`/sr-only handling for iconified state. Making it collapsible would be a breaking change to its markup.
- `vertical_menu` also emits **one `<nav>` per group**, which is wrong for an app shell (a shell wants one landmark with one accessible name). `<.sidebar>` emits exactly one `<nav aria-label>` and groups are plain `<div>`s.

So they are two shapes of the same idea, and I did not fork the *styling* doctrine - `pc-sidebar-item` follows `pc-vertical-menu-item`'s structure and gray ramp deliberately.

**What I did not do, and think is yours to call:** the issue says "the spec decides `vertical_menu`'s future, not this build." My read is that `<.sidebar>` supersedes `vertical_menu` for app shells, and `vertical_menu` should stay as the data-driven primitive for apps that want to pass a list (petal_pro's `sidebar_layout` is built on it and shouldn't be disturbed). I'd deprecate nothing in this PR. Flag if you disagree.

**Dogfood target.** The `dev.exs` mobile menu (its comment already says "the sidebar primitive planned for 4.9 replaces this and inherits its grammar") - I've confirmed the component can express it: grouped items, active state, the full sheet grammar, and `link_type="button"` + `phx-value-*` globals for the `phx-click="select"` wiring it uses. I have **not** done the swap in this PR - it's cross-cutting and would muddy the review of a new component. Happy to ticket it as the immediate follow-up, or do it here if you'd rather see it proven.

---

# Deviations from the issue's API sketch

| Sketch | Shipped | Why |
|---|---|---|
| `sidebar_layout` or provider wrapper | `sidebar_shell/1` | `sidebar_layout` is the one name that would break Petal Pro / Boilerplate installs on import conflict. See §2. |
| `sidebar_rail/1` as its own component | dropped | The rail is a *state* of the sidebar (`collapsible="icon"` + `collapsed`), not a separate element. A sixth exported name to render a click strip is collision surface for no expressive gain - `sidebar_trigger` already gives you the click target and can be placed in the header, footer or your topbar. |
| `sidebar_trigger` takes `id` (of the sidebar it toggles) | takes `for`, and `id` is its own | `id` meaning "some other element's id" reads wrong and makes focus-restore targeting ambiguous. `for` is the reference; `id` defaults to `"<for>-trigger"` so the close command can restore focus to it. `sidebar_shell` uses `for` for the same reason. |
| `sidebar_item` `link_type` default `"live_redirect"` | same | kept |
| `sidebar_item` icon: name / function / raw SVG | same | matches `menu.ex`'s `menu_icon` convention exactly |
| single trigger that does both jobs | `target="collapse"` / `target="mobile"` | shadcn branches on `isMobile` in JS. Without a hook there's no server-side breakpoint, so one trigger toggling both states would silently flip the desktop rail while you were on mobile. Two explicitly-targeted triggers (each hidden at the other breakpoint by CSS) is honest and matches how real shells are laid out - burger in the topbar, rail toggle in the sidebar header. |
| Cmd+B on the trigger | not shipped | needs a hook; flagged for sign-off. See §3. |

Also worth noting: **#640 (`feat/resizable`) is an obvious pairing** and I deliberately did not touch it. This is built against `origin/main` only and ships no resize machinery (v1 non-goal). If `resizable_group`/`panel`/`handle` land, a drag-to-resize sidebar should compose them and set `--pc-sidebar-width` from the panel size rather than growing its own.

---

# Styles

New `pc-sidebar*` section in `assets/default.css`, **appended inside its own `@layer components { }` block**.

That last bit matters and is worth a maintainer's eye: everything after the showcase-props section (line ~7016) currently sits *outside* any cascade layer, so those rules outrank consumer utilities passed via `class`. Appending into that tail would have quietly broken `<.sidebar class="...">` overrides. The new block re-opens a layer. The pre-existing unlayered carousel section above it is untouched but is probably a latent bug worth its own issue.

Otherwise: `--pc-radius` consumed via the usual `max(calc(...))` derivation, gray ramp for all neutrals, `dark:` throughout, `focus-visible` rings only (no persistent `:focus` fills), and `prefers-reduced-motion` reducing every transition to instant.

# Accessibility

- One `<nav>` landmark per sidebar with an `aria-label` (defaults to `"Sidebar"`, overridable)
- `aria-current="page"` on the active item, at any nesting depth; passed by the app, never inferred
- Collapsible groups and parent items follow the WAI-ARIA disclosure pattern (`aria-expanded` on the trigger, `aria-controls` pointing at the panel)
- Collapsed icon rail keeps labels in the accessibility tree via `sr-only` (not `display: none`), with `title` carrying the same text for sighted hover
- Mobile sheet: `focus_wrap` fence, `inert` background, Escape, scrim dismiss, focus restored to the trigger
- `prefers-reduced-motion: reduce` drops all transitions

# Hook

**None.** Collapse, disclosure, the sheet, Escape and focus restoration are all `Phoenix.LiveView.JS` + CSS. `npm test` is unchanged at 157 because there is no JS to test. The only thing that wanted a hook was Cmd+B, and it's flagged rather than shipped.

# Tests

| | before | after |
|---|---|---|
| `mix test` | 913 (0 failures, 1 skipped) | **972 (0 failures, 1 skipped)** - 59 new |
| `npm test` | 157 | **157** - unchanged, no hook |
| `mix credo` | 14 refactoring, 31 readability | **identical - zero new entries** |

`mix format --check-formatted` and `mix compile --force --warnings-as-errors` both clean.

Every attr, every value in every `values:` list, every slot and every `link_type` has a rendering assertion. ARIA is asserted explicitly rather than via class checks (`aria-current`, `aria-expanded`, `aria-controls`, `aria-label`, the `inert`/`focus_wrap` wiring), and there are tests specifically asserting two sidebars and two triggers do not cross-wire.

# Verified by hand in the playground

Light and dark at 1280px, the collapsed icon rail, and the mobile sheet at 390x844 (both closed, confirming the sidebar leaves the flow entirely, and open with the scrim over the content region). Screenshots below.

Three things the browser caught that the test suite could not, all fixed:

1. **The mobile sheet never slid in.** `[data-side="left"] .pc-sidebar__panel { transform: translateX(-100%) }` carries a `:not()` plus two attribute selectors; the open rule was one selector lighter, so it lost the tie and the panel stayed off-screen while the scrim dimmed the page. The open rule now carries matching weight. Pure CSS specificity - invisible to `rendered_to_string`.
2. **Two triggers for one sidebar collided on `id`.** Both defaulted to `"<for>-trigger"`, which is also the focus-restore target. Only `target="mobile"` claims it now; there's a test for it.
3. **A 3.5rem rail clipped a two-item header** (brand mark plus toggle). `--pc-sidebar-icon-width` is 4rem.
