### PR TITLE
feat(chat): questionnaire - structured human-in-the-loop input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
 # Changelog
+
+### Unreleased
+
+#### Added
+
+- **Answer grounding for the chat family: inline citation chips and a
+  `chat_sources` row.** RAG answers are only trustworthy if you can see
+  where they came from, and until now the chat kit rendered the prose but
+  not the receipts. Prompt the model to cite as `[^N]` and hand the same
+  source maps to `markdown/1`: every complete marker turns into a numbered
+  chip that opens the source in a new tab, with a preview card (title,
+  domain, snippet) on hover or focus. `chat_sources/1` renders the deduped
+  list underneath - a native `<details>`, no JS, with `expanded` to open it
+  on render and `max_visible` to cap the list behind a "Show all" reveal.
+  `citation/1` is the chip on its own for prose you assemble yourself.
+  The streaming path takes the same option: `to_html/2` accepts
+  `sources:`, so chips light up as their markers complete and a
+  half-arrived `[^` never flashes broken output. Sources are plain maps
+  (`%{id, url, title, snippet, favicon_url}`) with string or atom keys;
+  everything but `url` is optional and degrades - no favicon means a letter
+  avatar, no snippet means a shorter row. Chip markup is minted server-side
+  from the numeric index plus escaped source fields and spliced into the
+  already-sanitized HTML outside code blocks, so model text can never reach
+  the page as live markup.
+
 ### 4.14.0 - 2026-08-11
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 #### Added
 
+- **`Chat.questionnaire/1`: structured human-in-the-loop input in the
+  transcript.** When the model needs a decision rather than a sentence, it
+  emits a question spec and this renders it as a form inside the thread -
+  single-select, multi-select, short text and a 1-to-5 scale. Submit is a
+  plain `phx-submit` your LiveView forwards to the model; there is no
+  client form engine and no client state. Pass the answers back as
+  `resolved` and the form is replaced by quiet chips so the transcript
+  stays honest about what was asked and answered, with nothing focusable
+  left behind; `:skipped` renders the skipped line. It composes the
+  existing `field/1` primitives - radio-cards when the options carry
+  descriptions, plain radios when they don't, checkbox groups for
+  multi-select - so required markers, labels and error scaffolding come
+  for free. Only the scale is new markup: five real radios in a segmented
+  row, so arrow keys move between steps natively. Every question is a
+  `<fieldset>` with a `<legend>`, the form is `aria-labelledby` the title,
+  and the scale's end captions are tied in with `aria-describedby`.
+
 - **Composer attachments: `prompt_input` takes an upload, and
   `message_attachments` renders what was sent.** Hand `prompt_input` an
   `%UploadConfig{}` from `allow_upload/3` and it grows a paperclip trigger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 #### Added
 
+- **Composer attachments: `prompt_input` takes an upload, and
+  `message_attachments` renders what was sent.** Hand `prompt_input` an
+  `%UploadConfig{}` from `allow_upload/3` and it grows a paperclip trigger
+  (a `<label>` around a visually hidden `live_file_input`, so the keyboard
+  still works), a chip strip for the pending entries, `phx-drop-target` on
+  the composer with a drag-over tint, and paste-a-screenshot support in the
+  existing `PetalChatComposer` hook. Image entries get a `live_img_preview`
+  thumbnail, everything else gets an icon with the name and a formatted
+  size; each chip carries a `role="progressbar"` ring driven by
+  `entry.progress` and a remove button wired to `on_cancel_upload` with the
+  entry ref. Upload errors render inline under the composer with
+  `role="alert"`, per-entry ones named with the file they belong to.
+  `message_attachments/1` is the received side: images tile into a grid
+  (one goes large, two or more tile), files are download rows, and a mixed
+  list puts the images first. With no `upload` the composer renders exactly
+  as it always has - no extra markup, no behaviour change.
+
 - **Answer grounding for the chat family: inline citation chips and a
   `chat_sources` row.** RAG answers are only trustworthy if you can see
   where they came from, and until now the chat kit rendered the prose but

--- a/assets/default.css
+++ b/assets/default.css
@@ -7748,3 +7748,167 @@
     }
   }
 }
+
+/* Chat — composer attachments and the attachments rendered in a sent message. */
+@layer components {
+  /* Composer: paperclip trigger ------------------------------------------- */
+
+  /* A <label> wrapping the sr-only live_file_input: the input keeps the focus
+     ring and the keyboard, the label draws the paperclip. */
+  .pc-chat__composer-attach {
+    @apply flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center self-end text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-400/17 dark:hover:text-gray-200;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-chat__composer-attach:has(input:focus-visible) {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  .pc-chat__composer-attach-icon.pc-chat__composer-attach-icon {
+    width: 1.125rem !important;
+    height: 1.125rem !important;
+  }
+
+  /* Drag-over affordance. LiveView adds `phx-drop-target-active` to a
+     phx-drop-target element while a file drag is over it. */
+  .pc-chat__composer.phx-drop-target-active,
+  .pc-chat__composer--dragover {
+    @apply border-primary-400 bg-primary-50/40 dark:border-primary-500 dark:bg-primary-500/10;
+  }
+
+  /* Composer: pending attachment chips ------------------------------------ */
+
+  .pc-chat__composer-attachments {
+    @apply mb-2 flex list-none flex-wrap gap-2 p-0;
+  }
+
+  .pc-chat__attachment {
+    @apply relative flex items-center gap-2 border border-gray-200 bg-white p-1.5 text-xs text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-chat__attachment--image {
+    @apply p-0;
+  }
+
+  .pc-chat__attachment-thumb {
+    @apply h-14 w-14 object-cover;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-chat__attachment-icon.pc-chat__attachment-icon {
+    @apply shrink-0 text-gray-400 dark:text-gray-500;
+    width: 1.125rem !important;
+    height: 1.125rem !important;
+  }
+
+  .pc-chat__attachment-meta {
+    @apply flex min-w-0 max-w-40 flex-col;
+  }
+
+  .pc-chat__attachment-name {
+    @apply truncate font-medium;
+  }
+
+  .pc-chat__attachment-size {
+    @apply text-[0.9em] text-gray-500 dark:text-gray-400;
+  }
+
+  /* Progress ring: a conic sweep driven by --pc-attachment-progress (0-100),
+     so the server-rendered value is the only source of truth. */
+  .pc-chat__attachment-progress {
+    @apply pointer-events-none absolute inset-0 flex items-center justify-center;
+    border-radius: inherit;
+    background: conic-gradient(
+      color-mix(in oklab, var(--color-primary-500, #3b82f6) 55%, transparent)
+        calc(var(--pc-attachment-progress, 0) * 1%),
+      color-mix(in oklab, var(--color-gray-900, #111827) 45%, transparent) 0
+    );
+    transition: background 0.2s linear;
+  }
+
+  .pc-chat__attachment-remove {
+    @apply absolute -right-1.5 -top-1.5 z-10 flex h-5 w-5 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 shadow-sm transition-colors hover:bg-gray-100 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100;
+  }
+
+  .pc-chat__attachment-remove:focus-visible {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  .pc-chat__attachment-remove-icon.pc-chat__attachment-remove-icon {
+    width: 0.75rem !important;
+    height: 0.75rem !important;
+  }
+
+  /* Composer: inline upload errors ---------------------------------------- */
+
+  .pc-chat__composer-errors {
+    @apply mt-2 flex flex-col gap-1;
+  }
+
+  .pc-chat__composer-error {
+    @apply flex items-center gap-1.5 text-xs text-danger-600 dark:text-danger-400;
+  }
+
+  .pc-chat__composer-error-icon.pc-chat__composer-error-icon {
+    @apply shrink-0;
+    width: 0.875rem !important;
+    height: 0.875rem !important;
+  }
+
+  /* Attachments inside a sent message ------------------------------------- */
+
+  .pc-chat__message-attachments {
+    @apply flex flex-col gap-2;
+  }
+
+  .pc-chat__message-attachments-grid {
+    @apply grid gap-2;
+  }
+
+  .pc-chat__message-attachments-grid--multi {
+    @apply grid-cols-2;
+  }
+
+  .pc-chat__attachment-image {
+    @apply block overflow-hidden border border-gray-200 dark:border-gray-700;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-chat__attachment-image:focus-visible {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  /* A single image goes large but still has to sit in a bubble, so cap the
+     height and let it crop rather than push the thread around. */
+  .pc-chat__attachment-image img {
+    @apply h-full w-full max-w-full object-cover;
+    max-height: 16rem;
+  }
+
+  .pc-chat__message-attachments-grid--multi .pc-chat__attachment-image img {
+    max-height: 9rem;
+  }
+
+  .pc-chat__attachment-row {
+    @apply flex items-center gap-2 border border-gray-200 p-2 text-xs no-underline transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-400/10;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-chat__attachment-row:focus-visible {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  .pc-chat__attachment-row .pc-chat__attachment-size {
+    @apply ms-auto;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pc-chat__composer-attach,
+    .pc-chat__attachment-progress,
+    .pc-chat__attachment-remove,
+    .pc-chat__attachment-row {
+      transition-duration: 1ms;
+    }
+  }
+}

--- a/assets/default.css
+++ b/assets/default.css
@@ -7912,3 +7912,137 @@
     }
   }
 }
+
+/* Chat questionnaire — structured human-in-the-loop input in the transcript. */
+@layer components {
+  .pc-questionnaire {
+    @apply flex flex-col gap-3 border border-gray-200 bg-white p-4 text-sm dark:border-gray-700 dark:bg-gray-900;
+    border-radius: var(--pc-radius, 0.625rem);
+  }
+
+  /* Resolved and skipped read as transcript history, not as live controls. */
+  .pc-questionnaire--resolved,
+  .pc-questionnaire--skipped {
+    @apply gap-2 border-gray-200 bg-transparent dark:border-gray-700;
+  }
+
+  .pc-questionnaire__header {
+    @apply flex flex-col gap-1;
+  }
+
+  .pc-questionnaire__title {
+    @apply text-sm font-semibold text-gray-900 dark:text-gray-100;
+  }
+
+  .pc-questionnaire--resolved .pc-questionnaire__title,
+  .pc-questionnaire--skipped .pc-questionnaire__title {
+    @apply font-medium text-gray-600 dark:text-gray-400;
+  }
+
+  .pc-questionnaire__description {
+    @apply text-xs text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-questionnaire__form {
+    @apply flex flex-col gap-4;
+  }
+
+  /* Reset the browser's fieldset chrome; the field primitives own the look. */
+  .pc-questionnaire__field {
+    @apply m-0 border-0 p-0;
+  }
+
+  /* The 1-to-5 segmented row. Real radios, visually hidden, so arrow keys move
+     between the steps natively. */
+  .pc-questionnaire__scale {
+    @apply mt-1 flex w-full overflow-hidden border border-gray-200 dark:border-gray-700;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-questionnaire__scale-step {
+    @apply flex flex-1 cursor-pointer items-center justify-center border-e border-gray-200 py-2 text-sm font-medium text-gray-600 transition-colors last:border-e-0 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-400/10;
+  }
+
+  .pc-questionnaire__scale-step:has(.pc-questionnaire__scale-input:checked) {
+    @apply bg-primary-500 text-white dark:text-white;
+  }
+
+  .pc-questionnaire__scale-step:has(.pc-questionnaire__scale-input:focus-visible) {
+    @apply outline-2 -outline-offset-2 outline-primary-500;
+  }
+
+  .pc-questionnaire__scale-step:has(.pc-questionnaire__scale-input:disabled) {
+    @apply cursor-not-allowed opacity-60;
+  }
+
+  .pc-questionnaire__scale-captions {
+    @apply mt-1 flex justify-between text-xs text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-questionnaire__actions {
+    @apply flex items-center gap-2;
+  }
+
+  .pc-questionnaire__submit {
+    @apply inline-flex items-center gap-2 bg-primary-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-60;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-questionnaire__skip {
+    @apply inline-flex items-center px-3 py-1.5 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-400 dark:hover:bg-gray-400/17 dark:hover:text-gray-200;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-questionnaire__submit:focus-visible,
+  .pc-questionnaire__skip:focus-visible {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  .pc-questionnaire__spinner-wrap {
+    @apply inline-flex items-center;
+  }
+
+  .pc-questionnaire__spinner {
+    @apply inline-block h-3.5 w-3.5 rounded-full border-2 border-white/40 border-t-white;
+    animation: pc-chat-spin 0.6s linear infinite;
+  }
+
+  /* Resolved summary ------------------------------------------------------- */
+
+  .pc-questionnaire__summary {
+    @apply m-0 flex flex-col gap-2;
+  }
+
+  .pc-questionnaire__answer {
+    @apply flex flex-col gap-1;
+  }
+
+  .pc-questionnaire__answer-label {
+    @apply text-xs font-medium text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-questionnaire__answer-value {
+    @apply m-0 flex flex-wrap gap-1;
+  }
+
+  .pc-questionnaire__chip {
+    @apply inline-flex items-center border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-700 dark:border-gray-700 dark:bg-gray-400/10 dark:text-gray-200;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-questionnaire__skipped-note {
+    @apply text-xs text-gray-500 italic dark:text-gray-400;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pc-questionnaire__spinner {
+      animation: none;
+    }
+
+    .pc-questionnaire__scale-step,
+    .pc-questionnaire__submit,
+    .pc-questionnaire__skip {
+      transition-duration: 1ms;
+    }
+  }
+}

--- a/assets/default.css
+++ b/assets/default.css
@@ -7586,3 +7586,165 @@
       transition-duration: 1ms;
     }
   }
+
+/* Chat — answer grounding: inline citation chips + the RAG sources row. */
+@layer components {
+  /* Inline citation chip -------------------------------------------------- */
+
+  /* Positioning context for the hover/focus preview card. */
+  .pc-chat__citation-wrap {
+    @apply relative inline-block align-baseline;
+  }
+
+  .pc-chat__citation {
+    @apply inline-flex min-w-4 items-center justify-center px-1 align-super text-[0.65em] font-semibold leading-none text-gray-600 no-underline transition-colors dark:text-gray-300;
+    @apply bg-gray-100 dark:bg-gray-400/17;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.125rem);
+    padding-block: 0.15em;
+  }
+
+  .pc-chat__citation:hover {
+    @apply bg-gray-200 text-gray-900 dark:bg-gray-400/25 dark:text-gray-100;
+  }
+
+  .pc-chat__citation:focus-visible {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  /* The chip's own <sup> would double-raise it — the chip is already
+     align-super, so keep the number on the chip's baseline. */
+  .pc-chat__citation-num {
+    @apply align-baseline;
+    top: 0;
+  }
+
+  .pc-chat__citation-card {
+    @apply pointer-events-none invisible absolute bottom-full left-0 z-20 mb-1 flex w-56 flex-col gap-1 border border-gray-200 bg-white p-2 text-xs leading-snug text-gray-600 opacity-0 shadow-lg transition-opacity duration-100 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300;
+    border-radius: var(--pc-radius, 0.625rem);
+  }
+
+  .pc-chat__citation-wrap:hover .pc-chat__citation-card,
+  .pc-chat__citation-wrap:focus-within .pc-chat__citation-card {
+    @apply visible opacity-100;
+  }
+
+  .pc-chat__citation-card-title {
+    @apply font-semibold text-gray-900 dark:text-gray-100;
+  }
+
+  .pc-chat__citation-card-domain {
+    @apply text-[0.9em] text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-chat__citation-card-snippet {
+    @apply line-clamp-3 text-gray-500 dark:text-gray-400;
+  }
+
+  /* Sources row ----------------------------------------------------------- */
+
+  .pc-chat__sources {
+    @apply mt-2 text-xs;
+  }
+
+  .pc-chat__sources-row {
+    @apply inline-flex cursor-pointer list-none items-center gap-1.5 border border-gray-200 px-2 py-1 font-medium text-gray-500 select-none dark:border-gray-700 dark:text-gray-400;
+    border-radius: var(--pc-radius, 0.625rem);
+  }
+
+  .pc-chat__sources-row::-webkit-details-marker {
+    display: none;
+  }
+
+  .pc-chat__sources-row:hover {
+    @apply bg-gray-50 text-gray-700 dark:bg-gray-400/10 dark:text-gray-200;
+  }
+
+  .pc-chat__sources-row:focus-visible {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  .pc-chat__sources-favicons {
+    @apply flex items-center;
+  }
+
+  /* Stacked favicon cluster — each one overlaps the last. */
+  .pc-chat__sources-favicons > * + * {
+    @apply -ml-1.5;
+  }
+
+  .pc-chat__sources-chevron {
+    @apply shrink-0 transition-transform duration-150;
+  }
+
+  /* Doubled selector + !important: icon sizing contract (see reasoning). */
+  .pc-chat__sources-chevron.pc-chat__sources-chevron {
+    width: 0.875rem !important;
+    height: 0.875rem !important;
+  }
+
+  .pc-chat__sources[open] > .pc-chat__sources-row .pc-chat__sources-chevron {
+    @apply rotate-90;
+  }
+
+  .pc-chat__sources-list {
+    @apply mt-2 flex list-none flex-col gap-1 p-0;
+  }
+
+  .pc-chat__source-link {
+    @apply flex items-start gap-2 border border-transparent p-2 no-underline transition-colors;
+    border-radius: max(calc(var(--pc-radius, 0.625rem) - 0.25rem), 0.25rem);
+  }
+
+  .pc-chat__source-link:hover {
+    @apply border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-400/10;
+  }
+
+  .pc-chat__source-link:focus-visible {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  .pc-chat__source-favicon {
+    @apply mt-0.5 h-4 w-4 shrink-0 rounded-sm bg-gray-100 object-cover dark:bg-gray-400/17;
+  }
+
+  .pc-chat__source-favicon--letter {
+    @apply flex items-center justify-center text-[0.6rem] font-semibold text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-chat__source-text {
+    @apply flex min-w-0 flex-col gap-0.5;
+  }
+
+  .pc-chat__source-title {
+    @apply truncate font-medium text-gray-900 dark:text-gray-100;
+  }
+
+  .pc-chat__source-domain {
+    @apply truncate text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-chat__source-snippet {
+    @apply line-clamp-2 text-gray-500 dark:text-gray-400;
+  }
+
+  .pc-chat__sources-more-summary {
+    @apply mt-1 inline-flex cursor-pointer list-none items-center px-2 py-1 font-medium text-gray-500 select-none hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200;
+  }
+
+  .pc-chat__sources-more-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .pc-chat__sources-more-summary:focus-visible {
+    @apply outline-2 outline-offset-2 outline-primary-500;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pc-chat__citation,
+    .pc-chat__citation-card,
+    .pc-chat__sources-chevron,
+    .pc-chat__source-link {
+      transition-duration: 1ms;
+    }
+  }
+}

--- a/assets/js/petal_components.js
+++ b/assets/js/petal_components.js
@@ -81,9 +81,15 @@ export const PetalChatComposer = {
       }
     };
     this.onInput = () => this.autogrow();
+    // Paste a screenshot straight into the composer. LiveView's upload
+    // machinery only watches the file input, so hand it the clipboard's files
+    // and fire the input event it listens for. Text pastes fall through
+    // untouched.
+    this.onPaste = (e) => this.handlePaste(e);
 
     this.textarea.addEventListener("keydown", this.onKeydown);
     this.textarea.addEventListener("input", this.onInput);
+    this.textarea.addEventListener("paste", this.onPaste);
 
     // Set the field programmatically (edit a past message, quote, clear).
     // The textarea is phx-update="ignore" so the server can't render into it;
@@ -106,6 +112,26 @@ export const PetalChatComposer = {
     if (!this.textarea) return;
     this.textarea.removeEventListener("keydown", this.onKeydown);
     this.textarea.removeEventListener("input", this.onInput);
+    this.textarea.removeEventListener("paste", this.onPaste);
+  },
+
+  handlePaste(e) {
+    const fileInput = this.el.querySelector("input[type=file]");
+    if (!fileInput || !e.clipboardData) return;
+
+    const files = Array.from(e.clipboardData.files || []);
+    // Nothing pasted but text: leave the browser to it.
+    if (files.length === 0) return;
+
+    // No DataTransfer means no way to hand the input a FileList; degrade to a
+    // normal paste rather than throwing.
+    if (typeof DataTransfer === "undefined") return;
+
+    e.preventDefault();
+    const transfer = new DataTransfer();
+    files.forEach((file) => transfer.items.add(file));
+    fileInput.files = transfer.files;
+    fileInput.dispatchEvent(new Event("input", { bubbles: true }));
   },
 
   autogrow() {

--- a/dev.exs
+++ b/dev.exs
@@ -212,6 +212,46 @@ defmodule Dev.PlaygroundLive do
     """
   ]
 
+  # A mocked RAG answer: the model cites its context with [^N] footnote markers
+  # and the app hands the same source maps to markdown/1 + chat_sources/1.
+  @chat_rag_sources [
+    %{
+      id: "1",
+      url: "https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html",
+      title: "Phoenix.LiveView — behaviour and lifecycle",
+      snippet:
+        "LiveView provides rich, real-time user experiences with server-rendered HTML over a persistent connection."
+    },
+    %{
+      id: "2",
+      url: "https://hexdocs.pm/phoenix_live_view/js-interop.html",
+      title: "JavaScript interoperability",
+      snippet:
+        "Client hooks let you run JavaScript when an element is added, updated or removed from the page."
+    },
+    %{
+      id: "3",
+      url: "https://hexdocs.pm/phoenix/Phoenix.Endpoint.html",
+      title: "Phoenix.Endpoint",
+      snippet: "The endpoint is the boundary where all requests to your application start."
+    },
+    %{
+      id: "4",
+      url: "https://elixir-lang.org/getting-started/processes.html",
+      title: "Processes"
+    }
+  ]
+
+  @chat_rag_answer """
+  LiveView holds a **persistent connection** and diffs the rendered tree on the
+  server, pushing only the parts that changed [^1]. Anything the server can't
+  own - focus, clipboard, a third-party widget - drops down to a client
+  hook [^2].
+
+  Requests still enter through the endpoint like any other Phoenix request [^3],
+  and each connected tab is just another cheap process [^4].
+  """
+
   @chat_history [
     %{id: "m-yesterday", role: :marker, text: "Yesterday"},
     %{id: "hist-q", role: :user, text: "Does it support dark mode?", stream_id: nil},
@@ -733,6 +773,7 @@ defmodule Dev.PlaygroundLive do
        tg_device: "desktop",
        tg_variant: "solid",
        tg_size: "md",
+       chat_rag_sources: @chat_rag_sources,
        chat: %{
          turns: [
            %{id: "m-today", role: :marker, text: "Today"},
@@ -742,7 +783,20 @@ defmodule Dev.PlaygroundLive do
              text: "How do I install petal_components?",
              stream_id: nil
            },
-           %{id: "seed-a", role: :assistant, text: @chat_seed_answer, stream_id: nil}
+           %{id: "seed-a", role: :assistant, text: @chat_seed_answer, stream_id: nil},
+           %{
+             id: "seed-rag-q",
+             role: :user,
+             text: "How does LiveView keep the page in sync?",
+             stream_id: nil
+           },
+           %{
+             id: "seed-rag-a",
+             role: :assistant,
+             text: @chat_rag_answer,
+             stream_id: nil,
+             sources: @chat_rag_sources
+           }
          ],
          streaming: false,
          seq: 1,
@@ -750,7 +804,10 @@ defmodule Dev.PlaygroundLive do
          variant: "plain",
          actions: "always",
          editing: nil,
-         sent: false
+         sent: false,
+         sources_expanded: false,
+         sources_max: 5,
+         rag_streaming: false
        },
        alert: %{
          color: "gray",
@@ -1202,6 +1259,27 @@ defmodule Dev.PlaygroundLive do
 
   def handle_info(:pg_skeleton_loaded, socket),
     do: {:noreply, update(socket, :skeleton, &%{&1 | loading: false})}
+
+  def handle_info({:chat_rag_tick, buffer, []}, socket) do
+    {:noreply,
+     socket
+     |> assign(:chat, %{socket.assigns.chat | rag_streaming: false})
+     |> push_event("pc-chat-rag-token", %{
+       id: "pg-chat-rag-stream",
+       html: Chat.to_html(buffer, sources: @chat_rag_sources)
+     })}
+  end
+
+  def handle_info({:chat_rag_tick, buffer, [word | rest]}, socket) do
+    buffer = if buffer == "", do: word, else: buffer <> " " <> word
+    Process.send_after(self(), {:chat_rag_tick, buffer, rest}, 60)
+
+    {:noreply,
+     push_event(socket, "pc-chat-rag-token", %{
+       id: "pg-chat-rag-stream",
+       html: Chat.to_html(buffer, sources: @chat_rag_sources)
+     })}
+  end
 
   def handle_info({:chat_tick, id, chunks}, socket) do
     chat = socket.assigns.chat
@@ -1707,6 +1785,32 @@ defmodule Dev.PlaygroundLive do
   def handle_event("ctl_chat", %{"k" => "variant", "v" => v}, socket)
       when v in ~w(plain bubbles) do
     {:noreply, assign(socket, :chat, %{socket.assigns.chat | variant: v})}
+  end
+
+  def handle_event("ctl_chat", %{"k" => "sources_expanded", "v" => v}, socket) do
+    {:noreply, assign(socket, :chat, %{socket.assigns.chat | sources_expanded: v == "open"})}
+  end
+
+  def handle_event("ctl_chat", %{"k" => "sources_max", "v" => v}, socket) do
+    max = if v == "all", do: length(@chat_rag_sources), else: String.to_integer(v)
+    {:noreply, assign(socket, :chat, %{socket.assigns.chat | sources_max: max})}
+  end
+
+  # Streams the same grounded answer word by word. Each tick re-renders the
+  # buffer through to_html/2, so the [^N] chips appear as the markers complete
+  # and a half-arrived "[^" never flashes broken.
+  def handle_event("chat_rag_stream", _params, socket) do
+    if socket.assigns.chat.rag_streaming do
+      {:noreply, socket}
+    else
+      words = String.split(@chat_rag_answer, " ")
+      Process.send_after(self(), {:chat_rag_tick, "", words}, 150)
+
+      {:noreply,
+       socket
+       |> assign(:chat, %{socket.assigns.chat | rag_streaming: true})
+       |> push_event("pc-chat-rag-token", %{id: "pg-chat-rag-stream", html: ""})}
+    end
   end
 
   def handle_event("ctl_chat", %{"k" => "actions", "v" => v}, socket)
@@ -8731,7 +8835,17 @@ defmodule Dev.PlaygroundLive do
               <%= if turn.stream_id do %>
                 <Chat.streaming_text id={turn.stream_id} />
               <% else %>
-                <Chat.markdown content={turn.text} id={"pg-chat-md-#{turn.id}"} />
+                <Chat.markdown
+                  content={turn.text}
+                  id={"pg-chat-md-#{turn.id}"}
+                  sources={Map.get(turn, :sources)}
+                />
+                <Chat.chat_sources
+                  :if={Map.get(turn, :sources)}
+                  sources={Map.get(turn, :sources)}
+                  expanded={@chat.sources_expanded}
+                  max_visible={@chat.sources_max}
+                />
               <% end %>
               <:actions :if={turn.stream_id == nil}>
                 <Chat.message_actions visible={@chat.actions}>
@@ -8806,7 +8920,88 @@ defmodule Dev.PlaygroundLive do
               </:item>
             </.toggle_group>
           </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">
+              sources expanded
+            </div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Sources expanded"
+              value={if @chat.sources_expanded, do: "open", else: "closed"}
+              on_change="ctl_chat"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={v <- ~w(closed open)}
+                value={v}
+                phx-value-k="sources_expanded"
+                phx-value-v={v}
+              >
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">max_visible</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Max visible sources"
+              value={
+                if @chat.sources_max >= length(@chat_rag_sources),
+                  do: "all",
+                  else: to_string(@chat.sources_max)
+              }
+              on_change="ctl_chat"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item :for={v <- ~w(2 5 all)} value={v} phx-value-k="sources_max" phx-value-v={v}>
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
         </div>
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Citations while streaming</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        The same grounded answer, streamed. Each tick re-renders the growing buffer
+        through <code>to_html(buffer, sources: sources)</code>
+        and pushes the HTML at a format="markdown" streaming_text, so chips light up
+        as their markers complete. A half-arrived "[^" is left alone until the closing
+        bracket lands, so nothing flashes broken.
+      </p>
+      <div class="p-4 border border-gray-200 rounded-xl dark:border-gray-800">
+        <Chat.streaming_text id="pg-chat-rag-stream" event="pc-chat-rag-token" format="markdown" />
+        <div class="mt-3">
+          <Chat.chat_sources
+            sources={@chat_rag_sources}
+            expanded={@chat.sources_expanded}
+            max_visible={@chat.sources_max}
+          />
+        </div>
+        <.button
+          size="sm"
+          variant="outline"
+          class="mt-3"
+          phx-click="chat_rag_stream"
+          disabled={@chat.rag_streaming}
+        >
+          {if @chat.rag_streaming, do: "Streaming...", else: "Stream the grounded answer"}
+        </.button>
+      </div>
+
+      <div class="p-4 mt-3 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        Answer grounding is two pieces. Prompt the model to cite as <code>[^N]</code>
+        and pass the same source maps to <code>markdown/1</code>: complete markers
+        become chips, unmatched ones stay as plain text. Chips are real links - Tab
+        reaches one, the preview card opens on focus, Enter opens the source in a new
+        tab. <code>chat_sources</code>
+        is the deduped list underneath, a native
+        &lt;details&gt; with no JS: the dials above flip <code>expanded</code>
+        and cap the list with <code>max_visible</code>, which tucks the rest behind a
+        "Show all" reveal.
       </div>
       <div class="p-4 mt-3 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
         Streaming is real here: the LiveView pushes word-sized tokens with
@@ -8854,7 +9049,9 @@ defmodule Dev.PlaygroundLive do
           :message_actions,
           :copy_button,
           :suggestions,
-          :chat_error
+          :chat_error,
+          :chat_sources,
+          :citation
         ]}
       />
 

--- a/dev.exs
+++ b/dev.exs
@@ -252,6 +252,9 @@ defmodule Dev.PlaygroundLive do
   and each connected tab is just another cheap process [^4].
   """
 
+  # Inline SVG so the attachments example renders with no static asset host.
+  @chat_shot_image "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='480' height='300'><rect width='100%' height='100%' fill='%23e2e8f0'/><rect x='24' y='24' width='432' height='40' rx='6' fill='%23cbd5e1'/><rect x='24' y='88' width='300' height='16' rx='4' fill='%23cbd5e1'/><rect x='24' y='120' width='240' height='16' rx='4' fill='%23cbd5e1'/><rect x='24' y='176' width='432' height='96' rx='6' fill='%23fecaca'/><text x='40' y='232' font-family='monospace' font-size='18' fill='%23991b1b'>CardTokenExpired</text></svg>"
+
   @chat_history [
     %{id: "m-yesterday", role: :marker, text: "Yesterday"},
     %{id: "hist-q", role: :user, text: "Does it support dark mode?", stream_id: nil},
@@ -774,6 +777,7 @@ defmodule Dev.PlaygroundLive do
        tg_variant: "solid",
        tg_size: "md",
        chat_rag_sources: @chat_rag_sources,
+       chat_shot_image: @chat_shot_image,
        chat: %{
          turns: [
            %{id: "m-today", role: :marker, text: "Today"},
@@ -807,7 +811,9 @@ defmodule Dev.PlaygroundLive do
          sent: false,
          sources_expanded: false,
          sources_max: 5,
-         rag_streaming: false
+         rag_streaming: false,
+         attach_hint: true,
+         attach_limit: "5mb"
        },
        alert: %{
          color: "gray",
@@ -920,6 +926,11 @@ defmodule Dev.PlaygroundLive do
          gap: "cozy",
          points: 14
        }
+     )
+     |> allow_upload(:chat_attachments,
+       accept: ~w(.png .jpg .jpeg .pdf),
+       max_entries: 4,
+       max_file_size: 5_000_000
      )}
   end
 
@@ -1796,6 +1807,33 @@ defmodule Dev.PlaygroundLive do
     {:noreply, assign(socket, :chat, %{socket.assigns.chat | sources_max: max})}
   end
 
+  def handle_event("ctl_chat", %{"k" => "attach_hint", "v" => v}, socket) do
+    {:noreply, assign(socket, :chat, %{socket.assigns.chat | attach_hint: v == "on"})}
+  end
+
+  # Re-allow the upload with a tiny cap so the "too large" error is one drop
+  # away. disallow_upload first - allow_upload raises on a name it already owns.
+  def handle_event("ctl_chat", %{"k" => "attach_limit", "v" => v}, socket) do
+    max = if v == "tiny", do: 20_000, else: 5_000_000
+
+    {:noreply,
+     socket
+     |> disallow_upload(:chat_attachments)
+     |> allow_upload(:chat_attachments,
+       accept: ~w(.png .jpg .jpeg .pdf),
+       max_entries: 4,
+       max_file_size: max
+     )
+     |> assign(:chat, %{socket.assigns.chat | attach_limit: v})}
+  end
+
+  # Uploads need a change event on the form to make progress.
+  def handle_event("chat_validate", _params, socket), do: {:noreply, socket}
+
+  def handle_event("chat_cancel_upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :chat_attachments, ref)}
+  end
+
   # Streams the same grounded answer word by word. Each tick re-renders the
   # buffer through to_html/2, so the [^N] chips appear as the markers complete
   # and a half-arrived "[^" never flashes broken.
@@ -1842,10 +1880,12 @@ defmodule Dev.PlaygroundLive do
 
   defp chat_start(socket, prompt) do
     prompt = String.trim(prompt)
+    pending? = socket.assigns.uploads.chat_attachments.entries != []
 
-    if prompt == "" || socket.assigns.chat.streaming do
+    if (prompt == "" && !pending?) || socket.assigns.chat.streaming do
       {:noreply, socket}
     else
+      attachments = consume_chat_attachments(socket)
       chat = socket.assigns.chat
       seq = chat.seq + 1
       id = "pg-chat-ans-#{seq}"
@@ -1860,7 +1900,13 @@ defmodule Dev.PlaygroundLive do
       turns =
         base ++
           [
-            %{id: "u#{seq}", role: :user, text: prompt, stream_id: nil},
+            %{
+              id: "u#{seq}",
+              role: :user,
+              text: prompt,
+              stream_id: nil,
+              attachments: attachments
+            },
             %{id: "a#{seq}", role: :assistant, text: reply, stream_id: id}
           ]
 
@@ -1880,6 +1926,32 @@ defmodule Dev.PlaygroundLive do
        |> push_event("pc-chat-set-input", %{id: "pg-chat-composer", value: ""})
        |> assign(:chat, chat)}
     end
+  end
+
+  # A real app writes these somewhere it can serve from. The playground has no
+  # static host for a temp dir, so small images become data URIs (enough to
+  # prove message_attachments renders what was actually uploaded) and anything
+  # else becomes a file row.
+  defp consume_chat_attachments(socket) do
+    consume_uploaded_entries(socket, :chat_attachments, fn %{path: path}, entry ->
+      image? = String.starts_with?(entry.client_type, "image/")
+      inlineable? = image? && entry.client_size <= 1_000_000
+
+      url =
+        if inlineable? do
+          "data:#{entry.client_type};base64,#{Base.encode64(File.read!(path))}"
+        else
+          "#"
+        end
+
+      {:ok,
+       %{
+         kind: if(inlineable?, do: :image, else: :file),
+         url: url,
+         name: entry.client_name,
+         size: entry.client_size
+       }}
+    end)
   end
 
   defp patch_theme(socket, delta) do
@@ -8813,6 +8885,11 @@ defmodule Dev.PlaygroundLive do
               role="user"
               class={@chat.editing == i && "pc-chat__row--editing"}
             >
+              <Chat.message_attachments
+                :if={Map.get(turn, :attachments, []) != []}
+                attachments={Map.get(turn, :attachments)}
+                class="mb-2"
+              />
               {turn.text}
               <:actions>
                 <Chat.message_actions visible={@chat.actions}>
@@ -8881,11 +8958,15 @@ defmodule Dev.PlaygroundLive do
             <Chat.prompt_input
               id="pg-chat-composer"
               phx-submit="chat_send"
+              phx-change="chat_validate"
+              upload={@uploads.chat_attachments}
+              on_cancel_upload="chat_cancel_upload"
+              accept_hint={@chat.attach_hint && "Images and PDFs up to 5 MB"}
               editing={@chat.editing != nil}
               on_cancel_edit="chat_cancel_edit"
               loading={@chat.streaming}
               on_stop="chat_stop"
-              placeholder="Ask the (canned) assistant..."
+              placeholder="Ask the (canned) assistant, or paste a screenshot..."
             />
           </:footer>
         </Chat.conversation>
@@ -8961,8 +9042,79 @@ defmodule Dev.PlaygroundLive do
               </:item>
             </.toggle_group>
           </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">accept_hint</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Accept hint"
+              value={if @chat.attach_hint, do: "on", else: "off"}
+              on_change="ctl_chat"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item :for={v <- ~w(off on)} value={v} phx-value-k="attach_hint" phx-value-v={v}>
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">size limit</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Upload size limit"
+              value={@chat.attach_limit}
+              on_change="ctl_chat"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={v <- ~w(5mb tiny)}
+                value={v}
+                phx-value-k="attach_limit"
+                phx-value-v={v}
+              >
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
         </div>
       </div>
+
+      <div class="p-4 mt-3 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        The composer above takes real uploads. Click the paperclip, drag a file
+        onto the composer, or paste a screenshot straight into the textarea -
+        each one lands as a chip with a progress ring and a remove button, and
+        sending renders them back into the message with <code>message_attachments</code>. It's ordinary <code>allow_upload/3</code>: the component only renders <code>@uploads.name</code>. Flip the size limit dial to
+        <code>tiny</code>
+        (20 KB) and drop a normal screenshot to see the inline error, and <code>accept_hint</code>
+        off/on to toggle the paperclip's description. Keyboard: Tab reaches the
+        paperclip, then each chip's remove button, then the textarea, then send.
+      </div>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">A support thread with attachments</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        The received side. Images tile into a grid, files are download rows with
+        the size on the end, and a mixed list puts the images first.
+      </p>
+      <Chat.conversation id="pg-chat-attachments">
+        <Chat.chat_message role="user">
+          <Chat.message_attachments
+            attachments={[
+              %{kind: :image, url: @chat_shot_image, name: "checkout-error.png", size: 184_320},
+              %{kind: :file, url: "#", name: "invoice-4471.pdf", size: 96_400}
+            ]}
+            class="mb-2"
+          /> Checkout throws on submit. Screenshot and the invoice attached.
+        </Chat.chat_message>
+        <Chat.chat_message role="assistant">
+          That trace is a card token expiring before submit. I pulled the
+          gateway log for invoice 4471 - same window.
+          <Chat.message_attachments
+            attachments={[%{kind: :file, url: "#", name: "gateway-4471.log", size: 4_820}]}
+            class="mt-2"
+          />
+        </Chat.chat_message>
+      </Chat.conversation>
 
       <h2 class="mt-10 mb-1 text-lg font-semibold">Citations while streaming</h2>
       <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
@@ -9051,7 +9203,8 @@ defmodule Dev.PlaygroundLive do
           :suggestions,
           :chat_error,
           :chat_sources,
-          :citation
+          :citation,
+          :message_attachments
         ]}
       />
 

--- a/dev.exs
+++ b/dev.exs
@@ -252,6 +252,53 @@ defmodule Dev.PlaygroundLive do
   and each connected tab is just another cheap process [^4].
   """
 
+  # Two-step mocked agent flow: the assistant asks which framework, then what
+  # to scaffold. Both round-trip through real handle_event callbacks.
+  @q_framework %{
+    id: "q-framework",
+    title: "Which framework are you targeting?",
+    description: "This picks the generators I'll reach for.",
+    fields: [
+      %{
+        id: "framework",
+        type: :single_select,
+        label: "Framework",
+        required: true,
+        options: [
+          %{value: "phoenix", label: "Phoenix", description: "Elixir, LiveView, server-rendered"},
+          %{value: "rails", label: "Rails", description: "Ruby, Hotwire, convention-first"},
+          %{value: "next", label: "Next.js", description: "React, app router, RSC"}
+        ]
+      }
+    ]
+  }
+
+  @q_scope %{
+    id: "q-scope",
+    title: "Before I scaffold, two things",
+    fields: [
+      %{
+        id: "features",
+        type: :multi_select,
+        label: "Which features do you need?",
+        options: [
+          %{value: "auth", label: "Auth"},
+          %{value: "billing", label: "Billing"},
+          %{value: "admin", label: "Admin panel"}
+        ]
+      },
+      %{id: "team", type: :text, label: "Team name", placeholder: "Platform"},
+      %{
+        id: "confidence",
+        type: :scale,
+        label: "How settled is this scope?",
+        min_label: "Still exploring",
+        max_label: "Locked",
+        required: true
+      }
+    ]
+  }
+
   # Inline SVG so the attachments example renders with no static asset host.
   @chat_shot_image "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='480' height='300'><rect width='100%' height='100%' fill='%23e2e8f0'/><rect x='24' y='24' width='432' height='40' rx='6' fill='%23cbd5e1'/><rect x='24' y='88' width='300' height='16' rx='4' fill='%23cbd5e1'/><rect x='24' y='120' width='240' height='16' rx='4' fill='%23cbd5e1'/><rect x='24' y='176' width='432' height='96' rx='6' fill='%23fecaca'/><text x='40' y='232' font-family='monospace' font-size='18' fill='%23991b1b'>CardTokenExpired</text></svg>"
 
@@ -778,6 +825,19 @@ defmodule Dev.PlaygroundLive do
        tg_size: "md",
        chat_rag_sources: @chat_rag_sources,
        chat_shot_image: @chat_shot_image,
+       q_framework: @q_framework,
+       q_scope: @q_scope,
+       quiz: %{
+         # nil until answered; then the answer map or :skipped
+         framework: nil,
+         scope: nil,
+         asked_scope: false,
+         submitting: false,
+         # dial state for the standalone demo below the flow
+         field: "single_cards",
+         allow_skip: true,
+         state: "pending"
+       },
        chat: %{
          turns: [
            %{id: "m-today", role: :marker, text: "Today"},
@@ -1827,6 +1887,46 @@ defmodule Dev.PlaygroundLive do
      |> assign(:chat, %{socket.assigns.chat | attach_limit: v})}
   end
 
+  # The whole point of the component: submit is a plain phx-submit, the parent
+  # updates assigns, and the card flips to its resolved state. No client state.
+  def handle_event("questionnaire_submit", %{"spec_id" => "q-framework"} = params, socket) do
+    quiz = %{socket.assigns.quiz | framework: params["answers"] || %{}, asked_scope: true}
+    {:noreply, assign(socket, :quiz, quiz)}
+  end
+
+  def handle_event("questionnaire_submit", %{"spec_id" => "q-scope"} = params, socket) do
+    {:noreply, assign(socket, :quiz, %{socket.assigns.quiz | scope: params["answers"] || %{}})}
+  end
+
+  def handle_event("questionnaire_submit", _params, socket), do: {:noreply, socket}
+
+  def handle_event("questionnaire_skip", %{"id" => "q-framework"}, socket) do
+    {:noreply, assign(socket, :quiz, %{socket.assigns.quiz | framework: :skipped})}
+  end
+
+  def handle_event("questionnaire_skip", %{"id" => "q-scope"}, socket) do
+    {:noreply, assign(socket, :quiz, %{socket.assigns.quiz | scope: :skipped})}
+  end
+
+  def handle_event("questionnaire_skip", _params, socket), do: {:noreply, socket}
+
+  def handle_event("quiz_reset", _params, socket) do
+    quiz = %{socket.assigns.quiz | framework: nil, scope: nil, asked_scope: false}
+    {:noreply, assign(socket, :quiz, quiz)}
+  end
+
+  def handle_event("ctl_quiz", %{"k" => k, "v" => v}, socket) do
+    quiz =
+      case k do
+        "field" -> %{socket.assigns.quiz | field: v}
+        "allow_skip" -> %{socket.assigns.quiz | allow_skip: v == "on"}
+        "state" -> %{socket.assigns.quiz | state: v}
+        _ -> socket.assigns.quiz
+      end
+
+    {:noreply, assign(socket, :quiz, quiz)}
+  end
+
   # Uploads need a change event on the form to make progress.
   def handle_event("chat_validate", _params, socket), do: {:noreply, socket}
 
@@ -1927,6 +2027,59 @@ defmodule Dev.PlaygroundLive do
        |> assign(:chat, chat)}
     end
   end
+
+  # One field at a time, so each type can be looked at on its own.
+  defp quiz_demo_spec("single_cards"), do: @q_framework
+
+  defp quiz_demo_spec("single_buttons") do
+    %{
+      id: "q-demo",
+      title: "Which framework are you targeting?",
+      fields: [
+        %{
+          id: "framework",
+          type: :single_select,
+          label: "Framework",
+          style: "buttons",
+          required: true,
+          options: [
+            %{value: "phoenix", label: "Phoenix"},
+            %{value: "rails", label: "Rails"},
+            %{value: "next", label: "Next.js"}
+          ]
+        }
+      ]
+    }
+  end
+
+  defp quiz_demo_spec("multi") do
+    %{
+      id: "q-demo",
+      title: "Which features do you need?",
+      fields: [Enum.at(@q_scope.fields, 0)]
+    }
+  end
+
+  defp quiz_demo_spec("text") do
+    %{id: "q-demo", title: "What should I call it?", fields: [Enum.at(@q_scope.fields, 1)]}
+  end
+
+  defp quiz_demo_spec(_scale) do
+    %{id: "q-demo", title: "How settled is this scope?", fields: [Enum.at(@q_scope.fields, 2)]}
+  end
+
+  defp quiz_demo_resolved(%{state: "skipped"}), do: :skipped
+
+  defp quiz_demo_resolved(%{state: "resolved", field: field}) do
+    case field do
+      "multi" -> %{"features" => ["auth", "billing"]}
+      "text" -> %{"team" => "Platform"}
+      "scale" -> %{"confidence" => "5"}
+      _ -> %{"framework" => "phoenix"}
+    end
+  end
+
+  defp quiz_demo_resolved(_quiz), do: nil
 
   # A real app writes these somewhere it can serve from. The playground has no
   # static host for a temp dir, so small images become data URIs (enough to
@@ -9091,6 +9244,121 @@ defmodule Dev.PlaygroundLive do
         paperclip, then each chip's remove button, then the textarea, then send.
       </div>
 
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Human in the loop</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        A live two-step flow. The assistant asks which framework, you answer, the
+        card flips to resolved chips and it asks the follow-up. Submit is a plain
+        phx-submit into this page's handle_event - the component holds no client
+        state at all. Keyboard-only works end to end: arrows move within a group,
+        Space toggles a checkbox, Enter submits.
+      </p>
+      <Chat.conversation id="pg-chat-quiz">
+        <Chat.chat_message role="user">Scaffold me a starter app.</Chat.chat_message>
+        <Chat.chat_message role="assistant">
+          <Chat.questionnaire
+            spec={@q_framework}
+            resolved={@quiz.framework}
+            allow_skip
+            submitting={@quiz.submitting}
+          />
+        </Chat.chat_message>
+        <Chat.chat_message :if={@quiz.asked_scope || @quiz.framework == :skipped} role="assistant">
+          <Chat.questionnaire
+            spec={@q_scope}
+            resolved={@quiz.scope}
+            allow_skip
+            submit_label="Send answers"
+          />
+        </Chat.chat_message>
+        <:footer>
+          <.button size="sm" variant="outline" phx-click="quiz_reset">Reset the flow</.button>
+        </:footer>
+      </Chat.conversation>
+
+      <h2 class="mt-10 mb-1 text-lg font-semibold">Field types and states</h2>
+      <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+        One field at a time, through every state.
+      </p>
+      <div class="overflow-hidden border border-gray-200 rounded-xl dark:border-gray-800">
+        <div class="p-6">
+          <Chat.questionnaire
+            spec={quiz_demo_spec(@quiz.field)}
+            resolved={quiz_demo_resolved(@quiz)}
+            submitting={@quiz.state == "submitting"}
+            allow_skip={@quiz.allow_skip}
+          />
+        </div>
+        <div class="flex flex-wrap gap-6 px-6 py-4 border-t border-gray-100 dark:border-gray-800/80">
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">field type</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Field type"
+              value={@quiz.field}
+              on_change="ctl_quiz"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={v <- ~w(single_cards single_buttons multi text scale)}
+                value={v}
+                phx-value-k="field"
+                phx-value-v={v}
+              >
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">allow_skip</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Allow skip"
+              value={if @quiz.allow_skip, do: "on", else: "off"}
+              on_change="ctl_quiz"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item :for={v <- ~w(off on)} value={v} phx-value-k="allow_skip" phx-value-v={v}>
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+          <div>
+            <div class="mb-2 text-[11px] font-medium tracking-wide text-gray-400">state</div>
+            <.toggle_group
+              variant="outline"
+              size="sm"
+              aria_label="Questionnaire state"
+              value={@quiz.state}
+              on_change="ctl_quiz"
+              class="max-w-full overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            >
+              <:item
+                :for={v <- ~w(pending submitting resolved skipped)}
+                value={v}
+                phx-value-k="state"
+                phx-value-v={v}
+              >
+                {v}
+              </:item>
+            </.toggle_group>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-4 mt-3 text-sm text-gray-500 border border-gray-200 rounded-xl dark:border-gray-800 dark:text-gray-400">
+        The spec is a plain map the app (or the model) emits; the component is a
+        thin renderer over it. Single-select composes <code>field type="radio-card"</code>
+        when the options carry descriptions and <code>type="radio-group"</code>
+        when they don't; multi-select is a checkbox group, text is a text field.
+        Only the 1-to-5 scale is new markup - five real radios in a segmented
+        row, so arrows move between steps natively. Inputs are named <code>answers[field_id]</code>
+        so submit lands as a map with a "spec_id" key and an "answers" map.
+        Resolved replaces the form with chips - no disabled form left in the DOM
+        pretending to be interactive.
+      </div>
+
       <h2 class="mt-10 mb-1 text-lg font-semibold">A support thread with attachments</h2>
       <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
         The received side. Images tile into a grid, files are download rows with
@@ -9204,7 +9472,8 @@ defmodule Dev.PlaygroundLive do
           :chat_error,
           :chat_sources,
           :citation,
-          :message_attachments
+          :message_attachments,
+          :questionnaire
         ]}
       />
 

--- a/lib/petal_components/chat.ex
+++ b/lib/petal_components/chat.ex
@@ -13,6 +13,7 @@ defmodule PetalComponents.Chat do
     * `chat_sources/1`   — the RAG sources row under an answer
     * `citation/1`       — an inline numbered citation chip
     * `message_attachments/1` — images and files inside a sent message
+    * `questionnaire/1`  — structured human-in-the-loop input in the thread
 
   ## Importing
 
@@ -745,6 +746,375 @@ defmodule PetalComponents.Chat do
       </a>
     </div>
     """
+  end
+
+  @doc """
+  Structured human-in-the-loop input, rendered inside the conversation. The
+  model (via your app) emits a question spec; this renders it as a form in the
+  transcript, and once the app has the answer it renders back as a quiet
+  summary so the transcript stays honest about what was asked and answered.
+
+  Server-driven end to end — a plain `phx-submit`, no client state, no client
+  form engine.
+
+      <Chat.chat_message role="assistant">
+        <Chat.questionnaire spec={@question} resolved={@answers} allow_skip />
+      </Chat.chat_message>
+
+  ## The spec
+
+      %{
+        id: "q-framework",
+        title: "Which framework are you targeting?",
+        description: "This picks the generators I'll reach for.",
+        fields: [
+          %{id: "framework", type: :single_select, label: "Framework", required: true,
+            options: [
+              %{value: "phoenix", label: "Phoenix", description: "Elixir, LiveView"},
+              %{value: "rails", label: "Rails", description: "Ruby, Hotwire"}
+            ]},
+          %{id: "features", type: :multi_select, label: "Features",
+            options: [%{value: "auth", label: "Auth"}, %{value: "billing", label: "Billing"}]},
+          %{id: "team", type: :text, label: "Team name", placeholder: "Acme"},
+          %{id: "confidence", type: :scale, label: "How sure are you?",
+            min_label: "Not sure", max_label: "Certain", required: true}
+        ]
+      }
+
+  String and atom keys are both accepted. `:single_select` renders radio-cards
+  when any option carries a `description`, plain radios otherwise — override
+  per field with `style: "cards"` or `style: "buttons"`.
+
+  ## The params you get back
+
+  Inputs are named `answers[<field_id>]` (`answers[<field_id>][]` for
+  multi-select), plus a hidden `spec_id` echoing the spec:
+
+      def handle_event("questionnaire_submit", %{"spec_id" => id, "answers" => answers}, socket) do
+        # %{"framework" => "phoenix", "features" => ["auth"], "confidence" => "4"}
+        {:noreply, socket |> answer(id, answers) |> ask_the_model(answers)}
+      end
+
+      def handle_event("questionnaire_skip", %{"id" => id}, socket) do
+        {:noreply, assign(socket, :answers, :skipped)}
+      end
+
+  Required fields use the native `required` attribute — server-side validation
+  stays in your app.
+
+  ## Resolving it
+
+  Pass the answer map back as `resolved` and the form is replaced by chips;
+  pass `:skipped` for the skipped line. Nothing focusable is left behind — no
+  disabled form pretending to still be a control.
+  """
+  attr :spec, :map,
+    required: true,
+    doc:
+      "the question spec: %{id, title, description, fields: [...]}. Each field is %{id, type, label, required, options, placeholder, min_label, max_label, style}, where type is :single_select | :multi_select | :text | :scale. String or atom keys both accepted"
+
+  attr :resolved, :any,
+    default: nil,
+    doc:
+      "nil while pending. A map of answers keyed by field id renders the resolved summary; the atom :skipped renders the skipped state"
+
+  attr :on_submit, :string,
+    default: "questionnaire_submit",
+    doc: "phx-submit event name posted to the parent LiveView"
+
+  attr :allow_skip, :boolean,
+    default: false,
+    doc: "renders a Skip button that posts on_skip with the spec id"
+
+  attr :on_skip, :string,
+    default: "questionnaire_skip",
+    doc: "phx-click event for the skip button, with phx-value-id set to the spec id"
+
+  attr :submitting, :boolean,
+    default: false,
+    doc:
+      "disables every input and both buttons and shows a spinner while the app forwards the answer"
+
+  attr :submit_label, :string, default: "Submit", doc: "text on the submit button"
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  def questionnaire(assigns) do
+    spec = normalize_spec(assigns.spec)
+
+    assigns =
+      assigns
+      |> assign(:spec, spec)
+      |> assign(:title_id, "#{spec.id}-title")
+      |> assign(:answers, resolved_answers(spec, assigns.resolved))
+
+    ~H"""
+    <div
+      class={[
+        "pc-questionnaire",
+        @resolved == :skipped && "pc-questionnaire--skipped",
+        is_map(@resolved) && "pc-questionnaire--resolved",
+        @class
+      ]}
+      {@rest}
+    >
+      <div class="pc-questionnaire__header">
+        <h3 id={@title_id} class="pc-questionnaire__title">{@spec.title}</h3>
+        <p :if={@spec.description} class="pc-questionnaire__description">{@spec.description}</p>
+      </div>
+
+      <%= cond do %>
+        <% @resolved == :skipped -> %>
+          <p class="pc-questionnaire__skipped-note">Skipped</p>
+        <% is_map(@resolved) -> %>
+          <dl class="pc-questionnaire__summary">
+            <div :for={{field, chips} <- @answers} class="pc-questionnaire__answer">
+              <dt class="pc-questionnaire__answer-label">{field.label}</dt>
+              <dd class="pc-questionnaire__answer-value">
+                <span :for={chip <- chips} class="pc-questionnaire__chip">{chip}</span>
+              </dd>
+            </div>
+          </dl>
+        <% true -> %>
+          <form
+            phx-submit={@on_submit}
+            aria-labelledby={@title_id}
+            class="pc-questionnaire__form"
+          >
+            <input type="hidden" name="spec_id" value={@spec.id} />
+            <.questionnaire_field
+              :for={field <- @spec.fields}
+              field={field}
+              spec_id={@spec.id}
+              submitting={@submitting}
+            />
+            <div class="pc-questionnaire__actions">
+              <button
+                type="submit"
+                disabled={@submitting}
+                class="pc-questionnaire__submit"
+              >
+                <span :if={@submitting} role="status" class="pc-questionnaire__spinner-wrap">
+                  <span class="pc-questionnaire__spinner" aria-hidden="true"></span>
+                  <span class="sr-only">Submitting</span>
+                </span>
+                {@submit_label}
+              </button>
+              <button
+                :if={@allow_skip}
+                type="button"
+                phx-click={@on_skip}
+                phx-value-id={@spec.id}
+                disabled={@submitting}
+                class="pc-questionnaire__skip"
+              >
+                Skip
+              </button>
+            </div>
+          </form>
+      <% end %>
+    </div>
+    """
+  end
+
+  attr :field, :map, required: true
+  attr :spec_id, :string, required: true
+  attr :submitting, :boolean, required: true
+
+  defp questionnaire_field(assigns) do
+    assigns =
+      assigns
+      |> assign(:name, "answers[#{assigns.field.id}]")
+      |> assign(:legend, questionnaire_legend(assigns.field))
+
+    ~H"""
+    <fieldset class={["pc-questionnaire__field", "pc-questionnaire__field--#{@field.type}"]}>
+      <legend class="sr-only">{@legend}</legend>
+      <%= case @field.type do %>
+        <% :single_select -> %>
+          <PetalComponents.Field.field
+            :if={questionnaire_style(@field) == "cards"}
+            type="radio-card"
+            name={@name}
+            label={@field.label}
+            options={@field.options}
+            required={@field.required}
+            disabled={@submitting}
+            group_layout="col"
+            no_margin
+          />
+          <PetalComponents.Field.field
+            :if={questionnaire_style(@field) != "cards"}
+            type="radio-group"
+            name={@name}
+            label={@field.label}
+            options={option_tuples(@field.options)}
+            required={@field.required}
+            disabled={@submitting}
+            group_layout="col"
+            no_margin
+          />
+        <% :multi_select -> %>
+          <PetalComponents.Field.field
+            type="checkbox-group"
+            name={@name}
+            label={@field.label}
+            options={option_tuples(@field.options)}
+            required={@field.required}
+            disabled={@submitting}
+            group_layout="col"
+            no_margin
+          />
+        <% :text -> %>
+          <PetalComponents.Field.field
+            type="text"
+            name={@name}
+            label={@field.label}
+            placeholder={@field.placeholder}
+            required={@field.required}
+            disabled={@submitting}
+            no_margin
+          />
+        <% :scale -> %>
+          <.questionnaire_scale
+            field={@field}
+            name={@name}
+            spec_id={@spec_id}
+            submitting={@submitting}
+          />
+      <% end %>
+    </fieldset>
+    """
+  end
+
+  attr :field, :map, required: true
+  attr :name, :string, required: true
+  attr :spec_id, :string, required: true
+  attr :submitting, :boolean, required: true
+
+  defp questionnaire_scale(assigns) do
+    assigns = assign(assigns, :caption_id, "#{assigns.spec_id}-#{assigns.field.id}-captions")
+
+    ~H"""
+    <span class={["pc-label", @field.required && "pc-label--required"]}>{@field.label}</span>
+    <div class="pc-questionnaire__scale">
+      <label :for={value <- 1..5} class="pc-questionnaire__scale-step">
+        <input
+          type="radio"
+          name={@name}
+          value={value}
+          required={@field.required}
+          disabled={@submitting}
+          aria-describedby={(@field.min_label || @field.max_label) && @caption_id}
+          class="sr-only pc-questionnaire__scale-input"
+        />
+        <span class="pc-questionnaire__scale-number">{value}</span>
+      </label>
+    </div>
+    <div
+      :if={@field.min_label || @field.max_label}
+      id={@caption_id}
+      class="pc-questionnaire__scale-captions"
+    >
+      <span>{@field.min_label}</span>
+      <span>{@field.max_label}</span>
+    </div>
+    """
+  end
+
+  # -- questionnaire plumbing ------------------------------------------------
+
+  defp normalize_spec(spec) when is_map(spec) do
+    %{
+      id: to_string(source_key(spec, :id) || "questionnaire"),
+      title: source_key(spec, :title),
+      description: source_key(spec, :description),
+      fields: spec |> source_key(:fields) |> List.wrap() |> Enum.map(&normalize_spec_field/1)
+    }
+  end
+
+  defp normalize_spec_field(field) do
+    %{
+      id: to_string(source_key(field, :id)),
+      type: normalize_field_type(source_key(field, :type)),
+      label: source_key(field, :label),
+      required: source_key(field, :required) == true,
+      placeholder: source_key(field, :placeholder),
+      style: source_key(field, :style),
+      min_label: source_key(field, :min_label),
+      max_label: source_key(field, :max_label),
+      options: field |> source_key(:options) |> List.wrap() |> Enum.map(&normalize_option/1)
+    }
+  end
+
+  defp normalize_field_type(type) when type in [:single_select, "single_select"],
+    do: :single_select
+
+  defp normalize_field_type(type) when type in [:multi_select, "multi_select"], do: :multi_select
+  defp normalize_field_type(type) when type in [:scale, "scale"], do: :scale
+  defp normalize_field_type(_), do: :text
+
+  defp normalize_option(option) when is_map(option) do
+    %{
+      value: to_string(source_key(option, :value)),
+      label: source_key(option, :label) || to_string(source_key(option, :value)),
+      description: source_key(option, :description)
+    }
+  end
+
+  # Cards when the author asked for them, or when any option carries a
+  # description worth showing. Plain radios otherwise.
+  defp questionnaire_style(%{style: style}) when style in ["cards", "buttons"], do: style
+
+  defp questionnaire_style(%{options: options}) do
+    if Enum.any?(options, & &1.description), do: "cards", else: "buttons"
+  end
+
+  defp questionnaire_legend(%{label: label, required: true}), do: "#{label} (required)"
+  defp questionnaire_legend(%{label: label}), do: label
+
+  defp option_tuples(options), do: Enum.map(options, &{&1.label, &1.value})
+
+  # [{field, [chip, ...]}] for every field the answer map actually answered.
+  defp resolved_answers(_spec, resolved) when not is_map(resolved), do: []
+
+  defp resolved_answers(spec, resolved) do
+    spec.fields
+    |> Enum.map(fn field -> {field, answer_chips(field, answer_for(resolved, field.id))} end)
+    |> Enum.reject(fn {_field, chips} -> chips == [] end)
+  end
+
+  defp answer_for(resolved, id) do
+    case Map.fetch(resolved, id) do
+      {:ok, value} -> value
+      :error -> Map.get(resolved, String.to_atom(id))
+    end
+  end
+
+  defp answer_chips(_field, nil), do: []
+  defp answer_chips(_field, ""), do: []
+
+  defp answer_chips(field, values) when is_list(values),
+    do: Enum.flat_map(values, &answer_chips(field, &1))
+
+  defp answer_chips(%{type: :scale} = field, value) do
+    caption =
+      case to_string(value) do
+        "1" -> field.min_label
+        "5" -> field.max_label
+        _ -> nil
+      end
+
+    [if(caption, do: "#{value} · #{caption}", else: to_string(value))]
+  end
+
+  defp answer_chips(field, value) do
+    value = to_string(value)
+
+    case Enum.find(field.options, &(&1.value == value)) do
+      nil -> [value]
+      option -> [option.label]
+    end
   end
 
   # -- attachment plumbing ---------------------------------------------------

--- a/lib/petal_components/chat.ex
+++ b/lib/petal_components/chat.ex
@@ -12,6 +12,7 @@ defmodule PetalComponents.Chat do
     * `prompt_input/1`   — the composer (textarea + send)
     * `chat_sources/1`   — the RAG sources row under an answer
     * `citation/1`       — an inline numbered citation chip
+    * `message_attachments/1` — images and files inside a sent message
 
   ## Importing
 
@@ -441,6 +442,43 @@ defmodule PetalComponents.Chat do
   While `loading`, the input stays editable (so you can draft your next message)
   and the send button becomes a stop button that pushes `on_stop` — wire it to
   cancel your generation task.
+
+  ## Attachments
+
+  Pass an `%Phoenix.LiveView.UploadConfig{}` from `allow_upload/3` and the
+  composer grows a paperclip trigger, a chip strip for the pending entries,
+  drag-onto-the-composer, paste-an-image, and inline upload errors. It is
+  ordinary LiveView uploads — this component only renders them:
+
+      def mount(_, _, socket) do
+        {:ok, allow_upload(socket, :attachments, accept: ~w(.png .jpg .jpeg .pdf),
+                           max_entries: 4, max_file_size: 5_000_000)}
+      end
+
+      def handle_event("validate", _params, socket), do: {:noreply, socket}
+
+      def handle_event("cancel-upload", %{"ref" => ref}, socket) do
+        {:noreply, cancel_upload(socket, :attachments, ref)}
+      end
+
+      def handle_event("send", %{"prompt" => text}, socket) do
+        files = consume_uploaded_entries(socket, :attachments, fn %{path: path}, entry ->
+          {:ok, store(path, entry)}
+        end)
+        {:noreply, send_message(socket, text, files)}
+      end
+
+      <Chat.prompt_input
+        phx-submit="send"
+        phx-change="validate"
+        upload={@uploads.attachments}
+        on_cancel_upload="cancel-upload"
+        accept_hint="Images and PDFs up to 5 MB"
+      />
+
+  `phx-change` is required for uploads to progress — LiveView needs a change
+  event on the form. With no `upload` the composer renders exactly as it always
+  has.
   """
   attr :id, :string, doc: "defaults to a generated id so multiple composers can coexist"
 
@@ -473,6 +511,21 @@ defmodule PetalComponents.Chat do
     default: nil,
     doc: "event pushed when the edit banner's cancel (X) is clicked"
 
+  attr :upload, :any,
+    default: nil,
+    doc:
+      "a %Phoenix.LiveView.UploadConfig{} from allow_upload/3. When set the composer renders a paperclip trigger wrapping a visually hidden live_file_input, attachment chips for @upload.entries, becomes a phx-drop-target, and accepts pasted images"
+
+  attr :on_cancel_upload, :string,
+    default: "cancel-upload",
+    doc:
+      "event pushed by a chip's remove button, with phx-value-ref set to the entry ref (wire it to cancel_upload/3)"
+
+  attr :accept_hint, :string,
+    default: nil,
+    doc:
+      ~s|human-readable hint of accepted types and size (e.g. "Images and PDFs up to 10 MB"), used as the paperclip button's title and accessible description|
+
   attr :class, :any, default: nil
   attr :rest, :global, include: ~w(phx-submit phx-change phx-target)
   slot :actions, doc: "extra controls left of the send button"
@@ -484,6 +537,7 @@ defmodule PetalComponents.Chat do
     <form
       id={@id}
       phx-hook="PetalChatComposer"
+      phx-drop-target={@upload && @upload.ref}
       class={["pc-chat__composer", @editing && "pc-chat__composer--editing", @class]}
       {@rest}
     >
@@ -502,7 +556,28 @@ defmodule PetalComponents.Chat do
           <PetalComponents.Icon.icon name="hero-x-mark" class="pc-chat__composer-banner-icon" />
         </button>
       </div>
+      <ul
+        :if={@upload && @upload.entries != []}
+        role="list"
+        class="pc-chat__composer-attachments"
+      >
+        <.attachment_chip
+          :for={entry <- @upload.entries}
+          entry={entry}
+          upload={@upload}
+          on_cancel_upload={@on_cancel_upload}
+        />
+      </ul>
       <div class="pc-chat__composer-row">
+        <label :if={@upload} class="pc-chat__composer-attach" title={@accept_hint}>
+          <PetalComponents.Icon.icon name="hero-paper-clip" class="pc-chat__composer-attach-icon" />
+          <.live_file_input
+            upload={@upload}
+            class="sr-only"
+            aria-label="Attach files"
+            aria-description={@accept_hint}
+          />
+        </label>
         <textarea
           id={"#{@id}-input"}
           name={@name}
@@ -549,9 +624,179 @@ defmodule PetalComponents.Chat do
           <% end %>
         </button>
       </div>
+      <div :if={@upload && upload_error_messages(@upload) != []} class="pc-chat__composer-errors">
+        <p
+          :for={message <- upload_error_messages(@upload)}
+          role="alert"
+          class="pc-chat__composer-error"
+        >
+          <PetalComponents.Icon.icon
+            name="hero-exclamation-circle"
+            class="pc-chat__composer-error-icon"
+          />
+          {message}
+        </p>
+      </div>
     </form>
     """
   end
+
+  attr :entry, :any, required: true
+  attr :upload, :any, required: true
+  attr :on_cancel_upload, :string, required: true
+
+  defp attachment_chip(assigns) do
+    assigns = assign(assigns, :image?, image_entry?(assigns.entry))
+
+    ~H"""
+    <li class={[
+      "pc-chat__attachment",
+      if(@image?, do: "pc-chat__attachment--image", else: "pc-chat__attachment--file")
+    ]}>
+      <.live_img_preview :if={@image?} entry={@entry} class="pc-chat__attachment-thumb" />
+      <PetalComponents.Icon.icon
+        :if={!@image?}
+        name="hero-document"
+        class="pc-chat__attachment-icon"
+      />
+      <span :if={!@image?} class="pc-chat__attachment-meta">
+        <span class="pc-chat__attachment-name">{@entry.client_name}</span>
+        <span class="pc-chat__attachment-size">{format_bytes(@entry.client_size)}</span>
+      </span>
+      <span
+        :if={@entry.progress < 100}
+        role="progressbar"
+        aria-valuenow={@entry.progress}
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-label={"Uploading #{@entry.client_name}"}
+        data-progress={@entry.progress}
+        style={"--pc-attachment-progress: #{@entry.progress}"}
+        class="pc-chat__attachment-progress"
+      ></span>
+      <button
+        type="button"
+        phx-click={@on_cancel_upload}
+        phx-value-ref={@entry.ref}
+        aria-label={"Remove #{@entry.client_name}"}
+        class="pc-chat__attachment-remove"
+      >
+        <PetalComponents.Icon.icon name="hero-x-mark" class="pc-chat__attachment-remove-icon" />
+      </button>
+    </li>
+    """
+  end
+
+  @doc """
+  Attachments rendered inside a sent message — the images and files that went
+  along with the text. Drop it in a `chat_message/1` body, before or after the
+  prose:
+
+      <Chat.chat_message role="user">
+        <Chat.message_attachments attachments={msg.attachments} />
+        {msg.text}
+      </Chat.chat_message>
+
+  Images render as a thumbnail grid (one image goes large, two or more tile),
+  files as compact download rows. A mixed list puts the images first.
+  """
+  attr :attachments, :list,
+    required: true,
+    doc:
+      "list of maps: %{kind: :image | :file, url, name, size}. :kind picks the rendering, :size is bytes and is formatted for display or omitted when nil. String or atom keys both accepted"
+
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  def message_attachments(assigns) do
+    items = normalize_attachments(assigns.attachments)
+    {images, files} = Enum.split_with(items, &(&1.kind == :image))
+
+    assigns = assigns |> assign(:images, images) |> assign(:files, files)
+
+    ~H"""
+    <div :if={@images != [] or @files != []} class={["pc-chat__message-attachments", @class]} {@rest}>
+      <div
+        :if={@images != []}
+        class={[
+          "pc-chat__message-attachments-grid",
+          length(@images) > 1 && "pc-chat__message-attachments-grid--multi"
+        ]}
+      >
+        <a
+          :for={image <- @images}
+          href={image.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="pc-chat__attachment-image"
+        >
+          <img src={image.url} alt={image.name} loading="lazy" />
+        </a>
+      </div>
+      <a
+        :for={file <- @files}
+        href={file.url}
+        download
+        class="pc-chat__attachment-row"
+      >
+        <PetalComponents.Icon.icon name="hero-document" class="pc-chat__attachment-icon" />
+        <span class="pc-chat__attachment-name">{file.name}</span>
+        <span :if={file.size} class="pc-chat__attachment-size">{format_bytes(file.size)}</span>
+      </a>
+    </div>
+    """
+  end
+
+  # -- attachment plumbing ---------------------------------------------------
+
+  defp image_entry?(%{client_type: "image/" <> _}), do: true
+  defp image_entry?(_), do: false
+
+  defp normalize_attachments(attachments) when is_list(attachments) do
+    Enum.map(attachments, fn attachment ->
+      %{
+        kind: if(source_key(attachment, :kind) in [:image, "image"], do: :image, else: :file),
+        url: source_key(attachment, :url),
+        name: source_key(attachment, :name),
+        size: source_key(attachment, :size)
+      }
+    end)
+  end
+
+  defp normalize_attachments(_), do: []
+
+  # Config-level errors first (too_many_files and friends), then per-entry ones
+  # named with the file they belong to, so "too large" says which file.
+  defp upload_error_messages(upload) do
+    config_errors = Enum.map(upload_errors(upload), &upload_error_copy/1)
+
+    entry_errors =
+      Enum.flat_map(upload.entries, fn entry ->
+        Enum.map(upload_errors(upload, entry), fn error ->
+          "#{entry.client_name}: #{upload_error_copy(error)}"
+        end)
+      end)
+
+    config_errors ++ entry_errors
+  end
+
+  defp upload_error_copy(:too_large), do: "This file is too large."
+  defp upload_error_copy(:not_accepted), do: "This file type isn't accepted."
+  defp upload_error_copy(:too_many_files), do: "Too many files selected."
+
+  defp upload_error_copy(:external_client_failure),
+    do: "Something went wrong uploading this file."
+
+  defp upload_error_copy(other), do: "Upload failed (#{inspect(other)})."
+
+  defp format_bytes(nil), do: nil
+  defp format_bytes(bytes) when bytes < 1_000, do: "#{bytes} B"
+  defp format_bytes(bytes) when bytes < 1_000_000, do: "#{Float.round(bytes / 1_000, 1)} KB"
+
+  defp format_bytes(bytes) when bytes < 1_000_000_000,
+    do: "#{Float.round(bytes / 1_000_000, 1)} MB"
+
+  defp format_bytes(bytes), do: "#{Float.round(bytes / 1_000_000_000, 1)} GB"
 
   @doc """
   A collapsible "thinking" / reasoning block for reasoning-model output. Native

--- a/lib/petal_components/chat.ex
+++ b/lib/petal_components/chat.ex
@@ -10,6 +10,8 @@ defmodule PetalComponents.Chat do
     * `chat_message/1`  — a single message bubble (user or assistant)
     * `streaming_text/1` — token-by-token output via the `PetalChatStream` JS hook
     * `prompt_input/1`   — the composer (textarea + send)
+    * `chat_sources/1`   — the RAG sources row under an answer
+    * `citation/1`       — an inline numbered citation chip
 
   ## Importing
 
@@ -39,6 +41,42 @@ defmodule PetalComponents.Chat do
 
       import PetalComponents from "../../deps/petal_components/assets/js/petal_components"
       new LiveSocket("/live", Socket, { hooks: { ...PetalComponents }, ... })
+
+  ## Answer grounding (RAG citations)
+
+  Sources are plain maps — the host app supplies them, this library only renders
+  them. `url` is the only key that really matters; `title`, `snippet`,
+  `favicon_url` and `id` are optional and degrade gracefully:
+
+      sources = [
+        %{id: "1", url: "https://hexdocs.pm/phoenix_live_view", title: "Phoenix.LiveView",
+          snippet: "LiveView provides rich, real-time user experiences...",
+          favicon_url: "https://hexdocs.pm/favicon.ico"},
+        %{id: "2", url: "https://hexdocs.pm/phoenix", title: "Phoenix"}
+      ]
+
+  Prompt the model to cite with **`[^N]` footnote markers** ("cite your sources
+  inline as [^1], [^2] matching the numbered context"). Pass `sources` to
+  `markdown/1` and every complete marker becomes a chip; markers with no matching
+  source stay as plain text:
+
+      <Chat.chat_message role="assistant">
+        <Chat.markdown content={msg.text} sources={msg.sources} />
+        <Chat.chat_sources sources={msg.sources} />
+      </Chat.chat_message>
+
+  A marker resolves to the source whose `id` matches `N` and falls back to the
+  Nth source in the list, so an id-less list still works positionally.
+
+  The streaming path takes the same option — `to_html/2` renders the chips into
+  the HTML you push at a `format="markdown"` `streaming_text/1`. Half-arrived
+  markers (`[^` with no closing bracket yet) are left alone, so nothing flashes
+  broken mid-stream:
+
+      socket = push_event(socket, "pc-chat-token", %{
+        id: "answer",
+        html: PetalComponents.Chat.to_html(buffer, sources: sources)
+      })
 
   ## Styling
 
@@ -194,8 +232,22 @@ defmodule PetalComponents.Chat do
   `streaming_text/1`:
 
       socket = push_event(socket, "pc-chat-token", %{id: "answer", html: PetalComponents.Chat.to_html(buffer)})
+
+  Pass `:sources` to turn `[^N]` footnote markers into inline citation chips as
+  the answer streams (see the "Answer grounding" section in the moduledoc):
+
+      PetalComponents.Chat.to_html(buffer, sources: msg.sources)
+
+  ## Options
+
+    * `:sources` — list of source maps. `[^N]` markers matching a source render
+      as chips; unmatched and half-streamed markers are left untouched.
   """
-  def to_html(content), do: render_markdown(content)
+  def to_html(content, opts \\ []) do
+    content
+    |> render_markdown()
+    |> apply_citations(Keyword.get(opts, :sources))
+  end
 
   defp ensure_mdex! do
     if Code.ensure_loaded?(MDEx) do
@@ -275,10 +327,17 @@ defmodule PetalComponents.Chat do
   """
   attr :content, :string, required: true
   attr :id, :string, default: nil, doc: "pass a unique id to enable per-code-block copy buttons"
+
+  attr :sources, :list,
+    default: nil,
+    doc:
+      "when set, complete `[^N]` markers in the content render as inline citation chips for the matching source (by `id`, falling back to the Nth source). Unmatched markers stay as plain text"
+
   attr :class, :any, default: nil
 
   def markdown(assigns) do
-    assigns = assign(assigns, :html, render_markdown(assigns.content))
+    assigns =
+      assign(assigns, :html, apply_citations(render_markdown(assigns.content), assigns.sources))
 
     ~H"""
     <div id={@id} phx-hook={@id && "PetalCodeCopy"} class={["pc-chat__markdown", @class]}>
@@ -701,6 +760,288 @@ defmodule PetalComponents.Chat do
       </button>
     </div>
     """
+  end
+
+  @doc """
+  An inline numbered citation chip — the superscript marker that grounds a
+  sentence in a source. Hovering or focusing it reveals a small preview card
+  (title, domain, snippet); activating it opens the source in a new tab.
+
+  `markdown/1` and `to_html/2` mint these for you from `[^N]` markers, so you
+  rarely call it directly. Reach for it when you are assembling prose yourself:
+
+      Phoenix ships with LiveView <Chat.citation index={1} source={@source} />
+  """
+  attr :index, :integer, required: true, doc: "1-based citation number shown in the chip"
+
+  attr :source, :map,
+    required: true,
+    doc:
+      "the source map this chip points at: %{url, title, snippet, favicon_url}; every key but `url` is optional"
+
+  attr :class, :any, default: nil
+
+  def citation(assigns) do
+    assigns =
+      assign(assigns, :html, citation_html(assigns.index, normalize_source(assigns.source)))
+
+    ~H"""
+    <span class={@class && ["pc-chat__citation-outer", @class]}>{Phoenix.HTML.raw(@html)}</span>
+    """
+  end
+
+  @doc """
+  The sources row under a grounded answer. Collapsed it reads "4 sources" with a
+  stacked-favicon cluster; open it lists each source with its favicon, title,
+  domain and snippet. Native `<details>`, so no JS.
+
+      <Chat.chat_sources sources={@sources} />
+      <Chat.chat_sources sources={@sources} expanded max_visible={3} />
+
+  Sources are deduped by URL before render (the same page cited twice is one
+  row), and a nil or empty list renders nothing at all — no empty shell.
+  """
+  attr :sources, :list,
+    required: true,
+    doc:
+      "list of source maps: %{id, url, title, snippet, favicon_url}; snippet and favicon_url optional. Deduped by URL before render"
+
+  attr :expanded, :boolean,
+    default: false,
+    doc: "render the list open instead of the collapsed 'N sources' row"
+
+  attr :max_visible, :integer,
+    default: 5,
+    doc: "sources shown when expanded before a 'Show all (N)' control reveals the rest"
+
+  attr :label, :string,
+    default: nil,
+    doc: "override the collapsed row label; defaults to '{count} sources' / '1 source'"
+
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  def chat_sources(assigns) do
+    items = assigns.sources |> normalize_sources() |> dedupe_sources()
+
+    assigns =
+      assigns
+      |> assign(:items, items)
+      |> assign(:visible, Enum.take(items, max(assigns.max_visible, 0)))
+      |> assign(:overflow, Enum.drop(items, max(assigns.max_visible, 0)))
+      |> assign(:count, length(items))
+
+    ~H"""
+    <details :if={@items != []} class={["pc-chat__sources", @class]} open={@expanded} {@rest}>
+      <summary class="pc-chat__sources-row">
+        <span class="pc-chat__sources-favicons" aria-hidden="true">
+          <.source_favicon :for={source <- Enum.take(@items, 3)} source={source} />
+        </span>
+        <span class="pc-chat__sources-label">
+          {@label || if(@count == 1, do: "1 source", else: "#{@count} sources")}
+        </span>
+        <PetalComponents.Icon.icon name="hero-chevron-right" class="pc-chat__sources-chevron" />
+      </summary>
+      <ul class="pc-chat__sources-list" role="list">
+        <.source_row :for={source <- @visible} source={source} />
+      </ul>
+      <details :if={@overflow != []} class="pc-chat__sources-more">
+        <summary class="pc-chat__sources-more-summary">Show all ({@count})</summary>
+        <ul class="pc-chat__sources-list" role="list">
+          <.source_row :for={source <- @overflow} source={source} />
+        </ul>
+      </details>
+    </details>
+    """
+  end
+
+  attr :source, :map, required: true
+
+  defp source_row(assigns) do
+    ~H"""
+    <li class="pc-chat__source">
+      <a
+        href={@source.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="pc-chat__source-link"
+      >
+        <.source_favicon source={@source} />
+        <span class="pc-chat__source-text">
+          <span class="pc-chat__source-title">{@source.title || @source.url}</span>
+          <span :if={source_domain(@source)} class="pc-chat__source-domain">
+            {source_domain(@source)}
+          </span>
+          <span :if={@source.snippet} class="pc-chat__source-snippet">{@source.snippet}</span>
+        </span>
+      </a>
+    </li>
+    """
+  end
+
+  attr :source, :map, required: true
+
+  defp source_favicon(assigns) do
+    ~H"""
+    <img
+      :if={@source.favicon_url}
+      src={@source.favicon_url}
+      alt=""
+      aria-hidden="true"
+      loading="lazy"
+      class="pc-chat__source-favicon"
+    />
+    <span
+      :if={!@source.favicon_url}
+      aria-hidden="true"
+      class="pc-chat__source-favicon pc-chat__source-favicon--letter"
+    >
+      {source_initial(@source)}
+    </span>
+    """
+  end
+
+  # -- citation plumbing -----------------------------------------------------
+
+  # Only complete markers match, so a half-streamed "[^" never flashes a broken
+  # chip; it simply stays as text until the closing bracket arrives.
+  @citation_marker ~r/\[\^(\d+)\]/
+  @html_tag ~r/<[^>]*>/
+
+  defp apply_citations(html, sources) when is_binary(html) do
+    case citation_lookup(sources) do
+      lookup when map_size(lookup) == 0 -> html
+      lookup -> splice_citations(html, lookup)
+    end
+  end
+
+  # Walk the sanitized HTML as a tag/text token stream and rewrite markers in
+  # text nodes only: never inside an attribute, never inside <pre>/<code>. The
+  # chip markup is minted here from the numeric index plus escaped source
+  # fields, so model-controlled text can never reach the page as live markup.
+  defp splice_citations(html, lookup) do
+    @html_tag
+    |> Regex.split(html, include_captures: true)
+    |> Enum.reduce({[], 0}, fn part, {acc, depth} ->
+      cond do
+        String.starts_with?(part, "<") -> {[part | acc], code_depth(part, depth)}
+        depth > 0 -> {[part | acc], depth}
+        true -> {[replace_markers(part, lookup) | acc], depth}
+      end
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+    |> IO.iodata_to_binary()
+  end
+
+  defp code_depth(tag, depth) do
+    cond do
+      Regex.match?(~r{^</(?:pre|code)\s*>$}i, tag) -> max(depth - 1, 0)
+      Regex.match?(~r{^<(?:pre|code)(?:\s[^>]*)?>$}i, tag) -> depth + 1
+      true -> depth
+    end
+  end
+
+  defp replace_markers(text, lookup) do
+    Regex.replace(@citation_marker, text, fn marker, number ->
+      case Map.fetch(lookup, number) do
+        {:ok, source} -> citation_html(String.to_integer(number), source)
+        :error -> marker
+      end
+    end)
+  end
+
+  defp citation_lookup(sources) do
+    normalized = normalize_sources(sources)
+
+    by_position =
+      normalized
+      |> Enum.with_index(1)
+      |> Map.new(fn {source, index} -> {Integer.to_string(index), source} end)
+
+    by_id =
+      Enum.reduce(normalized, %{}, fn
+        %{id: nil}, acc -> acc
+        %{id: id} = source, acc -> Map.put_new(acc, to_string(id), source)
+      end)
+
+    Map.merge(by_position, by_id)
+  end
+
+  defp citation_html(index, source) do
+    title = source.title || source_domain(source) || "Source #{index}"
+    domain = source_domain(source)
+
+    ~s(<span class="pc-chat__citation-wrap"><a class="pc-chat__citation" href="#{esc(source.url)}") <>
+      ~s( target="_blank" rel="noopener noreferrer" aria-label="#{esc("Source #{index}: #{title}")}">) <>
+      ~s(<sup class="pc-chat__citation-num">#{index}</sup></a>) <>
+      ~s(<span class="pc-chat__citation-card" aria-hidden="true">) <>
+      citation_card_favicon(source) <>
+      ~s(<span class="pc-chat__citation-card-title">#{esc(title)}</span>) <>
+      if(domain,
+        do: ~s(<span class="pc-chat__citation-card-domain">#{esc(domain)}</span>),
+        else: ""
+      ) <>
+      if(source.snippet,
+        do: ~s(<span class="pc-chat__citation-card-snippet">#{esc(source.snippet)}</span>),
+        else: ""
+      ) <> ~s(</span></span>)
+  end
+
+  defp citation_card_favicon(%{favicon_url: nil} = source) do
+    ~s(<span class="pc-chat__source-favicon pc-chat__source-favicon--letter" aria-hidden="true">) <>
+      esc(source_initial(source)) <> ~s(</span>)
+  end
+
+  defp citation_card_favicon(source) do
+    ~s(<img class="pc-chat__source-favicon" src="#{esc(source.favicon_url)}" alt="") <>
+      ~s( aria-hidden="true" loading="lazy" />)
+  end
+
+  defp esc(nil), do: ""
+
+  defp esc(value),
+    do: value |> to_string() |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
+
+  defp normalize_sources(sources) when is_list(sources),
+    do: Enum.map(sources, &normalize_source/1)
+
+  defp normalize_sources(_), do: []
+
+  defp normalize_source(source) when is_map(source) do
+    %{
+      id: source_key(source, :id),
+      url: source_key(source, :url),
+      title: source_key(source, :title),
+      snippet: source_key(source, :snippet),
+      favicon_url: source_key(source, :favicon_url)
+    }
+  end
+
+  defp source_key(source, key) do
+    case Map.fetch(source, key) do
+      {:ok, value} -> value
+      :error -> Map.get(source, Atom.to_string(key))
+    end
+  end
+
+  defp dedupe_sources(sources), do: Enum.uniq_by(sources, & &1.url)
+
+  defp source_domain(%{url: url}) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{host: host} when is_binary(host) -> String.replace_prefix(host, "www.", "")
+      _ -> nil
+    end
+  end
+
+  defp source_domain(_), do: nil
+
+  defp source_initial(source) do
+    (source.title || source_domain(source) || "?")
+    |> String.trim()
+    |> String.first()
+    |> Kernel.||("?")
+    |> String.upcase()
   end
 
   defp render_markdown(nil), do: ""

--- a/lib/petal_components/showcase/chat.ex
+++ b/lib/petal_components/showcase/chat.ex
@@ -18,7 +18,8 @@ defmodule PetalComponents.Showcase.Chat do
       :suggestions,
       :chat_error,
       :chat_sources,
-      :citation
+      :citation,
+      :message_attachments
     ]
 
   @rag_sources [
@@ -51,9 +52,17 @@ defmodule PetalComponents.Showcase.Chat do
   # Chat is not pulled in by `use PetalComponents`, so import it here.
   import PetalComponents.Chat
 
+  # Inline SVG placeholders: the examples have to render standalone on
+  # petal.build and in the playground, so they can't reach for a static asset.
+  @shot_image "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='480' height='300'><rect width='100%' height='100%' fill='%23e2e8f0'/><rect x='24' y='24' width='432' height='40' rx='6' fill='%23cbd5e1'/><rect x='24' y='88' width='300' height='16' rx='4' fill='%23cbd5e1'/><rect x='24' y='120' width='240' height='16' rx='4' fill='%23cbd5e1'/><rect x='24' y='176' width='432' height='96' rx='6' fill='%23fecaca'/><text x='40' y='232' font-family='monospace' font-size='18' fill='%23991b1b'>CardTokenExpired</text></svg>"
+
+  @logs_image "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='480' height='300'><rect width='100%' height='100%' fill='%231e293b'/><rect x='20' y='28' width='380' height='12' rx='3' fill='%2394a3b8'/><rect x='20' y='60' width='300' height='12' rx='3' fill='%2394a3b8'/><rect x='20' y='92' width='420' height='12' rx='3' fill='%23f87171'/><rect x='20' y='124' width='260' height='12' rx='3' fill='%2394a3b8'/><rect x='20' y='156' width='340' height='12' rx='3' fill='%2394a3b8'/><rect x='20' y='188' width='200' height='12' rx='3' fill='%2394a3b8'/></svg>"
+
   # Examples render with `assigns = %{}`, so the seed data comes from here
   # rather than an assign.
   defp rag_sources, do: @rag_sources
+  defp shot_image, do: @shot_image
+  defp logs_image, do: @logs_image
 
   example :flagship, "A complete chat",
     description:
@@ -253,6 +262,26 @@ defmodule PetalComponents.Showcase.Chat do
       which is why a LiveView per tab is unremarkable
       <.citation index={1} source={Enum.at(rag_sources(), 0)} />.
     </p>
+    """
+  end
+
+  example :message_attachments, "Message attachments",
+    description:
+      "What the user sent along with the text. Images tile into a grid, files are download rows with the size on the end. A mixed list puts the images first." do
+    ~H"""
+    <.conversation id="showcase-chat-attachments" class="w-full max-w-xl mx-auto">
+      <.chat_message role="user">
+        <.message_attachments attachments={[
+          %{kind: :image, url: shot_image(), name: "checkout-error.png", size: 184_320},
+          %{kind: :image, url: logs_image(), name: "server-logs.png", size: 92_100},
+          %{kind: :file, url: "#", name: "invoice-4471.pdf", size: 96_400}
+        ]} /> The checkout page throws on submit. Screenshot, logs and the invoice attached.
+      </.chat_message>
+      <.chat_message role="assistant">
+        Thanks - the stack trace in that screenshot points at the card token
+        expiring before submit. I can see the charge attempt on invoice 4471.
+      </.chat_message>
+    </.conversation>
     """
   end
 

--- a/lib/petal_components/showcase/chat.ex
+++ b/lib/petal_components/showcase/chat.ex
@@ -16,11 +16,44 @@ defmodule PetalComponents.Showcase.Chat do
       :message_actions,
       :copy_button,
       :suggestions,
-      :chat_error
+      :chat_error,
+      :chat_sources,
+      :citation
     ]
+
+  @rag_sources [
+    %{
+      id: "1",
+      url: "https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html",
+      title: "Phoenix.LiveView — behaviour and lifecycle",
+      snippet:
+        "LiveView provides rich, real-time user experiences with server-rendered HTML over a persistent connection."
+    },
+    %{
+      id: "2",
+      url: "https://hexdocs.pm/phoenix_live_view/js-interop.html",
+      title: "JavaScript interoperability",
+      snippet: "Client hooks let you run JavaScript when an element is added, updated or removed."
+    },
+    %{
+      id: "3",
+      url: "https://hexdocs.pm/phoenix/Phoenix.Endpoint.html",
+      title: "Phoenix.Endpoint",
+      snippet: "The endpoint is the boundary where all requests to your application start."
+    },
+    %{
+      id: "4",
+      url: "https://elixir-lang.org/getting-started/processes.html",
+      title: "Processes"
+    }
+  ]
 
   # Chat is not pulled in by `use PetalComponents`, so import it here.
   import PetalComponents.Chat
+
+  # Examples render with `assigns = %{}`, so the seed data comes from here
+  # rather than an assign.
+  defp rag_sources, do: @rag_sources
 
   example :flagship, "A complete chat",
     description:
@@ -180,6 +213,46 @@ defmodule PetalComponents.Showcase.Chat do
       <.marker variant="border" icon="hero-wrench-screwdriver">Running search_docs</.marker>
       <.chat_message role="assistant">Found 3 matches. Here's the most relevant one.</.chat_message>
     </.conversation>
+    """
+  end
+
+  example :chat_sources, "Sources and citations",
+    description:
+      "Answer grounding for RAG. Prompt the model to cite as [^N]; pass the same source maps to markdown/1 and the markers become chips (hover or tab to one for the preview card). chat_sources renders the deduped list below - native <details>, no JS." do
+    ~H"""
+    <.conversation id="showcase-chat-sources" class="w-full max-w-xl mx-auto">
+      <.chat_message role="user">How does LiveView keep the page in sync?</.chat_message>
+      <.chat_message role="assistant">
+        <.markdown
+          content="LiveView holds a **persistent connection** and diffs the rendered tree server-side, pushing only what changed [^1]. Anything the server can't own - focus, clipboard, third-party widgets - drops down to a client hook [^2].\n\nEvery request still enters through the endpoint [^3]."
+          sources={rag_sources()}
+        />
+        <.chat_sources sources={rag_sources()} />
+      </.chat_message>
+    </.conversation>
+    """
+  end
+
+  example :chat_sources_expanded, "Sources expanded",
+    description:
+      "expanded opens the row on render; max_visible caps the list and tucks the rest behind a \"Show all\" reveal. A source with no favicon_url falls back to a letter avatar, and no snippet just means a shorter row." do
+    ~H"""
+    <div class="w-full max-w-xl mx-auto">
+      <.chat_sources sources={rag_sources()} expanded max_visible={2} />
+    </div>
+    """
+  end
+
+  example :citation, "Citation chip",
+    description:
+      "The chip on its own, for prose you assemble yourself. It's a real link - Tab reaches it, the preview card opens on hover or focus, and activating it opens the source in a new tab." do
+    ~H"""
+    <p class="w-full max-w-xl mx-auto text-sm text-gray-700 dark:text-gray-300">
+      Processes in Elixir are cheap and isolated
+      <.citation index={4} source={Enum.at(rag_sources(), 3)} />
+      which is why a LiveView per tab is unremarkable
+      <.citation index={1} source={Enum.at(rag_sources(), 0)} />.
+    </p>
     """
   end
 

--- a/lib/petal_components/showcase/chat.ex
+++ b/lib/petal_components/showcase/chat.ex
@@ -19,8 +19,54 @@ defmodule PetalComponents.Showcase.Chat do
       :chat_error,
       :chat_sources,
       :citation,
-      :message_attachments
+      :message_attachments,
+      :questionnaire
     ]
+
+  @framework_spec %{
+    id: "showcase-q-framework",
+    title: "Which framework are you targeting?",
+    description: "This picks the generators I'll reach for.",
+    fields: [
+      %{
+        id: "framework",
+        type: :single_select,
+        label: "Framework",
+        required: true,
+        options: [
+          %{value: "phoenix", label: "Phoenix", description: "Elixir, LiveView, server-rendered"},
+          %{value: "rails", label: "Rails", description: "Ruby, Hotwire, convention-first"},
+          %{value: "next", label: "Next.js", description: "React, app router, RSC"}
+        ]
+      }
+    ]
+  }
+
+  @scoping_spec %{
+    id: "showcase-q-scope",
+    title: "Before I scaffold, two things",
+    fields: [
+      %{
+        id: "features",
+        type: :multi_select,
+        label: "Which features do you need?",
+        options: [
+          %{value: "auth", label: "Auth"},
+          %{value: "billing", label: "Billing"},
+          %{value: "admin", label: "Admin panel"}
+        ]
+      },
+      %{id: "team", type: :text, label: "Team name", placeholder: "Platform"},
+      %{
+        id: "confidence",
+        type: :scale,
+        label: "How settled is this scope?",
+        min_label: "Still exploring",
+        max_label: "Locked",
+        required: true
+      }
+    ]
+  }
 
   @rag_sources [
     %{
@@ -63,6 +109,8 @@ defmodule PetalComponents.Showcase.Chat do
   defp rag_sources, do: @rag_sources
   defp shot_image, do: @shot_image
   defp logs_image, do: @logs_image
+  defp framework_spec, do: @framework_spec
+  defp scoping_spec, do: @scoping_spec
 
   example :flagship, "A complete chat",
     description:
@@ -280,6 +328,56 @@ defmodule PetalComponents.Showcase.Chat do
       <.chat_message role="assistant">
         Thanks - the stack trace in that screenshot points at the card token
         expiring before submit. I can see the charge attempt on invoice 4471.
+      </.chat_message>
+    </.conversation>
+    """
+  end
+
+  example :questionnaire, "Questionnaire",
+    description:
+      "The model pauses to ask a structured question and the answer lands in the transcript. Server-driven: a plain phx-submit, no client state. Options with descriptions render as radio cards, plain ones as radios." do
+    ~H"""
+    <.conversation id="showcase-chat-questionnaire" class="w-full max-w-xl mx-auto">
+      <.chat_message role="user">Scaffold me a starter app.</.chat_message>
+      <.chat_message role="assistant">
+        <.questionnaire spec={framework_spec()} allow_skip />
+      </.chat_message>
+    </.conversation>
+    """
+  end
+
+  example :questionnaire_mixed, "Questionnaire - mixed fields",
+    description:
+      "All four field types in one bubble: multi-select, short text, and a 1-to-5 scale with end captions. Required fields use the native required attribute, so enforcement is the browser's." do
+    ~H"""
+    <div class="w-full max-w-xl mx-auto">
+      <.questionnaire spec={scoping_spec()} submit_label="Send answers" />
+    </div>
+    """
+  end
+
+  example :questionnaire_resolved, "Questionnaire - resolved and skipped",
+    description:
+      "Once the app has the answer, pass it back as resolved and the form becomes quiet chips - nothing focusable is left behind. :skipped renders the one-line skipped state." do
+    ~H"""
+    <.conversation id="showcase-chat-questionnaire-resolved" class="w-full max-w-xl mx-auto">
+      <.chat_message role="assistant">
+        <.questionnaire spec={framework_spec()} resolved={%{"framework" => "phoenix"}} />
+      </.chat_message>
+      <.chat_message role="assistant">
+        <.questionnaire
+          spec={scoping_spec()}
+          resolved={
+            %{
+              "features" => ["auth", "billing"],
+              "team" => "Platform",
+              "confidence" => "5"
+            }
+          }
+        />
+      </.chat_message>
+      <.chat_message role="assistant">
+        <.questionnaire spec={framework_spec()} resolved={:skipped} />
       </.chat_message>
     </.conversation>
     """

--- a/test/js/chat_composer_paste.test.js
+++ b/test/js/chat_composer_paste.test.js
@@ -1,0 +1,140 @@
+// Pasting a screenshot into the composer.
+//
+// LiveView's upload machinery only ever watches the hidden file input, so a
+// clipboard image has to be handed to that input and announced with an input
+// event. Getting this wrong is silent - the paste looks like it did nothing -
+// so the contract is pinned here: files land in the input, an input event
+// fires and bubbles, and a plain text paste is left entirely alone.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { PetalChatComposer } from "../../assets/js/petal_components.js";
+
+// jsdom ships neither DataTransfer nor a settable input.files, both of which
+// every real browser has. Stand them up so the spec exercises the hook's
+// actual path instead of a mock of it.
+class FakeDataTransfer {
+  constructor() {
+    this._files = [];
+    this.items = { add: (file) => this._files.push(file) };
+  }
+
+  get files() {
+    return this._files;
+  }
+}
+
+globalThis.DataTransfer = FakeDataTransfer;
+
+function makeFilesWritable(input) {
+  let current = [];
+  Object.defineProperty(input, "files", {
+    get: () => current,
+    set: (files) => {
+      current = files;
+    },
+    configurable: true,
+  });
+}
+
+function mountComposer({ withFileInput = true } = {}) {
+  document.body.innerHTML = "";
+
+  const form = document.createElement("form");
+  form.id = "composer";
+  const textarea = document.createElement("textarea");
+  form.appendChild(textarea);
+
+  if (withFileInput) {
+    const fileInput = document.createElement("input");
+    fileInput.type = "file";
+    fileInput.multiple = true;
+    makeFilesWritable(fileInput);
+    form.appendChild(fileInput);
+  }
+
+  document.body.appendChild(form);
+
+  const hook = Object.create(PetalChatComposer);
+  hook.el = form;
+  hook.handleEvent = () => {};
+  hook.mounted();
+
+  return { hook, form, textarea, fileInput: form.querySelector("input[type=file]") };
+}
+
+// jsdom's ClipboardEvent doesn't carry a settable clipboardData, so build the
+// event and attach the payload the way the browser would.
+function pasteEvent(files) {
+  const event = new Event("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clipboardData", {
+    value: { files, items: [] },
+  });
+  return event;
+}
+
+function pngFile(name = "screenshot.png") {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: "image/png" });
+}
+
+describe("PetalChatComposer paste handler", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("puts pasted files on the hidden file input", () => {
+    const { textarea, fileInput } = mountComposer();
+
+    textarea.dispatchEvent(pasteEvent([pngFile()]));
+
+    expect(fileInput.files).toHaveLength(1);
+    expect(fileInput.files[0].name).toBe("screenshot.png");
+  });
+
+  it("fires a bubbling input event so LiveView picks the upload up", () => {
+    const { textarea, fileInput } = mountComposer();
+    const seen = [];
+    fileInput.addEventListener("input", (e) => seen.push(e.bubbles));
+
+    textarea.dispatchEvent(pasteEvent([pngFile()]));
+
+    expect(seen).toEqual([true]);
+  });
+
+  it("carries every pasted file, not just the first", () => {
+    const { textarea, fileInput } = mountComposer();
+
+    textarea.dispatchEvent(pasteEvent([pngFile("a.png"), pngFile("b.png")]));
+
+    expect(fileInput.files).toHaveLength(2);
+  });
+
+  it("leaves a text paste alone", () => {
+    const { textarea, fileInput } = mountComposer();
+    let fired = 0;
+    fileInput.addEventListener("input", () => (fired += 1));
+
+    const event = pasteEvent([]);
+    textarea.dispatchEvent(event);
+
+    expect(fired).toBe(0);
+    expect(event.defaultPrevented).toBe(false);
+    expect(fileInput.files).toHaveLength(0);
+  });
+
+  it("does nothing when the composer has no upload input", () => {
+    const { textarea } = mountComposer({ withFileInput: false });
+
+    const event = pasteEvent([pngFile()]);
+    expect(() => textarea.dispatchEvent(event)).not.toThrow();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("stops listening once the hook is destroyed", () => {
+    const { hook, textarea, fileInput } = mountComposer();
+    hook.destroyed();
+
+    textarea.dispatchEvent(pasteEvent([pngFile()]));
+
+    expect(fileInput.files).toHaveLength(0);
+  });
+});

--- a/test/petal/chat_test.exs
+++ b/test/petal/chat_test.exs
@@ -141,6 +141,325 @@ defmodule PetalComponents.ChatTest do
     end
   end
 
+  describe "citations in markdown/1" do
+    setup do
+      %{
+        sources: [
+          %{
+            id: "1",
+            url: "https://hexdocs.pm/phoenix_live_view",
+            title: "Phoenix.LiveView",
+            snippet: "Rich, real-time user experiences.",
+            favicon_url: "https://hexdocs.pm/favicon.ico"
+          },
+          %{id: "2", url: "https://hexdocs.pm/phoenix", title: "Phoenix"}
+        ]
+      }
+    end
+
+    test "turns a [^N] marker into a citation chip wired to the matching source", %{
+      sources: sources
+    } do
+      assigns = %{md: "LiveView is great [^1] and so is Phoenix [^2].", sources: sources}
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      assert_has_class(html, "pc-chat__citation")
+      assert html =~ ~s{href="https://hexdocs.pm/phoenix_live_view"}
+      assert html =~ ~s{href="https://hexdocs.pm/phoenix"}
+      assert html =~ ~s{<sup class="pc-chat__citation-num">1</sup>}
+      assert html =~ ~s{<sup class="pc-chat__citation-num">2</sup>}
+      # the raw marker is gone
+      refute html =~ "[^1]"
+    end
+
+    test "without sources the marker passes through as plain text (today's behaviour)" do
+      assigns = %{md: "LiveView is great [^1]."}
+
+      html = rendered_to_string(~H|<.markdown content={@md} />|)
+
+      refute html =~ "pc-chat__citation"
+      assert html =~ "[^1]"
+    end
+
+    test "an unmatched marker renders as plain text, not a broken chip", %{sources: sources} do
+      assigns = %{md: "Something unsourced [^9].", sources: sources}
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      assert html =~ "[^9]"
+      refute html =~ "pc-chat__citation-num\">9<"
+    end
+
+    test "chips carry an accessible name naming the source", %{sources: sources} do
+      assigns = %{md: "Grounded [^1].", sources: sources}
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      assert html =~ ~s{aria-label="Source 1: Phoenix.LiveView"}
+    end
+
+    test "chip links open in a new tab safely", %{sources: sources} do
+      assigns = %{md: "Grounded [^1].", sources: sources}
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      assert html =~ ~s{target="_blank"}
+      assert html =~ ~s{rel="noopener noreferrer"}
+    end
+
+    test "model-controlled source fields are escaped in the chip and its card" do
+      assigns = %{
+        md: "Careful [^1].",
+        sources: [
+          %{
+            id: "1",
+            url: "https://example.com",
+            title: "<script>alert('x')</script>",
+            snippet: "<img src=x onerror=alert(1)>"
+          }
+        ]
+      }
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      refute html =~ "<script>alert"
+      refute html =~ "<img src=x"
+      assert html =~ "&lt;script&gt;"
+      assert html =~ "&lt;img src=x"
+    end
+
+    test "markers inside code blocks are left alone", %{sources: sources} do
+      assigns = %{md: "```elixir\nfoo = \"[^1]\"\n```", sources: sources}
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      refute html =~ "pc-chat__citation"
+      assert html =~ "[^1]"
+    end
+
+    test "a marker resolves positionally when sources have no ids" do
+      assigns = %{
+        md: "Positional [^2].",
+        sources: [%{url: "https://a.example"}, %{url: "https://b.example", title: "B"}]
+      }
+
+      html = rendered_to_string(~H|<.markdown content={@md} sources={@sources} />|)
+
+      assert html =~ ~s{href="https://b.example"}
+      assert html =~ ~s{aria-label="Source 2: B"}
+    end
+  end
+
+  describe "to_html/2 with sources (the streaming path)" do
+    setup do
+      %{sources: [%{id: "1", url: "https://example.com/doc", title: "The Doc"}]}
+    end
+
+    test "renders chip markup for complete markers", %{sources: sources} do
+      html = PetalComponents.Chat.to_html("Grounded [^1].", sources: sources)
+
+      assert html =~ "pc-chat__citation"
+      assert html =~ ~s{href="https://example.com/doc"}
+    end
+
+    test "leaves a half-streamed marker untouched so nothing flashes broken", %{sources: sources} do
+      html = PetalComponents.Chat.to_html("Grounded [^", sources: sources)
+
+      refute html =~ "pc-chat__citation"
+      assert html =~ "[^"
+    end
+
+    test "to_html/1 is unchanged" do
+      assert PetalComponents.Chat.to_html("Grounded [^1].") =~ "[^1]"
+    end
+  end
+
+  describe "citation/1" do
+    test "renders a standalone chip for a source map" do
+      assigns = %{source: %{url: "https://example.com", title: "Example"}}
+
+      html = rendered_to_string(~H|<.citation index={3} source={@source} />|)
+
+      assert_has_class(html, "pc-chat__citation")
+      assert html =~ ~s{aria-label="Source 3: Example"}
+      assert html =~ ~s{<sup class="pc-chat__citation-num">3</sup>}
+    end
+
+    test "the preview card is decorative — the title lives in the accessible name" do
+      assigns = %{source: %{url: "https://example.com", title: "Example", snippet: "Snip"}}
+
+      html = rendered_to_string(~H|<.citation index={1} source={@source} />|)
+
+      assert_has_class(html, "pc-chat__citation-card")
+      assert html =~ ~s{class="pc-chat__citation-card" aria-hidden="true"}
+      assert html =~ "Snip"
+    end
+
+    test "class is appended last" do
+      assigns = %{source: %{url: "https://example.com"}}
+
+      html = rendered_to_string(~H|<.citation index={1} source={@source} class="custom-chip" />|)
+
+      assert html =~ "custom-chip"
+    end
+  end
+
+  describe "chat_sources/1" do
+    setup do
+      %{
+        sources: [
+          %{
+            id: "1",
+            url: "https://hexdocs.pm/phoenix_live_view",
+            title: "Phoenix.LiveView",
+            snippet: "Rich, real-time user experiences.",
+            favicon_url: "https://hexdocs.pm/favicon.ico"
+          },
+          %{id: "2", url: "https://hexdocs.pm/phoenix", title: "Phoenix"},
+          %{id: "3", url: "https://elixir-lang.org", title: "Elixir"}
+        ]
+      }
+    end
+
+    test "renders a collapsed details row labelled with the count", %{sources: sources} do
+      assigns = %{sources: sources}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} />|)
+
+      assert_has_class(html, "pc-chat__sources")
+      assert_has_class(html, "pc-chat__sources-row")
+      assert html =~ "<details"
+      assert html =~ "<summary"
+      assert html =~ "3 sources"
+      refute Regex.match?(~r/<details[^>]*\sopen[\s>]/, html)
+    end
+
+    test "one source reads in the singular" do
+      assigns = %{sources: [%{url: "https://example.com", title: "Only"}]}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} />|)
+
+      assert html =~ "1 source"
+      refute html =~ "1 sources"
+    end
+
+    test "a custom label overrides the count", %{sources: sources} do
+      assigns = %{sources: sources}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} label="Used 3 pages" />|)
+
+      assert html =~ "Used 3 pages"
+      refute html =~ "3 sources"
+    end
+
+    test "expanded opens the list by default", %{sources: sources} do
+      assigns = %{sources: sources}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      assert Regex.match?(~r/<details[^>]*\sopen[\s>]/, html)
+    end
+
+    test "each source is a safe external link with title, domain and snippet", %{
+      sources: sources
+    } do
+      assigns = %{sources: sources}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      assert html =~ ~s{href="https://hexdocs.pm/phoenix_live_view"}
+      assert html =~ ~s{target="_blank"}
+      assert html =~ ~s{rel="noopener noreferrer"}
+      assert html =~ "Phoenix.LiveView"
+      assert html =~ "hexdocs.pm"
+      assert html =~ "Rich, real-time user experiences."
+      assert html =~ ~s{role="list"}
+    end
+
+    test "dedupes by url — the same page cited twice is one row" do
+      assigns = %{
+        sources: [
+          %{id: "1", url: "https://example.com/a", title: "A"},
+          %{id: "2", url: "https://example.com/a", title: "A again"}
+        ]
+      }
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      assert html =~ "1 source"
+      refute html =~ "A again"
+    end
+
+    test "nil and empty sources render nothing at all" do
+      assigns = %{}
+
+      refute rendered_to_string(~H|<.chat_sources sources={[]} />|) =~ "pc-chat__sources"
+      refute rendered_to_string(~H|<.chat_sources sources={nil} />|) =~ "pc-chat__sources"
+    end
+
+    test "max_visible overflows into a 'Show all' reveal", %{sources: sources} do
+      assigns = %{sources: sources}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded max_visible={2} />|)
+
+      assert_has_class(html, "pc-chat__sources-more")
+      assert html =~ "Show all (3)"
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded max_visible={5} />|)
+
+      refute html =~ "pc-chat__sources-more"
+    end
+
+    test "a source without favicon_url degrades to a letter avatar" do
+      assigns = %{sources: [%{url: "https://example.com", title: "Example"}]}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      assert_has_class(html, "pc-chat__source-favicon--letter")
+      assert html =~ ">E<" or html =~ "E\n"
+    end
+
+    test "favicons are decorative", %{sources: sources} do
+      assigns = %{sources: sources}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      assert html =~ ~s{alt=""}
+      assert html =~ ~s{loading="lazy"}
+    end
+
+    test "a source without a snippet renders a clean row" do
+      assigns = %{sources: [%{url: "https://example.com", title: "Example"}]}
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      refute html =~ "pc-chat__source-snippet"
+      assert html =~ "Example"
+    end
+
+    test "string-keyed source maps render identically to atom-keyed ones" do
+      assigns = %{
+        sources: [%{"id" => "1", "url" => "https://example.com", "title" => "Stringy"}]
+      }
+
+      html = rendered_to_string(~H|<.chat_sources sources={@sources} expanded />|)
+
+      assert html =~ "Stringy"
+      assert html =~ ~s{href="https://example.com"}
+    end
+
+    test "class is appended last and rest passes through", %{sources: sources} do
+      assigns = %{sources: sources}
+
+      html =
+        rendered_to_string(~H|<.chat_sources sources={@sources} class="mine" id="src-block" />|)
+
+      assert html =~ "mine"
+      assert html =~ ~s{id="src-block"}
+    end
+  end
+
   describe "tool_call/1" do
     test "renders the tool name and a completed check" do
       assigns = %{}

--- a/test/petal/chat_test.exs
+++ b/test/petal/chat_test.exs
@@ -1002,6 +1002,385 @@ defmodule PetalComponents.ChatTest do
     end
   end
 
+  describe "questionnaire/1" do
+    defp full_spec do
+      %{
+        id: "q-framework",
+        title: "Which framework are you targeting?",
+        description: "This picks the generators I'll reach for.",
+        fields: [
+          %{
+            id: "framework",
+            type: :single_select,
+            label: "Framework",
+            required: true,
+            options: [
+              %{value: "phoenix", label: "Phoenix", description: "Elixir, LiveView"},
+              %{value: "rails", label: "Rails", description: "Ruby, Hotwire"}
+            ]
+          },
+          %{
+            id: "features",
+            type: :multi_select,
+            label: "Features",
+            options: [%{value: "auth", label: "Auth"}, %{value: "billing", label: "Billing"}]
+          },
+          %{id: "team", type: :text, label: "Team name", placeholder: "Acme"},
+          %{
+            id: "confidence",
+            type: :scale,
+            label: "How sure are you?",
+            min_label: "Not sure",
+            max_label: "Certain",
+            required: true
+          }
+        ]
+      }
+    end
+
+    test "renders the title, description and a form posting the default event" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} />|)
+
+      assert_has_class(html, "pc-questionnaire")
+      assert html =~ "Which framework are you targeting?"
+      assert html =~ "This picks the generators I&#39;ll reach for."
+      assert html =~ ~s{phx-submit="questionnaire_submit"}
+    end
+
+    test "a custom on_submit name is respected" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} on_submit="answer_it" />|)
+
+      assert html =~ ~s{phx-submit="answer_it"}
+      refute html =~ ~s{phx-submit="questionnaire_submit"}
+    end
+
+    test "input names produce the documented params shape" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} />|)
+
+      # hidden spec id, echoed back on submit
+      assert html =~ ~s{<input type="hidden" name="spec_id" value="q-framework">}
+      # single-select and text are scalar
+      assert html =~ ~s{name="answers[framework]"}
+      assert html =~ ~s{name="answers[team]"}
+      # multi-select collects into a list
+      assert html =~ ~s{name="answers[features][]"}
+      # the scale is a scalar radio group
+      assert html =~ ~s{name="answers[confidence]"}
+    end
+
+    test "single-select with option descriptions renders radio cards" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} />|)
+
+      assert html =~ "pc-radio-card"
+      assert html =~ "Phoenix"
+      assert html =~ "Elixir, LiveView"
+    end
+
+    test "single-select without descriptions renders a plain radio group" do
+      assigns = %{
+        spec: %{
+          id: "q",
+          title: "Pick",
+          fields: [
+            %{
+              id: "pick",
+              type: :single_select,
+              label: "Pick",
+              options: [%{value: "a", label: "A"}, %{value: "b", label: "B"}]
+            }
+          ]
+        }
+      }
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} />|)
+
+      assert html =~ "pc-radio-group"
+      refute html =~ "pc-radio-card"
+    end
+
+    test "style overrides the option-shape heuristic both ways" do
+      cards = %{
+        id: "q",
+        title: "Pick",
+        fields: [
+          %{
+            id: "pick",
+            type: :single_select,
+            label: "Pick",
+            style: "cards",
+            options: [%{value: "a", label: "A"}]
+          }
+        ]
+      }
+
+      buttons =
+        put_in(cards, [:fields], [
+          %{
+            id: "pick",
+            type: :single_select,
+            label: "Pick",
+            style: "buttons",
+            options: [%{value: "a", label: "A", description: "with a description"}]
+          }
+        ])
+
+      assigns = %{cards: cards, buttons: buttons}
+
+      assert rendered_to_string(~H|<.questionnaire spec={@cards} />|) =~ "pc-radio-card"
+
+      html = rendered_to_string(~H|<.questionnaire spec={@buttons} />|)
+      assert html =~ "pc-radio-group"
+      refute html =~ "pc-radio-card"
+    end
+
+    test "the scale renders exactly five radios sharing one name, values 1 to 5" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} />|)
+
+      assert_has_class(html, "pc-questionnaire__scale")
+
+      for value <- 1..5 do
+        assert html =~ ~s{name="answers[confidence]" value="#{value}"}
+      end
+
+      assert length(Regex.scan(~r/name="answers\[confidence\]"/, html)) == 5
+    end
+
+    test "the scale end captions are associated with the radios" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} />|)
+
+      assert html =~ "Not sure"
+      assert html =~ "Certain"
+      assert html =~ ~s{aria-describedby="q-framework-confidence-captions"}
+      assert html =~ ~s{id="q-framework-confidence-captions"}
+    end
+
+    test "a scale with no end labels renders no captions" do
+      assigns = %{
+        spec: %{id: "q", title: "T", fields: [%{id: "s", type: :scale, label: "Scale"}]}
+      }
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} />|)
+
+      refute html =~ "pc-questionnaire__scale-captions"
+      refute html =~ "aria-describedby"
+    end
+
+    test "required fields carry the native required attribute and a visible marker" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} />|)
+
+      assert html =~ "required"
+      assert html =~ "pc-label--required"
+    end
+
+    test "an optional-only spec has no required attribute" do
+      assigns = %{
+        spec: %{id: "q", title: "T", fields: [%{id: "team", type: :text, label: "Team"}]}
+      }
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} />|)
+
+      refute html =~ "required"
+    end
+
+    test "every field is a fieldset with a legend naming the question" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} />|)
+
+      assert length(Regex.scan(~r/<fieldset/, html)) == 4
+      assert html =~ "<legend"
+      assert html =~ "Framework (required)"
+      assert html =~ ">Features<"
+    end
+
+    test "the form is labelled by the questionnaire title" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} />|)
+
+      assert html =~ ~s{id="q-framework-title"}
+      assert html =~ ~s{aria-labelledby="q-framework-title"}
+    end
+
+    test "allow_skip renders a skip button carrying the spec id; absent by default" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} allow_skip />|)
+
+      assert_has_class(html, "pc-questionnaire__skip")
+      assert html =~ ~s{phx-click="questionnaire_skip"}
+      assert html =~ ~s{phx-value-id="q-framework"}
+
+      refute rendered_to_string(~H|<.questionnaire spec={@spec} />|) =~ "pc-questionnaire__skip"
+    end
+
+    test "a custom on_skip name is respected" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} allow_skip on_skip="pass" />|)
+
+      assert html =~ ~s{phx-click="pass"}
+    end
+
+    test "submitting disables every input and both buttons and shows a status spinner" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} allow_skip submitting />|)
+
+      assert html =~ ~s{role="status"}
+      assert_has_class(html, "pc-questionnaire__spinner")
+      assert html =~ "Submitting"
+      # radios, checkboxes, the text input, both buttons
+      assert length(Regex.scan(~r/disabled/, html)) >= 10
+    end
+
+    test "the pending form has no disabled controls" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} allow_skip />|)
+
+      refute html =~ "disabled"
+      refute html =~ ~s{role="status"}
+    end
+
+    test "a resolved map renders chips and no form at all" do
+      assigns = %{
+        spec: full_spec(),
+        resolved: %{
+          "framework" => "phoenix",
+          "features" => ["auth", "billing"],
+          "team" => "Platform",
+          "confidence" => "5"
+        }
+      }
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} resolved={@resolved} />|)
+
+      assert_has_class(html, "pc-questionnaire--resolved")
+      refute html =~ "<form"
+      refute html =~ "<input"
+      refute html =~ "<fieldset"
+
+      # option values render as their labels
+      assert html =~ "Phoenix"
+      refute html =~ "phoenix"
+      # multi-select gets one chip per choice
+      assert html =~ "Auth"
+      assert html =~ "Billing"
+      assert html =~ "Platform"
+      # the scale shows the number plus its end label
+      assert html =~ "5 · Certain"
+      # framework 1 + features 2 + team 1 + confidence 1
+      assert length(Regex.scan(~r/pc-questionnaire__chip/, html)) == 5
+    end
+
+    test "an unanswered field is left out of the summary" do
+      assigns = %{spec: full_spec(), resolved: %{"team" => "Platform"}}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} resolved={@resolved} />|)
+
+      assert html =~ "Platform"
+      assert length(Regex.scan(~r/pc-questionnaire__chip/, html)) == 1
+      refute html =~ "How sure are you?"
+    end
+
+    test "atom-keyed resolved maps work too" do
+      assigns = %{spec: full_spec(), resolved: %{team: "Platform"}}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} resolved={@resolved} />|)
+
+      assert html =~ "Platform"
+    end
+
+    test "resolved :skipped renders the skipped summary and no form" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} resolved={:skipped} />|)
+
+      assert_has_class(html, "pc-questionnaire--skipped")
+      assert html =~ "Skipped"
+      refute html =~ "<form"
+      refute html =~ "<input"
+    end
+
+    test "string-keyed and atom-keyed specs render identically" do
+      atom_spec = %{
+        id: "q",
+        title: "Pick one",
+        fields: [
+          %{
+            id: "pick",
+            type: :single_select,
+            label: "Pick",
+            required: true,
+            options: [%{value: "a", label: "A"}]
+          }
+        ]
+      }
+
+      string_spec = %{
+        "id" => "q",
+        "title" => "Pick one",
+        "fields" => [
+          %{
+            "id" => "pick",
+            "type" => "single_select",
+            "label" => "Pick",
+            "required" => true,
+            "options" => [%{"value" => "a", "label" => "A"}]
+          }
+        ]
+      }
+
+      assigns = %{atom_spec: atom_spec, string_spec: string_spec}
+
+      assert rendered_to_string(~H|<.questionnaire spec={@atom_spec} />|) ==
+               rendered_to_string(~H|<.questionnaire spec={@string_spec} />|)
+    end
+
+    test "a custom submit_label is used" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} submit_label="Send answers" />|)
+
+      assert html =~ "Send answers"
+      refute html =~ ">Submit<"
+    end
+
+    test "class is appended last and rest passes through" do
+      assigns = %{spec: full_spec()}
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} class="mine" id="q-block" />|)
+
+      assert html =~ "mine"
+      assert html =~ ~s{id="q-block"}
+    end
+
+    test "a spec with no description omits it" do
+      assigns = %{
+        spec: %{id: "q", title: "T", fields: [%{id: "t", type: :text, label: "T"}]}
+      }
+
+      html = rendered_to_string(~H|<.questionnaire spec={@spec} />|)
+
+      refute html =~ "pc-questionnaire__description"
+    end
+  end
+
   describe "marker" do
     test "inline with icon" do
       assigns = %{}

--- a/test/petal/chat_test.exs
+++ b/test/petal/chat_test.exs
@@ -688,6 +688,320 @@ defmodule PetalComponents.ChatTest do
     end
   end
 
+  describe "prompt_input/1 attachments" do
+    # A minimal UploadConfig standing in for allow_upload/3's, so the composer
+    # can be rendered without a live socket.
+    defp upload_config(entries, opts \\ []) do
+      %Phoenix.LiveView.UploadConfig{
+        name: :attachments,
+        ref: Keyword.get(opts, :ref, "phx-upload-ref"),
+        entries: entries,
+        errors: Keyword.get(opts, :errors, []),
+        max_entries: 4,
+        max_file_size: 5_000_000,
+        accept: ".png,.pdf",
+        acceptable_types: MapSet.new(["image/png", "application/pdf"]),
+        acceptable_exts: MapSet.new([".png", ".pdf"])
+      }
+    end
+
+    defp upload_entry(opts \\ []) do
+      %Phoenix.LiveView.UploadEntry{
+        ref: Keyword.get(opts, :ref, "0"),
+        upload_ref: "phx-upload-ref",
+        client_name: Keyword.get(opts, :client_name, "shot.png"),
+        client_size: Keyword.get(opts, :client_size, 12_345),
+        client_type: Keyword.get(opts, :client_type, "image/png"),
+        progress: Keyword.get(opts, :progress, 0),
+        valid?: Keyword.get(opts, :valid?, true),
+        done?: false
+      }
+    end
+
+    test "without an upload the composer is unchanged: no paperclip, drop target or chips" do
+      assigns = %{}
+
+      html = rendered_to_string(~H|<.prompt_input phx-submit="send" />|)
+
+      refute html =~ "pc-chat__composer-attach"
+      refute html =~ "pc-chat__composer-attachments"
+      refute html =~ "phx-drop-target"
+      refute html =~ ~s{type="file"}
+      refute html =~ "pc-chat__composer-errors"
+      # the shape that was always there is still there
+      assert html =~ "pc-chat__composer-row"
+      assert html =~ ~s{name="prompt"}
+    end
+
+    test "with an upload it renders the paperclip trigger and a hidden file input" do
+      assigns = %{upload: upload_config([])}
+
+      html = rendered_to_string(~H|<.prompt_input phx-submit="send" upload={@upload} />|)
+
+      assert_has_class(html, "pc-chat__composer-attach")
+      assert html =~ "hero-paper-clip"
+      assert html =~ ~s{type="file"}
+      assert html =~ "sr-only"
+      assert html =~ ~s{aria-label="Attach files"}
+      # no entries yet, so no chip strip
+      refute html =~ "pc-chat__composer-attachments"
+    end
+
+    test "the form becomes a drop target for the upload ref" do
+      assigns = %{upload: upload_config([], ref: "upload-123")}
+
+      html = rendered_to_string(~H|<.prompt_input phx-submit="send" upload={@upload} />|)
+
+      assert html =~ ~s{phx-drop-target="upload-123"}
+    end
+
+    test "an image entry renders a thumbnail chip" do
+      assigns = %{upload: upload_config([upload_entry(client_type: "image/png")])}
+
+      html = rendered_to_string(~H|<.prompt_input phx-submit="send" upload={@upload} />|)
+
+      assert_has_class(html, "pc-chat__attachment--image")
+      assert_has_class(html, "pc-chat__attachment-thumb")
+      assert html =~ ~s{role="list"}
+    end
+
+    test "a non-image entry renders name and formatted size" do
+      assigns = %{
+        upload:
+          upload_config([
+            upload_entry(
+              client_type: "application/pdf",
+              client_name: "invoice.pdf",
+              client_size: 2_400_000
+            )
+          ])
+      }
+
+      html = rendered_to_string(~H|<.prompt_input phx-submit="send" upload={@upload} />|)
+
+      assert_has_class(html, "pc-chat__attachment--file")
+      assert html =~ "invoice.pdf"
+      assert html =~ "2.4 MB"
+      refute html =~ "pc-chat__attachment-thumb"
+    end
+
+    test "the progress ring exposes the entry progress and progressbar semantics" do
+      assigns = %{upload: upload_config([upload_entry(progress: 42)])}
+
+      html = rendered_to_string(~H|<.prompt_input phx-submit="send" upload={@upload} />|)
+
+      assert html =~ ~s{role="progressbar"}
+      assert html =~ ~s{aria-valuenow="42"}
+      assert html =~ ~s{aria-valuemin="0"}
+      assert html =~ ~s{aria-valuemax="100"}
+      assert html =~ ~s{aria-label="Uploading shot.png"}
+      assert html =~ ~s{data-progress="42"}
+      assert html =~ "--pc-attachment-progress: 42"
+    end
+
+    test "the progress ring disappears at 100" do
+      assigns = %{upload: upload_config([upload_entry(progress: 100)])}
+
+      html = rendered_to_string(~H|<.prompt_input phx-submit="send" upload={@upload} />|)
+
+      refute html =~ ~s{role="progressbar"}
+    end
+
+    test "the remove button pushes the cancel event with the entry ref" do
+      assigns = %{upload: upload_config([upload_entry(ref: "entry-7")])}
+
+      html = rendered_to_string(~H|<.prompt_input phx-submit="send" upload={@upload} />|)
+
+      assert html =~ ~s{phx-click="cancel-upload"}
+      assert html =~ ~s{phx-value-ref="entry-7"}
+      assert html =~ ~s{aria-label="Remove shot.png"}
+    end
+
+    test "a custom on_cancel_upload name is respected" do
+      assigns = %{upload: upload_config([upload_entry()])}
+
+      html =
+        rendered_to_string(
+          ~H|<.prompt_input phx-submit="send" upload={@upload} on_cancel_upload="drop-it" />|
+        )
+
+      assert html =~ ~s{phx-click="drop-it"}
+      refute html =~ ~s{phx-click="cancel-upload"}
+    end
+
+    test "config-level errors render under the composer as alerts" do
+      # upload_errors/1 matches config-level errors by the config's own ref
+      assigns = %{upload: upload_config([], errors: [{"phx-upload-ref", :too_many_files}])}
+
+      html = rendered_to_string(~H|<.prompt_input phx-submit="send" upload={@upload} />|)
+
+      assert_has_class(html, "pc-chat__composer-errors")
+      assert html =~ ~s{role="alert"}
+      assert html =~ "Too many files selected."
+    end
+
+    test "per-entry errors name the file they belong to" do
+      entry = upload_entry(ref: "e1", client_name: "huge.png")
+
+      assigns = %{upload: upload_config([entry], errors: [{"e1", :too_large}])}
+
+      html = rendered_to_string(~H|<.prompt_input phx-submit="send" upload={@upload} />|)
+
+      assert html =~ "huge.png: This file is too large."
+      assert html =~ ~s{role="alert"}
+    end
+
+    test "the not_accepted error gets its own copy" do
+      entry = upload_entry(ref: "e1", client_name: "clip.mov")
+
+      assigns = %{upload: upload_config([entry], errors: [{"e1", :not_accepted}])}
+
+      html = rendered_to_string(~H|<.prompt_input phx-submit="send" upload={@upload} />|)
+
+      assert html =~ "clip.mov: This file type isn&#39;t accepted."
+    end
+
+    test "accept_hint lands in the accessible description and the tooltip" do
+      assigns = %{upload: upload_config([])}
+
+      html =
+        rendered_to_string(
+          ~H|<.prompt_input phx-submit="send" upload={@upload} accept_hint="PNGs up to 5 MB" />|
+        )
+
+      assert html =~ ~s{aria-description="PNGs up to 5 MB"}
+      assert html =~ ~s{title="PNGs up to 5 MB"}
+    end
+
+    test "chips coexist with the editing banner and the loading stop button" do
+      assigns = %{upload: upload_config([upload_entry()])}
+
+      html =
+        rendered_to_string(~H"""
+        <.prompt_input
+          phx-submit="send"
+          upload={@upload}
+          editing
+          on_cancel_edit="cancel"
+          loading={true}
+          on_stop="stop"
+        />
+        """)
+
+      assert html =~ "pc-chat__composer-banner"
+      assert html =~ "pc-chat__composer-stop"
+      assert html =~ "pc-chat__composer-attachments"
+    end
+  end
+
+  describe "message_attachments/1" do
+    test "a single image renders as a lazy thumbnail with the file name as alt text" do
+      assigns = %{
+        attachments: [%{kind: :image, url: "/uploads/shot.png", name: "shot.png", size: 1200}]
+      }
+
+      html = rendered_to_string(~H|<.message_attachments attachments={@attachments} />|)
+
+      assert_has_class(html, "pc-chat__message-attachments")
+      assert_has_class(html, "pc-chat__message-attachments-grid")
+      assert html =~ ~s{alt="shot.png"}
+      assert html =~ ~s{loading="lazy"}
+      assert html =~ ~s{src="/uploads/shot.png"}
+      refute html =~ "pc-chat__message-attachments-grid--multi"
+    end
+
+    test "two or more images tile into a grid" do
+      assigns = %{
+        attachments: [
+          %{kind: :image, url: "/a.png", name: "a.png", size: nil},
+          %{kind: :image, url: "/b.png", name: "b.png", size: nil}
+        ]
+      }
+
+      html = rendered_to_string(~H|<.message_attachments attachments={@attachments} />|)
+
+      assert_has_class(html, "pc-chat__message-attachments-grid--multi")
+    end
+
+    test "images are openable in a new tab" do
+      assigns = %{attachments: [%{kind: :image, url: "/a.png", name: "a.png", size: nil}]}
+
+      html = rendered_to_string(~H|<.message_attachments attachments={@attachments} />|)
+
+      assert html =~ ~s{target="_blank"}
+      assert html =~ ~s{rel="noopener noreferrer"}
+    end
+
+    test "files render as download rows with formatted sizes" do
+      assigns = %{
+        attachments: [
+          %{kind: :file, url: "/uploads/invoice.pdf", name: "invoice.pdf", size: 340_000}
+        ]
+      }
+
+      html = rendered_to_string(~H|<.message_attachments attachments={@attachments} />|)
+
+      assert_has_class(html, "pc-chat__attachment-row")
+      assert html =~ "download"
+      assert html =~ ~s{href="/uploads/invoice.pdf"}
+      assert html =~ "invoice.pdf"
+      assert html =~ "340.0 KB"
+    end
+
+    test "a nil size omits the size span" do
+      assigns = %{attachments: [%{kind: :file, url: "/a.pdf", name: "a.pdf", size: nil}]}
+
+      html = rendered_to_string(~H|<.message_attachments attachments={@attachments} />|)
+
+      refute html =~ "pc-chat__attachment-size"
+      assert html =~ "a.pdf"
+    end
+
+    test "a mixed list renders the images before the files" do
+      assigns = %{
+        attachments: [
+          %{kind: :file, url: "/doc.pdf", name: "doc.pdf", size: nil},
+          %{kind: :image, url: "/pic.png", name: "pic.png", size: nil}
+        ]
+      }
+
+      html = rendered_to_string(~H|<.message_attachments attachments={@attachments} />|)
+
+      image_at = :binary.match(html, "pic.png") |> elem(0)
+      file_at = :binary.match(html, "doc.pdf") |> elem(0)
+      assert image_at < file_at
+    end
+
+    test "string-keyed attachment maps render identically" do
+      assigns = %{
+        attachments: [%{"kind" => "image", "url" => "/x.png", "name" => "x.png", "size" => 100}]
+      }
+
+      html = rendered_to_string(~H|<.message_attachments attachments={@attachments} />|)
+
+      assert html =~ ~s{alt="x.png"}
+    end
+
+    test "an empty list renders nothing" do
+      assigns = %{}
+
+      refute rendered_to_string(~H|<.message_attachments attachments={[]} />|) =~
+               "pc-chat__message-attachments"
+    end
+
+    test "class is appended last and rest passes through" do
+      assigns = %{attachments: [%{kind: :file, url: "/a.pdf", name: "a.pdf", size: nil}]}
+
+      html =
+        rendered_to_string(
+          ~H|<.message_attachments attachments={@attachments} class="mine" id="att" />|
+        )
+
+      assert html =~ "mine"
+      assert html =~ ~s{id="att"}
+    end
+  end
+
   describe "marker" do
     test "inline with icon" do
       assigns = %{}


### PR DESCRIPTION
Closes #617

## Stack position

**3 of 4** in the 4.18.0 chat stack. This branch (`feat/chat-questionnaire`) is cut from **`feat/chat-attachments`** (#616, PR #644), which is itself cut from **`feat/chat-sources`** (#615, PR #643).

| # | Issue | Branch | Builds on |
|---|---|---|---|
| 1 | #615 chat_sources + citations | `feat/chat-sources` | `main` |
| 2 | #616 composer attachments | `feat/chat-attachments` | `feat/chat-sources` |
| **3** | **#617 chat questionnaire** | **`feat/chat-questionnaire`** | **`feat/chat-attachments`** |
| 4 | #618 tool_call states | `feat/chat-tool-call` | `feat/chat-questionnaire` |

⚠️ **The diff below is cumulative** — it carries #615's and #616's commits because this PR is opened against `main` while the branch sits on `feat/chat-attachments`. That's expected. **Merge #615 and #616 first** and this collapses to the single questionnaire commit (`2ab104f`) — review that commit alone if the combined diff is noisy.

**Merge order: 615 → 616 → 617 → 618.**

## Summary

`Chat.questionnaire/1` renders a question spec as a form inside the transcript, and renders it back as a quiet summary once the app has the answer. Server-driven throughout: a plain `phx-submit`, no client state, no client form engine, no JS hook.

- **Four field types** — `:single_select`, `:multi_select`, `:text`, `:scale`.
- **Four states** — pending, submitting, resolved, skipped.
- **Composes `field/1`** rather than reinventing inputs: `radio-card` when the options carry descriptions, `radio-group` when they don't (overridable per field with `style: "cards" | "buttons"`), `checkbox-group` for multi-select, `text` for text. Required markers, labels and error scaffolding come along for free.
- **The scale is the only new input rendering** — five real radios sharing a name in a segmented row, so arrow keys move between steps natively.
- Specs accept **string or atom keys** and normalise once at the top. There's a test asserting both render byte-identically.

## Deviations from the issue's sketch

1. **The hidden spec field is `spec_id`, not `id`** — so submit lands as `%{"spec_id" => "q-framework", "answers" => %{...}}`, not `%{"id" => ...}`.

   This is not a preference. `<input type="hidden" name="id">` inside a form makes the Phoenix HEEx compiler emit:

   > Setting the "name" attribute to "id" on an input tag overrides the ID of the corresponding form element. This leads to unexpected behavior, especially when using LiveView, and is not recommended.

   Under `--warnings-as-errors` that's a hard build failure, and the warning is describing a real LiveView footgun. The compiler's own suggested remedy is "use a different value for the name attribute". `spec_id` is that. **This is the one place the params shape differs from the brief** — flagging it loudly since the issue asked to assert the exact shape in tests. Say the word if you'd rather have `question_id`, `_id` or something else.

2. **Every field is a `<fieldset>`, including `:text`.** The brief asks for one fieldset per question, so `:text` gets one too even though a plain `<label for>` would do the job on its own. The legend is `sr-only` (the visible label comes from `field/1`), which means a text field is announced twice by some readers — once entering the group, once on the input. If you'd rather I dropped the fieldset for `:text`, that's a one-line change.

3. **`style` on a field overrides the cards-vs-radios choice.** The issue floated this as an option; it's implemented, with the heuristic (cards when any option has a `description`) as the default. Tested both ways.

4. **It lives in `chat.ex`, not a `chat/questionnaire.ex` submodule.** The issue allowed either. It reuses `chat.ex`'s existing `source_key/2` key-normaliser (added in #615), so keeping it in-module avoided a shared-helper module for one function. `chat.ex` is now ~1,700 lines — happy to split the file if you'd rather, but that's a bigger, separate change.

## Backward compatibility

**No existing test was modified or deleted, and no existing attr default changed.**

- `questionnaire/1` is a net-new function name. `Chat` is not pulled in by `use PetalComponents`, so it can't collide with a consumer's helpers.
- No existing chat component was touched by this commit at all — `git show 2ab104f --stat` shows additions to `chat.ex`, appended CSS, new tests, new showcase examples and playground additions, nothing else.
- CSS is appended in a **new `@layer components { }` block** at the tail of `assets/default.css`. Nothing above it reflowed, and being inside a layer means consumer utilities passed via `class` still win.

## Verification

| Check | Result |
|---|---|
| `mix format --check-formatted` | clean |
| `mix compile --force --warnings-as-errors` | clean |
| `mix credo` | 14 refactoring / 31 readability — **identical to `origin/main`, zero new entries** |
| `mix test` | **988 tests, 0 failures, 1 skipped** (963 after #616, **+25 new**; `main` baseline 913) |
| `npm test` | **163 passed** (unchanged from #616 — no JS touched by this commit) |

Tests cover the checklist: input names producing the documented params shape, the hidden spec field, radio-card vs radio-group selection and the `style` override both ways, exactly five scale radios with values 1–5 sharing one name, caption association, required present/absent, fieldset+legend per question, `aria-labelledby` on the form, skip button presence and event names, submitting disabling everything plus `role="status"`, resolved rendering one chip per value with no `<form>`/`<input>`/`<fieldset>` left behind, unanswered fields omitted from the summary, atom- and string-keyed resolved maps, `:skipped`, string vs atom spec parity, `class` appended last and `rest` passthrough.

## Playground

Extended the existing AI Chat page (slug `chat`) — **no new nav slug**, since `main` is a strict 1:1 slug-to-component mapping and chat already has its page. (The issue asked for a new page; flagging the deviation.)

- **"Human in the loop"** — a live two-step flow with real `handle_event` callbacks: the assistant asks which framework, you answer, the card flips to resolved chips and the follow-up question appears with multi-select + text + scale. A "Reset the flow" button starts over.
- **"Field types and states"** — dials for field type (`single_cards` / `single_buttons` / `multi` / `text` / `scale`), `allow_skip` off/on, and state (pending / submitting / resolved / skipped).

**Verified functionally in the browser** via accessibility-tree snapshots against the running playground: radio-cards render with their descriptions, all four field types render in the mixed question, and the flow genuinely round-trips — clicking Phoenix and submitting flipped the first card to resolved and revealed the follow-up, and the checkbox/text/scale controls all accepted input.

⚠️ **I could not attach screenshots.** The browser tooling on this machine stopped being able to rasterize part-way through this issue (`Page.captureScreenshot` timing out under heavy memory pressure). It fails identically on pages this branch never touches — I reproduced it on `/c/button` — so it isn't something in this change, but it does mean **light/dark screenshots are missing from this PR** where #643 and #644 have them. I'd rather say so than imply a visual check I didn't complete. Please eyeball the page yourself, or I can re-run the captures on a healthier box.

## Accessibility

- Each question is a `<fieldset>` with a `<legend>` naming it and marking it required.
- The form is `aria-labelledby` the questionnaire title heading.
- Radio and checkbox semantics come from the composed `field/1` primitives; the scale is a genuine radio group (native arrow-key movement), each radio labelled with its number, end captions tied in with `aria-describedby`.
- `required` is the native attribute, so it's announced and enforced by the browser.
- Submitting: every control disabled, spinner in a `role="status"` region with an "Submitting" sr-only label.
- Resolved: plain readable content, nothing focusable, no disabled form left pretending to be interactive.
- No keys are intercepted — Tab between fields, arrows within groups, Space toggles, Enter submits.
- `focus-visible` rings in primary only; `prefers-reduced-motion` stops the spinner and collapses the transitions with a legible rest state.
